### PR TITLE
Ship polish: lang sync, drop dead bell, list-page tokens

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -35,11 +35,11 @@ export default function DailyPage() {
 
       {(!entries || entries.length === 0) && (
         <Card className="p-10 text-center">
-          <CalendarDays className="mx-auto mb-3 h-8 w-8 text-slate-400" />
+          <CalendarDays className="mx-auto mb-3 h-8 w-8 text-ink-400" />
           <div className="text-sm font-medium">
             {locale === "zh" ? "还没有记录" : "No entries yet"}
           </div>
-          <div className="mx-auto mt-1 max-w-sm text-sm text-slate-500">
+          <div className="mx-auto mt-1 max-w-sm text-sm text-ink-500">
             {locale === "zh"
               ? "先开始今天的记录 —— 之后的趋势都以今天为起点。"
               : "Start today's entry — every trend begins here."}
@@ -55,13 +55,13 @@ export default function DailyPage() {
           <li key={e.id}>
             <Link
               href={`/daily/${e.id}`}
-              className="group flex items-center justify-between rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-slate-400 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-600"
+              className="group flex items-center justify-between rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300"
             >
               <div className="space-y-1">
-                <div className="text-sm font-medium">
+                <div className="text-sm font-medium text-ink-900">
                   {formatDate(e.date, locale)}
                 </div>
-                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-500">
                   <span>
                     {locale === "zh" ? "精力" : "energy"} {e.energy}
                   </span>
@@ -76,30 +76,48 @@ export default function DailyPage() {
                     <span>{e.walking_minutes} min walk</span>
                   )}
                   {e.resistance_training && (
-                    <span className="text-emerald-600 dark:text-emerald-400">
+                    <span className="text-[var(--ok)]">
                       {locale === "zh" ? "阻力 ✓" : "resistance ✓"}
                     </span>
                   )}
                 </div>
                 <div className="flex gap-1.5 text-xs">
                   {e.fever && (
-                    <span className="rounded-full bg-red-100 px-2 py-0.5 text-red-700 dark:bg-red-950 dark:text-red-300">
-                      fever
+                    <span
+                      className="rounded-full px-2 py-0.5 text-[11px]"
+                      style={{
+                        background: "var(--warn-soft)",
+                        color: "var(--warn)",
+                      }}
+                    >
+                      {locale === "zh" ? "发热" : "fever"}
                     </span>
                   )}
                   {(e.neuropathy_feet || e.neuropathy_hands) && (
-                    <span className="rounded-full bg-amber-100 px-2 py-0.5 text-amber-700 dark:bg-amber-950 dark:text-amber-300">
-                      neuropathy
+                    <span
+                      className="rounded-full px-2 py-0.5 text-[11px]"
+                      style={{
+                        background: "var(--sand)",
+                        color: "oklch(45% 0.06 70)",
+                      }}
+                    >
+                      {locale === "zh" ? "神经病变" : "neuropathy"}
                     </span>
                   )}
                   {e.new_bruising && (
-                    <span className="rounded-full bg-amber-100 px-2 py-0.5 text-amber-700 dark:bg-amber-950 dark:text-amber-300">
-                      bruising
+                    <span
+                      className="rounded-full px-2 py-0.5 text-[11px]"
+                      style={{
+                        background: "var(--sand)",
+                        color: "oklch(45% 0.06 70)",
+                      }}
+                    >
+                      {locale === "zh" ? "瘀斑" : "bruising"}
                     </span>
                   )}
                 </div>
               </div>
-              <ChevronRight className="h-4 w-4 text-slate-400 group-hover:text-slate-700 dark:group-hover:text-slate-200" />
+              <ChevronRight className="h-4 w-4 text-ink-400 group-hover:text-ink-700" />
             </Link>
           </li>
         ))}

--- a/src/app/fortnightly/page.tsx
+++ b/src/app/fortnightly/page.tsx
@@ -41,11 +41,11 @@ export default function FortnightlyListPage() {
 
       {(!assessments || assessments.length === 0) && (
         <Card className="p-10 text-center">
-          <Stethoscope className="mx-auto mb-3 h-8 w-8 text-slate-400" />
+          <Stethoscope className="mx-auto mb-3 h-8 w-8 text-ink-400" />
           <div className="text-sm font-medium">
             {locale === "zh" ? "还没有评估记录" : "No assessments yet"}
           </div>
-          <div className="mx-auto mt-1 max-w-sm text-sm text-slate-500">
+          <div className="mx-auto mt-1 max-w-sm text-sm text-ink-500">
             {locale === "zh"
               ? "第一次测试将作为之后对比的基线。"
               : "Your first measurements establish the baseline that later values compare against."}
@@ -61,13 +61,13 @@ export default function FortnightlyListPage() {
           <li key={a.id}>
             <Link
               href={`/fortnightly/${a.id}`}
-              className="group flex items-center justify-between rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-slate-400 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-600"
+              className="group flex items-center justify-between rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300"
             >
               <div className="space-y-1">
-                <div className="text-sm font-medium">
+                <div className="text-sm font-medium text-ink-900">
                   {formatDate(a.assessment_date, locale)}
                 </div>
-                <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500">
+                <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-ink-500">
                   <span>ECOG {a.ecog_self}</span>
                   {typeof a.grip_dominant_kg === "number" && (
                     <span>grip {a.grip_dominant_kg} kg</span>
@@ -83,7 +83,7 @@ export default function FortnightlyListPage() {
                   )}
                 </div>
               </div>
-              <ChevronRight className="h-4 w-4 text-slate-400 group-hover:text-slate-700 dark:group-hover:text-slate-200" />
+              <ChevronRight className="h-4 w-4 text-ink-400 group-hover:text-ink-700" />
             </Link>
           </li>
         ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,6 @@ import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
 import { TodayFeed } from "~/components/dashboard/today-feed";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { PageHeader, SectionHeader } from "~/components/ui/page-header";
-import { Bell } from "lucide-react";
 
 export default function DashboardPage() {
   const t = useT();
@@ -68,15 +67,6 @@ export default function DashboardPage() {
               </>
             )}
           </>
-        }
-        action={
-          <button
-            type="button"
-            aria-label="notifications"
-            className="flex h-10 w-10 items-center justify-center rounded-full bg-paper-2 text-ink-700 shadow-sm hover:bg-ink-100"
-          >
-            <Bell className="h-4 w-4" />
-          </button>
         }
       />
 

--- a/src/app/weekly/page.tsx
+++ b/src/app/weekly/page.tsx
@@ -37,11 +37,11 @@ export default function WeeklyListPage() {
 
       {(!assessments || assessments.length === 0) && (
         <Card className="p-10 text-center">
-          <CalendarRange className="mx-auto mb-3 h-8 w-8 text-slate-400" />
+          <CalendarRange className="mx-auto mb-3 h-8 w-8 text-ink-400" />
           <div className="text-sm font-medium">
             {locale === "zh" ? "还没有每周记录" : "No weekly entries yet"}
           </div>
-          <div className="mx-auto mt-1 max-w-sm text-sm text-slate-500">
+          <div className="mx-auto mt-1 max-w-sm text-sm text-ink-500">
             {locale === "zh"
               ? "每周日晚做一次，五分钟。"
               : "Best done Sunday evening. Takes ~5 minutes."}
@@ -57,13 +57,13 @@ export default function WeeklyListPage() {
           <li key={a.id}>
             <Link
               href={`/weekly/${a.id}`}
-              className="group flex items-center justify-between rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-slate-400 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-600"
+              className="group flex items-center justify-between rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300"
             >
               <div className="space-y-1">
-                <div className="text-sm font-medium">
+                <div className="text-sm font-medium text-ink-900">
                   {formatWeekRange(a.week_start, locale)}
                 </div>
-                <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500">
+                <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-ink-500">
                   <span>
                     {locale === "zh" ? "修习" : "practice"}{" "}
                     {a.practice_full_days + a.practice_reduced_days} / 7
@@ -85,12 +85,12 @@ export default function WeeklyListPage() {
                   )}
                 </div>
                 {a.concerns && (
-                  <div className="text-xs text-slate-600 dark:text-slate-400 line-clamp-1">
+                  <div className="text-xs text-ink-600 line-clamp-1">
                     {a.concerns}
                   </div>
                 )}
               </div>
-              <ChevronRight className="h-4 w-4 text-slate-400 group-hover:text-slate-700 dark:group-hover:text-slate-200" />
+              <ChevronRight className="h-4 w-4 text-ink-400 group-hover:text-ink-700" />
             </Link>
           </li>
         ))}

--- a/src/components/shared/providers.tsx
+++ b/src/components/shared/providers.tsx
@@ -3,15 +3,21 @@
 import { useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ensureSeeded } from "~/lib/db/seed";
+import { useUIStore } from "~/stores/ui-store";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [client] = useState(() => new QueryClient());
+  const locale = useUIStore((s) => s.locale);
 
   useEffect(() => {
     ensureSeeded().catch(() => {
       // seeding failures are non-fatal
     });
   }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
+  }, [locale]);
 
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }


### PR DESCRIPTION
## Summary
- `<html lang>` is now reactive: Providers writes `document.documentElement.lang` whenever the locale changes. Screen readers + browser translation now respect 中文 properly.
- Dashboard drops the unwired notification `Bell` button.
- `/daily`, `/weekly`, `/fortnightly` list pages migrated off `slate-*` onto the Anchor ink/paper tokens, including the status badges for fever / neuropathy / bruising so they match the rest of the app.

Runs in parallel with PR #13 (treatment CRUD) — no shared files.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 103/103
- [x] `pnpm build` — clean
- [ ] Switch locale to 中文 in Settings → DevTools shows `<html lang="zh-CN">`
- [ ] Dashboard header no longer shows bell icon
- [ ] Daily / weekly / fortnightly list rows match Anchor paper + ink palette

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH