### PR TITLE
Quick check-in card + backup nudge

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { QuickActions } from "~/components/dashboard/quick-actions";
 import { PillarsCard } from "~/components/dashboard/pillars-card";
 import { RecentTrends } from "~/components/dashboard/recent-trends";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
+import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
 import { TodayFeed } from "~/components/dashboard/today-feed";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
@@ -89,7 +90,9 @@ export default function DashboardPage() {
 
       <EmergencyCard />
 
-      <TodayFeed />
+      <QuickCheckinCard />
+
+      <TodayFeed excludeIds={["checkin_today"]} />
 
       <div className="a-horizon" />
 

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -82,6 +82,14 @@ export default function ReportsPage() {
       a.download = `anchor-backup-${todayISO()}.json`;
       a.click();
       URL.revokeObjectURL(url);
+      // Mark the export so the backup-nudge stops firing.
+      const existing = settingsRows[0];
+      if (existing?.id) {
+        await db.settings.update(existing.id, {
+          last_exported_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        });
+      }
     } finally {
       setExporting(false);
     }

--- a/src/components/dashboard/quick-checkin-card.tsx
+++ b/src/components/dashboard/quick-checkin-card.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, now } from "~/lib/db/dexie";
+import { todayISO } from "~/lib/utils/date";
+import { useLocale } from "~/hooks/use-translate";
+import { useUIStore } from "~/stores/ui-store";
+import { runEngineAndPersist } from "~/lib/rules/engine";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils/cn";
+import { Check, Pencil, Thermometer } from "lucide-react";
+
+const SCALES = [
+  { key: "energy", min: 0, max: 10, good: "high" as const, labelEn: "Energy", labelZh: "精力" },
+  { key: "pain", min: 0, max: 10, good: "low" as const, labelEn: "Pain", labelZh: "疼痛" },
+  { key: "nausea", min: 0, max: 10, good: "low" as const, labelEn: "Nausea", labelZh: "恶心" },
+] as const;
+
+type ScaleKey = (typeof SCALES)[number]["key"];
+
+export function QuickCheckinCard() {
+  const locale = useLocale();
+  const enteredBy = useUIStore((s) => s.enteredBy);
+  const today = todayISO();
+  const existing = useLiveQuery(
+    () => db.daily_entries.where("date").equals(today).first(),
+    [today],
+  );
+  const [values, setValues] = useState<Record<ScaleKey, number>>({
+    energy: 5,
+    pain: 0,
+    nausea: 0,
+  });
+  const [fever, setFever] = useState(false);
+  const [feverTemp, setFeverTemp] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  if (existing) return null;
+
+  async function save() {
+    setSaving(true);
+    try {
+      const ts = now();
+      const tempNum = Number.parseFloat(feverTemp);
+      await db.daily_entries.add({
+        date: today,
+        entered_at: ts,
+        entered_by: enteredBy,
+        energy: values.energy,
+        sleep_quality: 5,
+        appetite: 5,
+        pain_worst: values.pain,
+        pain_current: values.pain,
+        mood_clarity: 5,
+        nausea: values.nausea,
+        practice_morning_completed: false,
+        practice_evening_completed: false,
+        cold_dysaesthesia: false,
+        neuropathy_hands: false,
+        neuropathy_feet: false,
+        mouth_sores: false,
+        diarrhoea_count: 0,
+        new_bruising: false,
+        dyspnoea: false,
+        fever,
+        fever_temp: fever && Number.isFinite(tempNum) ? tempNum : undefined,
+        created_at: ts,
+        updated_at: ts,
+      });
+      await runEngineAndPersist();
+      setSavedAt(ts);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (savedAt) {
+    return (
+      <Card className="p-5">
+        <div className="flex items-center gap-3">
+          <div
+            className="flex h-8 w-8 items-center justify-center rounded-full"
+            style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
+          >
+            <Check className="h-4 w-4" />
+          </div>
+          <div className="flex-1">
+            <div className="text-[13.5px] font-semibold text-ink-900">
+              {locale === "zh" ? "今日记录已保存" : "Today's check-in saved"}
+            </div>
+            <div className="mt-0.5 text-xs text-ink-500">
+              {locale === "zh"
+                ? "需要补上饮食 / 运动 / 症状详情？打开完整日志。"
+                : "Want to add food, movement, symptom flags? Open the full log."}
+            </div>
+          </div>
+          <Link
+            href="/daily/new"
+            className="inline-flex items-center gap-1 rounded-md border border-ink-200 bg-paper-2 px-3 py-1.5 text-xs font-medium text-ink-700 hover:border-ink-300"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            {locale === "zh" ? "补记" : "Add detail"}
+          </Link>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="eyebrow">
+            {locale === "zh" ? "今日记录 · 快速" : "Today's check-in · quick"}
+          </div>
+          <p className="mt-1 text-xs text-ink-500">
+            {locale === "zh"
+              ? "三个滑块 —— 30 秒就好。详情可以稍后补。"
+              : "Three sliders. 30 seconds. Add detail later if you want."}
+          </p>
+        </div>
+        <Link
+          href="/daily/new"
+          className="mono text-[10px] uppercase tracking-wider text-ink-400 hover:text-ink-900"
+        >
+          {locale === "zh" ? "完整日志 →" : "Full log →"}
+        </Link>
+      </div>
+
+      <div className="mt-4 space-y-4">
+        {SCALES.map((s) => (
+          <ScaleRow
+            key={s.key}
+            label={locale === "zh" ? s.labelZh : s.labelEn}
+            value={values[s.key]}
+            good={s.good}
+            onChange={(v) =>
+              setValues((prev) => ({ ...prev, [s.key]: v }))
+            }
+          />
+        ))}
+        <FeverRow
+          locale={locale}
+          fever={fever}
+          temp={feverTemp}
+          onFeverChange={setFever}
+          onTempChange={setFeverTemp}
+        />
+      </div>
+
+      <div className="mt-5 flex items-center justify-between">
+        <div className="mono text-[10px] uppercase tracking-wider text-ink-400">
+          {today}
+        </div>
+        <Button onClick={save} disabled={saving} size="lg">
+          <Check className="h-4 w-4" />
+          {saving
+            ? locale === "zh"
+              ? "保存中…"
+              : "Saving…"
+            : locale === "zh"
+              ? "保存今日"
+              : "Save today"}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function ScaleRow({
+  label,
+  value,
+  good,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  good: "high" | "low";
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between">
+        <span className="text-[13px] font-medium text-ink-900">{label}</span>
+        <span className="serif num text-xl leading-none text-ink-900">
+          {value}
+          <span className="ml-0.5 mono text-[10px] font-normal text-ink-400">
+            /10
+          </span>
+        </span>
+      </div>
+      <div className="mt-2 grid grid-cols-11 gap-1.5">
+        {Array.from({ length: 11 }, (_, n) => {
+          const on = n === value;
+          const goodFill = good === "high" ? n >= value - 0 && false : false;
+          void goodFill;
+          return (
+            <button
+              key={n}
+              type="button"
+              onClick={() => onChange(n)}
+              className={cn(
+                "h-10 rounded-md border text-[11px] font-semibold transition-colors",
+                on
+                  ? "border-ink-900 bg-ink-900 text-paper"
+                  : "border-ink-200 bg-paper-2 text-ink-500 hover:border-ink-400",
+              )}
+              aria-label={`${label} ${n}`}
+            >
+              {n}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FeverRow({
+  locale,
+  fever,
+  temp,
+  onFeverChange,
+  onTempChange,
+}: {
+  locale: "en" | "zh";
+  fever: boolean;
+  temp: string;
+  onFeverChange: (v: boolean) => void;
+  onTempChange: (v: string) => void;
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-3 rounded-[var(--r-md)] p-3"
+      style={{
+        background: fever ? "var(--warn-soft)" : "var(--ink-100)",
+      }}
+    >
+      <div
+        className="flex h-8 w-8 items-center justify-center rounded-md"
+        style={{
+          background: fever ? "var(--warn)" : "var(--paper-2)",
+          color: fever ? "#fff" : "var(--ink-500)",
+        }}
+      >
+        <Thermometer className="h-4 w-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-[13px] font-semibold text-ink-900">
+          {locale === "zh" ? "发热" : "Fever"}
+        </div>
+        <div className="text-[11px] text-ink-500">
+          {locale === "zh"
+            ? "体温 ≥ 38 °C 立即联系值班"
+            : "≥ 38 °C is urgent — call the on-call team"}
+        </div>
+      </div>
+      <div className="flex items-center gap-1.5">
+        {(
+          [
+            ["no", false],
+            ["yes", true],
+          ] as const
+        ).map(([k, v]) => (
+          <button
+            key={k}
+            type="button"
+            onClick={() => onFeverChange(v)}
+            className={cn(
+              "rounded-md border px-3 py-1.5 text-xs font-semibold",
+              fever === v
+                ? "border-ink-900 bg-ink-900 text-paper"
+                : "border-ink-200 bg-paper-2 text-ink-500",
+            )}
+          >
+            {locale === "zh" ? (v ? "是" : "否") : v ? "Yes" : "No"}
+          </button>
+        ))}
+      </div>
+      {fever && (
+        <input
+          type="number"
+          step="0.1"
+          value={temp}
+          onChange={(e) => onTempChange(e.target.value)}
+          placeholder="°C"
+          className="h-9 w-20 rounded-md border border-ink-200 bg-paper-2 px-2 text-sm tabular-nums"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -72,10 +72,18 @@ const TONE_STYLES: Record<FeedItem["tone"], { bg: string; dot: string; border?: 
 
 const CACHE_KEY = "anchor_narrative";
 
-export function TodayFeed() {
+export function TodayFeed({
+  excludeIds = [],
+}: {
+  excludeIds?: string[];
+} = {}) {
   const locale = useLocale();
   const weather = useWeather();
-  const feed = useTodayFeed({ weather });
+  const rawFeed = useTodayFeed({ weather });
+  const feed =
+    excludeIds.length === 0
+      ? rawFeed
+      : rawFeed.filter((f) => !excludeIds.includes(f.id));
   const settings = useLiveQuery(() => db.settings.toArray());
   const apiKey = settings?.[0]?.anthropic_api_key;
   const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";

--- a/src/lib/nudges/trend-nudges.ts
+++ b/src/lib/nudges/trend-nudges.ts
@@ -272,5 +272,46 @@ export function computeTrendNudges({
     }
   }
 
+  // ── Backup nudge — fire when data sits on the device with no export ──
+  // Suppress until there are at least 3 logged dailies of real data so we
+  // don't nag fresh installs.
+  if (settings && recentDailies.length >= 3) {
+    const lastExport = settings.last_exported_at
+      ? new Date(settings.last_exported_at).getTime()
+      : null;
+    const daysSince =
+      lastExport !== null
+        ? Math.floor((Date.parse(todayISO) - lastExport) / (24 * 3600 * 1000))
+        : null;
+    if (lastExport === null || (daysSince !== null && daysSince >= 7)) {
+      out.push({
+        id: "trend_backup_due",
+        priority: 76,
+        category: "trend",
+        tone: "info",
+        title: {
+          en: "Back up your data",
+          zh: "备份你的数据",
+        },
+        body: {
+          en:
+            lastExport === null
+              ? "You haven't exported a backup yet. Everything lives on this device — one export keeps it safe."
+              : `Last backup ${daysSince ?? "?"} days ago. Save a JSON bundle to encrypted storage so a lost device can't take the history with it.`,
+          zh:
+            lastExport === null
+              ? "还没有导出过备份。所有数据都在本机 —— 导出一次就能存一份副本。"
+              : `上次备份已过 ${daysSince ?? "?"} 天。建议导出 JSON 备份并存到加密位置，避免设备丢失带走全部记录。`,
+        },
+        cta: {
+          href: "/reports",
+          label: { en: "Export now", zh: "现在备份" },
+        },
+        icon: "anchor",
+        source: "trend",
+      });
+    }
+  }
+
   return out;
 }

--- a/src/lib/validators/schemas.ts
+++ b/src/lib/validators/schemas.ts
@@ -66,6 +66,7 @@ export const settingsSchema = z.object({
   home_lon: z.number().optional(),
   home_timezone: z.string().optional(),
   onboarded_at: z.string().optional(),
+  last_exported_at: z.string().optional(),
   anthropic_api_key: z.string().optional(),
   default_ai_model: z.string().optional(),
 });

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -294,6 +294,7 @@ export interface Settings {
   home_lon?: number;
   home_timezone?: string;
   onboarded_at?: string;
+  last_exported_at?: string;
   anthropic_api_key?: string;
   default_ai_model?: string;
   created_at: string;

--- a/tests/unit/trend-nudges.test.ts
+++ b/tests/unit/trend-nudges.test.ts
@@ -222,4 +222,53 @@ describe("computeTrendNudges", () => {
     });
     expect(nudges.find((n) => n.id === "trend_streak_7")).toBeTruthy();
   });
+
+  it("backup nudge fires when never exported + 3 dailies logged", () => {
+    const dailies: DailyEntry[] = Array.from({ length: 3 }, (_, i) =>
+      d({ date: `2026-04-${18 + i}` }),
+    );
+    const nudges = computeTrendNudges({
+      settings: { ...settings, last_exported_at: undefined },
+      recentDailies: dailies,
+      recentLabs: [],
+      todayISO: "2026-04-21",
+    });
+    expect(nudges.find((n) => n.id === "trend_backup_due")).toBeTruthy();
+  });
+
+  it("backup nudge fires when last export > 7 days ago", () => {
+    const dailies: DailyEntry[] = Array.from({ length: 3 }, (_, i) =>
+      d({ date: `2026-04-${18 + i}` }),
+    );
+    const nudges = computeTrendNudges({
+      settings: { ...settings, last_exported_at: "2026-04-10T00:00:00Z" },
+      recentDailies: dailies,
+      recentLabs: [],
+      todayISO: "2026-04-21",
+    });
+    expect(nudges.find((n) => n.id === "trend_backup_due")).toBeTruthy();
+  });
+
+  it("backup nudge suppressed when recently exported", () => {
+    const dailies: DailyEntry[] = Array.from({ length: 3 }, (_, i) =>
+      d({ date: `2026-04-${18 + i}` }),
+    );
+    const nudges = computeTrendNudges({
+      settings: { ...settings, last_exported_at: "2026-04-20T00:00:00Z" },
+      recentDailies: dailies,
+      recentLabs: [],
+      todayISO: "2026-04-21",
+    });
+    expect(nudges.find((n) => n.id === "trend_backup_due")).toBeFalsy();
+  });
+
+  it("backup nudge suppressed on fresh installs (<3 dailies)", () => {
+    const nudges = computeTrendNudges({
+      settings: { ...settings, last_exported_at: undefined },
+      recentDailies: [d({ date: "2026-04-21" })],
+      recentLabs: [],
+      todayISO: "2026-04-21",
+    });
+    expect(nudges.find((n) => n.id === "trend_backup_due")).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Summary
- New `QuickCheckinCard` on the dashboard: 3 sliders (energy/pain/nausea) + fever Yes/No with conditional °C. Saves a minimal DailyEntry and runs the zone engine. Hides itself once today is logged.
- `TodayFeed` now accepts `excludeIds` so the dashboard can hide the `checkin_today` reminder while the quick card is visible.
- Backup nudge `trend_backup_due` fires when the user has never exported (and ≥3 dailies exist) or last export > 7 days old. `/reports` JSON export writes `last_exported_at` so the nudge clears after backup.
- 4 new unit tests on the backup-nudge rule (fire/suppress paths).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 103/103
- [x] `pnpm build` — clean
- [ ] Dashboard shows quick card on fresh day; save hides it and shows "saved" confirmation
- [ ] Backup nudge appears after 3 dailies if never exported; disappears after `/reports` export

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH