### PR TITLE
PWA manifest + anchor icons + theme meta

### DIFF
--- a/public/anchor-mark.svg
+++ b/public/anchor-mark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#f5f1e8"/>
+  <g stroke="#19212f" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="256" cy="150" r="36" stroke-width="20"/>
+    <path d="M256 186 L256 404" stroke-width="22"/>
+    <path d="M136 266 L376 266" stroke-width="22"/>
+    <path d="M116 330 C116 390 180 438 256 438 C332 438 396 390 396 330" stroke-width="22"/>
+  </g>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <g stroke="#19212f" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="16" cy="7" r="2.4" stroke-width="1.8"/>
+    <path d="M16 9.4 L16 28" stroke-width="2"/>
+    <path d="M8 17 L24 17" stroke-width="2"/>
+    <path d="M7 21.5 C7 25.5 11 28.5 16 28.5 C21 28.5 25 25.5 25 21.5" stroke-width="2"/>
+  </g>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Anchor",
+  "short_name": "Anchor",
+  "description": "Function preservation + bridge-strategy tracker",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait-primary",
+  "background_color": "#f5f1e8",
+  "theme_color": "#19212f",
+  "icons": [
+    {
+      "src": "/anchor-mark.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["health", "medical", "lifestyle"]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,14 +7,41 @@ import { RoleSwitcher } from "~/components/shared/role-switcher";
 import { AddFab } from "~/components/shared/add-fab";
 
 export const metadata: Metadata = {
-  title: "Anchor",
-  description: "Function preservation and bridge strategy tracking.",
+  title: {
+    default: "Anchor",
+    template: "%s · Anchor",
+  },
+  description: "Function preservation and bridge-strategy tracking for metastatic pancreatic cancer.",
+  applicationName: "Anchor",
+  manifest: "/manifest.webmanifest",
+  icons: {
+    icon: [
+      { url: "/favicon.svg", type: "image/svg+xml" },
+    ],
+    apple: [
+      { url: "/anchor-mark.svg", type: "image/svg+xml" },
+    ],
+    shortcut: ["/favicon.svg"],
+  },
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: "Anchor",
+  },
+  formatDetection: {
+    telephone: false,
+  },
 };
 
 export const viewport: Viewport = {
-  themeColor: "#0f172a",
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#f5f1e8" },
+    { media: "(prefers-color-scheme: dark)", color: "#19212f" },
+  ],
   width: "device-width",
   initialScale: 1,
+  maximumScale: 5,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
Makes "Add to Home Screen" install Anchor as a standalone app with the anchor mark icon, paper-tinted splash, and ink-coloured theme bar. No service worker yet (offline-first is a follow-up); this is the metadata layer the OS reads.

### Changes

- **`public/anchor-mark.svg`** — 512×512 rounded-square SVG icon. Paper background (`#f5f1e8`), ink strokes, the design bundle's anchor glyph weighted for icon contexts. Works at every size; maskable-friendly with ~22-px inner padding.
- **`public/favicon.svg`** — monochrome 32×32 version.
- **`public/manifest.webmanifest`** — `display: standalone`, `portrait-primary`, paper background, ink theme colour, single SVG icon (`"any maskable"`), health/medical categories.
- **`src/app/layout.tsx` metadata:**
  - `manifest: /manifest.webmanifest`
  - `icons`: SVG favicon + apple-touch-icon
  - `appleWebApp.capable=true, statusBarStyle="default", title="Anchor"` — removes browser chrome on iOS when installed from the home screen
  - `title` template `"%s · Anchor"`
  - `formatDetection.telephone=false` — stops iOS auto-linking phone numbers inside the emergency card
- **Viewport** — `themeColor` responds to `prefers-color-scheme` (paper in light, ink-900 in dark); `viewportFit="cover"` so the paper bg reaches the notch on iPhone.

### Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — 34 routes green

### Test plan

- [ ] Vercel preview loads
- [ ] iOS Safari → Share → Add to Home Screen → icon is the anchor mark on paper; tap opens Anchor full-screen with no Safari chrome
- [ ] Android Chrome → install prompt shows the icon and "Anchor" name
- [ ] `favicon.svg` renders in the browser tab
- [ ] Emergency-card phone numbers no longer get auto-underlined on iOS

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH