### PR TITLE
Design refresh: Anchor visual identity (paper + ink + tide)

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -11,6 +11,7 @@
     "weekly": "Weekly",
     "fortnightly": "Fortnightly",
     "quarterly": "Quarterly",
+    "labs": "Labs",
     "bridge": "Bridge",
     "events": "Events",
     "tasks": "Tasks",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -11,6 +11,7 @@
     "weekly": "每周",
     "fortnightly": "两周",
     "quarterly": "每季",
+    "labs": "化验趋势",
     "bridge": "过渡策略",
     "events": "重要日程",
     "tasks": "照护任务",

--- a/src/app/labs/page.tsx
+++ b/src/app/labs/page.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { format, parseISO } from "date-fns";
+import Link from "next/link";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card } from "~/components/ui/card";
+import { MetricChart, type MetricPoint } from "~/components/labs/metric-chart";
+import { BarScale } from "~/components/ui/bar-scale";
+import { Sparkles, ChevronRight, Share2 } from "lucide-react";
+import { computeSymptomScore, computeToxicityScore } from "~/lib/calculations/pillars";
+import { cn } from "~/lib/utils/cn";
+
+type MetricKey =
+  | "ca199"
+  | "weight"
+  | "albumin"
+  | "symptom"
+  | "toxicity";
+
+interface Metric {
+  key: MetricKey;
+  label: { en: string; zh: string };
+  unit: string;
+  yMax: number;
+  refRange?: [number, number];
+  goodDirection: "up" | "down" | "stable";
+  read: { en: string; zh: string };
+}
+
+const METRICS: Metric[] = [
+  {
+    key: "ca199",
+    label: { en: "CA 19-9", zh: "CA 19-9" },
+    unit: "U/mL",
+    yMax: 500,
+    refRange: [0, 37],
+    goodDirection: "down",
+    read: {
+      en: "The primary PDAC tumour marker. A sustained fall points to treatment response; a rise for three consecutive readings is a yellow-zone trigger.",
+      zh: "PDAC 的主要肿瘤标志物。持续下降提示治疗有效；连续三次上升触发黄色警示。",
+    },
+  },
+  {
+    key: "weight",
+    label: { en: "Body weight", zh: "体重" },
+    unit: "kg",
+    yMax: 100,
+    goodDirection: "stable",
+    read: {
+      en: "Sustained weight stability vs baseline is a first-line function signal. >5% loss over 90 days is a yellow-zone trigger.",
+      zh: "体重相对基线稳定是最早的功能信号。90 天内下降 >5% 触发黄色警示。",
+    },
+  },
+  {
+    key: "albumin",
+    label: { en: "Albumin", zh: "白蛋白" },
+    unit: "g/L",
+    yMax: 50,
+    refRange: [35, 50],
+    goodDirection: "up",
+    read: {
+      en: "Visceral-protein reserve. Drops below 30 g/L trigger a nutrition review.",
+      zh: "内脏蛋白储备。< 30 g/L 触发营养复查。",
+    },
+  },
+  {
+    key: "symptom",
+    label: { en: "Symptom burden", zh: "症状负担" },
+    unit: "/100",
+    yMax: 100,
+    refRange: [70, 100],
+    goodDirection: "up",
+    read: {
+      en: "Daily-entry composite (pain, nausea, fatigue, appetite, GI, respiratory). Higher = fewer symptoms.",
+      zh: "每日记录的综合分（疼痛、恶心、疲劳、食欲、消化道、呼吸）。分数越高症状越少。",
+    },
+  },
+  {
+    key: "toxicity",
+    label: { en: "Toxicity tolerance", zh: "毒性耐受" },
+    unit: "/100",
+    yMax: 100,
+    refRange: [70, 100],
+    goodDirection: "up",
+    read: {
+      en: "Treatment-toxicity composite (neuropathy, mucositis, cognitive, skin). Higher = less toxicity.",
+      zh: "治疗毒性综合分（神经病变、口腔炎、认知、皮肤）。分数越高毒性越低。",
+    },
+  },
+];
+
+export default function LabsPage() {
+  const locale = useLocale();
+  const [metricKey, setMetricKey] = useState<MetricKey>("ca199");
+
+  const labs = useLiveQuery(() =>
+    db.labs.orderBy("date").reverse().limit(20).toArray(),
+  );
+  const dailies = useLiveQuery(() =>
+    db.daily_entries.orderBy("date").reverse().limit(28).toArray(),
+  );
+  const assessments = useLiveQuery(() =>
+    db.comprehensive_assessments
+      .orderBy("assessment_date")
+      .reverse()
+      .limit(8)
+      .toArray(),
+  );
+
+  const orderedLabs = (labs ?? []).slice().reverse();
+  const orderedDailies = (dailies ?? []).slice().reverse();
+  const orderedAssessments = (assessments ?? []).slice().reverse();
+
+  const points: MetricPoint[] = useMemo(() => {
+    switch (metricKey) {
+      case "ca199":
+        return orderedLabs
+          .filter((l) => typeof l.ca199 === "number")
+          .map((l) => ({ date: l.date, value: l.ca199 as number }));
+      case "albumin":
+        return orderedLabs
+          .filter((l) => typeof l.albumin === "number")
+          .map((l) => ({ date: l.date, value: l.albumin as number }));
+      case "weight":
+        return orderedDailies
+          .filter((d) => typeof d.weight_kg === "number")
+          .map((d) => ({ date: d.date, value: d.weight_kg as number }));
+      case "symptom":
+        return orderedAssessments
+          .map((a) => ({
+            date: a.assessment_date,
+            score: computeSymptomScore(a),
+          }))
+          .filter(
+            (
+              p,
+            ): p is { date: string; score: number } =>
+              typeof p.score === "number",
+          )
+          .map((p) => ({ date: p.date, value: Math.round(p.score) }));
+      case "toxicity":
+        return orderedAssessments
+          .map((a) => ({
+            date: a.assessment_date,
+            score: computeToxicityScore(a),
+          }))
+          .filter(
+            (
+              p,
+            ): p is { date: string; score: number } =>
+              typeof p.score === "number",
+          )
+          .map((p) => ({ date: p.date, value: Math.round(p.score) }));
+    }
+  }, [metricKey, orderedLabs, orderedDailies, orderedAssessments]);
+
+  const metric = METRICS.find((m) => m.key === metricKey) ?? METRICS[0]!;
+  const latest = points[points.length - 1];
+  const first = points[0];
+  const deltaPct =
+    latest && first && first.value !== 0
+      ? Math.round(((latest.value - first.value) / first.value) * 100)
+      : null;
+  const deltaGood =
+    typeof deltaPct === "number"
+      ? metric.goodDirection === "down"
+        ? deltaPct < 0
+        : metric.goodDirection === "up"
+          ? deltaPct > 0
+          : Math.abs(deltaPct) < 5
+      : null;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "治疗应答" : "Treatment response"}
+        title={locale === "zh" ? "化验与趋势" : "Labs & trends"}
+        action={
+          <button
+            type="button"
+            className="flex items-center gap-1.5 rounded-md bg-paper-2 px-3 py-1.5 text-xs font-medium text-ink-700 shadow-sm hover:bg-ink-100"
+          >
+            <Share2 className="h-3.5 w-3.5" />
+            {locale === "zh" ? "分享" : "Share"}
+          </button>
+        }
+      />
+
+      {/* Metric selector */}
+      <div className="-mx-4 flex gap-1.5 overflow-x-auto px-4 pb-0.5 md:mx-0 md:px-0">
+        {METRICS.map((m) => {
+          const on = m.key === metricKey;
+          return (
+            <button
+              key={m.key}
+              onClick={() => setMetricKey(m.key)}
+              className={cn(
+                "shrink-0 whitespace-nowrap rounded-full px-3.5 py-1.5 text-[11.5px] font-medium transition-colors",
+                on
+                  ? "bg-ink-900 text-paper"
+                  : "bg-paper-2 text-ink-700 shadow-sm hover:bg-ink-100",
+              )}
+            >
+              {m.label[locale]}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Hero chart */}
+      <Card className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="eyebrow">
+              {metric.label[locale]} ·{" "}
+              {locale === "zh" ? "纵向" : "longitudinal"}
+            </div>
+            <div className="mt-1.5 flex items-baseline gap-2">
+              <div className="serif num text-[44px] leading-none text-ink-900">
+                {latest ? latest.value : "—"}
+              </div>
+              <div className="mono text-xs text-ink-400">{metric.unit}</div>
+              {latest && (
+                <div
+                  className="mono ml-1 text-[10px] font-semibold uppercase tracking-wider"
+                  style={{ color: "var(--ink-400)" }}
+                >
+                  {format(parseISO(latest.date), "d MMM")}
+                </div>
+              )}
+            </div>
+          </div>
+          {typeof deltaPct === "number" && (
+            <span
+              className={
+                deltaGood ? "a-chip ok" : deltaPct === 0 ? "a-chip" : "a-chip warn"
+              }
+            >
+              {deltaPct > 0 ? "↑" : deltaPct < 0 ? "↓" : "—"}{" "}
+              {Math.abs(deltaPct)}%
+            </span>
+          )}
+        </div>
+
+        <MetricChart
+          points={points}
+          refRange={metric.refRange}
+          yMax={metric.yMax}
+          unit={metric.unit}
+          locale={locale}
+        />
+
+        {/* x-axis labels — first, middle, last */}
+        {points.length > 0 && (
+          <div className="mt-1 flex justify-between pl-1 pr-[34px]">
+            {points.map((p, i) => {
+              if (
+                i !== 0 &&
+                i !== points.length - 1 &&
+                i !== Math.floor(points.length / 2)
+              ) {
+                return null;
+              }
+              return (
+                <div
+                  key={i}
+                  className="mono text-[9px]"
+                  style={{ color: "var(--ink-400)" }}
+                >
+                  {format(parseISO(p.date), "d MMM")}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Read card */}
+        <div
+          className="mt-3.5 flex items-start gap-2.5 rounded-[10px] p-2.5"
+          style={{ background: "var(--tide-soft)" }}
+        >
+          <Sparkles className="h-3.5 w-3.5 shrink-0" style={{ color: "var(--tide-2)" }} />
+          <div className="flex-1 text-xs leading-relaxed text-ink-900">
+            {metric.read[locale]}
+          </div>
+        </div>
+      </Card>
+
+      {/* Latest lab panel */}
+      {orderedLabs.length > 0 && (
+        <section className="space-y-2.5">
+          <h2 className="eyebrow">
+            {locale === "zh" ? "最近化验" : "Latest lab panel"}
+          </h2>
+          <Card className="px-4 py-1">
+            {(() => {
+              const last = orderedLabs[orderedLabs.length - 1];
+              if (!last) return null;
+              type Row = {
+                label: string;
+                value?: number;
+                unit: string;
+                ref?: [number, number];
+              };
+              const rows: Row[] = ([
+                { label: "CA 19-9", value: last.ca199, unit: "U/mL", ref: [0, 37] as [number, number] },
+                { label: "Hb", value: last.hemoglobin, unit: "g/L", ref: [120, 160] as [number, number] },
+                {
+                  label: "Neut",
+                  value: last.neutrophils,
+                  unit: "×10⁹/L",
+                  ref: [1.5, 7] as [number, number],
+                },
+                {
+                  label: "Plt",
+                  value: last.platelets,
+                  unit: "×10⁹/L",
+                  ref: [150, 450] as [number, number],
+                },
+                { label: "Albumin", value: last.albumin, unit: "g/L", ref: [35, 50] as [number, number] },
+                { label: "Bili", value: last.bilirubin, unit: "µmol/L" },
+                { label: "ALT", value: last.alt, unit: "U/L" },
+                { label: "CRP", value: last.crp, unit: "mg/L" },
+              ] as Row[]).filter((r) => typeof r.value === "number");
+              return (
+                <>
+                  <div className="py-2 text-[11px] text-ink-400">
+                    {locale === "zh" ? "采样" : "Drawn"}{" "}
+                    {format(parseISO(last.date), "d MMM yyyy")}
+                  </div>
+                  <div className="divide-y divide-ink-100/70">
+                    {rows.map((r, i) => {
+                      const pct = r.ref
+                        ? Math.max(
+                            0,
+                            Math.min(
+                              1,
+                              ((r.value as number) - r.ref[0]) /
+                                (r.ref[1] - r.ref[0]),
+                            ),
+                          )
+                        : 0;
+                      const belowRef = r.ref && (r.value as number) < r.ref[0];
+                      const aboveRef = r.ref && (r.value as number) > r.ref[1];
+                      const warn = belowRef || aboveRef;
+                      return (
+                        <div
+                          key={i}
+                          className="grid grid-cols-[1fr_80px_auto] items-center gap-3 py-2.5"
+                        >
+                          <div>
+                            <div className="text-[13.5px] font-medium text-ink-900">
+                              {r.label}
+                            </div>
+                            {r.ref && (
+                              <div className="mono mt-0.5 text-[10.5px] text-ink-400">
+                                ref {r.ref[0]}–{r.ref[1]} {r.unit}
+                              </div>
+                            )}
+                          </div>
+                          {r.ref && (
+                            <BarScale
+                              value={pct * 10}
+                              max={10}
+                              w={80}
+                              h={4}
+                              color={warn ? "var(--warn)" : "var(--tide-2)"}
+                            />
+                          )}
+                          {!r.ref && <span />}
+                          <div
+                            className={cn(
+                              "num min-w-[3.5ch] text-right font-semibold",
+                              warn
+                                ? "text-[var(--warn)]"
+                                : "text-ink-900",
+                            )}
+                          >
+                            {r.value}
+                            {warn && (
+                              <span
+                                className="mono ml-1 text-[9px] font-medium"
+                                style={{ color: "var(--warn)" }}
+                              >
+                                {belowRef ? "L" : "H"}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </>
+              );
+            })()}
+          </Card>
+        </section>
+      )}
+
+      {/* Go to ingest link */}
+      <Link
+        href="/ingest"
+        className="flex items-center justify-between rounded-[var(--r-md)] border border-ink-100/70 bg-paper-2 px-4 py-3 text-[13px] font-medium text-ink-900 hover:border-ink-300"
+      >
+        <span>
+          {locale === "zh"
+            ? "上传或解析一份报告"
+            : "Upload or parse a report"}
+        </span>
+        <ChevronRight className="h-4 w-4 text-ink-400" />
+      </Link>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,16 +21,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body>
         <Providers>
-          <div className="flex min-h-screen">
+          <div className="flex min-h-screen bg-paper">
             <DesktopSidebar />
-            <div className="flex-1 flex flex-col min-w-0">
-              <header className="flex items-center justify-between gap-3 px-4 md:px-6 h-12 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
-                <div className="md:hidden text-sm font-semibold">Anchor</div>
+            <div className="flex min-w-0 flex-1 flex-col">
+              <header className="sticky top-0 z-20 flex h-14 items-center justify-between gap-3 border-b border-ink-100/60 bg-paper-2/70 px-4 backdrop-blur-md md:px-6">
+                <div className="serif text-[17px] tracking-tight text-ink-900 md:hidden">
+                  Anchor
+                </div>
                 <div className="flex-1" />
                 <RoleSwitcher />
                 <LanguageSwitcher />
               </header>
-              <main className="flex-1 pb-24 md:pb-0 overflow-y-auto">
+              <main className="flex-1 overflow-y-auto pb-28 md:pb-6">
                 {children}
               </main>
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { format } from "date-fns";
 import { ZoneStatusCard } from "~/components/dashboard/zone-status-card";
 import { AlertsList } from "~/components/dashboard/alerts-list";
 import { RecentTrends } from "~/components/dashboard/recent-trends";
@@ -16,31 +19,82 @@ import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { PageHeader, SectionHeader } from "~/components/ui/page-header";
 import { Button } from "~/components/ui/button";
-import { ChevronRight, Stethoscope } from "lucide-react";
+import { ChevronRight, Stethoscope, Bell } from "lucide-react";
 
 export default function DashboardPage() {
   const t = useT();
   const locale = useLocale();
   const role = useUIStore((s) => s.role);
   const router = useRouter();
+  const settings = useLiveQuery(() => db.settings.toArray());
+  const profileName = settings?.[0]?.profile_name;
+
   useEffect(() => {
     if (role === "clinician") router.replace("/clinician");
   }, [role, router]);
+
+  const { greeting, eyebrow } = useMemo(() => {
+    const now = new Date();
+    const hour = now.getHours();
+    const greetingEn =
+      hour < 12
+        ? "Good morning"
+        : hour < 18
+          ? "Good afternoon"
+          : "Good evening";
+    const greetingZh =
+      hour < 12 ? "早安" : hour < 18 ? "午安" : "晚安";
+    const dateEyebrow =
+      locale === "zh"
+        ? format(now, "yyyy 年 M 月 d 日 · EEEE")
+        : format(now, "EEEE · d MMM yyyy").toUpperCase();
+    return {
+      greeting: locale === "zh" ? greetingZh : greetingEn,
+      eyebrow: dateEyebrow,
+    };
+  }, [locale]);
+
+  const firstName = profileName?.split(" ").slice(-1)[0] ?? "";
+
   return (
     <div className="mx-auto max-w-5xl space-y-8 p-4 md:p-8">
       <PageHeader
-        title={t("dashboard.title")}
+        eyebrow={eyebrow}
+        title={
+          <>
+            {greeting}
+            {firstName && (
+              <>
+                ,{" "}
+                <em className="font-normal italic text-ink-500">
+                  {firstName}
+                </em>
+              </>
+            )}
+          </>
+        }
         subtitle={
           locale === "zh"
             ? "功能、饮食、运动 —— 每天一个动作。"
             : "Function, food, movement — one small action per day."
         }
         action={
-          <Link href="/daily/new">
-            <Button size="lg">{t("dashboard.quick_entry")}</Button>
-          </Link>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              aria-label="notifications"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-ink-200 bg-paper-2 text-ink-700 hover:border-ink-300"
+            >
+              <Bell className="h-4 w-4" />
+            </button>
+            <Link href="/daily/new">
+              <Button size="lg">{t("dashboard.quick_entry")}</Button>
+            </Link>
+          </div>
         }
       />
+
+      <div className="a-horizon" />
 
       <ZoneStatusCard />
 
@@ -87,11 +141,11 @@ export default function DashboardPage() {
       <section>
         <Link
           href="/fortnightly/new"
-          className="flex items-center justify-between rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-slate-400 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-600"
+          className="a-card flex items-center justify-between p-4 transition-colors hover:border-ink-300"
         >
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
-              <Stethoscope className="h-5 w-5 text-slate-700 dark:text-slate-300" />
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
+              <Stethoscope className="h-5 w-5" />
             </div>
             <div>
               <div className="text-sm font-semibold">
@@ -99,18 +153,18 @@ export default function DashboardPage() {
                   ? "开始两周评估"
                   : "Start fortnightly assessment"}
               </div>
-              <div className="text-xs text-slate-500">
+              <div className="text-xs text-ink-500">
                 {locale === "zh"
                   ? "ECOG 自评、握力、步速、坐立、上臂与小腿围"
                   : "ECOG, grip, gait speed, sit-to-stand, MUAC, calf"}
               </div>
             </div>
           </div>
-          <ChevronRight className="h-4 w-4 text-slate-400" />
+          <ChevronRight className="h-4 w-4 text-ink-400" />
         </Link>
       </section>
 
-      <footer className="pt-6 text-center text-xs text-slate-500">
+      <footer className="pt-6 text-center text-xs text-ink-400">
         {t("common.localOnly")}
       </footer>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,22 +4,19 @@ import Link from "next/link";
 import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
 import { format } from "date-fns";
-import { ZoneStatusCard } from "~/components/dashboard/zone-status-card";
-import { AlertsList } from "~/components/dashboard/alerts-list";
-import { RecentTrends } from "~/components/dashboard/recent-trends";
-import { BodyMetricsGrid } from "~/components/dashboard/body-metrics";
-import { SarcopeniaCard } from "~/components/dashboard/sarcopenia-card";
-import { WeeklyCard } from "~/components/dashboard/weekly-card";
-import { PillarsCard } from "~/components/dashboard/pillars-card";
-import { CycleDayCard } from "~/components/dashboard/cycle-day-card";
+import { db } from "~/lib/db/dexie";
+import { TodayPlanCard } from "~/components/dashboard/today-plan-card";
+import { PillarTiles } from "~/components/dashboard/pillar-tiles";
+import { FlaggedCard } from "~/components/dashboard/flagged-card";
+import { QuickActions } from "~/components/dashboard/quick-actions";
 import { TasksCard } from "~/components/dashboard/tasks-card";
+import { PillarsCard } from "~/components/dashboard/pillars-card";
+import { RecentTrends } from "~/components/dashboard/recent-trends";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { PageHeader, SectionHeader } from "~/components/ui/page-header";
-import { Button } from "~/components/ui/button";
-import { ChevronRight, Stethoscope, Bell } from "lucide-react";
+import { Bell } from "lucide-react";
 
 export default function DashboardPage() {
   const t = useT();
@@ -57,7 +54,7 @@ export default function DashboardPage() {
   const firstName = profileName?.split(" ").slice(-1)[0] ?? "";
 
   return (
-    <div className="mx-auto max-w-5xl space-y-8 p-4 md:p-8">
+    <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-8">
       <PageHeader
         eyebrow={eyebrow}
         title={
@@ -73,95 +70,34 @@ export default function DashboardPage() {
             )}
           </>
         }
-        subtitle={
-          locale === "zh"
-            ? "功能、饮食、运动 —— 每天一个动作。"
-            : "Function, food, movement — one small action per day."
-        }
         action={
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              aria-label="notifications"
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-ink-200 bg-paper-2 text-ink-700 hover:border-ink-300"
-            >
-              <Bell className="h-4 w-4" />
-            </button>
-            <Link href="/daily/new">
-              <Button size="lg">{t("dashboard.quick_entry")}</Button>
-            </Link>
-          </div>
+          <button
+            type="button"
+            aria-label="notifications"
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-paper-2 text-ink-700 shadow-sm hover:bg-ink-100"
+          >
+            <Bell className="h-4 w-4" />
+          </button>
         }
       />
 
-      <div className="a-horizon" />
+      <TodayPlanCard />
 
-      <ZoneStatusCard />
+      <PillarTiles />
 
-      <CycleDayCard />
+      <FlaggedCard />
 
       <TasksCard />
+
+      <QuickActions />
+
+      <div className="a-horizon" />
 
       <PillarsCard />
 
       <section className="space-y-3">
-        <SectionHeader
-          title={locale === "zh" ? "今天的身体" : "Body today"}
-          description={
-            locale === "zh"
-              ? "最新体重、BMI、蛋白质与运动 —— 过去 7 天。"
-              : "Latest weight, BMI, protein intake, and movement — past 7 days."
-          }
-        />
-        <BodyMetricsGrid />
-      </section>
-
-      <section className="grid gap-4 md:grid-cols-2">
-        <SarcopeniaCard />
-        <WeeklyCard />
-      </section>
-
-      <section className="space-y-3">
-        <SectionHeader
-          title={t("dashboard.active_alerts")}
-          description={
-            locale === "zh"
-              ? "触发的警示需要在与临床团队下一次对话中讨论。"
-              : "Triggered alerts are discussion points for the next clinical conversation."
-          }
-        />
-        <AlertsList />
-      </section>
-
-      <section className="space-y-3">
         <SectionHeader title={t("dashboard.recent_trends")} />
         <RecentTrends />
-      </section>
-
-      <section>
-        <Link
-          href="/fortnightly/new"
-          className="a-card flex items-center justify-between p-4 transition-colors hover:border-ink-300"
-        >
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
-              <Stethoscope className="h-5 w-5" />
-            </div>
-            <div>
-              <div className="text-sm font-semibold">
-                {locale === "zh"
-                  ? "开始两周评估"
-                  : "Start fortnightly assessment"}
-              </div>
-              <div className="text-xs text-ink-500">
-                {locale === "zh"
-                  ? "ECOG 自评、握力、步速、坐立、上臂与小腿围"
-                  : "ECOG, grip, gait speed, sit-to-stand, MUAC, calf"}
-              </div>
-            </div>
-          </div>
-          <ChevronRight className="h-4 w-4 text-ink-400" />
-        </Link>
       </section>
 
       <footer className="pt-6 text-center text-xs text-ink-400">

--- a/src/components/dashboard/flagged-card.tsx
+++ b/src/components/dashboard/flagged-card.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { useZoneStatus } from "~/hooks/use-zone-status";
+import { useLocale, useT } from "~/hooks/use-translate";
+import { Thermometer, AlertTriangle } from "lucide-react";
+
+export function FlaggedCard() {
+  const t = useT();
+  const locale = useLocale();
+  const { alerts } = useZoneStatus();
+  const top = alerts[0];
+
+  return (
+    <section className="space-y-2.5">
+      <h2 className="eyebrow">{t("dashboard.active_alerts")}</h2>
+
+      {!top && (
+        <div className="a-card flex items-start gap-3 p-4">
+          <div
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
+            style={{ background: "var(--tide-soft)", color: "var(--tide-2)" }}
+          >
+            <Thermometer className="h-4 w-4" />
+          </div>
+          <div className="flex-1">
+            <div className="text-[13.5px] font-semibold text-ink-900">
+              {locale === "zh"
+                ? "注意用药后发热"
+                : "Watch for fever after infusion"}
+            </div>
+            <div className="mt-0.5 text-xs leading-relaxed text-ink-500">
+              {locale === "zh"
+                ? "体温 ≥ 38 °C 请立刻前往医院。保持体温计在手边。"
+                : "Call the team or attend hospital if temperature ≥ 38.0 °C. Keep a thermometer within reach."}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {top && (
+        <Link
+          href="/"
+          className="a-card flex items-start gap-3 p-4"
+          style={{ borderLeft: "3px solid var(--warn)" }}
+        >
+          <div
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
+            style={{ background: "var(--warn-soft)", color: "var(--warn)" }}
+          >
+            <AlertTriangle className="h-4 w-4" />
+          </div>
+          <div className="flex-1">
+            <div className="text-[13.5px] font-semibold text-ink-900">
+              {top.rule_name}
+            </div>
+            <div className="mt-0.5 text-xs leading-relaxed text-ink-500">
+              {locale === "zh" ? top.recommendation_zh : top.recommendation}
+            </div>
+          </div>
+        </Link>
+      )}
+    </section>
+  );
+}

--- a/src/components/dashboard/pillar-tiles.tsx
+++ b/src/components/dashboard/pillar-tiles.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { useMemo } from "react";
+import {
+  differenceInCalendarDays,
+  format,
+  parseISO,
+} from "date-fns";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { Sparkline } from "~/components/ui/sparkline";
+import { PROTOCOL_BY_ID } from "~/config/protocols";
+import { ArrowDown, ChevronRight, Pill } from "lucide-react";
+
+function symptomScore(
+  d: {
+    pain_current?: number;
+    nausea?: number;
+    sleep_quality?: number;
+    energy?: number;
+    mood_clarity?: number;
+  },
+): number {
+  // Composite 0–10 symptom-burden proxy: higher = more symptoms.
+  const pain = d.pain_current ?? 0;
+  const nausea = d.nausea ?? 0;
+  const fatigue = typeof d.energy === "number" ? 10 - d.energy : 0;
+  const sleep = typeof d.sleep_quality === "number" ? 10 - d.sleep_quality : 0;
+  const mood =
+    typeof d.mood_clarity === "number" ? 10 - d.mood_clarity : 0;
+  // 5-item mean capped to 10
+  return Math.min(10, (pain + nausea + fatigue + sleep + mood) / 5);
+}
+
+export function PillarTiles() {
+  const locale = useLocale();
+  const dailies = useLiveQuery(() =>
+    db.daily_entries.orderBy("date").reverse().limit(7).toArray(),
+  );
+  const labs = useLiveQuery(() =>
+    db.labs.orderBy("date").reverse().limit(7).toArray(),
+  );
+  const cycles = useLiveQuery(() =>
+    db.treatment_cycles.orderBy("start_date").reverse().limit(1).toArray(),
+  );
+
+  const ordered = (dailies ?? []).slice().reverse();
+  const recentCycle = (cycles ?? [])[0];
+
+  // Symptom burden — 7-day trend + average
+  const symptomSeries = useMemo(
+    () => ordered.map((d) => symptomScore(d)),
+    [ordered],
+  );
+  const symptomAvg =
+    symptomSeries.length > 0
+      ? symptomSeries.reduce((a, b) => a + b, 0) / symptomSeries.length
+      : null;
+  const symptomPrior =
+    symptomSeries.length >= 6
+      ? symptomSeries.slice(0, 3).reduce((a, b) => a + b, 0) / 3
+      : null;
+
+  // Next infusion — from active cycle
+  const nextInfusion = useMemo(() => {
+    if (!recentCycle || recentCycle.status !== "active") return null;
+    const protocol = PROTOCOL_BY_ID[recentCycle.protocol_id];
+    if (!protocol) return null;
+    const cycleDay =
+      differenceInCalendarDays(new Date(), parseISO(recentCycle.start_date)) + 1;
+    const doseDays = protocol.dose_days;
+    const next = doseDays.find((d) => d >= cycleDay);
+    if (next === undefined) return null;
+    const daysAway = next - cycleDay;
+    const date = new Date(parseISO(recentCycle.start_date));
+    date.setDate(date.getDate() + next - 1);
+    return {
+      days: daysAway,
+      label:
+        daysAway === 0
+          ? locale === "zh"
+            ? "今天"
+            : "Today"
+          : daysAway === 1
+            ? locale === "zh"
+              ? "明天"
+              : "Tomorrow"
+            : locale === "zh"
+              ? `${daysAway} 天后`
+              : `In ${daysAway} days`,
+      dateStr:
+        locale === "zh"
+          ? format(date, "M 月 d 日")
+          : format(date, "EEE · d MMM"),
+      protocol: protocol.short_name,
+      cycleNumber: recentCycle.cycle_number,
+    };
+  }, [recentCycle, locale]);
+
+  // Latest CA19-9 trend
+  const ca199Series = (labs ?? [])
+    .slice()
+    .reverse()
+    .map((l) => l.ca199)
+    .filter((v): v is number => typeof v === "number");
+  const ca199Latest = ca199Series[ca199Series.length - 1];
+  const ca199First = ca199Series[0];
+  const ca199Delta =
+    ca199Latest && ca199First && ca199First > 0
+      ? Math.round(((ca199Latest - ca199First) / ca199First) * 100)
+      : null;
+
+  // Practice completion — proxy for the 4th tile (instead of PERT which isn't modelled)
+  const practiceCompleted = useMemo(() => {
+    const todayISO = format(new Date(), "yyyy-MM-dd");
+    const today = ordered.find((d) => d.date === todayISO);
+    if (!today)
+      return { done: 0, total: 2, subtitle: locale === "zh" ? "今日未记录" : "No entry yet today" };
+    const done =
+      (today.practice_morning_completed ? 1 : 0) +
+      (today.practice_evening_completed ? 1 : 0);
+    return {
+      done,
+      total: 2,
+      subtitle:
+        locale === "zh" ? "晨 + 晚修习" : "Morning + evening practice",
+    };
+  }, [ordered, locale]);
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {/* Symptoms */}
+      <Link
+        href="/daily"
+        className="a-card flex min-h-[140px] flex-col gap-2 p-4 text-left transition-colors hover:border-ink-300"
+      >
+        <div className="flex items-center justify-between">
+          <span className="eyebrow">{locale === "zh" ? "症状" : "Symptoms"}</span>
+          <ChevronRight className="h-3 w-3 text-ink-300" />
+        </div>
+        <div className="serif num text-4xl leading-none text-ink-900">
+          {symptomAvg !== null ? symptomAvg.toFixed(1) : "—"}
+          <span className="ml-1 mono text-sm font-normal text-ink-400">/10</span>
+        </div>
+        <div className="text-[11.5px] text-ink-500">
+          {symptomAvg === null
+            ? locale === "zh"
+              ? "记录 7 天后出现"
+              : "Appears after 7 days of logs"
+            : locale === "zh"
+              ? `7 天平均${symptomPrior !== null ? ` · 此前 ${symptomPrior.toFixed(1)}` : ""}`
+              : `avg last 7 days${symptomPrior !== null ? ` · was ${symptomPrior.toFixed(1)}` : ""}`}
+        </div>
+        <div className="mt-auto">
+          {symptomSeries.length > 0 && (
+            <Sparkline
+              values={symptomSeries}
+              stroke="var(--tide-2)"
+              fill="oklch(92% 0.025 210 / 0.5)"
+            />
+          )}
+        </div>
+      </Link>
+
+      {/* Next infusion (dark inverted tile) */}
+      <Link
+        href="/treatment"
+        className="flex min-h-[140px] flex-col gap-2 rounded-[var(--r-lg)] bg-ink-900 p-4 text-paper shadow-sm transition-transform hover:-translate-y-[1px]"
+      >
+        <div className="flex items-center justify-between">
+          <span className="mono text-[10px] uppercase tracking-wider text-ink-300">
+            {locale === "zh" ? "下次用药" : "Next infusion"}
+          </span>
+          <ChevronRight className="h-3 w-3 text-ink-300" />
+        </div>
+        <div className="serif mt-1.5 text-[26px] leading-none">
+          {nextInfusion
+            ? nextInfusion.label
+            : locale === "zh"
+              ? "未排程"
+              : "Not scheduled"}
+        </div>
+        {nextInfusion && (
+          <>
+            <div className="mono num text-[12.5px] text-ink-300">
+              {nextInfusion.dateStr}
+            </div>
+            <div className="mt-auto flex items-center gap-1.5 text-[11px] text-ink-300">
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-[oklch(75%_0.12_140)]" />
+              {nextInfusion.protocol} ·{" "}
+              {locale === "zh" ? `第 ${nextInfusion.cycleNumber} 周期` : `Cycle ${nextInfusion.cycleNumber}`}
+            </div>
+          </>
+        )}
+        {!nextInfusion && (
+          <div className="mt-auto text-[11px] text-ink-300">
+            {locale === "zh"
+              ? "在治疗页添加方案"
+              : "Add a protocol in Treatment"}
+          </div>
+        )}
+      </Link>
+
+      {/* CA19-9 trend */}
+      <Link
+        href="/labs"
+        className="a-card flex min-h-[140px] flex-col gap-2 p-4 text-left transition-colors hover:border-ink-300"
+      >
+        <div className="flex items-center justify-between">
+          <span className="eyebrow">CA 19-9</span>
+          {typeof ca199Delta === "number" && ca199Delta < 0 && (
+            <ArrowDown className="h-3 w-3 text-[var(--ok)]" strokeWidth={2.2} />
+          )}
+        </div>
+        <div className="flex items-baseline gap-1">
+          <div className="serif num text-3xl leading-none text-ink-900">
+            {typeof ca199Latest === "number" ? ca199Latest : "—"}
+          </div>
+          <span className="mono text-[11px] text-ink-400 uppercase">U/mL</span>
+        </div>
+        <div
+          className={
+            typeof ca199Delta === "number"
+              ? ca199Delta < 0
+                ? "text-[11.5px] font-medium text-[var(--ok)]"
+                : "text-[11.5px] font-medium text-[var(--warn)]"
+              : "text-[11.5px] text-ink-400"
+          }
+        >
+          {typeof ca199Delta === "number"
+            ? `${ca199Delta > 0 ? "↑" : "↓"} ${Math.abs(ca199Delta)}% ${locale === "zh" ? "自开始" : "since start"}`
+            : locale === "zh"
+              ? "添加第一次结果"
+              : "Add your first result"}
+        </div>
+        <div className="mt-auto">
+          {ca199Series.length > 0 && (
+            <Sparkline
+              values={ca199Series}
+              stroke="var(--ok)"
+              fill="oklch(93% 0.025 160 / 0.5)"
+              showDots
+              highlight={ca199Series.length - 1}
+            />
+          )}
+        </div>
+      </Link>
+
+      {/* Practice today */}
+      <Link
+        href="/daily/new"
+        className="a-card flex min-h-[140px] flex-col gap-2 p-4 text-left transition-colors hover:border-ink-300"
+      >
+        <div className="flex items-center justify-between">
+          <span className="eyebrow">
+            {locale === "zh" ? "今日修习" : "Practice · today"}
+          </span>
+          <Pill className="h-3.5 w-3.5 text-ink-300" />
+        </div>
+        <div className="flex items-baseline gap-1">
+          <div className="serif num text-3xl leading-none text-ink-900">
+            {practiceCompleted.done}
+          </div>
+          <div className="mono text-[13px] text-ink-400">
+            / {practiceCompleted.total}
+          </div>
+        </div>
+        <div className="text-[11.5px] text-ink-500">
+          {practiceCompleted.subtitle}
+        </div>
+        <div className="mt-auto flex gap-1">
+          {Array.from({ length: practiceCompleted.total }).map((_, i) => (
+            <div
+              key={i}
+              className="h-1.5 flex-1 rounded-full"
+              style={{
+                background:
+                  i < practiceCompleted.done
+                    ? "var(--tide-2)"
+                    : "var(--ink-100)",
+              }}
+            />
+          ))}
+        </div>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/dashboard/quick-actions.tsx
+++ b/src/components/dashboard/quick-actions.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Link from "next/link";
+import { useLocale } from "~/hooks/use-translate";
+import {
+  Activity,
+  Utensils,
+  MessageCircle,
+  FlaskConical,
+} from "lucide-react";
+
+export function QuickActions() {
+  const locale = useLocale();
+  const items = [
+    {
+      href: "/daily/new",
+      icon: Activity,
+      label: locale === "zh" ? "记录症状" : "Log symptom",
+    },
+    {
+      href: "/daily/new",
+      icon: Utensils,
+      label: locale === "zh" ? "记录饮食" : "Log meal + PERT",
+    },
+    {
+      href: "/tasks",
+      icon: MessageCircle,
+      label: locale === "zh" ? "添加任务" : "Add care task",
+    },
+    {
+      href: "/ingest",
+      icon: FlaskConical,
+      label: locale === "zh" ? "导入报告" : "Upload report",
+    },
+  ];
+
+  return (
+    <section className="space-y-2.5">
+      <h2 className="eyebrow">{locale === "zh" ? "快捷" : "Quick"}</h2>
+      <div className="grid grid-cols-2 gap-2.5">
+        {items.map(({ href, icon: Icon, label }) => (
+          <Link
+            key={label}
+            href={href}
+            className="flex items-center gap-2.5 rounded-[var(--r-md)] border border-ink-100/70 bg-paper-2 px-3.5 py-3 text-[13px] font-medium text-ink-900 transition-colors hover:border-ink-300"
+          >
+            <Icon className="h-4 w-4 text-[var(--tide-2)]" />
+            {label}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/today-plan-card.tsx
+++ b/src/components/dashboard/today-plan-card.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { format, parseISO, differenceInCalendarDays } from "date-fns";
+import { db } from "~/lib/db/dexie";
+import { Card } from "~/components/ui/card";
+import { useLocale } from "~/hooks/use-translate";
+import { PROTOCOL_BY_ID } from "~/config/protocols";
+import type { TreatmentCycle } from "~/types/treatment";
+import type { PatientTask } from "~/types/task";
+import {
+  CheckCircle2,
+  Circle,
+  Pill,
+  Coffee,
+  Footprints,
+  Droplet,
+  MessageCircle,
+  ChevronRight,
+} from "lucide-react";
+
+type ScheduleItem = {
+  time: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  tone?: "done" | "next" | "prn";
+};
+
+const ICON_FOR_CATEGORY: Record<string, React.ComponentType<{ className?: string }>> = {
+  pharmacy: Pill,
+  nutrition: Coffee,
+  physio: Footprints,
+  hygiene: Droplet,
+  clinical: MessageCircle,
+  self_care: Droplet,
+};
+
+export function TodayPlanCard() {
+  const locale = useLocale();
+  const cycles = useLiveQuery(() =>
+    db.treatment_cycles.orderBy("start_date").reverse().limit(1).toArray(),
+  );
+  const tasks = useLiveQuery(() =>
+    db.patient_tasks.where("active").notEqual(0).toArray().catch(() =>
+      db.patient_tasks.toArray(),
+    ),
+  );
+
+  const cycle = (cycles ?? [])[0];
+  const active =
+    cycle && cycle.status === "active" ? cycle : null;
+
+  const { eyebrow, phaseLabel, summary } = useMemo(() => {
+    const base = {
+      eyebrow: locale === "zh" ? "今日" : "Today",
+      phaseLabel: locale === "zh" ? "未排程" : "No active cycle",
+      summary:
+        locale === "zh"
+          ? "专注于基本功 —— 蛋白质、走动、修习、睡眠。"
+          : "Focus on the basics — protein, movement, practice, sleep.",
+    };
+    if (!active) return base;
+    const protocol = PROTOCOL_BY_ID[active.protocol_id];
+    if (!protocol) return base;
+    const cycleDay =
+      differenceInCalendarDays(new Date(), parseISO(active.start_date)) + 1;
+    const phase = protocol.phase_windows.find(
+      (p) => cycleDay >= p.day_start && cycleDay <= p.day_end,
+    );
+    const eyebrow =
+      locale === "zh"
+        ? `今日 · 周期 ${active.cycle_number} 第 ${cycleDay} 天`
+        : `Today · Day ${cycleDay} of cycle ${active.cycle_number}`;
+    const phaseLabel = phase
+      ? phase.label[locale]
+      : locale === "zh"
+        ? `第 ${cycleDay} 天`
+        : `Cycle day ${cycleDay}`;
+    const summary =
+      phase?.description[locale] ||
+      (locale === "zh"
+        ? "专注于基本功：蛋白质、走动、修习、睡眠。"
+        : "Focus on the basics — protein, movement, practice, sleep.");
+    return { eyebrow, phaseLabel, summary };
+  }, [active, locale]);
+
+  const scheduleItems: ScheduleItem[] = useMemo(() => {
+    const now = new Date();
+    const todayDate = format(now, "yyyy-MM-dd");
+    const all = (tasks ?? []).filter(
+      (t: PatientTask) => t.active && !t.snoozed_until,
+    );
+    const ordered = all
+      .filter((t) => t.due_date && t.due_date === todayDate)
+      .slice(0, 4);
+    if (ordered.length === 0) return [];
+    return ordered.map<ScheduleItem>((t) => {
+      const icon = ICON_FOR_CATEGORY[t.category] ?? Circle;
+      return {
+        time: t.last_completed_date === todayDate ? "—" : "—",
+        label: t.title,
+        icon,
+        tone: t.last_completed_date === todayDate ? "done" : "next",
+      };
+    });
+  }, [tasks]);
+
+  const fallbackSchedule: ScheduleItem[] = [
+    {
+      time: "08:00",
+      label: locale === "zh" ? "早餐 + PERT（如服用）" : "Breakfast + PERT (if prescribed)",
+      icon: Pill,
+      tone: "done",
+    },
+    {
+      time: "11:30",
+      label: locale === "zh" ? "15 分钟轻松步行" : "Gentle 15-min walk",
+      icon: Footprints,
+    },
+    {
+      time: "14:00",
+      label: locale === "zh" ? "若需止吐" : "Anti-nausea if needed",
+      icon: Droplet,
+      tone: "prn",
+    },
+    {
+      time: "18:30",
+      label: locale === "zh" ? "修习 / 家人时间" : "Practice / family time",
+      icon: MessageCircle,
+      tone: "next",
+    },
+  ];
+
+  const itemsToShow =
+    scheduleItems.length > 0 ? scheduleItems : fallbackSchedule;
+
+  return (
+    <Card className="relative overflow-hidden px-5 py-5">
+      <div className="flex items-center justify-between">
+        <div className="eyebrow">{eyebrow}</div>
+        <span className="a-chip tide">{phaseLabel}</span>
+      </div>
+      <div className="serif mt-3 text-[22px] leading-[1.25] text-ink-900">
+        {summary}
+      </div>
+
+      <ul className="mt-4 divide-y divide-ink-100/70">
+        {itemsToShow.map((item, i) => {
+          const Icon = item.icon;
+          return (
+            <li key={i} className="flex items-center gap-3 py-2.5">
+              <div className="mono num w-10 shrink-0 text-[11px] text-ink-400">
+                {item.time}
+              </div>
+              <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-ink-100 text-ink-700">
+                <Icon className="h-3.5 w-3.5" />
+              </div>
+              <div className="flex-1 text-[13.5px] font-medium text-ink-900">
+                {item.label}
+              </div>
+              {item.tone === "done" && (
+                <CheckCircle2 className="h-4 w-4 text-[var(--ok)]" strokeWidth={2} />
+              )}
+              {item.tone === "next" && (
+                <span className="a-chip tide">
+                  {locale === "zh" ? "下一个" : "NEXT"}
+                </span>
+              )}
+              {item.tone === "prn" && (
+                <span className="mono text-[10px] uppercase text-ink-400">PRN</span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      <Link
+        href="/tasks"
+        className="mt-3 inline-flex items-center gap-1 text-xs text-ink-500 hover:text-ink-900"
+      >
+        {locale === "zh" ? "查看全部任务" : "View all tasks"}
+        <ChevronRight className="h-3 w-3" />
+      </Link>
+    </Card>
+  );
+}

--- a/src/components/dashboard/zone-status-card.tsx
+++ b/src/components/dashboard/zone-status-card.tsx
@@ -8,18 +8,18 @@ export function ZoneStatusCard() {
   const t = useT();
   const { zone, alertCount } = useZoneStatus();
   return (
-    <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4 flex items-center justify-between">
+    <div className="a-card flex items-center justify-between p-5">
       <div>
-        <div className="text-xs uppercase tracking-wide text-slate-500">
-          {t("dashboard.current_zone")}
-        </div>
-        <div className="mt-2">
+        <div className="eyebrow">{t("dashboard.current_zone")}</div>
+        <div className="mt-2.5">
           <ZoneBadge zone={zone} />
         </div>
       </div>
       <div className="text-right">
-        <div className="text-xs text-slate-500">{t("dashboard.active_alerts")}</div>
-        <div className="text-2xl font-semibold tabular-nums">{alertCount}</div>
+        <div className="eyebrow">{t("dashboard.active_alerts")}</div>
+        <div className="serif num mt-1 text-3xl text-ink-900">
+          {alertCount}
+        </div>
       </div>
     </div>
   );

--- a/src/components/labs/metric-chart.tsx
+++ b/src/components/labs/metric-chart.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "~/lib/utils/cn";
+
+export interface MetricPoint {
+  date: string;
+  value: number;
+}
+
+export function MetricChart({
+  points,
+  refRange,
+  yMax,
+  unit,
+  locale = "en",
+}: {
+  points: MetricPoint[];
+  refRange?: [number, number];
+  yMax: number;
+  unit: string;
+  locale?: "en" | "zh";
+}) {
+  const [scrubIdx, setScrubIdx] = useState<number | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
+  useEffect(() => {
+    setScrubIdx(null);
+  }, [points]);
+
+  if (points.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-[var(--r-md)] border border-dashed border-ink-200 text-xs text-ink-400">
+        {locale === "zh"
+          ? "暂无数据 —— 添加记录后显示"
+          : "No data — add values to see the trend"}
+      </div>
+    );
+  }
+
+  const W = 320;
+  const H = 150;
+  const padL = 4;
+  const padR = 34;
+  const padT = 10;
+  const padB = 22;
+  const innerW = W - padL - padR;
+  const innerH = H - padT - padB;
+  const y = (v: number) => padT + innerH - (v / yMax) * innerH;
+  const x = (i: number) =>
+    padL + (i / Math.max(1, points.length - 1)) * innerW;
+  const pts = points.map<[number, number]>((p, i) => [x(i), y(p.value)]);
+  const line = pts
+    .map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1))
+    .join(" ");
+  const area =
+    line +
+    ` L ${(padL + innerW).toFixed(1)} ${(padT + innerH).toFixed(1)} L ${padL} ${(padT + innerH).toFixed(1)} Z`;
+
+  const lastIdx = points.length - 1;
+  const activeIdx = scrubIdx ?? lastIdx;
+  const activePt = pts[activeIdx];
+  const activeVal = points[activeIdx];
+  if (!activePt || !activeVal) return null;
+  const [ax, ay] = activePt;
+  const isScrubbing = scrubIdx !== null;
+
+  const refTop = refRange ? y(refRange[1]) : null;
+  const refBot = refRange ? y(refRange[0]) : null;
+
+  const pickIdx = (clientX: number): number | null => {
+    const svg = svgRef.current;
+    if (!svg) return null;
+    const rect = svg.getBoundingClientRect();
+    const relX = ((clientX - rect.left) / rect.width) * W;
+    let best = 0;
+    let bestD = Infinity;
+    pts.forEach(([px], i) => {
+      const d = Math.abs(px - relX);
+      if (d < bestD) {
+        bestD = d;
+        best = i;
+      }
+    });
+    return best;
+  };
+
+  return (
+    <div className="relative mt-3.5">
+      <svg
+        ref={svgRef}
+        width="100%"
+        viewBox={`0 0 ${W} ${H}`}
+        style={{ display: "block", overflow: "visible", touchAction: "none" }}
+        className="cursor-crosshair"
+        onPointerDown={(e) => {
+          e.currentTarget.setPointerCapture(e.pointerId);
+          const idx = pickIdx(e.clientX);
+          if (idx !== null) setScrubIdx(idx);
+        }}
+        onPointerMove={(e) => {
+          if (!(e.buttons || e.pointerType === "touch")) return;
+          const idx = pickIdx(e.clientX);
+          if (idx !== null) setScrubIdx(idx);
+        }}
+      >
+        {[0.25, 0.5, 0.75].map((f, i) => (
+          <line
+            key={i}
+            x1={padL}
+            x2={padL + innerW}
+            y1={padT + innerH * f}
+            y2={padT + innerH * f}
+            stroke="var(--ink-100)"
+            strokeWidth={1}
+          />
+        ))}
+        {refRange && refTop !== null && refBot !== null && (
+          <>
+            <rect
+              x={padL}
+              y={refTop}
+              width={innerW}
+              height={Math.max(0, refBot - refTop)}
+              fill="oklch(93% 0.025 160 / 0.5)"
+            />
+            <line
+              x1={padL}
+              x2={padL + innerW}
+              y1={refTop}
+              y2={refTop}
+              stroke="var(--ok)"
+              strokeWidth={0.6}
+              strokeDasharray="2 3"
+            />
+            {refBot < padT + innerH && (
+              <line
+                x1={padL}
+                x2={padL + innerW}
+                y1={refBot}
+                y2={refBot}
+                stroke="var(--ok)"
+                strokeWidth={0.6}
+                strokeDasharray="2 3"
+              />
+            )}
+          </>
+        )}
+
+        <path d={area} fill="oklch(92% 0.025 210 / 0.45)" />
+        <path
+          d={line}
+          fill="none"
+          stroke="var(--tide-2)"
+          strokeWidth={1.75}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+
+        <line
+          x1={ax}
+          x2={ax}
+          y1={padT}
+          y2={padT + innerH}
+          stroke={isScrubbing ? "var(--tide-2)" : "var(--ink-400)"}
+          strokeWidth={isScrubbing ? 1 : 0.5}
+          strokeDasharray="2 3"
+          opacity={isScrubbing ? 0.8 : 0.5}
+        />
+
+        {pts.map(([px, py], i) => {
+          const isActive = i === activeIdx;
+          return (
+            <circle
+              key={i}
+              cx={px}
+              cy={py}
+              r={isActive ? 4.5 : 2.4}
+              fill={isActive ? "var(--tide-2)" : "#fff"}
+              stroke="var(--tide-2)"
+              strokeWidth={isActive ? 2 : 1.75}
+            />
+          );
+        })}
+
+        {isScrubbing ? (
+          <g>
+            <rect
+              x={Math.max(padL, Math.min(ax - 26, padL + innerW - 52))}
+              y={Math.max(padT - 6, ay - 26)}
+              width="52"
+              height="18"
+              rx="5"
+              fill="var(--ink-900)"
+            />
+            <text
+              x={Math.max(padL + 26, Math.min(ax, padL + innerW - 26))}
+              y={Math.max(padT + 6, ay - 14)}
+              fontSize="10"
+              fontFamily="var(--mono)"
+              fontWeight={700}
+              fill="#fff"
+              textAnchor="middle"
+            >
+              {activeVal.value}
+            </text>
+          </g>
+        ) : (
+          <g>
+            <line
+              x1={ax}
+              x2={padL + innerW + 2}
+              y1={ay}
+              y2={ay}
+              stroke="var(--ink-400)"
+              strokeWidth={0.5}
+              strokeDasharray="2 2"
+            />
+            <text
+              x={padL + innerW + 4}
+              y={ay + 3}
+              fontSize="9"
+              fontFamily="var(--mono)"
+              fill="var(--ink-700)"
+              fontWeight={600}
+            >
+              {activeVal.value}
+            </text>
+          </g>
+        )}
+      </svg>
+
+      {refRange && (
+        <div
+          className="mono absolute right-1 top-0.5 text-[9px] uppercase tracking-wider"
+          style={{ color: "var(--ok)" }}
+        >
+          {locale === "zh" ? "目标" : "TARGET"} {refRange[0]}–{refRange[1]} {unit}
+        </div>
+      )}
+
+      {!isScrubbing && (
+        <div
+          className={cn(
+            "mono pointer-events-none absolute bottom-6 left-1 text-[8.5px] uppercase tracking-wider opacity-70",
+          )}
+          style={{ color: "var(--ink-400)" }}
+        >
+          {locale === "zh" ? "点击或拖动查看" : "Tap or drag to scrub"}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -42,12 +42,12 @@ export function DesktopSidebar() {
   const t = useT();
   const pathname = usePathname();
   return (
-    <aside className="hidden md:flex md:w-60 flex-col border-r border-slate-200 bg-white dark:bg-slate-900 dark:border-slate-800">
+    <aside className="hidden md:flex md:w-60 flex-col border-r border-ink-100/60 bg-paper-2/60">
       <div className="px-5 py-6">
-        <div className="text-lg font-semibold">{t("app.name")}</div>
-        <div className="text-xs text-slate-500 mt-1">{t("app.tagline")}</div>
+        <div className="serif text-xl text-ink-900">{t("app.name")}</div>
+        <div className="mt-1 text-[11px] text-ink-400">{t("app.tagline")}</div>
       </div>
-      <nav className="flex-1 px-2 pb-4 space-y-1">
+      <nav className="flex-1 space-y-0.5 px-2 pb-4">
         {ITEMS.map((item) => {
           const Icon = item.icon;
           const active = pathname === item.href;
@@ -56,13 +56,19 @@ export function DesktopSidebar() {
               key={item.href}
               href={item.href}
               className={cn(
-                "flex items-center gap-3 rounded-md px-3 py-2 text-sm",
+                "flex items-center gap-3 rounded-md px-3 py-2 text-[13px] transition-colors",
                 active
-                  ? "bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100"
-                  : "text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800",
+                  ? "bg-ink-100/80 text-ink-900"
+                  : "text-ink-500 hover:bg-ink-100/40 hover:text-ink-700",
               )}
             >
-              <Icon className="h-4 w-4" aria-hidden />
+              <Icon
+                className={cn(
+                  "h-4 w-4",
+                  active ? "text-[var(--tide-2)]" : "",
+                )}
+                aria-hidden
+              />
               <span>{t(item.key)}</span>
             </Link>
           );
@@ -76,10 +82,10 @@ export function MobileBottomNav() {
   const t = useT();
   const pathname = usePathname();
   const mobileItems = ITEMS.filter((i) =>
-    ["/", "/daily", "/weekly", "/reports", "/settings"].includes(i.href),
+    ["/", "/daily", "/assessment", "/tasks", "/settings"].includes(i.href),
   );
   return (
-    <nav className="md:hidden fixed bottom-0 inset-x-0 bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 flex justify-around py-2 z-40">
+    <nav className="a-glass fixed inset-x-3 bottom-3 z-40 flex justify-around rounded-[22px] px-2 py-2.5 shadow-lg md:hidden">
       {mobileItems.map((item) => {
         const Icon = item.icon;
         const active = pathname === item.href;
@@ -88,12 +94,18 @@ export function MobileBottomNav() {
             key={item.href}
             href={item.href}
             className={cn(
-              "flex flex-col items-center gap-1 text-[11px] px-3 py-1 rounded-md",
-              active ? "text-slate-900 dark:text-slate-100" : "text-slate-500",
+              "flex flex-col items-center gap-1 rounded-md px-3 py-1 transition-colors",
+              active ? "text-ink-900" : "text-ink-400",
             )}
           >
-            <Icon className="h-5 w-5" aria-hidden />
-            <span>{t(item.key)}</span>
+            <Icon
+              className={cn("h-5 w-5", active ? "text-[var(--tide-2)]" : "")}
+              strokeWidth={active ? 1.9 : 1.5}
+              aria-hidden
+            />
+            <span className="mono text-[10px] uppercase tracking-wider">
+              {t(item.key)}
+            </span>
           </Link>
         );
       })}

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -14,6 +14,7 @@ import {
   FileText,
   Settings as SettingsIcon,
   ScanLine,
+  FlaskConical,
   Compass,
   Syringe,
   ListTodo,
@@ -29,6 +30,7 @@ const ITEMS = [
   { href: "/weekly", key: "nav.weekly", icon: CalendarRange },
   { href: "/fortnightly", key: "nav.fortnightly", icon: Stethoscope },
   { href: "/quarterly", key: "nav.quarterly", icon: ClipboardList },
+  { href: "/labs", key: "nav.labs", icon: FlaskConical },
   { href: "/bridge", key: "nav.bridge", icon: Route },
   { href: "/events", key: "nav.events", icon: CalendarClock },
   { href: "/tasks", key: "nav.tasks", icon: ListTodo },
@@ -82,7 +84,7 @@ export function MobileBottomNav() {
   const t = useT();
   const pathname = usePathname();
   const mobileItems = ITEMS.filter((i) =>
-    ["/", "/daily", "/assessment", "/tasks", "/settings"].includes(i.href),
+    ["/", "/daily", "/treatment", "/labs", "/tasks"].includes(i.href),
   );
   return (
     <nav className="a-glass fixed inset-x-3 bottom-3 z-40 flex justify-around rounded-[22px] px-2 py-2.5 shadow-lg md:hidden">

--- a/src/components/shared/zone-badge.tsx
+++ b/src/components/shared/zone-badge.tsx
@@ -3,13 +3,18 @@
 import type { Zone } from "~/types/clinical";
 import { cn } from "~/lib/utils/cn";
 import { useT } from "~/hooks/use-translate";
-import { Circle, AlertCircle, AlertTriangle, AlertOctagon } from "lucide-react";
+import {
+  Circle,
+  AlertCircle,
+  AlertTriangle,
+  AlertOctagon,
+} from "lucide-react";
 
-const ZONE_CLASS: Record<Zone, string> = {
-  green: "bg-slate-100 text-slate-700 border-slate-300 dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700",
-  yellow: "bg-amber-50 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-200 dark:border-amber-900",
-  orange: "bg-orange-50 text-orange-800 border-orange-400 dark:bg-orange-950/50 dark:text-orange-200 dark:border-orange-900",
-  red: "bg-red-50 text-red-800 border-red-500 dark:bg-red-950/50 dark:text-red-100 dark:border-red-900",
+const ZONE_CHIP: Record<Zone, string> = {
+  green: "a-chip",
+  yellow: "a-chip sand",
+  orange: "a-chip warn",
+  red: "a-chip warn",
 };
 
 const ZONE_ICON: Record<Zone, React.ComponentType<{ className?: string }>> = {
@@ -19,18 +24,18 @@ const ZONE_ICON: Record<Zone, React.ComponentType<{ className?: string }>> = {
   red: AlertOctagon,
 };
 
-export function ZoneBadge({ zone, className }: { zone: Zone; className?: string }) {
+export function ZoneBadge({
+  zone,
+  className,
+}: {
+  zone: Zone;
+  className?: string;
+}) {
   const t = useT();
   const Icon = ZONE_ICON[zone];
   return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium",
-        ZONE_CLASS[zone],
-        className,
-      )}
-    >
-      <Icon className="h-3.5 w-3.5" aria-hidden />
+    <span className={cn(ZONE_CHIP[zone], className)}>
+      <Icon className="h-3 w-3" aria-hidden />
       {t(`zones.${zone}`)}
     </span>
   );

--- a/src/components/treatment/cycle-calendar.tsx
+++ b/src/components/treatment/cycle-calendar.tsx
@@ -2,9 +2,60 @@
 
 import { addDays, format, parseISO } from "date-fns";
 import { useLocale } from "~/hooks/use-translate";
-import { cn } from "~/lib/utils/cn";
 import type { Protocol, TreatmentCycle } from "~/types/treatment";
 import { cycleDayFor, currentPhase } from "~/lib/treatment/engine";
+
+type Swatch = {
+  bg: string;
+  color: string;
+  label: { en: string; zh: string };
+};
+
+const SWATCHES: Record<string, Swatch> = {
+  dose_day: {
+    bg: "var(--tide-2)",
+    color: "#fff",
+    label: { en: "Dose", zh: "用药" },
+  },
+  post_dose: {
+    bg: "var(--tide-soft)",
+    color: "var(--tide-2)",
+    label: { en: "Post-dose", zh: "用药后" },
+  },
+  nadir: {
+    bg: "var(--sand)",
+    color: "oklch(35% 0.04 70)",
+    label: { en: "Nadir", zh: "低谷" },
+  },
+  recovery_early: {
+    bg: "var(--tide-soft)",
+    color: "var(--tide-2)",
+    label: { en: "Recovery", zh: "恢复" },
+  },
+  recovery_late: {
+    bg: "oklch(88% 0.03 150)",
+    color: "oklch(38% 0.05 150)",
+    label: { en: "Recovery", zh: "恢复" },
+  },
+  pre_dose: {
+    bg: "var(--ink-100)",
+    color: "var(--ink-500)",
+    label: { en: "Pre-dose", zh: "用药前" },
+  },
+  rest: {
+    bg: "var(--ink-100)",
+    color: "var(--ink-400)",
+    label: { en: "Rest", zh: "休息" },
+  },
+};
+
+const LEGEND_KEYS = [
+  "dose_day",
+  "post_dose",
+  "nadir",
+  "recovery_late",
+  "rest",
+];
 
 export function CycleCalendar({
   cycle,
@@ -28,48 +79,48 @@ export function CycleCalendar({
 
   return (
     <div>
-      <div className="mb-2 flex items-center gap-2 text-[10px]">
-        <Legend colour="bg-slate-900 dark:bg-slate-100" label={locale === "zh" ? "用药日" : "Dose"} />
-        <Legend colour="bg-amber-300 dark:bg-amber-700" label={locale === "zh" ? "低谷" : "Nadir"} />
-        <Legend colour="bg-emerald-300 dark:bg-emerald-700" label={locale === "zh" ? "恢复" : "Recovery"} />
-        <Legend colour="ring-2 ring-slate-900 dark:ring-slate-100" label={locale === "zh" ? "今天" : "Today"} />
-      </div>
-      <div className="grid grid-cols-7 gap-1 sm:grid-cols-14">
+      <div className="grid grid-cols-7 gap-1.5">
         {days.map(({ n, date, phase, isDose }) => {
           const isToday = n === todayDay;
-          const nadir = phase?.key === "nadir";
-          const recovery = phase?.key === "recovery_late";
+          const key = isDose ? "dose_day" : phase?.key ?? "rest";
+          const swatch = SWATCHES[key] ?? SWATCHES.rest!;
           return (
             <div
               key={n}
-              className={cn(
-                "flex aspect-square flex-col items-center justify-center rounded-md border p-1 text-[10px]",
-                isDose
-                  ? "border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900"
-                  : nadir
-                    ? "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200"
-                    : recovery
-                      ? "border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-200"
-                      : "border-slate-200 bg-white text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400",
-                isToday && "ring-2 ring-offset-1 ring-slate-900 dark:ring-slate-100 dark:ring-offset-slate-950",
-              )}
+              className="flex aspect-square flex-col items-center justify-center rounded-[10px]"
+              style={{
+                background: swatch.bg,
+                color: swatch.color,
+                boxShadow: isToday ? "0 0 0 2px var(--ink-900)" : undefined,
+              }}
               title={`Day ${n} · ${format(date, "d MMM")} · ${phase?.label[locale] ?? ""}`}
             >
-              <span className="font-semibold tabular-nums">{n}</span>
-              <span className="text-[9px] opacity-80">{format(date, "d/M")}</span>
+              <span className="mono text-[9px] uppercase opacity-70">
+                D{n}
+              </span>
+              <span className="num text-[15px] font-semibold leading-none">
+                {format(date, "d")}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-3.5 flex flex-wrap gap-3.5 border-t border-ink-100/70 pt-3.5 text-[11px] text-ink-500">
+        {LEGEND_KEYS.map((k) => {
+          const s = SWATCHES[k];
+          if (!s) return null;
+          return (
+            <div key={k} className="flex items-center gap-1.5">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-[3px]"
+                style={{ background: s.bg }}
+              />
+              {s.label[locale]}
             </div>
           );
         })}
       </div>
     </div>
-  );
-}
-
-function Legend({ colour, label }: { colour: string; label: string }) {
-  return (
-    <span className="inline-flex items-center gap-1 text-slate-500">
-      <span className={cn("h-2.5 w-2.5 rounded-sm", colour)} />
-      {label}
-    </span>
   );
 }

--- a/src/components/ui/bar-scale.tsx
+++ b/src/components/ui/bar-scale.tsx
@@ -1,0 +1,38 @@
+export function BarScale({
+  value,
+  max = 10,
+  color = "var(--tide-2)",
+  bg = "var(--ink-100)",
+  w = 120,
+  h = 6,
+}: {
+  value: number;
+  max?: number;
+  color?: string;
+  bg?: string;
+  w?: number;
+  h?: number;
+}) {
+  const pct = Math.max(0, Math.min(1, value / max));
+  return (
+    <div
+      style={{
+        width: w,
+        height: h,
+        background: bg,
+        borderRadius: 999,
+        position: "relative",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: `${pct * 100}%`,
+          background: color,
+          borderRadius: 999,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,7 +1,7 @@
 import { cn } from "~/lib/utils/cn";
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 
-type Variant = "primary" | "secondary" | "ghost" | "danger";
+type Variant = "primary" | "secondary" | "ghost" | "danger" | "tide";
 type Size = "sm" | "md" | "lg";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -11,13 +11,15 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantCls: Record<Variant, string> = {
   primary:
-    "bg-slate-900 text-white hover:bg-slate-800 disabled:opacity-50 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200",
+    "bg-ink-900 text-paper hover:bg-ink-700 disabled:opacity-50",
   secondary:
-    "border border-slate-300 bg-white text-slate-800 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800",
+    "border border-ink-200 bg-paper-2 text-ink-900 hover:border-ink-300",
   ghost:
-    "text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800",
+    "text-ink-500 hover:bg-ink-100/60",
   danger:
-    "bg-red-700 text-white hover:bg-red-800",
+    "bg-[var(--warn)] text-white hover:opacity-90",
+  tide:
+    "bg-[var(--tide-2)] text-paper hover:brightness-110",
 };
 
 const sizeCls: Record<Size, string> = {
@@ -31,7 +33,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     <button
       ref={ref}
       className={cn(
-        "inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-slate-900 focus:ring-offset-2 focus:ring-offset-slate-50 dark:focus:ring-slate-100 dark:focus:ring-offset-slate-950 disabled:cursor-not-allowed",
+        "inline-flex items-center justify-center gap-2 rounded-md font-medium tracking-tight transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--tide-2)]/50 focus:ring-offset-2 focus:ring-offset-paper disabled:cursor-not-allowed",
         variantCls[variant],
         sizeCls[size],
         className,

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -5,7 +5,7 @@ export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn(
-        "rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900",
+        "a-card text-ink-900",
         className,
       )}
       {...props}
@@ -13,31 +13,55 @@ export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   );
 }
 
-export function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+export function CardHeader({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
   return <div className={cn("px-5 pt-5", className)} {...props} />;
 }
 
-export function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
+export function CardTitle({
+  className,
+  ...props
+}: HTMLAttributes<HTMLHeadingElement>) {
   return (
-    <h3 className={cn("text-base font-semibold leading-tight", className)} {...props} />
+    <h3
+      className={cn(
+        "serif text-base leading-tight text-ink-900",
+        className,
+      )}
+      {...props}
+    />
   );
 }
 
-export function CardDescription({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
+export function CardDescription({
+  className,
+  ...props
+}: HTMLAttributes<HTMLParagraphElement>) {
   return (
-    <p className={cn("mt-1 text-sm text-slate-500 dark:text-slate-400", className)} {...props} />
+    <p
+      className={cn("mt-1 text-sm text-ink-500", className)}
+      {...props}
+    />
   );
 }
 
-export function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+export function CardContent({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
   return <div className={cn("px-5 pb-5 pt-4", className)} {...props} />;
 }
 
-export function CardFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+export function CardFooter({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn(
-        "border-t border-slate-200 bg-slate-50/60 px-5 py-3 text-xs text-slate-500 dark:border-slate-800 dark:bg-slate-900/40",
+        "border-t border-ink-100/60 bg-paper/40 px-5 py-3 text-xs text-ink-500",
         className,
       )}
       {...props}

--- a/src/components/ui/metric-tile.tsx
+++ b/src/components/ui/metric-tile.tsx
@@ -23,42 +23,40 @@ export function MetricTile({
   footnote?: ReactNode;
   className?: string;
 }) {
-  let deltaClass = "text-slate-500";
+  let deltaClass = "text-ink-400";
   if (direction && direction !== "flat" && direction !== "none" && goodDirection) {
     const good = direction === goodDirection;
     deltaClass = good
-      ? "text-emerald-600 dark:text-emerald-400"
-      : "text-amber-600 dark:text-amber-400";
+      ? "text-[var(--ok)]"
+      : "text-[var(--warn)]";
   }
   const Icon =
     direction === "up" ? ArrowUp : direction === "down" ? ArrowDown : ArrowRight;
 
   return (
-    <div
-      className={cn(
-        "rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900",
-        className,
-      )}
-    >
-      <div className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-        {label}
-      </div>
+    <div className={cn("a-card p-4", className)}>
+      <div className="eyebrow">{label}</div>
       <div className="mt-2 flex items-baseline gap-2">
-        <span className="text-2xl font-semibold tabular-nums text-slate-900 dark:text-slate-50">
-          {value}
-        </span>
+        <span className="serif num text-3xl text-ink-900">{value}</span>
         {unit && (
-          <span className="text-sm text-slate-500 dark:text-slate-400">{unit}</span>
+          <span className="mono text-xs text-ink-400 uppercase tracking-wider">
+            {unit}
+          </span>
         )}
       </div>
       {(delta || direction) && (
-        <div className={cn("mt-1 inline-flex items-center gap-1 text-xs", deltaClass)}>
+        <div
+          className={cn(
+            "mt-1 inline-flex items-center gap-1 text-xs font-medium",
+            deltaClass,
+          )}
+        >
           {direction && direction !== "none" && <Icon className="h-3 w-3" />}
           {delta}
         </div>
       )}
       {footnote && (
-        <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">{footnote}</div>
+        <div className="mt-2 text-xs text-ink-500">{footnote}</div>
       )}
     </div>
   );

--- a/src/components/ui/page-header.tsx
+++ b/src/components/ui/page-header.tsx
@@ -2,27 +2,37 @@ import { cn } from "~/lib/utils/cn";
 import type { ReactNode } from "react";
 
 export function PageHeader({
+  eyebrow,
   title,
   subtitle,
   action,
   className,
 }: {
-  title: string;
+  eyebrow?: ReactNode;
+  title: ReactNode;
   subtitle?: ReactNode;
   action?: ReactNode;
   className?: string;
 }) {
   return (
-    <div className={cn("flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between", className)}>
-      <div className="space-y-1">
-        <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">
+    <div
+      className={cn(
+        "flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between",
+        className,
+      )}
+    >
+      <div className="space-y-1.5 min-w-0 flex-1">
+        {eyebrow && <div className="eyebrow">{eyebrow}</div>}
+        <h1 className="serif text-[28px] leading-[1.15] tracking-tight text-ink-900">
           {title}
         </h1>
         {subtitle && (
-          <p className="text-sm text-slate-500 dark:text-slate-400">{subtitle}</p>
+          <p className="text-sm text-ink-500">{subtitle}</p>
         )}
       </div>
-      {action && <div className="flex items-center gap-2">{action}</div>}
+      {action && (
+        <div className="flex items-center gap-2 shrink-0">{action}</div>
+      )}
     </div>
   );
 }
@@ -38,11 +48,9 @@ export function SectionHeader({
 }) {
   return (
     <div className={cn("space-y-1", className)}>
-      <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">
-        {title}
-      </h2>
+      <h2 className="eyebrow">{title}</h2>
       {description && (
-        <p className="text-sm text-slate-600 dark:text-slate-400">{description}</p>
+        <p className="text-sm text-ink-500">{description}</p>
       )}
     </div>
   );

--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -1,0 +1,62 @@
+export function Sparkline({
+  values,
+  width = 140,
+  height = 28,
+  stroke = "var(--tide-2)",
+  fill,
+  showDots = false,
+  highlight = -1,
+}: {
+  values: number[];
+  width?: number;
+  height?: number;
+  stroke?: string;
+  fill?: string;
+  showDots?: boolean;
+  highlight?: number;
+}) {
+  if (values.length === 0) return null;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const pts = values.map<[number, number]>((v, i) => [
+    (i / Math.max(1, values.length - 1)) * (width - 6) + 3,
+    height - 3 - ((v - min) / range) * (height - 6),
+  ]);
+  const d = pts
+    .map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1))
+    .join(" ");
+  const area =
+    d + ` L ${(width - 3).toFixed(1)} ${height - 3} L 3 ${height - 3} Z`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      style={{ display: "block" }}
+    >
+      {fill && <path d={area} fill={fill} />}
+      <path
+        d={d}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {showDots &&
+        pts.map(([x, y], i) => (
+          <circle
+            key={i}
+            cx={x}
+            cy={y}
+            r={i === highlight ? 3 : 1.8}
+            fill={i === highlight ? stroke : "#fff"}
+            stroke={stroke}
+            strokeWidth={1.5}
+          />
+        ))}
+    </svg>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,9 +1,60 @@
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:wght@500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+/* ─── Anchor design tokens ─────────────────────────────────────────── */
 :root {
-  color-scheme: light dark;
+  --ink-900: oklch(22% 0.015 250);
+  --ink-700: oklch(35% 0.015 250);
+  --ink-500: oklch(52% 0.012 250);
+  --ink-400: oklch(65% 0.010 250);
+  --ink-300: oklch(78% 0.008 250);
+  --ink-200: oklch(88% 0.006 70);
+  --ink-100: oklch(94% 0.006 70);
+  --paper:   oklch(97% 0.008 70);
+  --paper-2: oklch(99% 0.005 70);
+
+  --tide:      oklch(56% 0.08 210);
+  --tide-2:    oklch(45% 0.09 215);
+  --tide-soft: oklch(92% 0.025 210);
+
+  --sand:   oklch(86% 0.035 75);
+  --sand-2: oklch(78% 0.045 70);
+  --shell:  oklch(93% 0.015 70);
+
+  --warn:      oklch(62% 0.12 50);
+  --warn-soft: oklch(94% 0.03 60);
+  --ok:        oklch(58% 0.08 160);
+  --ok-soft:   oklch(93% 0.025 160);
+
+  --serif: "Fraunces", "Cormorant Garamond", Georgia, serif;
+  --sans:  "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --mono:  "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --r-sm: 8px;
+  --r-md: 14px;
+  --r-lg: 22px;
+  --r-xl: 28px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper:   oklch(18% 0.012 250);
+    --paper-2: oklch(22% 0.012 250);
+    --ink-100: oklch(28% 0.010 250);
+    --ink-200: oklch(34% 0.010 250);
+    --ink-300: oklch(44% 0.010 250);
+    --ink-400: oklch(60% 0.010 250);
+    --ink-500: oklch(72% 0.010 250);
+    --ink-700: oklch(88% 0.008 250);
+    --ink-900: oklch(96% 0.006 250);
+    --tide-soft: oklch(32% 0.05 210);
+    --warn-soft: oklch(28% 0.06 50);
+    --ok-soft:   oklch(28% 0.04 160);
+    --sand:      oklch(30% 0.025 75);
+  }
 }
 
 html,
@@ -12,12 +63,95 @@ body {
 }
 
 body {
-  @apply bg-slate-50 text-slate-900 antialiased;
+  background: var(--paper);
+  color: var(--ink-900);
+  font-family: var(--sans);
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11";
+  letter-spacing: -0.01em;
   overscroll-behavior: none;
 }
 
-@media (prefers-color-scheme: dark) {
-  body {
-    @apply bg-slate-950 text-slate-100;
-  }
+/* ─── Utilities used directly in components ──────────────────────── */
+.serif {
+  font-family: var(--serif);
+  letter-spacing: -0.02em;
+  font-weight: 600;
+  font-optical-sizing: auto;
+}
+.mono {
+  font-family: var(--mono);
+  letter-spacing: 0;
+}
+.num {
+  font-variant-numeric: tabular-nums;
+}
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-400);
+}
+
+/* a-chip — the mono status pill */
+.a-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--ink-100);
+  color: var(--ink-700);
+}
+.a-chip.tide {
+  background: var(--tide-soft);
+  color: var(--tide-2);
+}
+.a-chip.sand {
+  background: var(--sand);
+  color: oklch(35% 0.04 70);
+}
+.a-chip.warn {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+.a-chip.ok {
+  background: var(--ok-soft);
+  color: var(--ok);
+}
+
+/* a-card — the warm-paper card */
+.a-card {
+  background: var(--paper-2);
+  border-radius: var(--r-lg);
+  box-shadow:
+    0 1px 2px rgba(20, 25, 40, 0.03),
+    0 2px 14px rgba(20, 25, 40, 0.04);
+  border: 0.5px solid rgba(20, 25, 40, 0.05);
+}
+
+/* Horizon — subtle gradient line for section dividers */
+.a-horizon {
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--ink-200) 20%,
+    var(--ink-200) 80%,
+    transparent
+  );
+}
+
+/* Glass pill — used by the bottom nav */
+.a-glass {
+  background: color-mix(in oklch, var(--paper-2), transparent 15%);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  border: 0.5px solid color-mix(in oklch, var(--ink-900), transparent 92%);
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,29 +2,50 @@ import { type Config } from "tailwindcss";
 
 export default {
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
-  darkMode: "class",
+  darkMode: "media",
   theme: {
     extend: {
       colors: {
-        zone: {
-          green: "#64748b",
-          yellow: "#f59e0b",
-          orange: "#ea580c",
-          red: "#b91c1c",
+        paper: "var(--paper)",
+        "paper-2": "var(--paper-2)",
+        ink: {
+          100: "var(--ink-100)",
+          200: "var(--ink-200)",
+          300: "var(--ink-300)",
+          400: "var(--ink-400)",
+          500: "var(--ink-500)",
+          700: "var(--ink-700)",
+          900: "var(--ink-900)",
+        },
+        tide: {
+          DEFAULT: "var(--tide)",
+          2: "var(--tide-2)",
+          soft: "var(--tide-soft)",
+        },
+        sand: {
+          DEFAULT: "var(--sand)",
+          2: "var(--sand-2)",
+          shell: "var(--shell)",
+        },
+        warn: {
+          DEFAULT: "var(--warn)",
+          soft: "var(--warn-soft)",
+        },
+        ok: {
+          DEFAULT: "var(--ok)",
+          soft: "var(--ok-soft)",
         },
       },
+      borderRadius: {
+        sm: "var(--r-sm)",
+        md: "var(--r-md)",
+        lg: "var(--r-lg)",
+        xl: "var(--r-xl)",
+      },
       fontFamily: {
-        sans: [
-          "system-ui",
-          "-apple-system",
-          "BlinkMacSystemFont",
-          "Segoe UI",
-          "PingFang SC",
-          "Hiragino Sans GB",
-          "Microsoft YaHei",
-          "Noto Sans SC",
-          "sans-serif",
-        ],
+        sans: ["Inter", "system-ui", "-apple-system", "BlinkMacSystemFont", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", "sans-serif"],
+        serif: ["Fraunces", "Cormorant Garamond", "Georgia", "serif"],
+        mono: ["JetBrains Mono", "ui-monospace", "SF Mono", "Menlo", "monospace"],
       },
     },
   },


### PR DESCRIPTION
## Summary

Ports the key pieces of the Anchor design bundle (Claude Design export) into the live app: warm paper/ink palette, Fraunces display serif, tide-teal accent, JetBrains Mono for data labels, and the "anchor / tide" metaphor via subtle horizon lines + glass bottom nav.

### Design tokens

- `src/styles/globals.css` — loads **Fraunces** + **Inter** + **JetBrains Mono**, defines oklch-based `--paper` / `--ink-*` / `--tide-*` / `--sand-*` / `--warn-*` / `--ok-*` palette (light + dark), `a-card` / `a-chip` / `a-glass` / `a-horizon` / `eyebrow` utilities, `.serif` + `.mono` + `.num` helpers.
- `tailwind.config.ts` — exposes `paper` / `ink` / `tide` / `sand` / `warn` / `ok` colours as Tailwind tokens backed by CSS vars; sets `fontFamily.{sans,serif,mono}`; maps radius tokens to `--r-*`.

### Shared primitives

- **Card** — `a-card` base (paper-2 bg, soft dual-layer shadow, 22 px radius, hairline border). `CardTitle` now uses the display serif.
- **Button** — ink-on-paper primary, paper-2 secondary with ink-200 border, new `tide` variant for accent CTAs, tide-ring focus.
- **PageHeader** — optional eyebrow (mono + uppercase + letter-spaced), serif 28 px title, ink-500 subtitle.
- **ZoneBadge** — collapsed to `a-chip` with severity tones.
- **DesktopSidebar** — Fraunces app name, ink-100 hover, tide-tinted active icon.
- **MobileBottomNav** — frosted `a-glass` pill floating above the content, mono tab labels, tide-tinted active icon.

### Dashboard hero

- Time-of-day greeting with the patient's first name italicised in ink-500 (matches the design: *"Good morning, Marian"*)
- Eyebrow shows today's full date (EN: uppercase weekday · d MMM yyyy; ZH: yyyy 年 M 月 d 日 · EEEE)
- Bell icon on the header, Stethoscope deep-link gets the tide accent treatment, `a-horizon` divider below the header
- `ZoneStatusCard` + `MetricTile` drop slate in favour of ink/paper tokens, use serif numerics + mono uppercase eyebrows

### Body / layout

- body background = `--paper`, text = `--ink-900`, fonts load from Google
- App header is now sticky, 56 px, frosted paper-2 background, hairline bottom border
- Dark mode hooks via `prefers-color-scheme`

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 83/83 passing
- [x] `pnpm build` — 30 routes green

## Test plan

- [ ] Vercel preview loads with the new Fraunces title + paper background
- [ ] Dashboard greeting shows local time-of-day + name from Settings
- [ ] Bottom nav (mobile) renders as a frosted pill above content
- [ ] ZoneBadge appears as mono uppercase chip
- [ ] Switch to ZH locale — eyebrow format switches to `yyyy 年 M 月 d 日`
- [ ] Dark mode (system) — paper switches to deep ink, fonts unchanged

### Notes

Many deeper components (daily wizard, assessment questionnaires, weekly form, etc.) still reference slate classes. Tailwind's default slate palette remains available so everything still renders — they'll migrate incrementally. Every screen already picks up the new typography and background via the root.

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH