### PR TITLE
Patient tasks: custom reminders + presets + cycle-aware surfacing

### DIFF
--- a/docs/PATIENT_TASKS.md
+++ b/docs/PATIENT_TASKS.md
@@ -1,0 +1,76 @@
+# Patient Tasks — custom reminders + cycle-aware surfacing
+
+## What it is
+
+A lightweight schedule of care-adjacent things to remember — environmental
+maintenance, dental reviews, nutrition follow-ups, pharmacy refills, admin
+work — that surface as CTAs on the dashboard **when they become relevant**,
+not on a fixed calendar.
+
+## Schedule kinds
+
+Every task belongs to one of four kinds:
+
+| Kind          | Fires when                                      | Example                                   |
+| ------------- | ----------------------------------------------- | ----------------------------------------- |
+| `once`        | A single calendar date                          | "Book a dental clean by 2026-06-15"       |
+| `recurring`   | Every *N* days; auto-rolls on completion        | "Change aircon filters every 90 days"     |
+| `cycle_phase` | During a phase of the active treatment cycle    | "Intensify hand hygiene during nadir"     |
+| `cycle_day`   | On a specific day of the active cycle           | "Pre-treatment labs on cycle day 1"       |
+
+Cycle-linked kinds consult the active `treatment_cycle` via the treatment
+layer's phase-window definitions.
+
+## Buckets
+
+`getActiveTaskInstances()` sorts every active task into:
+
+- `overdue` — past due
+- `due_today` — due today
+- `cycle_relevant` — inside the current cycle phase / day
+- `approaching` — within the task's `lead_time_days`
+- `scheduled` — further out
+- `snoozed` — user snoozed until a later date
+
+Dashboard only surfaces the first four — noise is the enemy.
+
+## Presets
+
+`src/config/task-presets.ts` ships 19 curated presets covering:
+
+- Environmental / household: HVAC filters, water filter, bed linen, vacuum
+- Dental: toothbrush swap (28d), 6-monthly dental clean
+- Nutrition: quarterly dietitian review
+- Physio: monthly exercise physiology
+- Pharmacy: PERT refill (60d), antiemetic refill (60d)
+- Vaccines: annual flu, 6-monthly COVID booster review
+- Clinical: annual skin / eye / GP review
+- Admin: 6-monthly advance care directive, annual will review
+- Cycle-relative: intensive hygiene at nadir, pet-care handoff, pre-dose labs
+
+Each preset has a rationale shown at pick time so the user understands *why*
+the task matters.
+
+## Adding custom tasks
+
+`/tasks/new` exposes every schedule kind with the matching fields. Schedule
+kind, lead time, and where to surface (dashboard / daily check-in) are all
+user-editable.
+
+## Completion + snooze
+
+- **Done** — appends to `completions[]` and, for recurring tasks, advances
+  `due_date` by the interval.
+- **Snooze 7d** — sets `snoozed_until`; the task disappears from the
+  dashboard until that date.
+
+## Extending
+
+Add a new preset: append to `TASK_PRESETS` in `src/config/task-presets.ts`.
+No code change required to the engine or UI.
+
+Add a new category: extend the `TaskCategory` union in
+`src/types/task.ts` and add the label to the `PresetPicker` grouping.
+
+Add a new schedule kind: extend `TaskScheduleKind` + the matching branch in
+`computeTaskInstance()` + the editor's schedule tabs.

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -13,6 +13,7 @@
     "quarterly": "Quarterly",
     "bridge": "Bridge",
     "events": "Events",
+    "tasks": "Tasks",
     "decisions": "Decisions",
     "ingest": "Ingest",
     "reports": "Reports",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -13,6 +13,7 @@
     "quarterly": "每季",
     "bridge": "过渡策略",
     "events": "重要日程",
+    "tasks": "照护任务",
     "decisions": "决策记录",
     "ingest": "导入",
     "reports": "报告",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { SarcopeniaCard } from "~/components/dashboard/sarcopenia-card";
 import { WeeklyCard } from "~/components/dashboard/weekly-card";
 import { PillarsCard } from "~/components/dashboard/pillars-card";
 import { CycleDayCard } from "~/components/dashboard/cycle-day-card";
+import { TasksCard } from "~/components/dashboard/tasks-card";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { PageHeader, SectionHeader } from "~/components/ui/page-header";
@@ -44,6 +45,8 @@ export default function DashboardPage() {
       <ZoneStatusCard />
 
       <CycleDayCard />
+
+      <TasksCard />
 
       <PillarsCard />
 

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { PageHeader } from "~/components/ui/page-header";
+import { TaskEditor } from "~/components/tasks/task-editor";
+import { useLocale } from "~/hooks/use-translate";
+
+export default function EditTaskPage() {
+  const locale = useLocale();
+  const params = useParams<{ id: string }>();
+  const id = Number(params?.id);
+  if (!Number.isFinite(id)) {
+    return <div className="p-6 text-sm text-red-700">Invalid id.</div>;
+  }
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-4 md:p-8">
+      <PageHeader title={locale === "zh" ? "编辑任务" : "Edit task"} />
+      <TaskEditor taskId={id} />
+    </div>
+  );
+}

--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { PageHeader } from "~/components/ui/page-header";
+import { TaskEditor } from "~/components/tasks/task-editor";
+import { useLocale } from "~/hooks/use-translate";
+
+export default function NewTaskPage() {
+  const locale = useLocale();
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-4 md:p-8">
+      <PageHeader
+        title={locale === "zh" ? "新建任务" : "New task"}
+        subtitle={
+          locale === "zh"
+            ? "任何与照护相关的事：环境维护、复查、补药、行政事项。"
+            : "Anything care-adjacent: environmental upkeep, reviews, refills, admin."
+        }
+      />
+      <TaskEditor />
+    </div>
+  );
+}

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useLocale, useT } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent } from "~/components/ui/card";
+import { TaskRow } from "~/components/tasks/task-row";
+import { PresetPicker } from "~/components/tasks/preset-picker";
+import {
+  completeTaskFromInstance,
+  snoozeTaskFromInstance,
+  useTaskInstances,
+} from "~/hooks/use-task-instances";
+import { Plus, Sparkles, ListTodo } from "lucide-react";
+
+export default function TasksPage() {
+  const t = useT();
+  const locale = useLocale();
+  const instances = useTaskInstances();
+  const [showPresets, setShowPresets] = useState(false);
+
+  const grouped = useMemo(() => {
+    const buckets: Record<string, typeof instances> = {
+      overdue: [],
+      due_today: [],
+      cycle_relevant: [],
+      approaching: [],
+      scheduled: [],
+      snoozed: [],
+    };
+    for (const i of instances) {
+      (buckets[i.bucket] ??= []).push(i);
+    }
+    return buckets;
+  }, [instances]);
+
+  const sectionOrder: [
+    string,
+    { en: string; zh: string },
+  ][] = [
+    ["overdue", { en: "Overdue", zh: "已超期" }],
+    ["due_today", { en: "Due today", zh: "今日到期" }],
+    ["cycle_relevant", { en: "Relevant now (cycle)", zh: "当前相关（周期）" }],
+    ["approaching", { en: "Approaching", zh: "即将到期" }],
+    ["scheduled", { en: "Scheduled", zh: "已排期" }],
+    ["snoozed", { en: "Snoozed", zh: "已暂缓" }],
+  ];
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-8">
+      <PageHeader
+        title={t("nav.tasks")}
+        subtitle={
+          locale === "zh"
+            ? "自定义提醒与行动。与化疗周期挂钩的任务在相关时间自动出现。"
+            : "Custom reminders and actions. Cycle-linked tasks surface when they matter."
+        }
+        action={
+          <div className="flex gap-2">
+            <Link href="/tasks/new">
+              <Button>
+                <Plus className="h-4 w-4" />
+                {locale === "zh" ? "新建" : "New task"}
+              </Button>
+            </Link>
+            <Button
+              variant="secondary"
+              onClick={() => setShowPresets((v) => !v)}
+            >
+              <Sparkles className="h-4 w-4" />
+              {showPresets
+                ? locale === "zh"
+                  ? "隐藏建议"
+                  : "Hide suggestions"
+                : locale === "zh"
+                  ? "建议任务"
+                  : "Suggested tasks"}
+            </Button>
+          </div>
+        }
+      />
+
+      {showPresets && (
+        <Card>
+          <CardContent className="pt-5">
+            <div className="mb-3 text-sm text-slate-500">
+              {locale === "zh"
+                ? "从常见的照护任务中挑选 —— 一点即添加。"
+                : "Add common care tasks in one click. You can edit any after adding."}
+            </div>
+            <PresetPicker />
+          </CardContent>
+        </Card>
+      )}
+
+      {instances.length === 0 && !showPresets && (
+        <Card className="p-10 text-center">
+          <ListTodo className="mx-auto mb-3 h-8 w-8 text-slate-400" />
+          <div className="text-sm font-medium">
+            {locale === "zh" ? "还没有任务" : "No tasks yet"}
+          </div>
+          <div className="mx-auto mt-1 max-w-sm text-sm text-slate-500">
+            {locale === "zh"
+              ? "从建议列表添加，或自己写一个。"
+              : "Start from a suggestion or write your own."}
+          </div>
+          <div className="mt-4 flex items-center justify-center gap-2">
+            <Button onClick={() => setShowPresets(true)}>
+              <Sparkles className="h-4 w-4" />
+              {locale === "zh" ? "建议任务" : "Suggestions"}
+            </Button>
+            <Link href="/tasks/new">
+              <Button variant="secondary">
+                <Plus className="h-4 w-4" />
+                {locale === "zh" ? "新建" : "New"}
+              </Button>
+            </Link>
+          </div>
+        </Card>
+      )}
+
+      {sectionOrder.map(([key, label]) => {
+        const items = grouped[key] ?? [];
+        if (items.length === 0) return null;
+        return (
+          <section key={key} className="space-y-2">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+              {label[locale]} · {items.length}
+            </h2>
+            <ul className="space-y-2">
+              {items.map((inst) => (
+                <li key={inst.task.id ?? inst.task.title}>
+                  <TaskRow
+                    instance={inst}
+                    onComplete={completeTaskFromInstance}
+                    onSnooze={snoozeTaskFromInstance}
+                  />
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/dashboard/tasks-card.tsx
+++ b/src/components/dashboard/tasks-card.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { useLocale } from "~/hooks/use-translate";
+import {
+  completeTaskFromInstance,
+  snoozeTaskFromInstance,
+  useTaskInstances,
+} from "~/hooks/use-task-instances";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { TaskRow } from "~/components/tasks/task-row";
+import { Button } from "~/components/ui/button";
+import { ListTodo, Sparkles, ChevronRight } from "lucide-react";
+
+export function TasksCard() {
+  const locale = useLocale();
+  const instances = useTaskInstances();
+  const actionable = instances.filter(
+    (i) => i.task.surface_dashboard !== false && i.bucket !== "snoozed" && i.bucket !== "scheduled",
+  );
+  const top = actionable.slice(0, 5);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>
+            {locale === "zh" ? "待办" : "To do"}
+          </CardTitle>
+          <Link
+            href="/tasks"
+            className="inline-flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900 dark:hover:text-slate-100"
+          >
+            {locale === "zh" ? "全部" : "View all"}
+            <ChevronRight className="h-3 w-3" />
+          </Link>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {top.length === 0 && (
+          <div className="flex items-start gap-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/60">
+            <ListTodo className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="flex-1">
+              <div className="font-medium text-slate-700 dark:text-slate-300">
+                {locale === "zh"
+                  ? "没有到期任务"
+                  : "Nothing due right now"}
+              </div>
+              <div className="mt-0.5 text-xs">
+                {locale === "zh"
+                  ? "从建议中添加照护任务，它们会在相关时自动出现。"
+                  : "Add care tasks from the suggestions — they surface automatically when relevant."}
+              </div>
+              <Link href="/tasks" className="mt-3 inline-block">
+                <Button size="sm" variant="secondary">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  {locale === "zh" ? "建议任务" : "Suggested tasks"}
+                </Button>
+              </Link>
+            </div>
+          </div>
+        )}
+        <ul className="space-y-2">
+          {top.map((inst) => (
+            <li key={inst.task.id ?? inst.task.title}>
+              <TaskRow
+                instance={inst}
+                onComplete={completeTaskFromInstance}
+                onSnooze={snoozeTaskFromInstance}
+                compact={false}
+              />
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -16,6 +16,7 @@ import {
   ScanLine,
   Compass,
   Syringe,
+  ListTodo,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { useT } from "~/hooks/use-translate";
@@ -30,6 +31,7 @@ const ITEMS = [
   { href: "/quarterly", key: "nav.quarterly", icon: ClipboardList },
   { href: "/bridge", key: "nav.bridge", icon: Route },
   { href: "/events", key: "nav.events", icon: CalendarClock },
+  { href: "/tasks", key: "nav.tasks", icon: ListTodo },
   { href: "/decisions", key: "nav.decisions", icon: ScrollText },
   { href: "/ingest", key: "nav.ingest", icon: ScanLine },
   { href: "/reports", key: "nav.reports", icon: FileText },

--- a/src/components/tasks/preset-picker.tsx
+++ b/src/components/tasks/preset-picker.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, now } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { addDays, parseISO } from "date-fns";
+import { TASK_PRESETS } from "~/config/task-presets";
+import type { PatientTask, TaskPreset } from "~/types/task";
+import { todayISO } from "~/lib/utils/date";
+import { cn } from "~/lib/utils/cn";
+import { Card, CardContent } from "~/components/ui/card";
+import { Plus, Check } from "lucide-react";
+
+function toISODate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
+}
+
+export function PresetPicker() {
+  const locale = useLocale();
+  const existing = useLiveQuery(() => db.patient_tasks.toArray());
+  const existingPresetIds = new Set(
+    (existing ?? []).map((t) => t.preset_id).filter((id): id is string => !!id),
+  );
+
+  async function add(preset: TaskPreset) {
+    const ts = now();
+    const base: PatientTask = {
+      title: preset.title.en,
+      title_zh: preset.title.zh,
+      notes: preset.rationale.en,
+      category: preset.category,
+      priority: preset.priority,
+      schedule_kind: preset.schedule_kind,
+      lead_time_days: preset.lead_time_days,
+      surface_dashboard: true,
+      surface_daily: false,
+      active: true,
+      preset_id: preset.id,
+      created_at: ts,
+      updated_at: ts,
+    };
+    if (preset.schedule_kind === "recurring") {
+      base.recurrence_interval_days = preset.recurrence_interval_days;
+      base.due_date = toISODate(
+        addDays(parseISO(todayISO()), preset.default_due_offset_days ?? 0),
+      );
+    } else if (preset.schedule_kind === "once") {
+      base.due_date = toISODate(
+        addDays(parseISO(todayISO()), preset.default_due_offset_days ?? 7),
+      );
+    } else if (preset.schedule_kind === "cycle_day") {
+      base.cycle_day = preset.cycle_day;
+    } else if (preset.schedule_kind === "cycle_phase") {
+      base.cycle_phase = preset.cycle_phase;
+    }
+    await db.patient_tasks.add(base);
+  }
+
+  const byCategory = TASK_PRESETS.reduce<Record<string, TaskPreset[]>>(
+    (acc, p) => {
+      (acc[p.category] ??= []).push(p);
+      return acc;
+    },
+    {},
+  );
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(byCategory).map(([cat, items]) => (
+        <section key={cat}>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            {cat.replace("_", " ")}
+          </h3>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {items.map((p) => {
+              const added = existingPresetIds.has(p.id);
+              return (
+                <Card
+                  key={p.id}
+                  className={cn(
+                    "transition-colors",
+                    added && "opacity-60",
+                  )}
+                >
+                  <CardContent className="flex items-start justify-between gap-3 pt-4">
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium">
+                        {p.title[locale]}
+                      </div>
+                      <div className="mt-1 text-xs text-slate-500">
+                        {p.rationale[locale]}
+                      </div>
+                      <div className="mt-2 text-[11px] text-slate-400">
+                        {p.schedule_kind === "recurring" &&
+                          p.recurrence_interval_days &&
+                          (locale === "zh"
+                            ? `每 ${p.recurrence_interval_days} 天`
+                            : `every ${p.recurrence_interval_days}d`)}
+                        {p.schedule_kind === "cycle_phase" &&
+                          ` · ${p.cycle_phase}`}
+                        {p.schedule_kind === "cycle_day" &&
+                          ` · ${locale === "zh" ? "周期日" : "day"} ${p.cycle_day}`}
+                        {" · "}
+                        {p.priority}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!added) void add(p);
+                      }}
+                      disabled={added}
+                      className={cn(
+                        "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border",
+                        added
+                          ? "border-emerald-500 text-emerald-600"
+                          : "border-slate-300 bg-white text-slate-700 hover:border-slate-500 dark:border-slate-700 dark:bg-slate-900",
+                      )}
+                      aria-label={added ? "added" : "add"}
+                    >
+                      {added ? (
+                        <Check className="h-4 w-4" />
+                      ) : (
+                        <Plus className="h-4 w-4" />
+                      )}
+                    </button>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/tasks/task-editor.tsx
+++ b/src/components/tasks/task-editor.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, now } from "~/lib/db/dexie";
+import { todayISO } from "~/lib/utils/date";
+import { useLocale } from "~/hooks/use-translate";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Field, TextInput, Textarea } from "~/components/ui/field";
+import type {
+  CyclePhaseKey,
+  PatientTask,
+  TaskCategory,
+  TaskPriority,
+  TaskScheduleKind,
+} from "~/types/task";
+import { Trash2 } from "lucide-react";
+
+const CATEGORIES: TaskCategory[] = [
+  "environmental",
+  "household",
+  "dental",
+  "nutrition",
+  "pharmacy",
+  "physio",
+  "clinical",
+  "vaccine",
+  "admin",
+  "self_care",
+  "other",
+];
+
+const PRIORITIES: TaskPriority[] = ["low", "normal", "high"];
+
+const PHASES: CyclePhaseKey[] = [
+  "pre_dose",
+  "dose_day",
+  "post_dose",
+  "recovery_early",
+  "nadir",
+  "recovery_late",
+  "rest",
+];
+
+interface Props {
+  taskId?: number;
+  presetId?: string;
+}
+
+export function TaskEditor({ taskId, presetId }: Props) {
+  const locale = useLocale();
+  const router = useRouter();
+  const existing = useLiveQuery(
+    () => (taskId ? db.patient_tasks.get(taskId) : undefined),
+    [taskId],
+  );
+
+  const [title, setTitle] = useState("");
+  const [titleZh, setTitleZh] = useState("");
+  const [notes, setNotes] = useState("");
+  const [category, setCategory] = useState<TaskCategory>("self_care");
+  const [priority, setPriority] = useState<TaskPriority>("normal");
+  const [scheduleKind, setScheduleKind] = useState<TaskScheduleKind>("once");
+  const [dueDate, setDueDate] = useState(todayISO());
+  const [interval, setInterval] = useState<number>(90);
+  const [cycleDay, setCycleDay] = useState<number>(16);
+  const [cyclePhase, setCyclePhase] = useState<CyclePhaseKey>("nadir");
+  const [leadTime, setLeadTime] = useState<number>(7);
+  const [surfaceDashboard, setSurfaceDashboard] = useState(true);
+  const [surfaceDaily, setSurfaceDaily] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (existing) {
+      setTitle(existing.title);
+      setTitleZh(existing.title_zh ?? "");
+      setNotes(existing.notes ?? "");
+      setCategory(existing.category);
+      setPriority(existing.priority);
+      setScheduleKind(existing.schedule_kind);
+      setDueDate(existing.due_date ?? todayISO());
+      setInterval(existing.recurrence_interval_days ?? 90);
+      setCycleDay(existing.cycle_day ?? 16);
+      setCyclePhase(existing.cycle_phase ?? "nadir");
+      setLeadTime(existing.lead_time_days);
+      setSurfaceDashboard(existing.surface_dashboard);
+      setSurfaceDaily(existing.surface_daily);
+    }
+  }, [existing]);
+
+  async function save() {
+    setSaving(true);
+    try {
+      const ts = now();
+      const payload: PatientTask = {
+        title: title.trim(),
+        title_zh: titleZh.trim() || undefined,
+        notes: notes.trim() || undefined,
+        category,
+        priority,
+        schedule_kind: scheduleKind,
+        due_date:
+          scheduleKind === "once" || scheduleKind === "recurring"
+            ? dueDate
+            : undefined,
+        recurrence_interval_days:
+          scheduleKind === "recurring" ? interval : undefined,
+        cycle_day: scheduleKind === "cycle_day" ? cycleDay : undefined,
+        cycle_phase:
+          scheduleKind === "cycle_phase" ? cyclePhase : undefined,
+        lead_time_days: leadTime,
+        surface_dashboard: surfaceDashboard,
+        surface_daily: surfaceDaily,
+        active: true,
+        preset_id: existing?.preset_id ?? presetId,
+        created_at: existing?.created_at ?? ts,
+        updated_at: ts,
+      };
+      if (existing?.id) {
+        await db.patient_tasks.put({ ...payload, id: existing.id });
+      } else {
+        await db.patient_tasks.add(payload);
+      }
+      router.push("/tasks");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function remove() {
+    if (!existing?.id) return;
+    if (!confirm(locale === "zh" ? "删除这个任务？" : "Delete this task?")) return;
+    await db.patient_tasks.delete(existing.id);
+    router.push("/tasks");
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {locale === "zh" ? "任务详情" : "Task details"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Field label={locale === "zh" ? "标题" : "Title"}>
+            <TextInput
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={
+                locale === "zh"
+                  ? "例如：更换空调滤网"
+                  : "e.g. Change aircon filters"
+              }
+            />
+          </Field>
+          <Field label={locale === "zh" ? "标题（中文，可选）" : "Title (Chinese, optional)"}>
+            <TextInput
+              value={titleZh}
+              onChange={(e) => setTitleZh(e.target.value)}
+            />
+          </Field>
+          <Field label={locale === "zh" ? "备注" : "Notes"}>
+            <Textarea
+              rows={3}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder={
+                locale === "zh"
+                  ? "为何重要、注意事项、联系人…"
+                  : "Why it matters, caveats, contact details…"
+              }
+            />
+          </Field>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label={locale === "zh" ? "类别" : "Category"}>
+              <select
+                value={category}
+                onChange={(e) => setCategory(e.target.value as TaskCategory)}
+                className="h-11 w-full rounded-lg border border-slate-300 bg-white px-3 text-sm dark:border-slate-700 dark:bg-slate-900"
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <Field label={locale === "zh" ? "优先级" : "Priority"}>
+              <select
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as TaskPriority)}
+                className="h-11 w-full rounded-lg border border-slate-300 bg-white px-3 text-sm dark:border-slate-700 dark:bg-slate-900"
+              >
+                {PRIORITIES.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {locale === "zh" ? "什么时候？" : "When?"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {(
+              [
+                ["once", locale === "zh" ? "一次" : "One-off"],
+                ["recurring", locale === "zh" ? "定期" : "Recurring"],
+                ["cycle_phase", locale === "zh" ? "周期阶段" : "Cycle phase"],
+                ["cycle_day", locale === "zh" ? "周期日" : "Cycle day"],
+              ] as [TaskScheduleKind, string][]
+            ).map(([k, label]) => {
+              const active = scheduleKind === k;
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => setScheduleKind(k)}
+                  className={
+                    active
+                      ? "rounded-lg border border-slate-900 bg-slate-900 px-3 py-2 text-sm font-medium text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900"
+                      : "rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 hover:border-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300"
+                  }
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+
+          {scheduleKind === "once" && (
+            <Field label={locale === "zh" ? "到期日" : "Due date"}>
+              <TextInput
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+              />
+            </Field>
+          )}
+          {scheduleKind === "recurring" && (
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Field label={locale === "zh" ? "首次到期" : "First due"}>
+                <TextInput
+                  type="date"
+                  value={dueDate}
+                  onChange={(e) => setDueDate(e.target.value)}
+                />
+              </Field>
+              <Field label={locale === "zh" ? "每几天" : "Every N days"}>
+                <TextInput
+                  type="number"
+                  min={1}
+                  value={interval}
+                  onChange={(e) => setInterval(Number(e.target.value) || 0)}
+                />
+              </Field>
+            </div>
+          )}
+          {scheduleKind === "cycle_day" && (
+            <Field label={locale === "zh" ? "化疗周期日（1–28）" : "Cycle day (1–28)"}>
+              <TextInput
+                type="number"
+                min={1}
+                max={28}
+                value={cycleDay}
+                onChange={(e) => setCycleDay(Number(e.target.value) || 1)}
+              />
+            </Field>
+          )}
+          {scheduleKind === "cycle_phase" && (
+            <Field label={locale === "zh" ? "周期阶段" : "Cycle phase"}>
+              <select
+                value={cyclePhase}
+                onChange={(e) => setCyclePhase(e.target.value as CyclePhaseKey)}
+                className="h-11 w-full rounded-lg border border-slate-300 bg-white px-3 text-sm dark:border-slate-700 dark:bg-slate-900"
+              >
+                {PHASES.map((p) => (
+                  <option key={p} value={p}>
+                    {p.replace("_", " ")}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          )}
+          <Field
+            label={locale === "zh" ? "提前几天提醒" : "Lead time (days before due)"}
+          >
+            <TextInput
+              type="number"
+              min={0}
+              value={leadTime}
+              onChange={(e) => setLeadTime(Number(e.target.value) || 0)}
+            />
+          </Field>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {locale === "zh" ? "在哪里出现" : "Where to surface"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={surfaceDashboard}
+              onChange={(e) => setSurfaceDashboard(e.target.checked)}
+              className="h-4 w-4"
+            />
+            {locale === "zh" ? "在仪表板显示" : "Show on dashboard"}
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={surfaceDaily}
+              onChange={(e) => setSurfaceDaily(e.target.checked)}
+              className="h-4 w-4"
+            />
+            {locale === "zh" ? "在每日记录中显示" : "Show on daily check-in"}
+          </label>
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex gap-2">
+          <Button onClick={save} disabled={saving || !title.trim()}>
+            {locale === "zh" ? "保存" : "Save"}
+          </Button>
+          <Button variant="ghost" onClick={() => router.push("/tasks")}>
+            {locale === "zh" ? "取消" : "Cancel"}
+          </Button>
+        </div>
+        {existing?.id && (
+          <Button variant="danger" size="sm" onClick={remove}>
+            <Trash2 className="h-3.5 w-3.5" />
+            {locale === "zh" ? "删除" : "Delete"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/tasks/task-row.tsx
+++ b/src/components/tasks/task-row.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import Link from "next/link";
+import { formatDate } from "~/lib/utils/date";
+import { cn } from "~/lib/utils/cn";
+import { useLocale } from "~/hooks/use-translate";
+import type { TaskBucket, TaskInstance } from "~/types/task";
+import { localizedTitle } from "~/types/task";
+import { Button } from "~/components/ui/button";
+import { Check, Clock, AlertTriangle, CalendarClock, MoonStar } from "lucide-react";
+
+const BUCKET_META: Record<
+  TaskBucket,
+  { tone: string; icon: React.ComponentType<{ className?: string }>; label: { en: string; zh: string } }
+> = {
+  overdue: {
+    tone: "border-red-400 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200",
+    icon: AlertTriangle,
+    label: { en: "Overdue", zh: "已超期" },
+  },
+  due_today: {
+    tone: "border-amber-400 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200",
+    icon: Clock,
+    label: { en: "Due today", zh: "今日到期" },
+  },
+  cycle_relevant: {
+    tone: "border-orange-400 bg-orange-50 text-orange-800 dark:border-orange-900 dark:bg-orange-950/40 dark:text-orange-200",
+    icon: CalendarClock,
+    label: { en: "Relevant now", zh: "当前相关" },
+  },
+  approaching: {
+    tone: "border-slate-300 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300",
+    icon: Clock,
+    label: { en: "Approaching", zh: "即将到期" },
+  },
+  scheduled: {
+    tone: "border-slate-200 bg-white text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300",
+    icon: CalendarClock,
+    label: { en: "Scheduled", zh: "已排期" },
+  },
+  snoozed: {
+    tone: "border-dashed border-slate-300 bg-slate-50 text-slate-500 dark:border-slate-700 dark:bg-slate-900/40",
+    icon: MoonStar,
+    label: { en: "Snoozed", zh: "已暂缓" },
+  },
+};
+
+export function TaskRow({
+  instance,
+  onComplete,
+  onSnooze,
+  compact = false,
+}: {
+  instance: TaskInstance;
+  onComplete?: (instance: TaskInstance) => void;
+  onSnooze?: (instance: TaskInstance, days: number) => void;
+  compact?: boolean;
+}) {
+  const locale = useLocale();
+  const meta = BUCKET_META[instance.bucket];
+  const Icon = meta.icon;
+  const { task } = instance;
+  const title = localizedTitle(task, locale);
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-xl border p-3 transition-colors",
+        meta.tone,
+      )}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-sm font-medium truncate">{title}</div>
+          <span className="text-[10px] uppercase tracking-wide font-semibold shrink-0">
+            {meta.label[locale]}
+          </span>
+        </div>
+        <div className="mt-0.5 text-xs opacity-80 flex flex-wrap gap-x-2">
+          <span>
+            {task.category}
+            {task.priority === "high" ? " · high" : ""}
+          </span>
+          <span>
+            {instance.days_until_due === 0
+              ? locale === "zh"
+                ? "今天"
+                : "today"
+              : instance.days_until_due < 0
+                ? locale === "zh"
+                  ? `超期 ${-instance.days_until_due} 天`
+                  : `${-instance.days_until_due}d overdue`
+                : locale === "zh"
+                  ? `${instance.days_until_due} 天后`
+                  : `in ${instance.days_until_due}d`}
+          </span>
+          <span className="opacity-60">
+            {formatDate(instance.due_on, locale)}
+          </span>
+          {instance.reason && <span className="opacity-80">· {instance.reason}</span>}
+        </div>
+      </div>
+      {!compact && (
+        <div className="flex items-center gap-1 shrink-0">
+          {onComplete && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => onComplete(instance)}
+              aria-label="mark complete"
+            >
+              <Check className="h-3.5 w-3.5" />
+              {locale === "zh" ? "完成" : "Done"}
+            </Button>
+          )}
+          {onSnooze && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onSnooze(instance, 7)}
+              aria-label="snooze"
+            >
+              <MoonStar className="h-3.5 w-3.5" />
+              7d
+            </Button>
+          )}
+          {task.id !== undefined && (
+            <Link
+              href={`/tasks/${task.id}`}
+              className="rounded-md px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              {locale === "zh" ? "编辑" : "Edit"}
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/config/task-presets.ts
+++ b/src/config/task-presets.ts
@@ -1,0 +1,318 @@
+import type { TaskPreset } from "~/types/task";
+
+export const TASK_PRESETS: readonly TaskPreset[] = [
+  // Environmental / household
+  {
+    id: "aircon_filter",
+    title: {
+      en: "Change airconditioner / HVAC filters",
+      zh: "更换空调 / 新风系统滤网",
+    },
+    category: "environmental",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 90,
+    lead_time_days: 7,
+    priority: "normal",
+    default_due_offset_days: 0,
+    rationale: {
+      en: "Clean filters reduce airborne pathogens and dust exposure — matters most during nadir windows.",
+      zh: "干净的滤网减少空气中的病原体与灰尘 —— 在骨髓抑制低谷期尤其重要。",
+    },
+  },
+  {
+    id: "water_filter",
+    title: {
+      en: "Replace water filter cartridge",
+      zh: "更换净水器滤芯",
+    },
+    category: "environmental",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 90,
+    lead_time_days: 7,
+    priority: "normal",
+    rationale: {
+      en: "Tap water via a tested carbon + reverse osmosis filter is safer than unfiltered during treatment.",
+      zh: "经过活性炭 + 反渗透的自来水在治疗期间更安全。",
+    },
+  },
+  {
+    id: "toothbrush_swap",
+    title: {
+      en: "Replace toothbrush (soft)",
+      zh: "更换软毛牙刷",
+    },
+    category: "dental",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 28,
+    lead_time_days: 3,
+    priority: "normal",
+    rationale: {
+      en: "After each chemotherapy cycle — fresh soft bristles reduce mucositis and bleeding gums risk.",
+      zh: "每个化疗周期后更换 —— 新的软毛减少口腔炎与牙龈出血。",
+    },
+  },
+  {
+    id: "bed_linen_weekly",
+    title: {
+      en: "Change bed linen (weekly; daily during nadir)",
+      zh: "更换床单（每周一次；低谷期每日）",
+    },
+    category: "household",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 7,
+    lead_time_days: 0,
+    priority: "normal",
+    rationale: {
+      en: "Regular linen change lowers skin infection risk. During nadir (D16–21 GnP weekly), change daily.",
+      zh: "定期更换降低皮肤感染风险。GnP 每周方案的低谷期（D16–21）改为每日更换。",
+    },
+  },
+  {
+    id: "vacuum_damp_mop",
+    title: {
+      en: "Vacuum + damp mop living spaces",
+      zh: "吸尘并湿拖起居空间",
+    },
+    category: "household",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 7,
+    lead_time_days: 0,
+    priority: "low",
+    rationale: {
+      en: "Someone other than Hu Lin does this — reduces dust and mould exposure.",
+      zh: "由其他家人完成 —— 减少灰尘和霉菌暴露。",
+    },
+  },
+  // Dental + clinical periphery
+  {
+    id: "dental_clean",
+    title: { en: "Dental cleaning + check", zh: "洗牙 + 牙科检查" },
+    category: "dental",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 180,
+    lead_time_days: 21,
+    priority: "high",
+    rationale: {
+      en: "Every 6 months. Always disclose chemo regimen + last neutrophil count. Ask about antibiotic prophylaxis.",
+      zh: "每 6 个月。告知化疗方案与最近中性粒细胞；询问是否需要抗生素预防。",
+    },
+  },
+  {
+    id: "nutrition_review",
+    title: { en: "Dietitian review", zh: "营养师复查" },
+    category: "nutrition",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 90,
+    lead_time_days: 14,
+    priority: "high",
+    rationale: {
+      en: "Quarterly with an oncology dietitian. Reviews weight trajectory, protein intake, PERT dose, symptom-specific eating strategies.",
+      zh: "每季度与肿瘤营养师复查：体重轨迹、蛋白摄入、胰酶替代剂量、针对症状的饮食策略。",
+    },
+  },
+  {
+    id: "exercise_physiology",
+    title: {
+      en: "Exercise physiology session",
+      zh: "运动生理学 / 康复",
+    },
+    category: "physio",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 28,
+    lead_time_days: 7,
+    priority: "high",
+    rationale: {
+      en: "Monthly with a cancer-trained exercise physiologist. Key lever against sarcopenia.",
+      zh: "每月一次，由肿瘤方向的运动生理学家指导 —— 是抗肌少症最有效的手段。",
+    },
+  },
+  {
+    id: "pert_refill",
+    title: {
+      en: "PERT (Creon) refill",
+      zh: "胰酶替代剂（Creon）补药",
+    },
+    category: "pharmacy",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 60,
+    lead_time_days: 10,
+    priority: "high",
+    rationale: {
+      en: "Never run out — ordering takes time. 25 000 u with meals, 10 000 u with snacks.",
+      zh: "不要断药 —— 订药需时。正餐 25 000 单位，加餐 10 000 单位。",
+    },
+  },
+  {
+    id: "antiemetic_refill",
+    title: {
+      en: "Antiemetic + supportive med refill",
+      zh: "止吐与辅助药补药",
+    },
+    category: "pharmacy",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 60,
+    lead_time_days: 10,
+    priority: "high",
+    rationale: {
+      en: "Check ondansetron, olanzapine, dexamethasone, loperamide stock before each cycle.",
+      zh: "每周期前检查昂丹司琼、奥氮平、地塞米松、洛哌丁胺库存。",
+    },
+  },
+  // Vaccines + preventive
+  {
+    id: "flu_vaccine",
+    title: {
+      en: "Influenza vaccine (annual)",
+      zh: "流感疫苗（每年）",
+    },
+    category: "vaccine",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 365,
+    lead_time_days: 30,
+    priority: "high",
+    rationale: {
+      en: "Ideally in Autumn before flu season. Get it with oncologist timing — avoid dose days.",
+      zh: "最佳时间是秋季、流感季之前。与主诊协调时间 —— 避开用药日。",
+    },
+  },
+  {
+    id: "covid_booster",
+    title: { en: "COVID-19 booster review", zh: "新冠疫苗加强针评估" },
+    category: "vaccine",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 180,
+    lead_time_days: 14,
+    priority: "normal",
+    rationale: {
+      en: "Every 6 months, check current immunocompromised-specific recommendations with GP or oncology.",
+      zh: "每 6 个月一次，与家庭医师 / 肿瘤科核对免疫抑制相关的最新建议。",
+    },
+  },
+  {
+    id: "skin_check",
+    title: {
+      en: "Skin cancer check (dermatology)",
+      zh: "皮肤癌筛查（皮肤科）",
+    },
+    category: "clinical",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 365,
+    lead_time_days: 30,
+    priority: "normal",
+    rationale: {
+      en: "Annual. Increased skin cancer risk with immunosuppression + sun exposure in Australia.",
+      zh: "每年一次。免疫抑制加澳洲日照环境下皮肤癌风险升高。",
+    },
+  },
+  {
+    id: "eye_check",
+    title: { en: "Optometry / eye check", zh: "验光 / 眼科检查" },
+    category: "clinical",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 365,
+    lead_time_days: 30,
+    priority: "low",
+    rationale: {
+      en: "Annual. Some chemo affects tear film; good visual function supports independence.",
+      zh: "每年一次。部分化疗影响泪膜；视力良好有助保持独立。",
+    },
+  },
+  {
+    id: "gp_review",
+    title: { en: "GP health review", zh: "家庭医师综合复查" },
+    category: "clinical",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 90,
+    lead_time_days: 14,
+    priority: "normal",
+    rationale: {
+      en: "Quarterly — BP, weight, medication reconciliation, anything non-oncology.",
+      zh: "每季度 —— 血压、体重、用药整理、与肿瘤无关的问题。",
+    },
+  },
+  {
+    id: "advance_care_review",
+    title: {
+      en: "Advance care directive review",
+      zh: "预立医疗指示复查",
+    },
+    category: "admin",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 180,
+    lead_time_days: 30,
+    priority: "high",
+    rationale: {
+      en: "Every 6 months, or after any significant change. Review with family; update with GP.",
+      zh: "每 6 个月或出现重大变化后复查。与家人讨论，由家庭医师更新。",
+    },
+  },
+  {
+    id: "will_review",
+    title: {
+      en: "Will / estate document review",
+      zh: "遗嘱 / 财产文件复查",
+    },
+    category: "admin",
+    schedule_kind: "recurring",
+    recurrence_interval_days: 365,
+    lead_time_days: 30,
+    priority: "normal",
+    rationale: {
+      en: "Annual review. Check executors, beneficiaries, powers of attorney are current.",
+      zh: "每年复查。确认遗嘱执行人、受益人、授权书仍为最新。",
+    },
+  },
+  // Cycle-relative tasks
+  {
+    id: "nadir_hygiene_check",
+    title: {
+      en: "Intensive hygiene — start of nadir",
+      zh: "加强手卫生 —— 进入低谷期",
+    },
+    category: "self_care",
+    schedule_kind: "cycle_phase",
+    cycle_phase: "nadir",
+    lead_time_days: 0,
+    priority: "high",
+    rationale: {
+      en: "Hand sanitiser at every door, avoid sick contacts, temp twice daily, fresh linen daily, no raw food.",
+      zh: "每个门口放手部消毒剂、远离患病者、一天两次测体温、每日换床品、不吃生食。",
+    },
+  },
+  {
+    id: "pet_care_handoff",
+    title: {
+      en: "Pet care handoff — no litter / cage cleaning",
+      zh: "宠物护理移交 —— 不清理猫砂 / 鸟笼",
+    },
+    category: "self_care",
+    schedule_kind: "cycle_phase",
+    cycle_phase: "nadir",
+    lead_time_days: 1,
+    priority: "normal",
+    rationale: {
+      en: "Another household member handles litter / cage / fish tank during nadir to avoid zoonotic infection.",
+      zh: "低谷期由其他家人清理猫砂 / 鸟笼 / 鱼缸以避免人畜共患感染。",
+    },
+  },
+  {
+    id: "pre_cycle_labs",
+    title: {
+      en: "Pre-treatment labs (CBC + LFT)",
+      zh: "用药前化验（血常规 + 肝功能）",
+    },
+    category: "clinical",
+    schedule_kind: "cycle_phase",
+    cycle_phase: "pre_dose",
+    lead_time_days: 1,
+    priority: "high",
+    rationale: {
+      en: "24–48 h before each dose day. Needed for dose decision.",
+      zh: "每个用药日前 24–48 小时。剂量决定需要此化验。",
+    },
+  },
+];
+
+export const TASK_PRESET_BY_ID: Record<string, TaskPreset> = Object.fromEntries(
+  TASK_PRESETS.map((p) => [p.id, p]),
+);

--- a/src/hooks/use-task-instances.ts
+++ b/src/hooks/use-task-instances.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { getActiveTaskInstances, markCompleted } from "~/lib/tasks/engine";
+import { PROTOCOL_BY_ID } from "~/config/protocols";
+import type { CycleContext } from "~/types/treatment";
+import type { TaskInstance } from "~/types/task";
+import { differenceInCalendarDays, parseISO } from "date-fns";
+import { now } from "~/lib/db/dexie";
+import { todayISO } from "~/lib/utils/date";
+
+function deriveActiveCycleContext(): CycleContext | null {
+  // Lightweight context synth without pulling the full engine — just enough
+  // for task phase/cycle-day matching. We re-derive elsewhere where needed.
+  return null;
+}
+
+export function useTaskInstances(): TaskInstance[] {
+  const tasks = useLiveQuery(() => db.patient_tasks.toArray());
+  const cycles = useLiveQuery(() =>
+    db.treatment_cycles
+      .orderBy("start_date")
+      .reverse()
+      .limit(1)
+      .toArray(),
+  );
+
+  return useMemo(() => {
+    const today = new Date();
+    const activeCycle = (cycles ?? [])[0];
+    let ctx: CycleContext | null = null;
+    if (activeCycle && activeCycle.status === "active") {
+      const protocol = PROTOCOL_BY_ID[activeCycle.protocol_id];
+      if (protocol) {
+        const start = parseISO(activeCycle.start_date);
+        const cycleDay =
+          differenceInCalendarDays(today, start) + 1;
+        const phase = protocol.phase_windows.find(
+          (p) => cycleDay >= p.day_start && cycleDay <= p.day_end,
+        );
+        ctx = {
+          cycle: activeCycle,
+          protocol,
+          cycle_day: cycleDay,
+          phase: phase ?? null,
+          is_dose_day: protocol.dose_days.includes(cycleDay),
+          days_until_next_dose: null,
+          days_until_nadir: null,
+          applicable_nudges: [],
+        };
+      }
+    }
+    return getActiveTaskInstances(tasks ?? [], today, ctx);
+  }, [tasks, cycles]);
+}
+
+export async function completeTaskFromInstance(instance: TaskInstance) {
+  const t = instance.task;
+  if (!t.id) return;
+  const updated = markCompleted(t, todayISO());
+  await db.patient_tasks.update(t.id, {
+    ...updated,
+    updated_at: now(),
+  });
+}
+
+export async function snoozeTaskFromInstance(
+  instance: TaskInstance,
+  days: number,
+) {
+  const t = instance.task;
+  if (!t.id) return;
+  const snoozeUntil = new Date();
+  snoozeUntil.setDate(snoozeUntil.getDate() + days);
+  const iso = snoozeUntil.toISOString().slice(0, 10);
+  await db.patient_tasks.update(t.id, {
+    snoozed_until: iso,
+    updated_at: now(),
+  });
+}
+
+// re-export for convenience
+export { deriveActiveCycleContext };

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -21,6 +21,7 @@ import type {
 } from "~/types/clinical";
 import type { Trial } from "~/types/bridge";
 import type { TreatmentCycle } from "~/types/treatment";
+import type { PatientTask } from "~/types/task";
 
 export class AnchorDB extends Dexie {
   daily_entries!: Table<DailyEntry, number>;
@@ -43,6 +44,7 @@ export class AnchorDB extends Dexie {
   ingested_documents!: Table<IngestedDocument, number>;
   comprehensive_assessments!: Table<ComprehensiveAssessment, number>;
   treatment_cycles!: Table<TreatmentCycle, number>;
+  patient_tasks!: Table<PatientTask, number>;
 
   constructor() {
     super("anchor_db");
@@ -75,6 +77,10 @@ export class AnchorDB extends Dexie {
     this.version(4).stores({
       treatment_cycles:
         "++id, start_date, status, protocol_id, cycle_number",
+    });
+    this.version(5).stores({
+      patient_tasks:
+        "++id, due_date, active, category, schedule_kind, preset_id",
     });
   }
 }

--- a/src/lib/tasks/engine.ts
+++ b/src/lib/tasks/engine.ts
@@ -1,0 +1,216 @@
+import { addDays, differenceInCalendarDays, parseISO } from "date-fns";
+import type {
+  PatientTask,
+  TaskBucket,
+  TaskCompletion,
+  TaskInstance,
+} from "~/types/task";
+import type { CycleContext } from "~/types/treatment";
+
+function toISODate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
+}
+
+export function nextRecurringDueDate(task: PatientTask, today: Date): string {
+  if (task.schedule_kind !== "recurring") return task.due_date ?? toISODate(today);
+  const interval = Math.max(1, task.recurrence_interval_days ?? 30);
+  const anchor = task.last_completed_date
+    ? parseISO(task.last_completed_date)
+    : task.due_date
+      ? parseISO(task.due_date)
+      : today;
+  let due = task.last_completed_date
+    ? addDays(anchor, interval)
+    : anchor;
+  // if in the past, keep rolling forward
+  while (differenceInCalendarDays(today, due) > interval) {
+    due = addDays(due, interval);
+  }
+  return toISODate(due);
+}
+
+function nextOccurrenceForCyclePhase(
+  task: PatientTask,
+  ctx: CycleContext,
+  today: Date,
+): { date: string; reason: string } | null {
+  if (task.schedule_kind === "cycle_phase" && task.cycle_phase) {
+    const phase = ctx.protocol.phase_windows.find(
+      (p) => p.key === task.cycle_phase,
+    );
+    if (!phase) return null;
+    const phaseStartDay = phase.day_start;
+    const phaseEndDay = phase.day_end;
+    const cycleStart = parseISO(ctx.cycle.start_date);
+    const phaseStartDate = addDays(cycleStart, phaseStartDay - 1);
+    const phaseEndDate = addDays(cycleStart, phaseEndDay - 1);
+    const todayDay = ctx.cycle_day;
+    if (todayDay >= phaseStartDay && todayDay <= phaseEndDay) {
+      return {
+        date: toISODate(today),
+        reason: `Currently in ${phase.label.en}`,
+      };
+    }
+    if (todayDay < phaseStartDay) {
+      return {
+        date: toISODate(phaseStartDate),
+        reason: `Approaching ${phase.label.en}`,
+      };
+    }
+    // phase already passed this cycle — return phase start for next cycle
+    const nextStart = addDays(phaseStartDate, ctx.protocol.cycle_length_days);
+    // phaseEndDate retained for future range-aware surfacing
+    void phaseEndDate;
+    return {
+      date: toISODate(nextStart),
+      reason: `Next cycle's ${phase.label.en}`,
+    };
+  }
+  if (task.schedule_kind === "cycle_day" && typeof task.cycle_day === "number") {
+    const cycleStart = parseISO(ctx.cycle.start_date);
+    const thisCycleDayDate = addDays(cycleStart, task.cycle_day - 1);
+    if (ctx.cycle_day <= task.cycle_day) {
+      return {
+        date: toISODate(thisCycleDayDate),
+        reason: `Cycle day ${task.cycle_day}`,
+      };
+    }
+    const nextCycleDayDate = addDays(
+      thisCycleDayDate,
+      ctx.protocol.cycle_length_days,
+    );
+    return {
+      date: toISODate(nextCycleDayDate),
+      reason: `Next cycle's day ${task.cycle_day}`,
+    };
+  }
+  return null;
+}
+
+export function computeTaskInstance(
+  task: PatientTask,
+  today: Date,
+  ctx: CycleContext | null,
+): TaskInstance | null {
+  if (!task.active) return null;
+
+  // Snoozed?
+  if (task.snoozed_until) {
+    const snoozeUntil = parseISO(task.snoozed_until);
+    if (differenceInCalendarDays(snoozeUntil, today) > 0) {
+      return {
+        task,
+        bucket: "snoozed",
+        due_on: task.snoozed_until,
+        days_until_due: differenceInCalendarDays(snoozeUntil, today),
+      };
+    }
+  }
+
+  let dueOn: string;
+  let reason: string | undefined;
+
+  if (task.schedule_kind === "once") {
+    dueOn = task.due_date ?? toISODate(today);
+  } else if (task.schedule_kind === "recurring") {
+    dueOn = nextRecurringDueDate(task, today);
+  } else {
+    if (!ctx) return null;
+    const out = nextOccurrenceForCyclePhase(task, ctx, today);
+    if (!out) return null;
+    dueOn = out.date;
+    reason = out.reason;
+  }
+
+  const daysUntil = differenceInCalendarDays(parseISO(dueOn), today);
+  const bucket = bucketFor(task, daysUntil, ctx);
+
+  return {
+    task,
+    bucket,
+    due_on: dueOn,
+    days_until_due: daysUntil,
+    reason,
+  };
+}
+
+function bucketFor(
+  task: PatientTask,
+  daysUntil: number,
+  ctx: CycleContext | null,
+): TaskBucket {
+  if (task.schedule_kind === "cycle_phase" || task.schedule_kind === "cycle_day") {
+    if (ctx && daysUntil === 0) return "cycle_relevant";
+  }
+  if (daysUntil < 0) return "overdue";
+  if (daysUntil === 0) return "due_today";
+  if (daysUntil <= task.lead_time_days) return "approaching";
+  return "scheduled";
+}
+
+export function rankBucket(b: TaskBucket): number {
+  switch (b) {
+    case "overdue":
+      return 0;
+    case "due_today":
+      return 1;
+    case "cycle_relevant":
+      return 2;
+    case "approaching":
+      return 3;
+    case "scheduled":
+      return 4;
+    case "snoozed":
+      return 5;
+  }
+}
+
+export function sortTaskInstances(a: TaskInstance, b: TaskInstance): number {
+  const rb = rankBucket(a.bucket) - rankBucket(b.bucket);
+  if (rb !== 0) return rb;
+  // Within same bucket, priority then due date.
+  const prioOrder = { high: 0, normal: 1, low: 2 } as const;
+  const rp =
+    prioOrder[a.task.priority] - prioOrder[b.task.priority];
+  if (rp !== 0) return rp;
+  return a.due_on.localeCompare(b.due_on);
+}
+
+export function getActiveTaskInstances(
+  tasks: PatientTask[],
+  today: Date,
+  ctx: CycleContext | null,
+): TaskInstance[] {
+  const out: TaskInstance[] = [];
+  for (const t of tasks) {
+    const inst = computeTaskInstance(t, today, ctx);
+    if (inst) out.push(inst);
+  }
+  return out.sort(sortTaskInstances);
+}
+
+export function markCompleted(
+  task: PatientTask,
+  completionDate: string,
+  note?: string,
+): PatientTask {
+  const completions: TaskCompletion[] = [
+    ...(task.completions ?? []),
+    { date: completionDate, note },
+  ];
+  const update: PatientTask = {
+    ...task,
+    last_completed_date: completionDate,
+    completions,
+  };
+  if (task.schedule_kind === "recurring") {
+    const interval = Math.max(1, task.recurrence_interval_days ?? 30);
+    update.due_date = toISODate(
+      addDays(parseISO(completionDate), interval),
+    );
+  }
+  return update;
+}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,107 @@
+import type { Locale } from "./clinical";
+import type { PhaseKey } from "./treatment";
+
+export type TaskCategory =
+  | "environmental"
+  | "dental"
+  | "nutrition"
+  | "pharmacy"
+  | "physio"
+  | "clinical"
+  | "admin"
+  | "vaccine"
+  | "self_care"
+  | "household"
+  | "other";
+
+export type TaskPriority = "low" | "normal" | "high";
+
+export type TaskScheduleKind =
+  | "once"
+  | "recurring"
+  | "cycle_day"
+  | "cycle_phase";
+
+export type CyclePhaseKey = PhaseKey;
+
+export interface TaskCompletion {
+  date: string;
+  note?: string;
+}
+
+export interface PatientTask {
+  id?: number;
+  title: string;
+  title_zh?: string;
+  notes?: string;
+  category: TaskCategory;
+  priority: TaskPriority;
+
+  schedule_kind: TaskScheduleKind;
+
+  // schedule_kind = "once" or "recurring"
+  due_date?: string;
+  // schedule_kind = "recurring"
+  recurrence_interval_days?: number;
+
+  // schedule_kind = "cycle_day" — trigger on a specific cycle day number
+  cycle_day?: number;
+  // schedule_kind = "cycle_phase"
+  cycle_phase?: CyclePhaseKey;
+
+  // How many days before due_date the task should appear on the dashboard
+  lead_time_days: number;
+
+  last_completed_date?: string;
+  completions?: TaskCompletion[];
+
+  // If the user snoozes, hide until this date
+  snoozed_until?: string;
+
+  surface_dashboard: boolean;
+  surface_daily: boolean;
+
+  active: boolean;
+
+  // Optional provenance — which preset id this came from (for upgrade paths)
+  preset_id?: string;
+
+  created_at: string;
+  updated_at: string;
+}
+
+export type TaskBucket =
+  | "overdue"
+  | "due_today"
+  | "approaching"
+  | "cycle_relevant"
+  | "snoozed"
+  | "scheduled";
+
+export interface TaskInstance {
+  task: PatientTask;
+  bucket: TaskBucket;
+  due_on: string; // YYYY-MM-DD (next occurrence)
+  days_until_due: number; // negative if overdue
+  reason?: string; // e.g. "Nadir day — peak infection risk"
+}
+
+export interface TaskPreset {
+  id: string;
+  title: { en: string; zh: string };
+  category: TaskCategory;
+  notes?: { en: string; zh: string };
+  schedule_kind: TaskScheduleKind;
+  recurrence_interval_days?: number;
+  cycle_day?: number;
+  cycle_phase?: CyclePhaseKey;
+  lead_time_days: number;
+  priority: TaskPriority;
+  default_due_offset_days?: number; // for one-off, set due N days from now
+  rationale: { en: string; zh: string };
+}
+
+export function localizedTitle(task: PatientTask, locale: Locale): string {
+  if (locale === "zh" && task.title_zh) return task.title_zh;
+  return task.title;
+}

--- a/tests/unit/task-engine.test.ts
+++ b/tests/unit/task-engine.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeTaskInstance,
+  getActiveTaskInstances,
+  markCompleted,
+  nextRecurringDueDate,
+} from "~/lib/tasks/engine";
+import type { PatientTask } from "~/types/task";
+import type { CycleContext } from "~/types/treatment";
+
+function baseTask(overrides: Partial<PatientTask> = {}): PatientTask {
+  return {
+    title: "Test task",
+    category: "admin",
+    priority: "normal",
+    schedule_kind: "once",
+    lead_time_days: 7,
+    surface_dashboard: true,
+    surface_daily: false,
+    active: true,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function cycleCtx(
+  startDate: string,
+  cycleDay: number,
+): CycleContext {
+  return {
+    cycle: {
+      protocol_id: "gnp_weekly",
+      cycle_number: 1,
+      start_date: startDate,
+      status: "active",
+      dose_level: 0,
+      created_at: startDate + "T00:00:00Z",
+      updated_at: startDate + "T00:00:00Z",
+    },
+    protocol: {
+      id: "gnp_weekly",
+      name: { en: "GnP weekly", zh: "" },
+      short_name: "GnP weekly",
+      description: { en: "", zh: "" },
+      cycle_length_days: 28,
+      agents: [],
+      dose_days: [1, 8, 15],
+      phase_windows: [
+        {
+          key: "nadir",
+          day_start: 16,
+          day_end: 21,
+          label: { en: "Nadir", zh: "" },
+          description: { en: "", zh: "" },
+        },
+      ],
+      side_effect_profile: { en: "", zh: "" },
+      typical_supportive: [],
+    },
+    cycle_day: cycleDay,
+    phase: null,
+    is_dose_day: false,
+    days_until_next_dose: null,
+    days_until_nadir: null,
+    applicable_nudges: [],
+  };
+}
+
+const TODAY = new Date("2026-04-21T10:00:00Z");
+
+describe("computeTaskInstance — one-off", () => {
+  it("buckets overdue when due_date is in the past", () => {
+    const inst = computeTaskInstance(
+      baseTask({ schedule_kind: "once", due_date: "2026-04-15" }),
+      TODAY,
+      null,
+    );
+    expect(inst?.bucket).toBe("overdue");
+    expect(inst?.days_until_due).toBeLessThan(0);
+  });
+  it("buckets due_today when due_date is today", () => {
+    const inst = computeTaskInstance(
+      baseTask({ schedule_kind: "once", due_date: "2026-04-21" }),
+      TODAY,
+      null,
+    );
+    expect(inst?.bucket).toBe("due_today");
+    expect(inst?.days_until_due).toBe(0);
+  });
+  it("buckets approaching when within lead_time", () => {
+    const inst = computeTaskInstance(
+      baseTask({
+        schedule_kind: "once",
+        due_date: "2026-04-25",
+        lead_time_days: 7,
+      }),
+      TODAY,
+      null,
+    );
+    expect(inst?.bucket).toBe("approaching");
+  });
+  it("buckets scheduled when further than lead_time away", () => {
+    const inst = computeTaskInstance(
+      baseTask({
+        schedule_kind: "once",
+        due_date: "2026-05-30",
+        lead_time_days: 7,
+      }),
+      TODAY,
+      null,
+    );
+    expect(inst?.bucket).toBe("scheduled");
+  });
+});
+
+describe("computeTaskInstance — recurring", () => {
+  it("uses last_completed + interval when completed", () => {
+    const due = nextRecurringDueDate(
+      baseTask({
+        schedule_kind: "recurring",
+        recurrence_interval_days: 28,
+        last_completed_date: "2026-04-01",
+      }),
+      TODAY,
+    );
+    expect(due).toBe("2026-04-29");
+  });
+  it("rolls forward when last_completed is old", () => {
+    const task = baseTask({
+      schedule_kind: "recurring",
+      recurrence_interval_days: 7,
+      last_completed_date: "2025-12-01",
+    });
+    const due = nextRecurringDueDate(task, TODAY);
+    expect(new Date(due).getTime()).toBeGreaterThanOrEqual(
+      new Date("2026-04-14").getTime(),
+    );
+  });
+});
+
+describe("computeTaskInstance — cycle_phase", () => {
+  it("fires cycle_relevant during nadir", () => {
+    const ctx = cycleCtx("2026-04-01", 17);
+    const inst = computeTaskInstance(
+      baseTask({
+        schedule_kind: "cycle_phase",
+        cycle_phase: "nadir",
+        lead_time_days: 0,
+      }),
+      new Date("2026-04-17T10:00:00Z"),
+      ctx,
+    );
+    expect(inst?.bucket).toBe("cycle_relevant");
+  });
+  it("approaches as nadir gets close", () => {
+    const ctx = cycleCtx("2026-04-01", 14);
+    const inst = computeTaskInstance(
+      baseTask({
+        schedule_kind: "cycle_phase",
+        cycle_phase: "nadir",
+        lead_time_days: 3,
+      }),
+      new Date("2026-04-14T10:00:00Z"),
+      ctx,
+    );
+    expect(inst?.bucket).toBe("approaching");
+  });
+});
+
+describe("markCompleted", () => {
+  it("records completion and advances recurring due_date", () => {
+    const t = baseTask({
+      schedule_kind: "recurring",
+      recurrence_interval_days: 90,
+      due_date: "2026-04-15",
+    });
+    const updated = markCompleted(t, "2026-04-21", "done at clinic");
+    expect(updated.last_completed_date).toBe("2026-04-21");
+    expect(updated.due_date).toBe("2026-07-20");
+    expect(updated.completions).toHaveLength(1);
+    expect(updated.completions?.[0]?.note).toBe("done at clinic");
+  });
+});
+
+describe("getActiveTaskInstances ordering", () => {
+  it("puts overdue first, then due_today, then approaching, then scheduled", () => {
+    const tasks: PatientTask[] = [
+      baseTask({ title: "later", due_date: "2026-06-30", lead_time_days: 7 }),
+      baseTask({ title: "overdue", due_date: "2026-04-10", lead_time_days: 7 }),
+      baseTask({ title: "today", due_date: "2026-04-21", lead_time_days: 7 }),
+      baseTask({
+        title: "approaching",
+        due_date: "2026-04-25",
+        lead_time_days: 7,
+      }),
+    ];
+    const ordered = getActiveTaskInstances(tasks, TODAY, null);
+    expect(ordered.map((i) => i.task.title)).toEqual([
+      "overdue",
+      "today",
+      "approaching",
+      "later",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

New `/tasks` module lets the patient / caregiver capture anything care-adjacent — environmental maintenance, dental reviews, nutrition follow-ups, pharmacy refills, admin — and have CTAs surface on the dashboard when they matter.

### Data model

`src/types/task.ts` — `PatientTask` with four schedule kinds:
- **once** — single due date
- **recurring** — fires every N days, auto-rolls forward on completion
- **cycle_phase** — triggers during a treatment-cycle phase (nadir, post-dose, etc.)
- **cycle_day** — triggers on a specific cycle day number

Dexie **v4 → v5** adds `patient_tasks` (backward-compatible).

### Engine (`src/lib/tasks/engine.ts`)

- `computeTaskInstance()` buckets each task into `overdue` / `due_today` / `approaching` / `cycle_relevant` / `scheduled` / `snoozed` based on today plus (for cycle-linked tasks) the active cycle context derived from the treatment layer.
- `getActiveTaskInstances()` sorts by bucket rank, then priority, then due date.
- `markCompleted()` rolls recurring due-dates forward and appends to `completions[]`.
- 10 new unit tests covering each bucket, recurring roll-forward, cycle-phase matching, completion, and ordering.

### Presets — 19 curated care tasks

- **Environmental**: HVAC filters (90d), water filter (90d), bed linen (7d), vacuum/mop (7d)
- **Dental**: toothbrush swap (28d — after every cycle), 6-monthly clean + check
- **Clinical periphery**: quarterly dietitian review, monthly exercise physiology, PERT / antiemetic refills (60d), flu vaccine (annual), COVID booster review (6m), annual skin / eye / GP reviews
- **Admin**: advance care directive review (6m), will review (annual)
- **Cycle-relative**: intensive hygiene at nadir, pet-care handoff during nadir, pre-treatment labs before each dose day

Each preset carries a rationale shown in the picker (e.g. *"Clean filters reduce airborne pathogens and dust exposure — matters most during nadir windows."*).

### UI

- `/tasks` — list grouped by bucket, empty state, "Suggested tasks" sheet
- `/tasks/new` + `/tasks/[id]` — shared `TaskEditor` with schedule-kind tabs that swap the relevant fields
- `TaskRow` with per-bucket colour + icon, Done / Snooze 7d / Edit actions
- `PresetPicker` groups suggestions by category and disables already-added ones

### Dashboard

New `TasksCard` between `CycleDayCard` and `PillarsCard`. Shows top 5 actionable items (excludes snoozed / scheduled). Empty state links directly to the suggestions picker.

### Nav + i18n

New "Tasks" / 照护任务 entry between Events and Decisions. EN + ZH translations added.

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 83/83 passing (+10 task-engine)
- [x] `pnpm build` — 30 routes green

## Test plan

- [ ] Vercel preview deploy succeeds
- [ ] `/tasks` → "Suggested tasks" → add preset → it appears in the list
- [ ] `/tasks/new` → create a one-off task with due date in the past → appears in "Overdue" on dashboard
- [ ] Create a recurring task (every 30d), mark Done → due date rolls forward 30d
- [ ] Snooze 7d → disappears from dashboard, moves to "Snoozed" section on `/tasks`
- [ ] With an active treatment cycle (from `/treatment`), cycle_phase: "nadir" preset surfaces during nadir days
- [ ] Dexie v4 → v5: existing data survives, patient_tasks table exists

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH