### PR TITLE
Bulk ingest + camera capture + meal/notes vision + floating +

### DIFF
--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { format } from "date-fns";
+import { db, now } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { CameraCapture } from "~/components/ingest/camera-capture";
+import {
+  prepareImageForVision,
+  type PreparedImage,
+} from "~/lib/ingest/image";
+import {
+  estimateMeal,
+  type MealEstimate,
+} from "~/lib/ingest/meal-vision";
+import { todayISO } from "~/lib/utils/date";
+import { Sparkles, Check, Loader2, AlertCircle } from "lucide-react";
+
+export default function MealIngestPage() {
+  const locale = useLocale();
+  const settings = useLiveQuery(() => db.settings.toArray());
+  const apiKey = settings?.[0]?.anthropic_api_key;
+  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+
+  const [prepared, setPrepared] = useState<PreparedImage | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [estimate, setEstimate] = useState<MealEstimate | null>(null);
+  const [busy, setBusy] = useState<"prepare" | "estimate" | "save" | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  async function onPhoto(file: File) {
+    reset();
+    setBusy("prepare");
+    try {
+      const p = await prepareImageForVision(file, { maxEdge: 1400 });
+      setPrepared(p);
+      const blob = new Blob([Uint8Array.from(atob(p.base64), (c) => c.charCodeAt(0))]);
+      setPreview(URL.createObjectURL(blob));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function runEstimate() {
+    if (!prepared || !apiKey) return;
+    setBusy("estimate");
+    setError(null);
+    try {
+      const result = await estimateMeal({ apiKey, model, image: prepared });
+      setEstimate(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function saveToToday() {
+    if (!estimate) return;
+    setBusy("save");
+    try {
+      const today = todayISO();
+      const existing = await db.daily_entries
+        .where("date")
+        .equals(today)
+        .first();
+      const ts = now();
+      const proteinAdd = Math.round(estimate.protein_g);
+      if (existing?.id) {
+        await db.daily_entries.update(existing.id, {
+          protein_grams: (existing.protein_grams ?? 0) + proteinAdd,
+          meals_count: (existing.meals_count ?? 0) + 1,
+          updated_at: ts,
+        });
+      } else {
+        await db.daily_entries.add({
+          date: today,
+          entered_at: ts,
+          entered_by: "hulin",
+          energy: 5,
+          sleep_quality: 5,
+          appetite: 5,
+          pain_worst: 0,
+          pain_current: 0,
+          mood_clarity: 5,
+          nausea: 0,
+          practice_morning_completed: false,
+          practice_evening_completed: false,
+          cold_dysaesthesia: false,
+          neuropathy_hands: false,
+          neuropathy_feet: false,
+          mouth_sores: false,
+          diarrhoea_count: 0,
+          new_bruising: false,
+          dyspnoea: false,
+          fever: false,
+          protein_grams: proteinAdd,
+          meals_count: 1,
+          created_at: ts,
+          updated_at: ts,
+        });
+      }
+      reset();
+      alert(
+        locale === "zh"
+          ? `已加入 ${proteinAdd} g 蛋白到今日记录`
+          : `Added ${proteinAdd} g protein to today's log`,
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  function reset() {
+    setPrepared(null);
+    setPreview(null);
+    setEstimate(null);
+    setError(null);
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "餐食识别" : "Meal photo"}
+        title={locale === "zh" ? "拍一张餐食" : "Snap a meal"}
+        subtitle={
+          locale === "zh"
+            ? "Claude 视觉估算蛋白、碳水、脂肪与胰酶建议。"
+            : "Claude Vision estimates protein / carbs / fat and a PERT suggestion."
+        }
+      />
+
+      {!apiKey && (
+        <Card>
+          <CardContent className="flex items-start gap-3 pt-5 text-sm">
+            <AlertCircle
+              className="mt-0.5 h-4 w-4 shrink-0"
+              style={{ color: "var(--warn)" }}
+            />
+            <div>
+              <div className="font-semibold text-ink-900">
+                {locale === "zh"
+                  ? "需要 Anthropic API Key"
+                  : "Claude API key required"}
+              </div>
+              <div className="mt-0.5 text-ink-500">
+                {locale === "zh"
+                  ? "餐食视觉分析使用 Claude Vision。在设置中添加你的密钥。"
+                  : "This flow uses Claude Vision. Add your key in Settings."}
+              </div>
+              <Link
+                href="/settings"
+                className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-[var(--tide-2)]"
+              >
+                {locale === "zh" ? "打开设置" : "Open Settings"} →
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardContent className="space-y-4 pt-5">
+          {!prepared && (
+            <div className="space-y-3">
+              <CameraCapture
+                onPhoto={onPhoto}
+                label={locale === "zh" ? "拍一张餐食" : "Take photo of meal"}
+              />
+              <p className="text-xs text-ink-500">
+                {locale === "zh"
+                  ? "或从相册中选一张。照片会在设备上压缩到 1400 px 以内再发送。"
+                  : "Or pick from your camera roll. Image resizes to 1400 px on-device before sending."}
+              </p>
+            </div>
+          )}
+
+          {preview && (
+            <div className="overflow-hidden rounded-[var(--r-md)] border border-ink-100">
+              <img
+                src={preview}
+                alt="meal"
+                className="max-h-[320px] w-full object-cover"
+              />
+            </div>
+          )}
+
+          {busy === "prepare" && (
+            <Status
+              icon={Loader2}
+              text={locale === "zh" ? "准备图片" : "Preparing image"}
+            />
+          )}
+
+          {prepared && !estimate && busy !== "estimate" && (
+            <Button onClick={runEstimate} disabled={!apiKey}>
+              <Sparkles className="h-4 w-4" />
+              {locale === "zh" ? "让 Claude 估算" : "Estimate with Claude"}
+            </Button>
+          )}
+
+          {busy === "estimate" && (
+            <Status
+              icon={Loader2}
+              text={locale === "zh" ? "分析中" : "Analysing"}
+            />
+          )}
+
+          {estimate && (
+            <MealResult
+              estimate={estimate}
+              locale={locale}
+              onSave={() => void saveToToday()}
+              onDiscard={reset}
+              saving={busy === "save"}
+            />
+          )}
+
+          {error && (
+            <div className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2 text-xs text-ink-900">
+              {error}
+            </div>
+          )}
+
+          <div className="flex items-center gap-1 text-[10.5px] uppercase tracking-wider text-ink-400">
+            {format(new Date(), "EEE d MMM yyyy")}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Status({
+  icon: Icon,
+  text,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  text: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-sm text-ink-500">
+      <Icon className="h-4 w-4 animate-spin" />
+      {text}
+    </div>
+  );
+}
+
+function MealResult({
+  estimate,
+  locale,
+  onSave,
+  onDiscard,
+  saving,
+}: {
+  estimate: MealEstimate;
+  locale: "en" | "zh";
+  onSave: () => void;
+  onDiscard: () => void;
+  saving: boolean;
+}) {
+  const confidenceLabel: Record<MealEstimate["confidence"], { en: string; zh: string }> = {
+    low: { en: "low confidence", zh: "置信度低" },
+    medium: { en: "medium confidence", zh: "置信度中" },
+    high: { en: "high confidence", zh: "置信度高" },
+  };
+  return (
+    <div className="space-y-3 rounded-[var(--r-md)] bg-[var(--paper)] p-3.5">
+      <div>
+        <div className="serif text-lg leading-tight text-ink-900">
+          {estimate.description}
+        </div>
+        <div
+          className="mono mt-1 text-[10px] uppercase tracking-wider"
+          style={{
+            color:
+              estimate.confidence === "high"
+                ? "var(--ok)"
+                : estimate.confidence === "low"
+                  ? "var(--warn)"
+                  : "var(--ink-500)",
+          }}
+        >
+          {confidenceLabel[estimate.confidence][locale]}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-4 gap-2">
+        <Stat
+          label={locale === "zh" ? "蛋白" : "Protein"}
+          value={`${Math.round(estimate.protein_g)} g`}
+          tint="tide"
+        />
+        <Stat
+          label={locale === "zh" ? "碳水" : "Carbs"}
+          value={`${Math.round(estimate.carbs_g)} g`}
+        />
+        <Stat
+          label={locale === "zh" ? "脂肪" : "Fat"}
+          value={`${Math.round(estimate.fat_g)} g`}
+        />
+        <Stat
+          label={locale === "zh" ? "热量" : "kcal"}
+          value={`${Math.round(estimate.calories)}`}
+        />
+      </div>
+
+      {estimate.pert_suggestion && (
+        <div className="rounded-md bg-[var(--tide-soft)] px-3 py-2 text-xs text-ink-900">
+          <span className="mono mr-1 text-[10px] uppercase tracking-wider text-[var(--tide-2)]">
+            PERT
+          </span>
+          {estimate.pert_suggestion}
+        </div>
+      )}
+
+      {estimate.notes && (
+        <div className="text-[11.5px] text-ink-500">{estimate.notes}</div>
+      )}
+
+      <div className="flex items-center gap-2 pt-1">
+        <Button onClick={onSave} disabled={saving}>
+          <Check className="h-4 w-4" />
+          {saving
+            ? locale === "zh"
+              ? "保存中…"
+              : "Saving…"
+            : locale === "zh"
+              ? "加到今日"
+              : "Add to today"}
+        </Button>
+        <Button variant="ghost" onClick={onDiscard}>
+          {locale === "zh" ? "再拍一张" : "Try another"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tint,
+}: {
+  label: string;
+  value: string;
+  tint?: "tide";
+}) {
+  return (
+    <div
+      className="rounded-md border border-ink-100/80 bg-paper-2 p-2 text-center"
+      style={tint === "tide" ? { borderColor: "var(--tide-2)" } : undefined}
+    >
+      <div className="mono text-[9.5px] uppercase tracking-wider text-ink-400">
+        {label}
+      </div>
+      <div className="serif num mt-0.5 text-lg leading-none text-ink-900">
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/app/ingest/notes/page.tsx
+++ b/src/app/ingest/notes/page.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, now } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { CameraCapture } from "~/components/ingest/camera-capture";
+import {
+  prepareImageForVision,
+  type PreparedImage,
+} from "~/lib/ingest/image";
+import {
+  structureNotes,
+  type NotesStructure,
+} from "~/lib/ingest/notes-vision";
+import { todayISO } from "~/lib/utils/date";
+import { Sparkles, Check, Loader2, AlertCircle } from "lucide-react";
+
+type DailyPatch = NonNullable<NotesStructure["daily_patch"]>;
+
+export default function NotesIngestPage() {
+  const locale = useLocale();
+  const settings = useLiveQuery(() => db.settings.toArray());
+  const apiKey = settings?.[0]?.anthropic_api_key;
+  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+
+  const [prepared, setPrepared] = useState<PreparedImage | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [structured, setStructured] = useState<NotesStructure | null>(null);
+  const [busy, setBusy] = useState<"prepare" | "structure" | "save" | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  async function onPhoto(file: File) {
+    reset();
+    setBusy("prepare");
+    try {
+      const p = await prepareImageForVision(file, { maxEdge: 1800 });
+      setPrepared(p);
+      const blob = new Blob([Uint8Array.from(atob(p.base64), (c) => c.charCodeAt(0))]);
+      setPreview(URL.createObjectURL(blob));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function runStructure() {
+    if (!prepared || !apiKey) return;
+    setBusy("structure");
+    setError(null);
+    try {
+      const result = await structureNotes({ apiKey, model, image: prepared });
+      setStructured(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function applyToToday() {
+    if (!structured) return;
+    setBusy("save");
+    try {
+      const today = todayISO();
+      const patch = strip(structured.daily_patch);
+      const existing = await db.daily_entries
+        .where("date")
+        .equals(today)
+        .first();
+      const ts = now();
+      if (existing?.id) {
+        await db.daily_entries.update(existing.id, {
+          ...patch,
+          updated_at: ts,
+        });
+      } else {
+        await db.daily_entries.add({
+          date: today,
+          entered_at: ts,
+          entered_by: "hulin",
+          energy: 5,
+          sleep_quality: 5,
+          appetite: 5,
+          pain_worst: 0,
+          pain_current: 0,
+          mood_clarity: 5,
+          nausea: 0,
+          practice_morning_completed: false,
+          practice_evening_completed: false,
+          cold_dysaesthesia: false,
+          neuropathy_hands: false,
+          neuropathy_feet: false,
+          mouth_sores: false,
+          diarrhoea_count: 0,
+          new_bruising: false,
+          dyspnoea: false,
+          fever: false,
+          ...patch,
+          created_at: ts,
+          updated_at: ts,
+        });
+      }
+      reset();
+      alert(
+        locale === "zh"
+          ? "已合并到今日记录"
+          : "Merged into today's daily entry",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  function reset() {
+    setPrepared(null);
+    setPreview(null);
+    setStructured(null);
+    setError(null);
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "手写笔记" : "Handwritten notes"}
+        title={
+          locale === "zh" ? "笔记转成今日日志" : "Turn notes into today's log"
+        }
+        subtitle={
+          locale === "zh"
+            ? "拍一张手写页，Claude 先原样转录再映射到日志字段。"
+            : "Snap a page; Claude transcribes verbatim, then maps to daily-log fields."
+        }
+      />
+
+      {!apiKey && (
+        <Card>
+          <CardContent className="flex items-start gap-3 pt-5 text-sm">
+            <AlertCircle
+              className="mt-0.5 h-4 w-4 shrink-0"
+              style={{ color: "var(--warn)" }}
+            />
+            <div>
+              <div className="font-semibold text-ink-900">
+                {locale === "zh"
+                  ? "需要 Anthropic API Key"
+                  : "Claude API key required"}
+              </div>
+              <div className="mt-0.5 text-ink-500">
+                {locale === "zh"
+                  ? "手写识别使用 Claude Vision。在设置中添加你的密钥。"
+                  : "This flow uses Claude Vision. Add your key in Settings."}
+              </div>
+              <Link
+                href="/settings"
+                className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-[var(--tide-2)]"
+              >
+                {locale === "zh" ? "打开设置" : "Open Settings"} →
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardContent className="space-y-4 pt-5">
+          {!prepared && (
+            <div className="space-y-3">
+              <CameraCapture
+                onPhoto={onPhoto}
+                label={locale === "zh" ? "拍一张笔记" : "Take photo of note"}
+              />
+              <p className="text-xs text-ink-500">
+                {locale === "zh"
+                  ? "光线充足、对焦清晰即可。整页或一页的一部分都行。"
+                  : "Well-lit and in focus works best. Whole page or part is fine."}
+              </p>
+            </div>
+          )}
+
+          {preview && (
+            <div className="overflow-hidden rounded-[var(--r-md)] border border-ink-100">
+              <img
+                src={preview}
+                alt="note"
+                className="max-h-[360px] w-full object-cover"
+              />
+            </div>
+          )}
+
+          {busy === "prepare" && (
+            <Status
+              icon={Loader2}
+              text={locale === "zh" ? "准备图片" : "Preparing image"}
+            />
+          )}
+
+          {prepared && !structured && busy !== "structure" && (
+            <Button onClick={runStructure} disabled={!apiKey}>
+              <Sparkles className="h-4 w-4" />
+              {locale === "zh" ? "让 Claude 识别" : "Read with Claude"}
+            </Button>
+          )}
+
+          {busy === "structure" && (
+            <Status
+              icon={Loader2}
+              text={locale === "zh" ? "识别中" : "Reading"}
+            />
+          )}
+
+          {structured && (
+            <NotesResult
+              structured={structured}
+              locale={locale}
+              onSave={() => void applyToToday()}
+              onDiscard={reset}
+              saving={busy === "save"}
+            />
+          )}
+
+          {error && (
+            <div className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2 text-xs text-ink-900">
+              {error}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Status({
+  icon: Icon,
+  text,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  text: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-sm text-ink-500">
+      <Icon className="h-4 w-4 animate-spin" />
+      {text}
+    </div>
+  );
+}
+
+function NotesResult({
+  structured,
+  locale,
+  onSave,
+  onDiscard,
+  saving,
+}: {
+  structured: NotesStructure;
+  locale: "en" | "zh";
+  onSave: () => void;
+  onDiscard: () => void;
+  saving: boolean;
+}) {
+  const patch = strip(structured.daily_patch);
+  const patchEntries = Object.entries(patch).filter(
+    ([, v]) => v !== undefined && v !== null && v !== "",
+  );
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="eyebrow mb-1">
+          {locale === "zh" ? "原文转录" : "Transcription"}
+          <span className="ml-2 text-[9.5px] text-ink-400">
+            · {structured.confidence}
+          </span>
+        </div>
+        <div className="rounded-md bg-[var(--paper)] p-3 text-sm leading-relaxed text-ink-900 whitespace-pre-line">
+          {structured.transcription}
+        </div>
+      </div>
+
+      <div>
+        <div className="eyebrow mb-1">
+          {locale === "zh" ? "结构化字段" : "Structured fields"}
+        </div>
+        {patchEntries.length === 0 ? (
+          <p className="text-xs text-ink-500">
+            {locale === "zh"
+              ? "没有映射到标准字段 —— 只保存转录到反思。"
+              : "No fields mapped — reflection stays as free text."}
+          </p>
+        ) : (
+          <ul className="divide-y divide-ink-100/80 rounded-md border border-ink-100/80 bg-paper-2">
+            {patchEntries.map(([k, v]) => (
+              <li
+                key={k}
+                className="flex items-center justify-between px-3 py-2 text-sm"
+              >
+                <span className="mono text-[10.5px] uppercase tracking-wider text-ink-500">
+                  {k}
+                </span>
+                <span className="num font-semibold text-ink-900">
+                  {String(v)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {structured.ambiguities && structured.ambiguities.length > 0 && (
+        <div className="rounded-md bg-[var(--sand)]/40 px-3 py-2 text-[11.5px] text-ink-900">
+          <span className="mono mr-2 text-[9.5px] uppercase tracking-wider">
+            {locale === "zh" ? "不确定之处" : "Unclear"}
+          </span>
+          {structured.ambiguities.join(" · ")}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 pt-1">
+        <Button onClick={onSave} disabled={saving}>
+          <Check className="h-4 w-4" />
+          {saving
+            ? locale === "zh"
+              ? "保存中…"
+              : "Saving…"
+            : locale === "zh"
+              ? "合并到今日"
+              : "Merge into today"}
+        </Button>
+        <Button variant="ghost" onClick={onDiscard}>
+          {locale === "zh" ? "再试一张" : "Try another"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function strip(patch: DailyPatch): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === null || v === undefined) continue;
+    out[k] = v;
+  }
+  return out;
+}

--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -1,386 +1,289 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import Link from "next/link";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db, now } from "~/lib/db/dexie";
+import { db } from "~/lib/db/dexie";
+import { useLocale, useT } from "~/hooks/use-translate";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
-import { UploadZone } from "~/components/ingest/upload-zone";
-import { useLocale, useT } from "~/hooks/use-translate";
-import { ocrFile } from "~/lib/ingest/ocr";
-import { parseHeuristic } from "~/lib/ingest/heuristic-parser";
-import { extractWithClaude } from "~/lib/ingest/claude-parser";
+import { CameraCapture } from "~/components/ingest/camera-capture";
+import { BulkQueue } from "~/components/ingest/bulk-queue";
 import {
-  fromClaude,
-  fromHeuristic,
-  saveExtraction,
-  type UnifiedExtraction,
-} from "~/lib/ingest/save";
-import type { IngestedDocument } from "~/types/clinical";
-import { Sparkles, ScanText, Loader2, Check } from "lucide-react";
-import Link from "next/link";
+  parseBulkItem,
+  processBulkItemOcr,
+  saveBulkItem,
+  type BulkItem,
+} from "~/lib/ingest/bulk";
+import { Upload, Utensils, NotebookPen, ChevronRight } from "lucide-react";
 
-type Phase =
-  | "idle"
-  | "ocr"
-  | "ocr_done"
-  | "structuring"
-  | "structured"
-  | "saving"
-  | "saved"
-  | "error";
+function newId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
 
 export default function IngestPage() {
   const t = useT();
   const locale = useLocale();
   const settings = useLiveQuery(() => db.settings.toArray());
   const apiKey = settings?.[0]?.anthropic_api_key;
-  const docs = useLiveQuery(() =>
-    db.ingested_documents.orderBy("uploaded_at").reverse().limit(15).toArray(),
+  const apiKeyConfigured = !!apiKey;
+
+  const [items, setItems] = useState<BulkItem[]>([]);
+  const itemsRef = useRef<BulkItem[]>([]);
+  itemsRef.current = items;
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const mutate = useCallback((id: string, patch: Partial<BulkItem>) => {
+    setItems((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, ...patch } : i)),
+    );
+    itemsRef.current = itemsRef.current.map((i) =>
+      i.id === id ? { ...i, ...patch } : i,
+    );
+  }, []);
+
+  async function enqueueFiles(files: FileList | File[] | null) {
+    if (!files) return;
+    const arr = Array.from(files);
+    if (arr.length === 0) return;
+    const newItems: BulkItem[] = arr.map((f) => ({
+      id: newId(),
+      file: f,
+      status: "queued",
+    }));
+    setItems((prev) => [...prev, ...newItems]);
+    itemsRef.current = [...itemsRef.current, ...newItems];
+
+    // Process OCR one at a time to avoid memory pressure from tesseract
+    for (const item of newItems) {
+      await processBulkItemOcr(item, mutate);
+      // auto-run heuristic parser so user sees a result quickly
+      const latest =
+        itemsRef.current.find((i) => i.id === item.id) ?? item;
+      if (latest.status === "parsing") {
+        await parseBulkItem(latest, "heuristic", apiKey, mutate);
+      }
+    }
+  }
+
+  async function reparseItem(id: string, method: "heuristic" | "claude") {
+    const item = itemsRef.current.find((i) => i.id === id);
+    if (!item) return;
+    await parseBulkItem(item, method, apiKey, mutate);
+  }
+
+  async function saveItem(id: string) {
+    const item = itemsRef.current.find((i) => i.id === id);
+    if (!item) return;
+    await saveBulkItem(item, mutate);
+  }
+
+  async function saveAll() {
+    const ready = itemsRef.current.filter((i) => i.status === "ready");
+    for (const item of ready) {
+      await saveBulkItem(item, mutate);
+    }
+  }
+
+  function discardItem(id: string) {
+    setItems((prev) => prev.filter((i) => i.id !== id));
+    itemsRef.current = itemsRef.current.filter((i) => i.id !== id);
+  }
+
+  function clearAll() {
+    setItems([]);
+    itemsRef.current = [];
+  }
+
+  const recent = useLiveQuery(() =>
+    db.ingested_documents.orderBy("uploaded_at").reverse().limit(8).toArray(),
   );
 
-  const [file, setFile] = useState<File | null>(null);
-  const [phase, setPhase] = useState<Phase>("idle");
-  const [progress, setProgress] = useState<string>("");
-  const [ocrText, setOcrText] = useState<string>("");
-  const [ocrConfidence, setOcrConfidence] = useState<number | null>(null);
-  const [docId, setDocId] = useState<number | null>(null);
-  const [extraction, setExtraction] = useState<UnifiedExtraction | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  function reset() {
-    setFile(null);
-    setPhase("idle");
-    setProgress("");
-    setOcrText("");
-    setOcrConfidence(null);
-    setDocId(null);
-    setExtraction(null);
-    setError(null);
-  }
-
-  async function handleFile(f: File) {
-    reset();
-    setFile(f);
-    setPhase("ocr");
-    setError(null);
-
-    const newDoc: IngestedDocument = {
-      filename: f.name,
-      mime_type: f.type || "application/octet-stream",
-      size_bytes: f.size,
-      kind: "other",
-      uploaded_at: now(),
-      status: "ocr_pending",
-      created_at: now(),
-      updated_at: now(),
-    };
-    const newId = (await db.ingested_documents.add(newDoc)) as number;
-    setDocId(newId);
-
-    try {
-      const r = await ocrFile(f, (phase, p) => {
-        setProgress(`${phase} — ${Math.round((p ?? 0) * 100)}%`);
-      });
-      setOcrText(r.text);
-      setOcrConfidence(r.confidence);
-      await db.ingested_documents.update(newId, {
-        ocr_text: r.text,
-        ocr_confidence: r.confidence,
-        status: "ocr_complete",
-        updated_at: now(),
-      });
-      setPhase("ocr_done");
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      setError(msg);
-      setPhase("error");
-      await db.ingested_documents.update(newId, {
-        status: "error",
-        error_message: msg,
-        updated_at: now(),
-      });
-    }
-  }
-
-  async function runHeuristic() {
-    if (!ocrText) return;
-    setPhase("structuring");
-    const parsed = parseHeuristic(ocrText);
-    const unified = fromHeuristic(parsed);
-    setExtraction(unified);
-    if (docId) {
-      await db.ingested_documents.update(docId, {
-        extraction_method: "heuristic",
-        kind: unified.kind,
-        status: "extracted",
-        updated_at: now(),
-      });
-    }
-    setPhase("structured");
-  }
-
-  async function runClaude() {
-    if (!ocrText || !apiKey) return;
-    setPhase("structuring");
-    setError(null);
-    try {
-      const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
-      const claude = await extractWithClaude({ apiKey, text: ocrText, model });
-      const unified = fromClaude(claude);
-      setExtraction(unified);
-      if (docId) {
-        await db.ingested_documents.update(docId, {
-          extraction_method: "claude",
-          extraction_model: model,
-          kind: unified.kind,
-          status: "extracted",
-          updated_at: now(),
-        });
-      }
-      setPhase("structured");
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      setError(msg);
-      setPhase("ocr_done");
-    }
-  }
-
-  async function confirmSave() {
-    if (!extraction || !docId) return;
-    setPhase("saving");
-    const doc = await db.ingested_documents.get(docId);
-    if (!doc) return;
-    await saveExtraction(doc, extraction);
-    setPhase("saved");
-  }
-
   return (
-    <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-8">
+    <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-8">
       <PageHeader
-        title={locale === "zh" ? "报告导入" : "Ingest reports"}
+        eyebrow={locale === "zh" ? "导入" : "Ingest"}
+        title={locale === "zh" ? "报告、照片、手写笔记" : "Reports, photos, handwritten notes"}
         subtitle={
           locale === "zh"
-            ? "OCR 在本机进行。结构化可选择本地规则或你的 Claude API Key。"
-            : "OCR runs on your device. Structuring uses local rules or your own Claude API key — never our servers."
+            ? "本机 OCR，可选 Claude 结构化。一次拖入多个文件。"
+            : "On-device OCR. Optional Claude structuring. Drop several files at once."
         }
         action={
           <Link href="/ingest/pending">
-            <Button variant="secondary">
+            <Button variant="secondary" size="sm">
               {locale === "zh" ? "待出结果" : "Pending results"}
             </Button>
           </Link>
         }
       />
 
-      {phase === "idle" && <UploadZone onFile={handleFile} />}
-
-      {phase !== "idle" && file && (
-        <Card>
-          <CardHeader>
-            <CardTitle>{file.name}</CardTitle>
-            <div className="mt-1 text-xs text-slate-500">
-              {formatBytes(file.size)} · {file.type || "unknown"}
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {(phase === "ocr") && (
-              <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {locale === "zh" ? "本机 OCR 中" : "Running OCR on device"} — {progress}
-              </div>
-            )}
-
-            {phase === "error" && error && (
-              <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200">
-                {error}
-              </div>
-            )}
-
-            {ocrText && (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                    {locale === "zh" ? "OCR 输出（可编辑）" : "OCR output (editable)"}
-                    {ocrConfidence != null && (
-                      <span className="ml-2 text-slate-400">
-                        · {Math.round(ocrConfidence)}%
-                      </span>
-                    )}
-                  </span>
-                </div>
-                <textarea
-                  className="h-48 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 font-mono text-xs focus:border-slate-900 focus:outline-none dark:border-slate-700 dark:bg-slate-900"
-                  value={ocrText}
-                  onChange={(e) => setOcrText(e.target.value)}
-                />
-              </div>
-            )}
-
-            {(phase === "ocr_done" || phase === "structured" || phase === "structuring") && (
-              <div className="flex flex-wrap items-center gap-2">
-                <Button
-                  onClick={runHeuristic}
-                  disabled={phase === "structuring"}
-                  variant="secondary"
-                >
-                  <ScanText className="h-4 w-4" />
-                  {locale === "zh" ? "本地规则解析" : "Parse with local rules"}
-                </Button>
-                <Button
-                  onClick={runClaude}
-                  disabled={!apiKey || phase === "structuring"}
-                >
-                  <Sparkles className="h-4 w-4" />
-                  {locale === "zh" ? "用 Claude 解析" : "Parse with Claude"}
-                </Button>
-                {!apiKey && (
-                  <Link
-                    href="/settings"
-                    className="text-xs text-slate-500 underline"
-                  >
-                    {locale === "zh"
-                      ? "在设置里填 API Key 解锁"
-                      : "Add your API key in Settings to enable"}
-                  </Link>
-                )}
-              </div>
-            )}
-
-            {phase === "structuring" && (
-              <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {locale === "zh" ? "结构化中" : "Structuring"}
-              </div>
-            )}
-
-            {extraction && (
-              <div className="space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-900/60">
-                <div className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                  {locale === "zh" ? "即将保存" : "Ready to save"}
-                </div>
-                <ExtractionPreview extraction={extraction} />
-                {phase === "structured" && (
-                  <div className="flex items-center gap-2 pt-1">
-                    <Button onClick={confirmSave}>
-                      <Check className="h-4 w-4" />
-                      {locale === "zh" ? "确认并保存" : "Save to Anchor"}
-                    </Button>
-                    <Button variant="ghost" onClick={reset}>
-                      {locale === "zh" ? "丢弃" : "Discard"}
-                    </Button>
-                  </div>
-                )}
-              </div>
-            )}
-
-            {phase === "saved" && (
-              <div className="rounded-lg border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200">
+      <Card>
+        <CardContent className="space-y-4 pt-5">
+          <div className="flex flex-wrap items-center gap-2">
+            <CameraCapture
+              onPhoto={(f) => void enqueueFiles([f])}
+              label={
+                locale === "zh" ? "拍一张报告照片" : "Snap a report photo"
+              }
+            />
+            <Button
+              variant="secondary"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload className="h-4 w-4" />
+              {locale === "zh" ? "选择多份文件" : "Choose files"}
+            </Button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              multiple
+              accept="image/*,application/pdf"
+              onChange={(e) => {
+                void enqueueFiles(e.target.files);
+                e.target.value = "";
+              }}
+            />
+            {!apiKeyConfigured && (
+              <span className="mono text-[10px] uppercase tracking-wider text-ink-400">
                 {locale === "zh"
-                  ? "已保存到 Anchor。新值会进入趋势和规则引擎。"
-                  : "Saved to Anchor. New values flow into trends and the rule engine."}
-                <div className="mt-2">
-                  <Button onClick={reset} size="sm">
-                    {locale === "zh" ? "继续" : "Ingest another"}
-                  </Button>
-                </div>
-              </div>
+                  ? "· 未配置 Claude 密钥，使用本地规则解析"
+                  : "· No Claude key — local rules only"}
+              </span>
             )}
-          </CardContent>
-        </Card>
-      )}
+          </div>
 
-      {docs && docs.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>
-              {locale === "zh" ? "最近导入" : "Recent ingestions"}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="divide-y divide-slate-200 dark:divide-slate-800">
-              {docs.map((d) => (
-                <li
-                  key={d.id}
-                  className="flex items-center justify-between py-2.5"
-                >
-                  <div>
-                    <div className="text-sm font-medium">{d.filename}</div>
-                    <div className="text-xs text-slate-500">
-                      {d.kind.replace("_", " ")} · {d.status} ·{" "}
-                      {d.extraction_method ?? "—"}
-                    </div>
+          <DropZone onFiles={(fs) => void enqueueFiles(fs)} locale={locale} />
+
+          {items.length === 0 && (
+            <p className="text-xs text-ink-500">
+              {locale === "zh"
+                ? "一次可导入多份报告 — 每份都会出现在下方队列。"
+                : "Queue as many reports as you like — each one appears in the list below."}
+            </p>
+          )}
+
+          {items.length > 0 && (
+            <BulkQueue
+              items={items}
+              apiKeyConfigured={apiKeyConfigured}
+              onParseHeuristic={(id) => void reparseItem(id, "heuristic")}
+              onParseClaude={(id) => void reparseItem(id, "claude")}
+              onSave={(id) => void saveItem(id)}
+              onSaveAll={() => void saveAll()}
+              onDiscard={discardItem}
+              onReset={clearAll}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <section className="grid gap-3 sm:grid-cols-2">
+        <Link
+          href="/ingest/meal"
+          className="a-card flex items-start gap-3 p-4 transition-colors hover:border-ink-300"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
+            <Utensils className="h-5 w-5" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-[13.5px] font-semibold text-ink-900">
+              {locale === "zh" ? "餐食照片 → 蛋白与热量" : "Meal photo → protein + calories"}
+            </div>
+            <div className="mt-0.5 text-xs text-ink-500">
+              {locale === "zh"
+                ? "拍一张盘中餐，Claude 估算宏量并建议胰酶剂量。"
+                : "Snap the plate; Claude estimates macros and a PERT suggestion."}
+            </div>
+          </div>
+          <ChevronRight className="mt-1.5 h-4 w-4 text-ink-300" />
+        </Link>
+
+        <Link
+          href="/ingest/notes"
+          className="a-card flex items-start gap-3 p-4 transition-colors hover:border-ink-300"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
+            <NotebookPen className="h-5 w-5" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-[13.5px] font-semibold text-ink-900">
+              {locale === "zh"
+                ? "手写笔记 → 今日日志"
+                : "Handwritten notes → daily log"}
+            </div>
+            <div className="mt-0.5 text-xs text-ink-500">
+              {locale === "zh"
+                ? "拍一张手写日记，结构化成今日条目。"
+                : "Photograph a paper note; it's transcribed and structured into today's entry."}
+            </div>
+          </div>
+          <ChevronRight className="mt-1.5 h-4 w-4 text-ink-300" />
+        </Link>
+      </section>
+
+      {recent && recent.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="eyebrow">
+            {locale === "zh" ? "最近导入" : "Recent"}
+          </h2>
+          <ul className="divide-y divide-ink-100/80 rounded-[var(--r-md)] border border-ink-100/80 bg-paper-2">
+            {recent.map((d) => (
+              <li key={d.id} className="flex items-center justify-between p-3">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] font-medium text-ink-900">
+                    {d.filename}
                   </div>
-                  <span className="text-xs text-slate-400">
-                    {new Date(d.uploaded_at).toLocaleDateString()}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
+                  <div className="mono text-[10.5px] uppercase tracking-wider text-ink-400">
+                    {d.kind} · {d.status}
+                    {d.extraction_method ? ` · ${d.extraction_method}` : ""}
+                  </div>
+                </div>
+                <div className="mono text-[10.5px] text-ink-400">
+                  {new Date(d.uploaded_at).toLocaleDateString()}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
     </div>
   );
 }
 
-function ExtractionPreview({ extraction }: { extraction: UnifiedExtraction }) {
+function DropZone({
+  onFiles,
+  locale,
+}: {
+  onFiles: (files: File[]) => void;
+  locale: "en" | "zh";
+}) {
+  const [over, setOver] = useState(false);
   return (
-    <div className="space-y-2 text-xs">
-      <div>
-        <span className="font-medium">Kind:</span> {extraction.kind}
-      </div>
-      {extraction.document_date && (
-        <div>
-          <span className="font-medium">Date:</span> {extraction.document_date}
-        </div>
-      )}
-      {extraction.summary && (
-        <div>
-          <span className="font-medium">Summary:</span> {extraction.summary}
-        </div>
-      )}
-      {extraction.labs && Object.keys(extraction.labs).length > 0 && (
-        <div>
-          <span className="font-medium">Labs:</span>{" "}
-          {Object.entries(extraction.labs)
-            .map(([k, v]) => `${k}=${v}`)
-            .join(", ")}
-        </div>
-      )}
-      {extraction.imaging?.modality && (
-        <div>
-          <span className="font-medium">Imaging:</span>{" "}
-          {extraction.imaging.modality}
-          {extraction.imaging.recist_status
-            ? ` · ${extraction.imaging.recist_status}`
-            : ""}
-          {extraction.imaging.findings_summary
-            ? ` — ${extraction.imaging.findings_summary.slice(0, 140)}`
-            : ""}
-        </div>
-      )}
-      {extraction.ctdna && (
-        <div>
-          <span className="font-medium">ctDNA:</span>{" "}
-          {extraction.ctdna.platform} ·{" "}
-          {extraction.ctdna.detected ? "detected" : "not detected"}
-          {extraction.ctdna.value ? ` · ${extraction.ctdna.value}` : ""}
-        </div>
-      )}
-      {extraction.pending_items && extraction.pending_items.length > 0 && (
-        <div>
-          <span className="font-medium">Pending:</span>{" "}
-          {extraction.pending_items.map((p) => p.test_name).join(", ")}
-        </div>
-      )}
+    <div
+      onDragOver={(e) => {
+        e.preventDefault();
+        setOver(true);
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setOver(false);
+        const files = Array.from(e.dataTransfer.files ?? []);
+        if (files.length > 0) onFiles(files);
+      }}
+      className={
+        over
+          ? "rounded-[var(--r-md)] border-2 border-dashed border-ink-700 bg-ink-100/40 px-4 py-5 text-center text-xs text-ink-700"
+          : "rounded-[var(--r-md)] border-2 border-dashed border-ink-200 bg-paper px-4 py-5 text-center text-xs text-ink-500"
+      }
+    >
+      {locale === "zh"
+        ? "拖放任意数量的文件到这里（PDF / JPG / PNG）"
+        : "Drop any number of files here (PDF · JPG · PNG)"}
     </div>
   );
-}
-
-function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Providers } from "~/components/shared/providers";
 import { DesktopSidebar, MobileBottomNav } from "~/components/shared/nav";
 import { LanguageSwitcher } from "~/components/shared/language-switcher";
 import { RoleSwitcher } from "~/components/shared/role-switcher";
+import { AddFab } from "~/components/shared/add-fab";
 
 export const metadata: Metadata = {
   title: "Anchor",
@@ -38,6 +39,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </div>
           </div>
           <MobileBottomNav />
+          <AddFab />
         </Providers>
       </body>
     </html>

--- a/src/components/ingest/bulk-queue.tsx
+++ b/src/components/ingest/bulk-queue.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import type { BulkItem } from "~/lib/ingest/bulk";
+import type { UnifiedExtraction } from "~/lib/ingest/save";
+import { useLocale } from "~/hooks/use-translate";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils/cn";
+import {
+  Check,
+  Loader2,
+  AlertCircle,
+  FileText,
+  Trash2,
+  Sparkles,
+  ScanText,
+} from "lucide-react";
+
+const STATUS_META: Record<
+  BulkItem["status"],
+  { label: { en: string; zh: string }; tone: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  queued: {
+    label: { en: "Queued", zh: "排队" },
+    tone: "text-ink-400",
+    icon: FileText,
+  },
+  ocr: {
+    label: { en: "OCR running", zh: "识别中" },
+    tone: "text-ink-500",
+    icon: Loader2,
+  },
+  ocr_failed: {
+    label: { en: "OCR failed", zh: "识别失败" },
+    tone: "text-[var(--warn)]",
+    icon: AlertCircle,
+  },
+  parsing: {
+    label: { en: "Structuring", zh: "结构化中" },
+    tone: "text-ink-500",
+    icon: Loader2,
+  },
+  parse_failed: {
+    label: { en: "Parse failed", zh: "解析失败" },
+    tone: "text-[var(--warn)]",
+    icon: AlertCircle,
+  },
+  ready: {
+    label: { en: "Ready to save", zh: "可保存" },
+    tone: "text-[var(--tide-2)]",
+    icon: Check,
+  },
+  saving: {
+    label: { en: "Saving", zh: "保存中" },
+    tone: "text-ink-500",
+    icon: Loader2,
+  },
+  saved: {
+    label: { en: "Saved", zh: "已保存" },
+    tone: "text-[var(--ok)]",
+    icon: Check,
+  },
+  discarded: {
+    label: { en: "Discarded", zh: "已丢弃" },
+    tone: "text-ink-400",
+    icon: Trash2,
+  },
+};
+
+export function BulkQueue({
+  items,
+  apiKeyConfigured,
+  onParseHeuristic,
+  onParseClaude,
+  onSave,
+  onSaveAll,
+  onDiscard,
+  onReset,
+}: {
+  items: BulkItem[];
+  apiKeyConfigured: boolean;
+  onParseHeuristic: (id: string) => void;
+  onParseClaude: (id: string) => void;
+  onSave: (id: string) => void;
+  onSaveAll: () => void;
+  onDiscard: (id: string) => void;
+  onReset: () => void;
+}) {
+  const locale = useLocale();
+  const readyCount = items.filter((i) => i.status === "ready").length;
+  const activeCount = items.filter(
+    (i) => i.status !== "saved" && i.status !== "discarded",
+  ).length;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="eyebrow">
+          {locale === "zh"
+            ? `${activeCount} 个文件 · ${readyCount} 可保存`
+            : `${activeCount} file${activeCount === 1 ? "" : "s"} · ${readyCount} ready`}
+        </div>
+        <div className="flex items-center gap-2">
+          {readyCount > 0 && (
+            <Button size="sm" onClick={onSaveAll}>
+              <Check className="h-3.5 w-3.5" />
+              {locale === "zh" ? `全部保存（${readyCount}）` : `Save all (${readyCount})`}
+            </Button>
+          )}
+          <Button size="sm" variant="ghost" onClick={onReset}>
+            {locale === "zh" ? "清空" : "Clear"}
+          </Button>
+        </div>
+      </div>
+
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <BulkRow
+            key={item.id}
+            item={item}
+            locale={locale}
+            apiKeyConfigured={apiKeyConfigured}
+            onParseHeuristic={() => onParseHeuristic(item.id)}
+            onParseClaude={() => onParseClaude(item.id)}
+            onSave={() => onSave(item.id)}
+            onDiscard={() => onDiscard(item.id)}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function BulkRow({
+  item,
+  locale,
+  apiKeyConfigured,
+  onParseHeuristic,
+  onParseClaude,
+  onSave,
+  onDiscard,
+}: {
+  item: BulkItem;
+  locale: "en" | "zh";
+  apiKeyConfigured: boolean;
+  onParseHeuristic: () => void;
+  onParseClaude: () => void;
+  onSave: () => void;
+  onDiscard: () => void;
+}) {
+  const meta = STATUS_META[item.status];
+  const Icon = meta.icon;
+  const isBusy =
+    item.status === "ocr" ||
+    item.status === "parsing" ||
+    item.status === "saving";
+
+  return (
+    <li
+      className={cn(
+        "rounded-[var(--r-md)] border border-ink-100/80 bg-paper-2 p-3",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[13.5px] font-medium text-ink-900">
+            {item.file.name}
+          </div>
+          <div className="mt-0.5 flex items-center gap-1.5 text-xs">
+            <Icon
+              className={cn(
+                "h-3 w-3",
+                meta.tone,
+                isBusy && "animate-spin",
+              )}
+            />
+            <span className={meta.tone}>{meta.label[locale]}</span>
+            {item.progress && (
+              <span className="mono text-[10px] text-ink-400">
+                · {item.progress}
+              </span>
+            )}
+            {item.error && (
+              <span className="text-[11px] text-[var(--warn)]">
+                · {item.error.slice(0, 60)}
+              </span>
+            )}
+          </div>
+        </div>
+        {item.status !== "saved" && item.status !== "discarded" && (
+          <button
+            type="button"
+            onClick={onDiscard}
+            className="flex h-7 w-7 items-center justify-center rounded-md text-ink-400 hover:bg-ink-100 hover:text-ink-700"
+            aria-label="discard"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {item.status === "ocr_failed" && (
+        <div className="mt-2 flex gap-2">
+          <Button size="sm" variant="secondary" onClick={onParseHeuristic}>
+            {locale === "zh" ? "重试" : "Retry"}
+          </Button>
+        </div>
+      )}
+
+      {(item.ocrText && item.status === "parsing") || item.status === "parse_failed" ? (
+        <div className="mt-2 flex flex-wrap gap-2">
+          <Button size="sm" variant="secondary" onClick={onParseHeuristic}>
+            <ScanText className="h-3.5 w-3.5" />
+            {locale === "zh" ? "本地规则" : "Local rules"}
+          </Button>
+          {apiKeyConfigured && (
+            <Button size="sm" onClick={onParseClaude}>
+              <Sparkles className="h-3.5 w-3.5" />
+              {locale === "zh" ? "用 Claude" : "Claude"}
+            </Button>
+          )}
+        </div>
+      ) : null}
+
+      {item.status === "ready" && item.extraction && (
+        <div className="mt-2 space-y-1.5 rounded-md bg-[var(--paper)] p-2.5 text-[11.5px] text-ink-700">
+          <ExtractionPreview extraction={item.extraction} />
+          <div className="flex gap-2 pt-1">
+            <Button size="sm" onClick={onSave}>
+              <Check className="h-3.5 w-3.5" />
+              {locale === "zh" ? "保存" : "Save"}
+            </Button>
+            {apiKeyConfigured && item.method === "heuristic" && (
+              <Button size="sm" variant="ghost" onClick={onParseClaude}>
+                {locale === "zh" ? "改用 Claude" : "Re-parse with Claude"}
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function ExtractionPreview({ extraction }: { extraction: UnifiedExtraction }) {
+  return (
+    <div className="space-y-0.5">
+      <div>
+        <span className="font-medium">Kind:</span> {extraction.kind}
+      </div>
+      {extraction.document_date && (
+        <div>
+          <span className="font-medium">Date:</span> {extraction.document_date}
+        </div>
+      )}
+      {extraction.labs && Object.keys(extraction.labs).length > 0 && (
+        <div>
+          <span className="font-medium">Labs:</span>{" "}
+          {Object.entries(extraction.labs)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(", ")}
+        </div>
+      )}
+      {extraction.imaging?.modality && (
+        <div>
+          <span className="font-medium">Imaging:</span>{" "}
+          {extraction.imaging.modality}
+          {extraction.imaging.recist_status
+            ? ` · ${extraction.imaging.recist_status}`
+            : ""}
+        </div>
+      )}
+      {extraction.ctdna && (
+        <div>
+          <span className="font-medium">ctDNA:</span>{" "}
+          {extraction.ctdna.platform ?? "other"} ·{" "}
+          {extraction.ctdna.detected ? "detected" : "not detected"}
+        </div>
+      )}
+      {extraction.summary && (
+        <div className="text-ink-500">{extraction.summary}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ingest/camera-capture.tsx
+++ b/src/components/ingest/camera-capture.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useRef } from "react";
+import { Camera } from "lucide-react";
+import { useLocale } from "~/hooks/use-translate";
+
+export function CameraCapture({
+  onPhoto,
+  accept = "image/*",
+  label,
+}: {
+  onPhoto: (file: File) => void;
+  accept?: string;
+  label?: string;
+}) {
+  const locale = useLocale();
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        capture="environment"
+        className="hidden"
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) {
+            onPhoto(f);
+            // reset so the same photo can be selected again
+            e.target.value = "";
+          }
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        className="inline-flex items-center gap-2 rounded-md bg-ink-900 px-4 py-2 text-sm font-medium text-paper transition-colors hover:bg-ink-700"
+      >
+        <Camera className="h-4 w-4" />
+        {label ?? (locale === "zh" ? "拍照" : "Take photo")}
+      </button>
+    </>
+  );
+}

--- a/src/components/shared/add-fab.tsx
+++ b/src/components/shared/add-fab.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useLocale } from "~/hooks/use-translate";
+import { cn } from "~/lib/utils/cn";
+import {
+  Plus,
+  X,
+  CalendarDays,
+  CalendarRange,
+  Stethoscope,
+  ClipboardList,
+  Utensils,
+  NotebookPen,
+  FileText,
+  ListTodo,
+  Camera,
+} from "lucide-react";
+
+interface FabItem {
+  href: string;
+  label: { en: string; zh: string };
+  hint: { en: string; zh: string };
+  icon: React.ComponentType<{ className?: string }>;
+  tone?: "tide" | "sand";
+}
+
+const ITEMS: FabItem[] = [
+  {
+    href: "/daily/new",
+    label: { en: "Today's check-in", zh: "今日记录" },
+    hint: { en: "Symptoms, weight, practice", zh: "症状、体重、修习" },
+    icon: CalendarDays,
+    tone: "tide",
+  },
+  {
+    href: "/ingest/meal",
+    label: { en: "Meal photo", zh: "餐食照片" },
+    hint: {
+      en: "Protein + PERT estimate",
+      zh: "蛋白与胰酶建议",
+    },
+    icon: Utensils,
+    tone: "tide",
+  },
+  {
+    href: "/ingest/notes",
+    label: { en: "Handwritten notes", zh: "手写笔记" },
+    hint: { en: "Photo → daily log", zh: "照片 → 每日日志" },
+    icon: NotebookPen,
+  },
+  {
+    href: "/ingest",
+    label: { en: "Upload report", zh: "上传报告" },
+    hint: { en: "Lab / imaging / referral", zh: "化验 / 影像 / 转诊" },
+    icon: Camera,
+  },
+  {
+    href: "/weekly/new",
+    label: { en: "Weekly reflection", zh: "每周回顾" },
+    hint: { en: "Sunday evening, ~5 min", zh: "周日晚约 5 分钟" },
+    icon: CalendarRange,
+  },
+  {
+    href: "/fortnightly/new",
+    label: { en: "Functional tests", zh: "两周功能评估" },
+    hint: {
+      en: "Grip, gait, SARC-F",
+      zh: "握力、步速、SARC-F",
+    },
+    icon: Stethoscope,
+  },
+  {
+    href: "/quarterly",
+    label: { en: "Quarterly review", zh: "每季复查" },
+    hint: { en: "Imaging, CA 19-9, CGA", zh: "影像、CA 19-9、CGA" },
+    icon: ClipboardList,
+  },
+  {
+    href: "/tasks/new",
+    label: { en: "New task", zh: "新建任务" },
+    hint: {
+      en: "Reminder or action",
+      zh: "提醒或行动",
+    },
+    icon: ListTodo,
+  },
+  {
+    href: "/reports",
+    label: { en: "Generate report", zh: "生成报告" },
+    hint: { en: "Pre-clinic PDF / JSON", zh: "就诊前 PDF / 备份" },
+    icon: FileText,
+  },
+];
+
+export function AddFab() {
+  const locale = useLocale();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    function onClick(e: MouseEvent) {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    if (open) {
+      window.addEventListener("keydown", onKey);
+      window.addEventListener("mousedown", onClick);
+    }
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("mousedown", onClick);
+    };
+  }, [open]);
+
+  return (
+    <div
+      ref={ref}
+      className="fixed bottom-24 right-4 z-50 md:bottom-6 md:right-6"
+    >
+      {open && (
+        <div className="mb-3 w-[280px] overflow-hidden rounded-[var(--r-lg)] border border-ink-100/80 bg-paper-2 shadow-xl">
+          <div className="px-4 py-2.5">
+            <div className="mono text-[10px] uppercase tracking-[0.12em] text-ink-400">
+              {locale === "zh" ? "添加 / 记录" : "Add / capture"}
+            </div>
+          </div>
+          <ul className="max-h-[70vh] overflow-y-auto">
+            {ITEMS.map((item) => {
+              const Icon = item.icon;
+              return (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    onClick={() => setOpen(false)}
+                    className="flex items-start gap-3 border-t border-ink-100/60 px-4 py-2.5 hover:bg-ink-100/40"
+                  >
+                    <div
+                      className={cn(
+                        "flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
+                        item.tone === "tide"
+                          ? "bg-[var(--tide-soft)] text-[var(--tide-2)]"
+                          : item.tone === "sand"
+                            ? "bg-[var(--sand)] text-ink-900"
+                            : "bg-ink-100 text-ink-700",
+                      )}
+                    >
+                      <Icon className="h-4 w-4" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[13px] font-semibold text-ink-900">
+                        {item.label[locale]}
+                      </div>
+                      <div className="mt-0.5 text-[11.5px] text-ink-500">
+                        {item.hint[locale]}
+                      </div>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? "Close add menu" : "Open add menu"}
+        className={cn(
+          "flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-all",
+          open
+            ? "bg-paper-2 text-ink-700 border border-ink-200 rotate-45"
+            : "bg-ink-900 text-paper hover:scale-105",
+        )}
+      >
+        {open ? (
+          <X className="h-5 w-5 -rotate-45" />
+        ) : (
+          <Plus className="h-6 w-6" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -4,10 +4,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
-  CalendarDays,
-  CalendarRange,
-  Stethoscope,
-  ClipboardList,
   Route,
   CalendarClock,
   ScrollText,
@@ -26,10 +22,6 @@ const ITEMS = [
   { href: "/", key: "nav.dashboard", icon: LayoutDashboard },
   { href: "/assessment", key: "nav.assessment", icon: Compass },
   { href: "/treatment", key: "nav.treatment", icon: Syringe },
-  { href: "/daily", key: "nav.daily", icon: CalendarDays },
-  { href: "/weekly", key: "nav.weekly", icon: CalendarRange },
-  { href: "/fortnightly", key: "nav.fortnightly", icon: Stethoscope },
-  { href: "/quarterly", key: "nav.quarterly", icon: ClipboardList },
   { href: "/labs", key: "nav.labs", icon: FlaskConical },
   { href: "/bridge", key: "nav.bridge", icon: Route },
   { href: "/events", key: "nav.events", icon: CalendarClock },
@@ -84,7 +76,7 @@ export function MobileBottomNav() {
   const t = useT();
   const pathname = usePathname();
   const mobileItems = ITEMS.filter((i) =>
-    ["/", "/daily", "/treatment", "/labs", "/tasks"].includes(i.href),
+    ["/", "/treatment", "/labs", "/tasks", "/assessment"].includes(i.href),
   );
   return (
     <nav className="a-glass fixed inset-x-3 bottom-3 z-40 flex justify-around rounded-[22px] px-2 py-2.5 shadow-lg md:hidden">

--- a/src/lib/ingest/bulk.ts
+++ b/src/lib/ingest/bulk.ts
@@ -1,0 +1,142 @@
+"use client";
+
+import { ocrFile } from "./ocr";
+import { parseHeuristic } from "./heuristic-parser";
+import { extractWithClaude } from "./claude-parser";
+import {
+  fromClaude,
+  fromHeuristic,
+  saveExtraction,
+  type UnifiedExtraction,
+} from "./save";
+import { db, now } from "~/lib/db/dexie";
+import type { IngestedDocument } from "~/types/clinical";
+
+export type BulkItemStatus =
+  | "queued"
+  | "ocr"
+  | "ocr_failed"
+  | "parsing"
+  | "parse_failed"
+  | "ready"
+  | "saving"
+  | "saved"
+  | "discarded";
+
+export interface BulkItem {
+  id: string;
+  file: File;
+  status: BulkItemStatus;
+  progress?: string;
+  error?: string;
+  ocrText?: string;
+  ocrConfidence?: number;
+  extraction?: UnifiedExtraction;
+  method?: "heuristic" | "claude";
+  documentId?: number;
+}
+
+export type BulkMutator = (
+  id: string,
+  patch: Partial<BulkItem>,
+) => void;
+
+export async function processBulkItemOcr(
+  item: BulkItem,
+  mutate: BulkMutator,
+): Promise<void> {
+  if (!item.file) return;
+  // Create a document row up-front
+  const docRow: IngestedDocument = {
+    filename: item.file.name,
+    mime_type: item.file.type || "application/octet-stream",
+    size_bytes: item.file.size,
+    kind: "other",
+    uploaded_at: now(),
+    status: "ocr_pending",
+    created_at: now(),
+    updated_at: now(),
+  };
+  const docId = (await db.ingested_documents.add(docRow)) as number;
+  mutate(item.id, { status: "ocr", documentId: docId });
+
+  try {
+    const r = await ocrFile(item.file, (phase, p) => {
+      mutate(item.id, {
+        progress: `${phase} — ${Math.round((p ?? 0) * 100)}%`,
+      });
+    });
+    await db.ingested_documents.update(docId, {
+      ocr_text: r.text,
+      ocr_confidence: r.confidence,
+      status: "ocr_complete",
+      updated_at: now(),
+    });
+    mutate(item.id, {
+      ocrText: r.text,
+      ocrConfidence: r.confidence,
+      status: "parsing",
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await db.ingested_documents.update(docId, {
+      status: "error",
+      error_message: msg,
+      updated_at: now(),
+    });
+    mutate(item.id, { status: "ocr_failed", error: msg });
+  }
+}
+
+export async function parseBulkItem(
+  item: BulkItem,
+  method: "heuristic" | "claude",
+  apiKey: string | undefined,
+  mutate: BulkMutator,
+): Promise<void> {
+  if (!item.ocrText || !item.documentId) return;
+  mutate(item.id, { status: "parsing", method });
+  try {
+    let extraction: UnifiedExtraction;
+    if (method === "claude" && apiKey) {
+      const claudeOut = await extractWithClaude({
+        apiKey,
+        text: item.ocrText,
+      });
+      extraction = fromClaude(claudeOut);
+    } else {
+      extraction = fromHeuristic(parseHeuristic(item.ocrText));
+    }
+    await db.ingested_documents.update(item.documentId, {
+      extraction_method: method,
+      kind: extraction.kind,
+      status: "extracted",
+      updated_at: now(),
+    });
+    mutate(item.id, { extraction, status: "ready" });
+  } catch (err) {
+    mutate(item.id, {
+      status: "parse_failed",
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export async function saveBulkItem(
+  item: BulkItem,
+  mutate: BulkMutator,
+): Promise<void> {
+  if (!item.extraction || !item.documentId) return;
+  const doc = await db.ingested_documents.get(item.documentId);
+  if (!doc) return;
+  mutate(item.id, { status: "saving" });
+  try {
+    await saveExtraction(doc, item.extraction);
+    mutate(item.id, { status: "saved" });
+  } catch (err) {
+    mutate(item.id, {
+      status: "parse_failed",
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/lib/ingest/image.ts
+++ b/src/lib/ingest/image.ts
@@ -1,0 +1,79 @@
+"use client";
+
+export interface PreparedImage {
+  base64: string;
+  mediaType: "image/jpeg";
+  width: number;
+  height: number;
+  approxKB: number;
+}
+
+/**
+ * Load a File as an HTMLImageElement (browser-only).
+ */
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = (e) => {
+      URL.revokeObjectURL(url);
+      reject(e);
+    };
+    img.src = url;
+  });
+}
+
+/**
+ * Resize + re-encode an image to keep Claude Vision payloads small.
+ * Caps the long edge at `maxEdge` (default 1600 px) and JPEG quality.
+ */
+export async function prepareImageForVision(
+  file: File,
+  { maxEdge = 1600, quality = 0.82 }: { maxEdge?: number; quality?: number } = {},
+): Promise<PreparedImage> {
+  if (typeof window === "undefined") {
+    throw new Error("prepareImageForVision is browser-only");
+  }
+  const img = await loadImage(file);
+  const scale = Math.min(1, maxEdge / Math.max(img.width, img.height));
+  const w = Math.round(img.width * scale);
+  const h = Math.round(img.height * scale);
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Unable to get 2D canvas context");
+  ctx.drawImage(img, 0, 0, w, h);
+
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error("Canvas blob failed"))),
+      "image/jpeg",
+      quality,
+    );
+  });
+  const buf = await blob.arrayBuffer();
+  const base64 = arrayBufferToBase64(buf);
+  return {
+    base64,
+    mediaType: "image/jpeg",
+    width: w,
+    height: h,
+    approxKB: Math.round(blob.size / 1024),
+  };
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode.apply(null, Array.from(chunk));
+  }
+  return btoa(binary);
+}

--- a/src/lib/ingest/meal-vision.ts
+++ b/src/lib/ingest/meal-vision.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { z } from "zod";
+import type { PreparedImage } from "./image";
+
+export const MealSchema = z.object({
+  description: z
+    .string()
+    .describe("One-sentence description of what's on the plate."),
+  protein_g: z.number().describe("Estimated protein in grams."),
+  carbs_g: z.number().describe("Estimated carbohydrates in grams."),
+  fat_g: z.number().describe("Estimated fat in grams."),
+  calories: z.number().describe("Estimated calories in kcal."),
+  pert_suggestion: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "For PDAC patients: brief PERT (Creon) suggestion if the meal is fatty or rich — e.g. '25,000u with this meal'. Null if not applicable.",
+    ),
+  confidence: z
+    .enum(["low", "medium", "high"])
+    .describe(
+      "How confident the estimate is. Low = generic plate, partial view, or unfamiliar dish.",
+    ),
+  notes: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Any caveats, e.g. 'portion estimated', 'sauce adds fat', 'no protein visible'.",
+    ),
+});
+
+export type MealEstimate = z.infer<typeof MealSchema>;
+
+const MEAL_SYSTEM = `You estimate the macronutrients of a meal from a single photo for Hu Lin, a patient with metastatic pancreatic adenocarcinoma on first-line gemcitabine + nab-paclitaxel.
+
+Rules:
+1. Keep estimates conservative; if unsure, err low on protein and say so in 'notes'.
+2. Assume one adult portion unless obviously multiple servings.
+3. For PDAC, flag fatty/rich meals with a practical PERT suggestion (e.g. '25,000u with this meal; 10,000u with any follow-up snack'). If low fat, set pert_suggestion to null.
+4. If the photo is too unclear to judge (blur, distant, empty plate), set confidence=low and note what's missing.
+5. Never invent specific brands or recipes. Describe what's visually present.`;
+
+export async function estimateMeal({
+  apiKey,
+  model = "claude-opus-4-7",
+  image,
+}: {
+  apiKey: string;
+  model?: string;
+  image: PreparedImage;
+}): Promise<MealEstimate> {
+  const [{ default: Anthropic }, { zodOutputFormat }] = await Promise.all([
+    import("@anthropic-ai/sdk"),
+    import("@anthropic-ai/sdk/helpers/zod"),
+  ]);
+  const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
+
+  const response = await client.messages.parse({
+    model,
+    max_tokens: 1024,
+    system: [
+      { type: "text", text: MEAL_SYSTEM, cache_control: { type: "ephemeral" } },
+    ],
+    output_config: { format: zodOutputFormat(MealSchema) },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: image.mediaType,
+              data: image.base64,
+            },
+          },
+          {
+            type: "text",
+            text: "Estimate the macros for this meal and, if relevant, the PERT dose.",
+          },
+        ],
+      },
+    ],
+  });
+
+  if (!response.parsed_output) {
+    throw new Error("No meal estimate returned");
+  }
+  return response.parsed_output;
+}

--- a/src/lib/ingest/notes-vision.ts
+++ b/src/lib/ingest/notes-vision.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { z } from "zod";
+import type { PreparedImage } from "./image";
+
+export const NotesStructureSchema = z.object({
+  transcription: z
+    .string()
+    .describe("Faithful transcription of the note as written. No additions."),
+  daily_patch: z
+    .object({
+      energy: z.number().min(0).max(10).nullable().optional(),
+      sleep_quality: z.number().min(0).max(10).nullable().optional(),
+      appetite: z.number().min(0).max(10).nullable().optional(),
+      pain_worst: z.number().min(0).max(10).nullable().optional(),
+      pain_current: z.number().min(0).max(10).nullable().optional(),
+      nausea: z.number().min(0).max(10).nullable().optional(),
+      mood_clarity: z.number().min(0).max(10).nullable().optional(),
+      weight_kg: z.number().nullable().optional(),
+      diarrhoea_count: z.number().int().nullable().optional(),
+      fever: z.boolean().nullable().optional(),
+      fever_temp: z.number().nullable().optional(),
+      protein_grams: z.number().nullable().optional(),
+      walking_minutes: z.number().nullable().optional(),
+      practice_morning_completed: z.boolean().nullable().optional(),
+      practice_evening_completed: z.boolean().nullable().optional(),
+      reflection: z.string().nullable().optional(),
+    })
+    .describe(
+      "Structured patch onto today's daily entry. Include ONLY fields the user actually wrote about; leave everything else absent or null.",
+    ),
+  confidence: z
+    .enum(["low", "medium", "high"])
+    .describe("Overall confidence in the transcription and structuring."),
+  ambiguities: z
+    .array(z.string())
+    .default([])
+    .describe(
+      "List specific phrases or numbers you were uncertain about, each with what you interpreted.",
+    ),
+});
+
+export type NotesStructure = z.infer<typeof NotesStructureSchema>;
+
+const NOTES_SYSTEM = `You're reading a photo of Hu Lin's handwritten daily notes from his cancer-tracking journal and structuring them into Anchor's daily-log fields.
+
+Rules:
+1. First transcribe the note faithfully — no rewording, no added words, no interpretation.
+2. Then populate daily_patch with ONLY the fields the user explicitly wrote about.
+3. Scales default to 0–10 (0 = none, 10 = worst). Convert loose language conservatively: "mild pain" → 2–3, "moderate" → 4–6, "severe" → 7–9, "unbearable" → 10.
+4. If a number is ambiguous (e.g. "pain 4 or 5"), pick the lower value and list the ambiguity.
+5. For practice completion: only set true if the note says the practice was done today.
+6. Never invent metrics. If the note doesn't mention something, omit it (leave absent / null).
+7. Put any free-text reflection (non-metric sentences) into the 'reflection' field.`;
+
+export async function structureNotes({
+  apiKey,
+  model = "claude-opus-4-7",
+  image,
+}: {
+  apiKey: string;
+  model?: string;
+  image: PreparedImage;
+}): Promise<NotesStructure> {
+  const [{ default: Anthropic }, { zodOutputFormat }] = await Promise.all([
+    import("@anthropic-ai/sdk"),
+    import("@anthropic-ai/sdk/helpers/zod"),
+  ]);
+  const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
+
+  const response = await client.messages.parse({
+    model,
+    max_tokens: 1500,
+    system: [
+      { type: "text", text: NOTES_SYSTEM, cache_control: { type: "ephemeral" } },
+    ],
+    output_config: { format: zodOutputFormat(NotesStructureSchema) },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: image.mediaType,
+              data: image.base64,
+            },
+          },
+          {
+            type: "text",
+            text: "Transcribe this note and structure it into Anchor's daily log fields.",
+          },
+        ],
+      },
+    ],
+  });
+  if (!response.parsed_output) {
+    throw new Error("No notes structure returned");
+  }
+  return response.parsed_output;
+}


### PR DESCRIPTION
Four capture flows unified behind a universal "+" floating action. Daily / Weekly / Fortnightly / Quarterly tabs dropped from the nav — they're all one tap away from the FAB now.

## Bulk report upload (`/ingest`)

- Multi-file picker + drag-and-drop zone + camera-capture button (opens rear camera on iOS/Android via `<input capture="environment">`)
- Each file gets its own state-machine row: `queued → ocr → parsing → ready → saving → saved` (or `ocr_failed` / `parse_failed` / `discarded`)
- OCR runs sequentially (tesseract memory pressure). Heuristic parser auto-runs so there's always a local-only result. "Re-parse with Claude" switches to Claude when an API key is set
- **Save all** commits every ready item in one action

## Meal photo → nutrition (`/ingest/meal`)

- Camera or file → on-device resize to 1400 px → base64 → Claude Vision with a Zod-schemaed `messages.parse()` output:  
  `{description, protein_g, carbs_g, fat_g, calories, pert_suggestion, confidence, notes}`
- Result UI: macro tiles, tide-tinted PERT suggestion, confidence chip, "Add to today" patches (or creates) today's DailyEntry — adds `protein_g` to `protein_grams`, bumps `meals_count`

## Handwritten notes → daily log (`/ingest/notes`)

- Same image pipeline, max edge 1800 px for handwriting detail
- Claude structures into `{transcription, daily_patch, confidence, ambiguities}`. `daily_patch` maps to real DailyEntry fields (energy, sleep, pain, nausea, weight, walking, practice flags, reflection…) — only fields actually written
- UI shows the raw transcription, the mapped fields, any ambiguities as a sand-tinted chip list, and a merge-to-today action

## Floating "+" FAB

- Circular button, bottom-right on desktop, above the mobile bottom nav
- Opens a 280-px sheet with nine shortcuts: Today's check-in · Meal photo · Handwritten notes · Upload report · Weekly reflection · Functional tests · Quarterly review · New task · Generate report
- Esc / outside click to close, rotates to X when open

## Nav trim

- Sidebar + bottom nav drop Daily / Weekly / Fortnightly / Quarterly (routes still work, just behind the FAB)
- Mobile bottom nav becomes: Today · Assessment · Treatment · Labs · Tasks

## Privacy

Both vision flows only fire when the user has their own Anthropic API key in Settings. Image is resized client-side, sent to `api.anthropic.com` directly via `dangerouslyAllowBrowser: true`. No other network egress.

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 99/99 passing
- [x] `pnpm build` — 34 routes green (+ `/ingest/meal`, `/ingest/notes`)

## Test plan

- [ ] Vercel preview loads
- [ ] Drop 5 PDFs onto `/ingest` → queue populates, OCR runs one at a time, heuristic parse lands, Save all works
- [ ] On mobile, "Snap a report photo" opens the rear camera directly
- [ ] `/ingest/meal` with a meal photo and API key → Claude returns macros → "Add to today" writes to DailyEntry
- [ ] `/ingest/notes` with a handwritten page → transcription + daily_patch → merge to today
- [ ] FAB opens on every screen; all nine shortcuts navigate correctly
- [ ] Sidebar/bottom nav no longer shows Daily/Weekly/Fortnightly/Quarterly

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH