### PR TITLE
Treatment CRUD + list polish

### DIFF
--- a/src/app/treatment/[id]/edit/page.tsx
+++ b/src/app/treatment/[id]/edit/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, now } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { CycleForm, type CycleFormValues } from "~/components/treatment/cycle-form";
+
+export default function EditCyclePage() {
+  const locale = useLocale();
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = Number(params?.id);
+  const cycle = useLiveQuery(
+    () => (Number.isFinite(id) ? db.treatment_cycles.get(id) : undefined),
+    [id],
+  );
+
+  async function save(values: CycleFormValues) {
+    if (!cycle?.id) return;
+    await db.treatment_cycles.update(cycle.id, {
+      ...values,
+      updated_at: now(),
+    });
+    router.push(`/treatment/${cycle.id}`);
+  }
+
+  if (!cycle) {
+    return <div className="p-6 text-sm text-ink-500">Loading…</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-8">
+      <PageHeader
+        title={locale === "zh" ? "编辑周期" : "Edit cycle"}
+        subtitle={
+          locale === "zh"
+            ? "调整方案、开始日期、剂量等级或状态。"
+            : "Adjust protocol, start date, dose level, or status."
+        }
+      />
+
+      <CycleForm
+        initial={cycle}
+        submitLabel={{ en: "Save changes", zh: "保存更改" }}
+        onSubmit={save}
+        onCancel={() => router.push(`/treatment/${cycle.id}`)}
+      />
+    </div>
+  );
+}

--- a/src/app/treatment/[id]/page.tsx
+++ b/src/app/treatment/[id]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { buildCycleContext } from "~/lib/treatment/engine";
@@ -15,7 +15,7 @@ import { NudgeCard } from "~/components/treatment/nudge-card";
 import { formatDate } from "~/lib/utils/date";
 import { addDays, parseISO } from "date-fns";
 import type { NudgeCategory } from "~/types/treatment";
-import { CheckCircle2 } from "lucide-react";
+import { CheckCircle2, Pencil, Trash2 } from "lucide-react";
 
 const CATEGORY_ORDER: NudgeCategory[] = [
   "safety",
@@ -31,6 +31,7 @@ const CATEGORY_ORDER: NudgeCategory[] = [
 
 export default function CycleDetailPage() {
   const locale = useLocale();
+  const router = useRouter();
   const params = useParams<{ id: string }>();
   const id = Number(params?.id);
   const cycle = useLiveQuery(
@@ -40,6 +41,8 @@ export default function CycleDetailPage() {
   const latestDaily = useLiveQuery(() =>
     db.daily_entries.orderBy("date").reverse().limit(1).toArray(),
   );
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const ctx = useMemo(() => {
     if (!cycle) return null;
@@ -94,6 +97,17 @@ export default function CycleDetailPage() {
       snoozed_nudge_ids: next,
       updated_at: now(),
     });
+  }
+
+  async function deleteCycle() {
+    if (!cycle?.id) return;
+    setDeleting(true);
+    try {
+      await db.treatment_cycles.delete(cycle.id);
+      router.push("/treatment");
+    } finally {
+      setDeleting(false);
+    }
   }
 
   const byCategory = new Map<NudgeCategory, typeof ctx.applicable_nudges>();
@@ -241,14 +255,59 @@ export default function CycleDetailPage() {
         </CardContent>
       </Card>
 
-      {cycle.status !== "completed" && (
-        <div className="flex justify-end">
-          <Button variant="secondary" onClick={markCompleted}>
-            <CheckCircle2 className="h-4 w-4" />
-            {locale === "zh" ? "标记为完成" : "Mark cycle complete"}
+      <div className="flex flex-wrap items-center justify-between gap-2 pt-2">
+        <Link href={`/treatment/${cycle.id}/edit`}>
+          <Button variant="secondary">
+            <Pencil className="h-4 w-4" />
+            {locale === "zh" ? "编辑" : "Edit cycle"}
           </Button>
+        </Link>
+        <div className="flex flex-wrap items-center gap-2">
+          {cycle.status !== "completed" && (
+            <Button variant="secondary" onClick={markCompleted}>
+              <CheckCircle2 className="h-4 w-4" />
+              {locale === "zh" ? "标记为完成" : "Mark cycle complete"}
+            </Button>
+          )}
+          {!confirmDelete ? (
+            <Button
+              variant="secondary"
+              onClick={() => setConfirmDelete(true)}
+              className="text-[var(--warn)]"
+            >
+              <Trash2 className="h-4 w-4" />
+              {locale === "zh" ? "删除" : "Delete"}
+            </Button>
+          ) : (
+            <div className="flex items-center gap-2 rounded-lg border border-[var(--warn)]/40 bg-[var(--warn-soft)] px-3 py-2 text-xs">
+              <span className="text-ink-900">
+                {locale === "zh" ? "确认删除此周期？" : "Delete this cycle?"}
+              </span>
+              <Button
+                variant="secondary"
+                onClick={() => setConfirmDelete(false)}
+                disabled={deleting}
+              >
+                {locale === "zh" ? "取消" : "Cancel"}
+              </Button>
+              <button
+                type="button"
+                onClick={deleteCycle}
+                disabled={deleting}
+                className="rounded-md bg-[var(--warn)] px-3 py-1.5 text-xs font-semibold text-white hover:brightness-95 disabled:opacity-60"
+              >
+                {deleting
+                  ? locale === "zh"
+                    ? "删除中…"
+                    : "Deleting…"
+                  : locale === "zh"
+                    ? "确认删除"
+                    : "Confirm delete"}
+              </button>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/app/treatment/new/page.tsx
+++ b/src/app/treatment/new/page.tsx
@@ -1,18 +1,12 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
-import { PROTOCOL_LIBRARY } from "~/config/protocols";
 import { useLocale } from "~/hooks/use-translate";
 import { todayISO } from "~/lib/utils/date";
 import { PageHeader } from "~/components/ui/page-header";
-import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { Button } from "~/components/ui/button";
-import { Field, TextInput } from "~/components/ui/field";
-import { cn } from "~/lib/utils/cn";
-import type { ProtocolId } from "~/types/treatment";
+import { CycleForm, type CycleFormValues } from "~/components/treatment/cycle-form";
 
 export default function NewTreatmentCyclePage() {
   const locale = useLocale();
@@ -23,20 +17,9 @@ export default function NewTreatmentCyclePage() {
   );
   const nextNumber = (prior?.cycle_number ?? 0) + 1;
 
-  const [protocolId, setProtocolId] = useState<ProtocolId>("gnp_weekly");
-  const [startDate, setStartDate] = useState<string>(todayISO());
-  const [cycleNumber, setCycleNumber] = useState<number>(nextNumber);
-  const [doseLevel, setDoseLevel] = useState<number>(0);
-  const [notes, setNotes] = useState("");
-
-  async function save() {
+  async function save(values: CycleFormValues) {
     const id = await db.treatment_cycles.add({
-      protocol_id: protocolId,
-      cycle_number: cycleNumber,
-      start_date: startDate,
-      status: "active",
-      dose_level: doseLevel,
-      notes: notes || undefined,
+      ...values,
       created_at: now(),
       updated_at: now(),
     });
@@ -54,116 +37,23 @@ export default function NewTreatmentCyclePage() {
         }
       />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>{locale === "zh" ? "方案" : "Protocol"}</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {PROTOCOL_LIBRARY.map((p) => {
-            const active = protocolId === p.id;
-            return (
-              <button
-                key={p.id}
-                type="button"
-                onClick={() => setProtocolId(p.id)}
-                className={cn(
-                  "flex w-full flex-col items-start rounded-xl border p-3 text-left transition-colors",
-                  active
-                    ? "border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900"
-                    : "border-slate-200 bg-white hover:border-slate-400 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-600",
-                )}
-                aria-pressed={active}
-              >
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold">
-                    {p.name[locale]}
-                  </span>
-                  <span
-                    className={cn(
-                      "rounded-full px-2 py-0.5 text-[10px]",
-                      active
-                        ? "bg-white/20 text-white dark:bg-slate-900/20 dark:text-slate-900"
-                        : "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400",
-                    )}
-                  >
-                    {p.cycle_length_days}d · dose D{p.dose_days.join(", D")}
-                  </span>
-                </div>
-                <p
-                  className={cn(
-                    "mt-1 text-xs",
-                    active
-                      ? "text-slate-200 dark:text-slate-700"
-                      : "text-slate-500",
-                  )}
-                >
-                  {p.description[locale]}
-                </p>
-              </button>
-            );
-          })}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>{locale === "zh" ? "周期信息" : "Cycle details"}</CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-3 sm:grid-cols-2">
-          <Field label={locale === "zh" ? "周期编号" : "Cycle number"}>
-            <TextInput
-              type="number"
-              min={1}
-              value={cycleNumber}
-              onChange={(e) => setCycleNumber(Number(e.target.value))}
-            />
-          </Field>
-          <Field label={locale === "zh" ? "开始日期 (D1)" : "Start date (D1)"}>
-            <TextInput
-              type="date"
-              value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
-            />
-          </Field>
-          <Field
-            label={
-              locale === "zh"
-                ? "减量等级 (0 = 全剂量)"
-                : "Dose level (0 = full)"
-            }
-            hint={
-              locale === "zh"
-                ? "每级 -1 约减 20%"
-                : "Each level = ~20% reduction"
-            }
-          >
-            <TextInput
-              type="number"
-              max={0}
-              min={-4}
-              value={doseLevel}
-              onChange={(e) => setDoseLevel(Number(e.target.value))}
-            />
-          </Field>
-          <Field label={locale === "zh" ? "备注" : "Notes"}>
-            <TextInput
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              placeholder={
-                locale === "zh"
-                  ? "e.g. 减量 nab-P，因 CIPN"
-                  : "e.g. nab-P reduced for CIPN"
-              }
-            />
-          </Field>
-        </CardContent>
-      </Card>
-
-      <div className="flex justify-end">
-        <Button onClick={save} size="lg">
-          {locale === "zh" ? "保存并开始" : "Save and activate"}
-        </Button>
-      </div>
+      <CycleForm
+        initial={{
+          protocol_id: "gnp_weekly",
+          cycle_number: nextNumber,
+          start_date: todayISO(),
+          status: "active",
+          dose_level: 0,
+          created_at: now(),
+          updated_at: now(),
+        }}
+        submitLabel={{
+          en: "Save and activate",
+          zh: "保存并开始",
+        }}
+        onSubmit={save}
+        onCancel={() => router.push("/treatment")}
+      />
     </div>
   );
 }

--- a/src/app/treatment/page.tsx
+++ b/src/app/treatment/page.tsx
@@ -9,7 +9,32 @@ import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { PROTOCOL_BY_ID } from "~/config/protocols";
 import { formatDate } from "~/lib/utils/date";
-import { ChevronRight, Syringe } from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+import type { CycleStatus } from "~/types/treatment";
+import { ChevronRight, Pencil, Syringe } from "lucide-react";
+
+const STATUS_STYLES: Record<CycleStatus, { label: { en: string; zh: string }; cls: string }> = {
+  planned: {
+    label: { en: "Planned", zh: "已计划" },
+    cls: "bg-ink-100 text-ink-600",
+  },
+  active: {
+    label: { en: "Active", zh: "进行中" },
+    cls: "bg-[var(--ok-soft)] text-[var(--ok)]",
+  },
+  completed: {
+    label: { en: "Completed", zh: "已完成" },
+    cls: "bg-ink-100 text-ink-500",
+  },
+  delayed: {
+    label: { en: "Delayed", zh: "延迟" },
+    cls: "bg-[var(--sand)]/40 text-[oklch(45%_0.06_70)]",
+  },
+  cancelled: {
+    label: { en: "Cancelled", zh: "已取消" },
+    cls: "bg-[var(--warn-soft)] text-[var(--warn)]",
+  },
+};
 
 export default function TreatmentListPage() {
   const locale = useLocale();
@@ -34,11 +59,11 @@ export default function TreatmentListPage() {
       />
       {(!cycles || cycles.length === 0) && (
         <Card className="p-10 text-center">
-          <Syringe className="mx-auto mb-3 h-8 w-8 text-slate-400" />
+          <Syringe className="mx-auto mb-3 h-8 w-8 text-ink-400" />
           <div className="text-sm font-medium">
             {locale === "zh" ? "还没有化疗方案" : "No protocol set"}
           </div>
-          <div className="mx-auto mt-1 max-w-sm text-sm text-slate-500">
+          <div className="mx-auto mt-1 max-w-sm text-sm text-ink-500">
             {locale === "zh"
               ? "选择一个方案，Anchor 会按周期日给出饮食、卫生、运动、睡眠、情绪的贴身提示。"
               : "Pick a protocol and Anchor will surface day-specific nudges across diet, hygiene, exercise, sleep, and mental health."}
@@ -51,34 +76,58 @@ export default function TreatmentListPage() {
       <ul className="space-y-2">
         {(cycles ?? []).map((c) => {
           const proto = PROTOCOL_BY_ID[c.protocol_id];
+          const style = STATUS_STYLES[c.status];
           return (
             <li key={c.id}>
-              <Link
-                href={`/treatment/${c.id}`}
-                className="group flex items-center justify-between rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-slate-400 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-600"
-              >
-                <div className="space-y-1">
-                  <div className="text-sm font-medium">
-                    {proto?.short_name ?? c.protocol_id} ·{" "}
-                    {locale === "zh" ? "周期 " : "Cycle "}
-                    {c.cycle_number}
-                  </div>
-                  <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500">
-                    <span>
-                      {locale === "zh" ? "开始：" : "Start "}
-                      {formatDate(c.start_date, locale)}
-                    </span>
-                    <span className="capitalize">{c.status}</span>
-                    {c.dose_level !== 0 && (
+              <div className="group flex items-center justify-between rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300">
+                <Link
+                  href={`/treatment/${c.id}`}
+                  className="flex min-w-0 flex-1 items-center gap-3"
+                >
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2 text-sm font-medium text-ink-900">
                       <span>
-                        {locale === "zh" ? "减量 " : "Dose level "}
-                        {c.dose_level}
+                        {proto?.short_name ?? c.protocol_id} ·{" "}
+                        {locale === "zh" ? "周期 " : "Cycle "}
+                        {c.cycle_number}
                       </span>
-                    )}
+                      <span
+                        className={cn(
+                          "mono rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.1em]",
+                          style.cls,
+                        )}
+                      >
+                        {style.label[locale]}
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-ink-500">
+                      <span>
+                        {locale === "zh" ? "开始：" : "Start "}
+                        {formatDate(c.start_date, locale)}
+                      </span>
+                      {c.dose_level !== 0 && (
+                        <span>
+                          {locale === "zh" ? "减量 " : "Dose level "}
+                          {c.dose_level}
+                        </span>
+                      )}
+                      {c.notes && (
+                        <span className="truncate text-ink-400">
+                          · {c.notes}
+                        </span>
+                      )}
+                    </div>
                   </div>
-                </div>
-                <ChevronRight className="h-4 w-4 text-slate-400 group-hover:text-slate-700 dark:group-hover:text-slate-200" />
-              </Link>
+                  <ChevronRight className="h-4 w-4 shrink-0 text-ink-400 group-hover:text-ink-700" />
+                </Link>
+                <Link
+                  href={`/treatment/${c.id}/edit`}
+                  aria-label={locale === "zh" ? "编辑" : "Edit"}
+                  className="ml-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-ink-400 hover:bg-ink-100 hover:text-ink-900"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Link>
+              </div>
             </li>
           );
         })}

--- a/src/components/treatment/cycle-form.tsx
+++ b/src/components/treatment/cycle-form.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import { useLocale } from "~/hooks/use-translate";
+import { PROTOCOL_LIBRARY } from "~/config/protocols";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, TextInput } from "~/components/ui/field";
+import { cn } from "~/lib/utils/cn";
+import type { CycleStatus, ProtocolId, TreatmentCycle } from "~/types/treatment";
+
+export interface CycleFormValues {
+  protocol_id: ProtocolId;
+  cycle_number: number;
+  start_date: string;
+  status: CycleStatus;
+  dose_level: number;
+  notes?: string;
+  actual_end_date?: string;
+}
+
+const STATUSES: CycleStatus[] = [
+  "planned",
+  "active",
+  "completed",
+  "delayed",
+  "cancelled",
+];
+
+const STATUS_LABEL: Record<CycleStatus, { en: string; zh: string }> = {
+  planned: { en: "Planned", zh: "已计划" },
+  active: { en: "Active", zh: "进行中" },
+  completed: { en: "Completed", zh: "已完成" },
+  delayed: { en: "Delayed", zh: "延迟" },
+  cancelled: { en: "Cancelled", zh: "已取消" },
+};
+
+export function CycleForm({
+  initial,
+  submitLabel,
+  onSubmit,
+  onCancel,
+}: {
+  initial?: TreatmentCycle;
+  submitLabel: { en: string; zh: string };
+  onSubmit: (values: CycleFormValues) => Promise<void>;
+  onCancel?: () => void;
+}) {
+  const locale = useLocale();
+
+  const [protocolId, setProtocolId] = useState<ProtocolId>(
+    initial?.protocol_id ?? "gnp_weekly",
+  );
+  const [cycleNumber, setCycleNumber] = useState<number>(
+    initial?.cycle_number ?? 1,
+  );
+  const [startDate, setStartDate] = useState<string>(
+    initial?.start_date ?? new Date().toISOString().slice(0, 10),
+  );
+  const [status, setStatus] = useState<CycleStatus>(initial?.status ?? "active");
+  const [doseLevel, setDoseLevel] = useState<number>(initial?.dose_level ?? 0);
+  const [notes, setNotes] = useState(initial?.notes ?? "");
+  const [actualEnd, setActualEnd] = useState<string>(
+    initial?.actual_end_date ?? "",
+  );
+  const [saving, setSaving] = useState(false);
+
+  async function handleSubmit() {
+    setSaving(true);
+    try {
+      await onSubmit({
+        protocol_id: protocolId,
+        cycle_number: cycleNumber,
+        start_date: startDate,
+        status,
+        dose_level: doseLevel,
+        notes: notes.trim() ? notes.trim() : undefined,
+        actual_end_date:
+          status === "completed" && actualEnd ? actualEnd : undefined,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{locale === "zh" ? "方案" : "Protocol"}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {PROTOCOL_LIBRARY.map((p) => {
+            const active = protocolId === p.id;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setProtocolId(p.id)}
+                className={cn(
+                  "flex w-full flex-col items-start rounded-xl border p-3 text-left transition-colors",
+                  active
+                    ? "border-ink-900 bg-ink-900 text-paper"
+                    : "border-ink-200 bg-paper-2 hover:border-ink-400",
+                )}
+                aria-pressed={active}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold">
+                    {p.name[locale]}
+                  </span>
+                  <span
+                    className={cn(
+                      "rounded-full px-2 py-0.5 text-[10px]",
+                      active
+                        ? "bg-paper/20 text-paper"
+                        : "bg-ink-100 text-ink-600",
+                    )}
+                  >
+                    {p.cycle_length_days}d · dose D{p.dose_days.join(", D")}
+                  </span>
+                </div>
+                <p
+                  className={cn(
+                    "mt-1 text-xs",
+                    active ? "text-ink-200" : "text-ink-500",
+                  )}
+                >
+                  {p.description[locale]}
+                </p>
+              </button>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {locale === "zh" ? "周期信息" : "Cycle details"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-3 sm:grid-cols-2">
+          <Field label={locale === "zh" ? "周期编号" : "Cycle number"}>
+            <TextInput
+              type="number"
+              min={1}
+              value={cycleNumber}
+              onChange={(e) => setCycleNumber(Number(e.target.value))}
+            />
+          </Field>
+          <Field label={locale === "zh" ? "开始日期 (D1)" : "Start date (D1)"}>
+            <TextInput
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+            />
+          </Field>
+          <Field label={locale === "zh" ? "状态" : "Status"}>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value as CycleStatus)}
+              className="h-10 w-full rounded-md border border-ink-200 bg-paper-2 px-3 text-sm"
+            >
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {STATUS_LABEL[s][locale]}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field
+            label={
+              locale === "zh"
+                ? "减量等级 (0 = 全剂量)"
+                : "Dose level (0 = full)"
+            }
+            hint={
+              locale === "zh"
+                ? "每级 -1 约减 20%"
+                : "Each level = ~20% reduction"
+            }
+          >
+            <TextInput
+              type="number"
+              max={0}
+              min={-4}
+              value={doseLevel}
+              onChange={(e) => setDoseLevel(Number(e.target.value))}
+            />
+          </Field>
+          {status === "completed" && (
+            <Field
+              label={
+                locale === "zh" ? "实际结束日期" : "Actual end date"
+              }
+            >
+              <TextInput
+                type="date"
+                value={actualEnd}
+                onChange={(e) => setActualEnd(e.target.value)}
+              />
+            </Field>
+          )}
+          <Field
+            label={locale === "zh" ? "备注" : "Notes"}
+            className={status === "completed" ? "" : "sm:col-span-2"}
+          >
+            <TextInput
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder={
+                locale === "zh"
+                  ? "例如：减量 nab-P，因 CIPN"
+                  : "e.g. nab-P reduced for CIPN"
+              }
+            />
+          </Field>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end gap-2">
+        {onCancel && (
+          <Button variant="secondary" onClick={onCancel} disabled={saving}>
+            {locale === "zh" ? "取消" : "Cancel"}
+          </Button>
+        )}
+        <Button onClick={handleSubmit} disabled={saving} size="lg">
+          {saving
+            ? locale === "zh"
+              ? "保存中…"
+              : "Saving…"
+            : submitLabel[locale]}
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Shared `CycleForm` drives both `/treatment/new` and the new `/treatment/[id]/edit`. Every cycle field is editable (protocol, cycle #, start date, status, dose level, actual end date, notes).
- `/treatment/[id]` gains three footer actions: **Edit cycle**, **Mark complete** (kept), and **Delete** (two-step confirm that routes back to the list).
- List polish: coloured status pill (planned/active/completed/delayed/cancelled), pencil quick-link to the edit form, ink/paper tokens replacing the old slate styles.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 103/103
- [x] `pnpm build` — `/treatment/[id]/edit` registered
- [ ] Start → edit → save reflects the changes
- [ ] Delete prompt appears before the cycle disappears
- [ ] Dashboard `PillarTiles` Next-infusion tile clears after deleting the active cycle

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH