### PR TITLE
Onboarding: first-run gate + emergency contacts + Settings parity

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,788 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, now } from "~/lib/db/dexie";
+import { todayISO } from "~/lib/utils/date";
+import { useLocale } from "~/hooks/use-translate";
+import { useUIStore } from "~/stores/ui-store";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, TextInput, Textarea } from "~/components/ui/field";
+import { PROTOCOL_LIBRARY, PROTOCOL_BY_ID } from "~/config/protocols";
+import type { ProtocolId } from "~/types/treatment";
+import type { Locale, Settings } from "~/types/clinical";
+import {
+  Anchor,
+  ChevronLeft,
+  ChevronRight,
+  Check,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+const STEPS = [
+  "welcome",
+  "profile",
+  "team",
+  "baselines",
+  "treatment",
+  "preferences",
+  "done",
+] as const;
+
+type StepKey = (typeof STEPS)[number];
+
+const STEP_LABELS: Record<Locale, Record<StepKey, string>> = {
+  en: {
+    welcome: "Welcome",
+    profile: "About you",
+    team: "Clinical team",
+    baselines: "Baselines",
+    treatment: "Treatment",
+    preferences: "Preferences",
+    done: "All set",
+  },
+  zh: {
+    welcome: "欢迎",
+    profile: "基本信息",
+    team: "医疗团队",
+    baselines: "基线数据",
+    treatment: "治疗方案",
+    preferences: "偏好设置",
+    done: "完成",
+  },
+};
+
+interface FormState {
+  profile_name: string;
+  dob: string;
+  diagnosis_date: string;
+  managing_oncologist: string;
+  managing_oncologist_phone: string;
+  hospital_name: string;
+  hospital_phone: string;
+  hospital_address: string;
+  oncall_phone: string;
+  emergency_instructions: string;
+  height_cm: string;
+  baseline_weight_kg: string;
+  baseline_grip_dominant_kg: string;
+  baseline_gait_speed_ms: string;
+  baseline_muac_cm: string;
+  baseline_calf_cm: string;
+  start_cycle: boolean;
+  protocol_id: ProtocolId;
+  cycle_start_date: string;
+  locale: Locale;
+  anthropic_api_key: string;
+}
+
+const EMPTY: FormState = {
+  profile_name: "",
+  dob: "",
+  diagnosis_date: "",
+  managing_oncologist: "",
+  managing_oncologist_phone: "",
+  hospital_name: "",
+  hospital_phone: "",
+  hospital_address: "",
+  oncall_phone: "",
+  emergency_instructions: "",
+  height_cm: "",
+  baseline_weight_kg: "",
+  baseline_grip_dominant_kg: "",
+  baseline_gait_speed_ms: "",
+  baseline_muac_cm: "",
+  baseline_calf_cm: "",
+  start_cycle: false,
+  protocol_id: "gnp_weekly",
+  cycle_start_date: todayISO(),
+  locale: "en",
+  anthropic_api_key: "",
+};
+
+function toNum(s: string): number | undefined {
+  if (!s) return undefined;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export default function OnboardingPage() {
+  const locale = useLocale();
+  const router = useRouter();
+  const setUILocale = useUIStore((s) => s.setLocale);
+  const setEnteredBy = useUIStore((s) => s.setEnteredBy);
+  const existingSettings = useLiveQuery(() => db.settings.toArray());
+
+  const [form, setForm] = useState<FormState>({ ...EMPTY, locale });
+  const [step, setStep] = useState<StepKey>("welcome");
+  const [saving, setSaving] = useState(false);
+
+  // If already onboarded, bounce back to dashboard.
+  useEffect(() => {
+    const s = existingSettings?.[0];
+    if (s?.onboarded_at) {
+      router.replace("/");
+    } else if (s) {
+      // Prefill from partial existing settings
+      setForm((f) => ({
+        ...f,
+        profile_name: s.profile_name ?? "",
+        dob: s.dob ?? "",
+        diagnosis_date: s.diagnosis_date ?? "",
+        managing_oncologist: s.managing_oncologist ?? "",
+        managing_oncologist_phone: s.managing_oncologist_phone ?? "",
+        hospital_name: s.hospital_name ?? "",
+        hospital_phone: s.hospital_phone ?? "",
+        hospital_address: s.hospital_address ?? "",
+        oncall_phone: s.oncall_phone ?? "",
+        emergency_instructions: s.emergency_instructions ?? "",
+        height_cm: s.height_cm ? String(s.height_cm) : "",
+        baseline_weight_kg: s.baseline_weight_kg
+          ? String(s.baseline_weight_kg)
+          : "",
+        baseline_grip_dominant_kg: s.baseline_grip_dominant_kg
+          ? String(s.baseline_grip_dominant_kg)
+          : "",
+        baseline_gait_speed_ms: s.baseline_gait_speed_ms
+          ? String(s.baseline_gait_speed_ms)
+          : "",
+        baseline_muac_cm: s.baseline_muac_cm ? String(s.baseline_muac_cm) : "",
+        baseline_calf_cm: s.baseline_calf_cm ? String(s.baseline_calf_cm) : "",
+        locale: s.locale,
+        anthropic_api_key: s.anthropic_api_key ?? "",
+      }));
+    }
+  }, [existingSettings, router]);
+
+  function update<K extends keyof FormState>(k: K, v: FormState[K]) {
+    setForm((f) => ({ ...f, [k]: v }));
+  }
+
+  const stepIdx = STEPS.indexOf(step);
+  const progress = ((stepIdx + 1) / STEPS.length) * 100;
+
+  function back() {
+    const i = STEPS.indexOf(step);
+    if (i > 0) {
+      const prev = STEPS[i - 1];
+      if (prev) setStep(prev);
+    }
+  }
+
+  function forward() {
+    const i = STEPS.indexOf(step);
+    if (i < STEPS.length - 1) {
+      const next = STEPS[i + 1];
+      if (next) setStep(next);
+    }
+  }
+
+  const canContinue = useMemo(() => {
+    if (step === "profile") return form.profile_name.trim().length > 0;
+    return true;
+  }, [step, form.profile_name]);
+
+  async function finish() {
+    setSaving(true);
+    try {
+      const ts = now();
+      const payload: Settings = {
+        profile_name: form.profile_name.trim() || "Patient",
+        dob: form.dob || undefined,
+        diagnosis_date: form.diagnosis_date || undefined,
+        height_cm: toNum(form.height_cm),
+        baseline_weight_kg: toNum(form.baseline_weight_kg),
+        baseline_date: form.baseline_weight_kg ? todayISO() : undefined,
+        baseline_grip_dominant_kg: toNum(form.baseline_grip_dominant_kg),
+        baseline_gait_speed_ms: toNum(form.baseline_gait_speed_ms),
+        baseline_muac_cm: toNum(form.baseline_muac_cm),
+        baseline_calf_cm: toNum(form.baseline_calf_cm),
+        locale: form.locale,
+        managing_oncologist: form.managing_oncologist.trim() || undefined,
+        managing_oncologist_phone:
+          form.managing_oncologist_phone.trim() || undefined,
+        hospital_name: form.hospital_name.trim() || undefined,
+        hospital_phone: form.hospital_phone.trim() || undefined,
+        hospital_address: form.hospital_address.trim() || undefined,
+        oncall_phone: form.oncall_phone.trim() || undefined,
+        emergency_instructions:
+          form.emergency_instructions.trim() || undefined,
+        anthropic_api_key: form.anthropic_api_key.trim() || undefined,
+        onboarded_at: ts,
+        created_at: existingSettings?.[0]?.created_at ?? ts,
+        updated_at: ts,
+      };
+      const existing = existingSettings?.[0];
+      if (existing?.id) {
+        await db.settings.put({ ...payload, id: existing.id });
+      } else {
+        await db.settings.add(payload);
+      }
+      setUILocale(form.locale);
+      setEnteredBy("hulin");
+
+      if (form.start_cycle && form.cycle_start_date) {
+        await db.treatment_cycles.add({
+          protocol_id: form.protocol_id,
+          cycle_number: 1,
+          start_date: form.cycle_start_date,
+          status: "active",
+          dose_level: 0,
+          created_at: ts,
+          updated_at: ts,
+        });
+      }
+      router.replace("/");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-6 p-4 md:p-8">
+      <header className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Anchor className="h-5 w-5 text-[var(--tide-2)]" />
+          <div className="serif text-lg tracking-tight">Anchor</div>
+        </div>
+        <div className="eyebrow">
+          {STEP_LABELS[locale][step]} · {stepIdx + 1}/{STEPS.length}
+        </div>
+        <div className="h-1 w-full overflow-hidden rounded-full bg-ink-100">
+          <div
+            className="h-full bg-ink-900 transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </header>
+
+      {step === "welcome" && <WelcomeStep locale={locale} />}
+      {step === "profile" && (
+        <ProfileStep form={form} update={update} locale={locale} />
+      )}
+      {step === "team" && (
+        <TeamStep form={form} update={update} locale={locale} />
+      )}
+      {step === "baselines" && (
+        <BaselinesStep form={form} update={update} locale={locale} />
+      )}
+      {step === "treatment" && (
+        <TreatmentStep form={form} update={update} locale={locale} />
+      )}
+      {step === "preferences" && (
+        <PreferencesStep form={form} update={update} locale={locale} />
+      )}
+      {step === "done" && <DoneStep form={form} locale={locale} />}
+
+      <div className="flex items-center justify-between pt-2">
+        {step !== "welcome" ? (
+          <Button variant="ghost" onClick={back}>
+            <ChevronLeft className="h-4 w-4" />
+            {locale === "zh" ? "返回" : "Back"}
+          </Button>
+        ) : (
+          <span />
+        )}
+        {step !== "done" ? (
+          <Button
+            onClick={forward}
+            disabled={!canContinue}
+            size="lg"
+          >
+            {step === "welcome"
+              ? locale === "zh"
+                ? "开始"
+                : "Begin"
+              : locale === "zh"
+                ? "继续"
+                : "Continue"}
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        ) : (
+          <Button onClick={finish} disabled={saving} size="lg">
+            <Check className="h-4 w-4" />
+            {saving
+              ? locale === "zh"
+                ? "保存中…"
+                : "Saving…"
+              : locale === "zh"
+                ? "保存并继续"
+                : "Save and continue"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WelcomeStep({ locale }: { locale: Locale }) {
+  return (
+    <Card className="p-6">
+      <div className="serif text-[26px] leading-tight">
+        {locale === "zh"
+          ? "我们一起开始吧"
+          : "Let's set up Anchor together"}
+      </div>
+      <p className="mt-3 text-[14px] leading-relaxed text-ink-700">
+        {locale === "zh"
+          ? "接下来大约需要 5 分钟。我们会问一些基本信息，好让每日记录、警示与给医师的摘要都能与你的情况匹配。"
+          : "This takes about 5 minutes. We'll capture a few essentials so the daily check-in, the zone engine, and the pre-clinic summary all know who you are."}
+      </p>
+      <ul className="mt-4 space-y-2 text-[13px] text-ink-500">
+        {(locale === "zh"
+          ? [
+              "所有数据都留在这台设备上。不上传任何云端。",
+              "随时可以在设置里修改。",
+              "没有任何必填项是硬性的 —— 可以先跳过再补。",
+            ]
+          : [
+              "Everything stays on this device. Nothing is uploaded.",
+              "You can edit anything later in Settings.",
+              "Fields are optional — skip what you don't have yet.",
+            ]
+        ).map((t, i) => (
+          <li key={i} className="flex items-start gap-2">
+            <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-[var(--tide-2)]" />
+            {t}
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}
+
+function ProfileStep({
+  form,
+  update,
+  locale,
+}: {
+  form: FormState;
+  update: <K extends keyof FormState>(k: K, v: FormState[K]) => void;
+  locale: Locale;
+}) {
+  return (
+    <Card className="p-6 space-y-4">
+      <div className="serif text-[22px] leading-tight">
+        {locale === "zh" ? "你的信息" : "About you"}
+      </div>
+      <Field label={locale === "zh" ? "姓名" : "Name"}>
+        <TextInput
+          value={form.profile_name}
+          onChange={(e) => update("profile_name", e.target.value)}
+          placeholder={locale === "zh" ? "例如：胡林" : "e.g. Hu Lin"}
+          autoFocus
+        />
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field label={locale === "zh" ? "出生日期" : "Date of birth"}>
+          <TextInput
+            type="date"
+            value={form.dob}
+            onChange={(e) => update("dob", e.target.value)}
+          />
+        </Field>
+        <Field label={locale === "zh" ? "确诊日期" : "Diagnosis date"}>
+          <TextInput
+            type="date"
+            value={form.diagnosis_date}
+            onChange={(e) => update("diagnosis_date", e.target.value)}
+          />
+        </Field>
+      </div>
+    </Card>
+  );
+}
+
+function TeamStep({
+  form,
+  update,
+  locale,
+}: {
+  form: FormState;
+  update: <K extends keyof FormState>(k: K, v: FormState[K]) => void;
+  locale: Locale;
+}) {
+  return (
+    <Card className="p-6 space-y-4">
+      <div>
+        <div className="serif text-[22px] leading-tight">
+          {locale === "zh" ? "医疗团队" : "Clinical team"}
+        </div>
+        <p className="mt-1 text-xs text-ink-500">
+          {locale === "zh"
+            ? "这些电话会出现在紧急情况下的提示卡上。"
+            : "These numbers appear on the emergency card when a red-zone alert fires."}
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field label={locale === "zh" ? "主诊肿瘤科医师" : "Managing oncologist"}>
+          <TextInput
+            value={form.managing_oncologist}
+            onChange={(e) => update("managing_oncologist", e.target.value)}
+            placeholder="Dr Michael Lee"
+          />
+        </Field>
+        <Field label={locale === "zh" ? "主诊电话" : "Oncologist phone"}>
+          <TextInput
+            type="tel"
+            value={form.managing_oncologist_phone}
+            onChange={(e) =>
+              update("managing_oncologist_phone", e.target.value)
+            }
+            placeholder="+61 …"
+          />
+        </Field>
+        <Field label={locale === "zh" ? "医院 / 中心" : "Hospital / centre"}>
+          <TextInput
+            value={form.hospital_name}
+            onChange={(e) => update("hospital_name", e.target.value)}
+            placeholder="Epworth Richmond"
+          />
+        </Field>
+        <Field label={locale === "zh" ? "医院电话" : "Hospital main line"}>
+          <TextInput
+            type="tel"
+            value={form.hospital_phone}
+            onChange={(e) => update("hospital_phone", e.target.value)}
+          />
+        </Field>
+        <Field
+          label={locale === "zh" ? "24 小时值班电话" : "24/7 on-call"}
+          className="sm:col-span-2"
+        >
+          <TextInput
+            type="tel"
+            value={form.oncall_phone}
+            onChange={(e) => update("oncall_phone", e.target.value)}
+            placeholder={
+              locale === "zh"
+                ? "发热或急症时拨打"
+                : "Ring this for fever or emergency"
+            }
+          />
+        </Field>
+        <Field
+          label={locale === "zh" ? "医院地址" : "Hospital address"}
+          className="sm:col-span-2"
+        >
+          <TextInput
+            value={form.hospital_address}
+            onChange={(e) => update("hospital_address", e.target.value)}
+          />
+        </Field>
+        <Field
+          label={
+            locale === "zh"
+              ? "何时直接去医院（可选）"
+              : "When to go straight to hospital (optional)"
+          }
+          className="sm:col-span-2"
+        >
+          <Textarea
+            rows={3}
+            value={form.emergency_instructions}
+            onChange={(e) =>
+              update("emergency_instructions", e.target.value)
+            }
+            placeholder={
+              locale === "zh"
+                ? "体温 ≥ 38 °C、寒战、持续呕吐…"
+                : "Temp ≥ 38 °C, uncontrolled vomiting, new bleeding…"
+            }
+          />
+        </Field>
+      </div>
+    </Card>
+  );
+}
+
+function BaselinesStep({
+  form,
+  update,
+  locale,
+}: {
+  form: FormState;
+  update: <K extends keyof FormState>(k: K, v: FormState[K]) => void;
+  locale: Locale;
+}) {
+  return (
+    <Card className="p-6 space-y-4">
+      <div>
+        <div className="serif text-[22px] leading-tight">
+          {locale === "zh" ? "基线数据" : "Baselines"}
+        </div>
+        <p className="mt-1 text-xs text-ink-500">
+          {locale === "zh"
+            ? "用于后续的体重、握力、步速等对比。没有测量过的可以先跳过。"
+            : "Used to compare weight / grip / gait over time. Skip any you haven't measured."}
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field label={locale === "zh" ? "身高 (cm)" : "Height (cm)"}>
+          <TextInput
+            type="number"
+            step="0.5"
+            value={form.height_cm}
+            onChange={(e) => update("height_cm", e.target.value)}
+          />
+        </Field>
+        <Field label={locale === "zh" ? "体重 (kg)" : "Weight (kg)"}>
+          <TextInput
+            type="number"
+            step="0.1"
+            value={form.baseline_weight_kg}
+            onChange={(e) => update("baseline_weight_kg", e.target.value)}
+          />
+        </Field>
+        <Field
+          label={
+            locale === "zh"
+              ? "握力 — 惯用手 (kg)"
+              : "Grip — dominant (kg)"
+          }
+        >
+          <TextInput
+            type="number"
+            step="0.5"
+            value={form.baseline_grip_dominant_kg}
+            onChange={(e) =>
+              update("baseline_grip_dominant_kg", e.target.value)
+            }
+          />
+        </Field>
+        <Field
+          label={locale === "zh" ? "4 米步速 (m/s)" : "4 m gait speed (m/s)"}
+        >
+          <TextInput
+            type="number"
+            step="0.05"
+            value={form.baseline_gait_speed_ms}
+            onChange={(e) => update("baseline_gait_speed_ms", e.target.value)}
+          />
+        </Field>
+        <Field
+          label={locale === "zh" ? "上臂围 MUAC (cm)" : "Upper arm (MUAC, cm)"}
+        >
+          <TextInput
+            type="number"
+            step="0.5"
+            value={form.baseline_muac_cm}
+            onChange={(e) => update("baseline_muac_cm", e.target.value)}
+          />
+        </Field>
+        <Field label={locale === "zh" ? "小腿围 (cm)" : "Calf (cm)"}>
+          <TextInput
+            type="number"
+            step="0.5"
+            value={form.baseline_calf_cm}
+            onChange={(e) => update("baseline_calf_cm", e.target.value)}
+          />
+        </Field>
+      </div>
+    </Card>
+  );
+}
+
+function TreatmentStep({
+  form,
+  update,
+  locale,
+}: {
+  form: FormState;
+  update: <K extends keyof FormState>(k: K, v: FormState[K]) => void;
+  locale: Locale;
+}) {
+  const protocol = PROTOCOL_BY_ID[form.protocol_id];
+  return (
+    <Card className="p-6 space-y-4">
+      <div>
+        <div className="serif text-[22px] leading-tight">
+          {locale === "zh" ? "当前化疗" : "Active treatment"}
+        </div>
+        <p className="mt-1 text-xs text-ink-500">
+          {locale === "zh"
+            ? "如果现在在化疗中，选方案和第 1 次用药日期 —— 今日卡片就会显示周期第几天。"
+            : "If chemotherapy is underway, pick the protocol and day-1 date. The Today card and nudges key off this."}
+        </p>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={form.start_cycle}
+          onChange={(e) => update("start_cycle", e.target.checked)}
+          className="h-4 w-4"
+        />
+        {locale === "zh"
+          ? "我当前正在治疗"
+          : "I'm currently on a protocol"}
+      </label>
+
+      {form.start_cycle && (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Field label={locale === "zh" ? "方案" : "Protocol"}>
+            <select
+              value={form.protocol_id}
+              onChange={(e) =>
+                update("protocol_id", e.target.value as ProtocolId)
+              }
+              className="h-11 w-full rounded-[var(--r-md)] border border-ink-200 bg-paper-2 px-3 text-sm"
+            >
+              {PROTOCOL_LIBRARY.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.short_name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label={locale === "zh" ? "第 1 天日期" : "Day-1 date"}>
+            <TextInput
+              type="date"
+              value={form.cycle_start_date}
+              onChange={(e) => update("cycle_start_date", e.target.value)}
+            />
+          </Field>
+          {protocol && (
+            <div className="sm:col-span-2 rounded-[var(--r-md)] bg-[var(--tide-soft)] p-3 text-xs leading-relaxed text-ink-900">
+              <div className="eyebrow mb-1 text-[var(--tide-2)]">
+                {protocol.short_name}
+              </div>
+              {protocol.description[locale]}
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function PreferencesStep({
+  form,
+  update,
+  locale,
+}: {
+  form: FormState;
+  update: <K extends keyof FormState>(k: K, v: FormState[K]) => void;
+  locale: Locale;
+}) {
+  return (
+    <Card className="p-6 space-y-4">
+      <div>
+        <div className="serif text-[22px] leading-tight">
+          {locale === "zh" ? "偏好设置" : "Preferences"}
+        </div>
+      </div>
+
+      <Field label={locale === "zh" ? "语言" : "Language"}>
+        <div className="flex gap-2">
+          {(
+            [
+              ["en", "English"],
+              ["zh", "中文"],
+            ] as const
+          ).map(([v, label]) => {
+            const active = form.locale === v;
+            return (
+              <button
+                key={v}
+                type="button"
+                onClick={() => update("locale", v)}
+                className={cn(
+                  "flex-1 rounded-[var(--r-md)] border px-3 py-2 text-sm font-medium",
+                  active
+                    ? "border-ink-900 bg-ink-900 text-paper"
+                    : "border-ink-200 bg-paper-2 text-ink-700",
+                )}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </Field>
+
+      <Field
+        label={
+          locale === "zh"
+            ? "Anthropic API Key（可选 — 用于 AI 教练和报告解析）"
+            : "Anthropic API key (optional — unlocks the AI coach and report parsing)"
+        }
+        hint={
+          locale === "zh"
+            ? "留空也没关系，本地功能全部可用。之后可以在设置里加。"
+            : "Leave blank and everything local still works. You can add it later in Settings."
+        }
+      >
+        <TextInput
+          type="password"
+          value={form.anthropic_api_key}
+          onChange={(e) => update("anthropic_api_key", e.target.value)}
+          placeholder="sk-ant-..."
+          autoComplete="off"
+        />
+      </Field>
+    </Card>
+  );
+}
+
+function DoneStep({ form, locale }: { form: FormState; locale: Locale }) {
+  const rows: Array<[string, string]> = [
+    [
+      locale === "zh" ? "姓名" : "Name",
+      form.profile_name || (locale === "zh" ? "—" : "—"),
+    ],
+    [
+      locale === "zh" ? "主诊" : "Oncologist",
+      form.managing_oncologist || (locale === "zh" ? "未填" : "Not set"),
+    ],
+    [
+      locale === "zh" ? "医院" : "Hospital",
+      form.hospital_name || (locale === "zh" ? "未填" : "Not set"),
+    ],
+    [
+      locale === "zh" ? "24 小时值班" : "24/7 on-call",
+      form.oncall_phone || (locale === "zh" ? "未填" : "Not set"),
+    ],
+    [
+      locale === "zh" ? "体重基线" : "Weight baseline",
+      form.baseline_weight_kg
+        ? `${form.baseline_weight_kg} kg`
+        : locale === "zh"
+          ? "未填"
+          : "Not set",
+    ],
+    [
+      locale === "zh" ? "方案" : "Protocol",
+      form.start_cycle
+        ? `${form.protocol_id} · ${form.cycle_start_date}`
+        : locale === "zh"
+          ? "暂未开始"
+          : "Not started",
+    ],
+  ];
+
+  return (
+    <Card className="p-6 space-y-4">
+      <div className="serif text-[22px] leading-tight">
+        {locale === "zh" ? "准备好了" : "You're ready"}
+      </div>
+      <p className="text-sm text-ink-500">
+        {locale === "zh"
+          ? "下面是你的设置摘要。按“保存并继续”进入今日页面。"
+          : "Here's what we've captured. Hit save to go to Today."}
+      </p>
+      <CardContent className="p-0">
+        <dl className="divide-y divide-ink-100">
+          {rows.map(([label, value]) => (
+            <div key={label} className="flex items-center justify-between py-2.5">
+              <dt className="text-sm text-ink-500">{label}</dt>
+              <dd className="text-sm font-medium text-ink-900">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { QuickActions } from "~/components/dashboard/quick-actions";
 import { TasksCard } from "~/components/dashboard/tasks-card";
 import { PillarsCard } from "~/components/dashboard/pillars-card";
 import { RecentTrends } from "~/components/dashboard/recent-trends";
+import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { PageHeader, SectionHeader } from "~/components/ui/page-header";
@@ -27,8 +28,15 @@ export default function DashboardPage() {
   const profileName = settings?.[0]?.profile_name;
 
   useEffect(() => {
-    if (role === "clinician") router.replace("/clinician");
-  }, [role, router]);
+    if (role === "clinician") {
+      router.replace("/clinician");
+      return;
+    }
+    // First-run gate: no settings row (or no onboarded_at) → onboarding.
+    if (settings && !settings[0]?.onboarded_at) {
+      router.replace("/onboarding");
+    }
+  }, [role, router, settings]);
 
   const { greeting, eyebrow } = useMemo(() => {
     const now = new Date();
@@ -80,6 +88,8 @@ export default function DashboardPage() {
           </button>
         }
       />
+
+      <EmergencyCard />
 
       <TodayPlanCard />
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -40,6 +40,12 @@ export default function SettingsPage() {
         baseline_calf_cm: current.baseline_calf_cm,
         locale: current.locale,
         managing_oncologist: current.managing_oncologist,
+        managing_oncologist_phone: current.managing_oncologist_phone,
+        hospital_name: current.hospital_name,
+        hospital_phone: current.hospital_phone,
+        hospital_address: current.hospital_address,
+        oncall_phone: current.oncall_phone,
+        emergency_instructions: current.emergency_instructions,
         anthropic_api_key: current.anthropic_api_key,
         default_ai_model: current.default_ai_model,
       });
@@ -79,15 +85,59 @@ export default function SettingsPage() {
           <Field label={t("settings.diagnosis_date")}>
             <input type="date" className={inputCls} {...register("diagnosis_date")} />
           </Field>
-          <Field label={t("settings.managing_oncologist")}>
-            <input className={inputCls} {...register("managing_oncologist")} />
-          </Field>
           <Field label={t("settings.locale")}>
             <select className={inputCls} {...register("locale")}>
               <option value="en">{t("settings.locale_en")}</option>
               <option value="zh">{t("settings.locale_zh")}</option>
             </select>
           </Field>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+            Clinical team & emergency
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label={t("settings.managing_oncologist")}>
+              <input className={inputCls} {...register("managing_oncologist")} />
+            </Field>
+            <Field label="Oncologist phone">
+              <input
+                type="tel"
+                className={inputCls}
+                {...register("managing_oncologist_phone")}
+              />
+            </Field>
+            <Field label="Hospital / centre">
+              <input className={inputCls} {...register("hospital_name")} />
+            </Field>
+            <Field label="Hospital phone">
+              <input
+                type="tel"
+                className={inputCls}
+                {...register("hospital_phone")}
+              />
+            </Field>
+            <Field label="24/7 on-call">
+              <input
+                type="tel"
+                className={inputCls}
+                {...register("oncall_phone")}
+              />
+            </Field>
+            <Field label="Hospital address">
+              <input className={inputCls} {...register("hospital_address")} />
+            </Field>
+            <div className="sm:col-span-2">
+              <Field label="When to go straight to hospital">
+                <textarea
+                  rows={3}
+                  className={inputCls}
+                  {...register("emergency_instructions")}
+                />
+              </Field>
+            </div>
+          </div>
         </section>
 
         <section className="space-y-3">

--- a/src/components/dashboard/emergency-card.tsx
+++ b/src/components/dashboard/emergency-card.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useZoneStatus } from "~/hooks/use-zone-status";
+import { useLocale } from "~/hooks/use-translate";
+import { Phone, AlertOctagon, MapPin } from "lucide-react";
+
+export function EmergencyCard() {
+  const locale = useLocale();
+  const settings = useLiveQuery(() => db.settings.toArray());
+  const s = settings?.[0];
+  const { zone } = useZoneStatus();
+
+  const hasAnyContact =
+    s?.oncall_phone ||
+    s?.managing_oncologist_phone ||
+    s?.hospital_phone;
+
+  if (!hasAnyContact) return null;
+
+  const showExpanded = zone === "red" || zone === "orange";
+
+  return (
+    <section
+      className="rounded-[var(--r-md)] border"
+      style={{
+        background: showExpanded ? "var(--warn-soft)" : "var(--paper-2)",
+        borderColor: showExpanded
+          ? "var(--warn)"
+          : "color-mix(in oklch, var(--ink-900), transparent 92%)",
+      }}
+    >
+      <div className="flex items-center gap-3 px-4 py-3">
+        <div
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
+          style={{
+            background: showExpanded ? "var(--warn)" : "var(--tide-soft)",
+            color: showExpanded ? "white" : "var(--tide-2)",
+          }}
+        >
+          <AlertOctagon className="h-4 w-4" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-[12.5px] font-semibold text-ink-900">
+            {showExpanded
+              ? locale === "zh"
+                ? "警示激活 — 必要时拨打"
+                : "Alert active — call if needed"
+              : locale === "zh"
+                ? "紧急联络人"
+                : "Emergency contacts"}
+          </div>
+          <div className="mono mt-0.5 text-[10px] uppercase tracking-wider text-ink-400">
+            {locale === "zh"
+              ? "体温 ≥ 38 °C → 立即前往医院"
+              : "Temp ≥ 38 °C → hospital now"}
+          </div>
+        </div>
+      </div>
+
+      {showExpanded && (
+        <div className="border-t border-ink-100/70 px-4 py-3 space-y-1.5">
+          {s?.oncall_phone && (
+            <ContactLink
+              icon={Phone}
+              label={locale === "zh" ? "24 小时值班" : "24/7 on-call"}
+              value={s.oncall_phone}
+              href={`tel:${s.oncall_phone.replace(/\s/g, "")}`}
+              tone="warn"
+            />
+          )}
+          {s?.managing_oncologist_phone && (
+            <ContactLink
+              icon={Phone}
+              label={s.managing_oncologist ?? (locale === "zh" ? "主诊" : "Oncologist")}
+              value={s.managing_oncologist_phone}
+              href={`tel:${s.managing_oncologist_phone.replace(/\s/g, "")}`}
+            />
+          )}
+          {s?.hospital_phone && (
+            <ContactLink
+              icon={Phone}
+              label={s.hospital_name ?? (locale === "zh" ? "医院" : "Hospital")}
+              value={s.hospital_phone}
+              href={`tel:${s.hospital_phone.replace(/\s/g, "")}`}
+            />
+          )}
+          {s?.hospital_address && (
+            <ContactLink
+              icon={MapPin}
+              label={locale === "zh" ? "医院地址" : "Hospital address"}
+              value={s.hospital_address}
+              href={`https://maps.google.com/?q=${encodeURIComponent(s.hospital_address)}`}
+            />
+          )}
+          {s?.emergency_instructions && (
+            <p className="mt-2 text-xs leading-relaxed text-ink-700">
+              {s.emergency_instructions}
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ContactLink({
+  icon: Icon,
+  label,
+  value,
+  href,
+  tone,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  href: string;
+  tone?: "warn";
+}) {
+  return (
+    <a
+      href={href}
+      className="flex items-center justify-between gap-3 rounded-[var(--r-sm)] px-2 py-1.5 hover:bg-ink-100/40"
+    >
+      <span className="flex items-center gap-2 text-xs text-ink-500">
+        <Icon className="h-3 w-3" />
+        {label}
+      </span>
+      <span
+        className="mono num text-[12.5px] font-semibold"
+        style={{
+          color: tone === "warn" ? "var(--warn)" : "var(--ink-900)",
+        }}
+      >
+        {value}
+      </span>
+    </a>
+  );
+}

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -2,15 +2,9 @@ import { db, now } from "./dexie";
 import trialWatchlist from "~/config/trial-watchlist.json";
 
 export async function ensureSeeded(): Promise<void> {
-  const settingsCount = await db.settings.count();
-  if (settingsCount === 0) {
-    await db.settings.add({
-      profile_name: "Hu Lin",
-      locale: "en",
-      created_at: now(),
-      updated_at: now(),
-    });
-  }
+  // Settings row is created by the onboarding wizard on first run.
+  // We don't auto-seed a placeholder — "no settings row (or onboarded_at
+  // missing)" is what triggers the onboarding gate on the dashboard.
 
   const trialsCount = await db.trials.count();
   if (trialsCount === 0) {

--- a/src/lib/validators/schemas.ts
+++ b/src/lib/validators/schemas.ts
@@ -55,6 +55,13 @@ export const settingsSchema = z.object({
   baseline_calf_cm: z.number().min(20).max(60).optional(),
   locale: z.enum(["en", "zh"]),
   managing_oncologist: z.string().optional(),
+  managing_oncologist_phone: z.string().optional(),
+  hospital_name: z.string().optional(),
+  hospital_phone: z.string().optional(),
+  hospital_address: z.string().optional(),
+  oncall_phone: z.string().optional(),
+  emergency_instructions: z.string().optional(),
+  onboarded_at: z.string().optional(),
   anthropic_api_key: z.string().optional(),
   default_ai_model: z.string().optional(),
 });

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -283,6 +283,13 @@ export interface Settings {
   height_cm?: number;
   locale: Locale;
   managing_oncologist?: string;
+  managing_oncologist_phone?: string;
+  hospital_name?: string;
+  hospital_phone?: string;
+  hospital_address?: string;
+  oncall_phone?: string;
+  emergency_instructions?: string;
+  onboarded_at?: string;
   anthropic_api_key?: string;
   default_ai_model?: string;
   created_at: string;


### PR DESCRIPTION
Ship-gate item **1 of 6** from the review: first-run onboarding + emergency info surface.

## What this does

**`/onboarding` wizard** (6 steps, all styled with the new design tokens):
1. Welcome — explains what we're about to capture
2. Profile — name, DOB, diagnosis date
3. Clinical team — oncologist + phone, hospital + phone + address, 24/7 on-call, free-text "when to go straight to hospital"
4. Baselines — height, weight, grip, gait, MUAC, calf (all skippable)
5. Treatment — optional active protocol + day-1 date → creates a `treatment_cycles` row so the Today card and nudges work immediately
6. Preferences — locale, optional Anthropic API key
7. Summary + "Save and continue" → redirects to `/`

Prefills from any partial Settings row so repeat visits don't blank fields out.

**Dashboard gate** — `src/app/page.tsx` now redirects to `/onboarding` whenever `settings[0]?.onboarded_at` is undefined. Previous placeholder seed in `src/lib/db/seed.ts` is removed so "no settings row" unambiguously signals "needs onboarding".

**Emergency info card** on the dashboard:
- Compact one-line bar with the "temp ≥ 38 °C → hospital now" reminder
- Expands automatically when the zone engine enters orange or red — surfaces tappable `tel:` links for on-call, oncologist, hospital, plus a Google Maps link for the address and any free-text instructions the user entered
- Hidden entirely if no contact field is set (so doesn't clutter an empty install)

**Settings parity** — new "Clinical team & emergency" section in `/settings` with every onboarding field exposed so Dad can update later.

## Data model

Added to `Settings`: `managing_oncologist_phone`, `hospital_name`, `hospital_phone`, `hospital_address`, `oncall_phone`, `emergency_instructions`, `onboarded_at`. All optional — existing data keeps validating.

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 83/83 passing
- [x] `pnpm build` — 32 routes green (+ `/onboarding`)

## Test plan

- [ ] Vercel preview loads; first visit redirects to `/onboarding`
- [ ] Walk through all six steps end to end; verify Settings row writes + a `treatment_cycles` row when "I'm currently on a protocol" is ticked
- [ ] Force a red zone (log a fever on `/daily/new`) → emergency card expands and the on-call number is tappable
- [ ] Visit `/settings` → fields round-trip correctly, update persists

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH