### PR TITLE
Treatment detail + emergency-card always-reachable + tasks tokens

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -85,7 +85,7 @@ export default function TasksPage() {
       {showPresets && (
         <Card>
           <CardContent className="pt-5">
-            <div className="mb-3 text-sm text-slate-500">
+            <div className="mb-3 text-sm text-ink-500">
               {locale === "zh"
                 ? "从常见的照护任务中挑选 —— 一点即添加。"
                 : "Add common care tasks in one click. You can edit any after adding."}
@@ -97,11 +97,11 @@ export default function TasksPage() {
 
       {instances.length === 0 && !showPresets && (
         <Card className="p-10 text-center">
-          <ListTodo className="mx-auto mb-3 h-8 w-8 text-slate-400" />
+          <ListTodo className="mx-auto mb-3 h-8 w-8 text-ink-400" />
           <div className="text-sm font-medium">
             {locale === "zh" ? "还没有任务" : "No tasks yet"}
           </div>
-          <div className="mx-auto mt-1 max-w-sm text-sm text-slate-500">
+          <div className="mx-auto mt-1 max-w-sm text-sm text-ink-500">
             {locale === "zh"
               ? "从建议列表添加，或自己写一个。"
               : "Start from a suggestion or write your own."}
@@ -126,7 +126,7 @@ export default function TasksPage() {
         if (items.length === 0) return null;
         return (
           <section key={key} className="space-y-2">
-            <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+            <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
               {label[locale]} · {items.length}
             </h2>
             <ul className="space-y-2">

--- a/src/app/treatment/[id]/page.tsx
+++ b/src/app/treatment/[id]/page.tsx
@@ -57,7 +57,7 @@ export default function CycleDetailPage() {
   }, [cycle, latestDaily]);
 
   if (!cycle || !ctx) {
-    return <div className="p-6 text-sm text-slate-500">Loading…</div>;
+    return <div className="p-6 text-sm text-ink-500">Loading…</div>;
   }
 
   const { protocol } = ctx;
@@ -136,7 +136,7 @@ export default function CycleDetailPage() {
           <CardTitle>
             {locale === "zh" ? "今天在周期中" : "Where you are in the cycle"}
           </CardTitle>
-          <div className="mt-1 text-sm text-slate-500">
+          <div className="mt-1 text-sm text-ink-500">
             {locale === "zh" ? "第 " : "Day "}
             {ctx.cycle_day}
             {locale === "zh" ? " 天 · " : " · "}
@@ -146,7 +146,7 @@ export default function CycleDetailPage() {
         <CardContent className="space-y-3">
           <CycleCalendar cycle={cycle} protocol={protocol} />
           {ctx.phase?.description[locale] && (
-            <div className="text-xs text-slate-600 dark:text-slate-400">
+            <div className="text-xs text-ink-600">
               {ctx.phase.description[locale]}
             </div>
           )}
@@ -160,18 +160,18 @@ export default function CycleDetailPage() {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3 text-sm">
-          <p className="text-slate-600 dark:text-slate-400">
+          <p className="text-ink-600">
             {protocol.description[locale]}
           </p>
           <div className="space-y-1">
-            <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <div className="text-xs font-semibold uppercase tracking-wide text-ink-500">
               {locale === "zh" ? "药物" : "Agents"}
             </div>
             <ul className="space-y-1">
               {protocol.agents.map((a) => (
                 <li key={a.id}>
                   <span className="font-medium">{a.display[locale]}</span>
-                  <span className="ml-2 text-xs text-slate-500">
+                  <span className="ml-2 text-xs text-ink-500">
                     {a.typical_dose} · D{a.dose_days.join(", D")}
                   </span>
                 </li>
@@ -179,18 +179,18 @@ export default function CycleDetailPage() {
             </ul>
           </div>
           <div className="space-y-1">
-            <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <div className="text-xs font-semibold uppercase tracking-wide text-ink-500">
               {locale === "zh" ? "预用药" : "Premeds"}
             </div>
-            <p className="text-xs text-slate-600 dark:text-slate-400">
+            <p className="text-xs text-ink-600">
               {protocol.premeds?.[locale] ?? "—"}
             </p>
           </div>
           <div className="space-y-1">
-            <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <div className="text-xs font-semibold uppercase tracking-wide text-ink-500">
               {locale === "zh" ? "典型副作用谱" : "Side effect profile"}
             </div>
-            <p className="text-xs text-slate-600 dark:text-slate-400">
+            <p className="text-xs text-ink-600">
               {protocol.side_effect_profile[locale]}
             </p>
           </div>
@@ -202,7 +202,7 @@ export default function CycleDetailPage() {
           <CardTitle>
             {locale === "zh" ? "今日提示" : "Today's nudges"}
           </CardTitle>
-          <div className="mt-1 text-xs text-slate-500">
+          <div className="mt-1 text-xs text-ink-500">
             {ctx.applicable_nudges.length}{" "}
             {locale === "zh" ? "条" : "items"}
             {(cycle.snoozed_nudge_ids?.length ?? 0) > 0 &&
@@ -215,7 +215,7 @@ export default function CycleDetailPage() {
             if (!items || items.length === 0) return null;
             return (
               <div key={cat}>
-                <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-500">
+                <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-500">
                   {cat}
                 </div>
                 <div className="space-y-1.5">
@@ -227,7 +227,7 @@ export default function CycleDetailPage() {
             );
           })}
           {ctx.applicable_nudges.length === 0 && (
-            <div className="text-xs text-slate-500">
+            <div className="text-xs text-ink-500">
               {locale === "zh"
                 ? "今天没有特别提示。"
                 : "No contextual nudges for today."}
@@ -235,7 +235,7 @@ export default function CycleDetailPage() {
           )}
           {(cycle.snoozed_nudge_ids?.length ?? 0) > 0 && (
             <div className="pt-2">
-              <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-500">
+              <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-500">
                 {locale === "zh" ? "已暂隐" : "Snoozed"}
               </div>
               <div className="flex flex-wrap gap-1.5 text-xs">
@@ -244,7 +244,7 @@ export default function CycleDetailPage() {
                     key={id}
                     type="button"
                     onClick={() => restoreNudge(id)}
-                    className="rounded-full border border-slate-300 bg-white px-2.5 py-1 text-slate-600 hover:border-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400"
+                    className="rounded-full border border-ink-200 bg-paper-2 px-2.5 py-1 text-ink-600 hover:border-ink-400"
                   >
                     ↺ {id}
                   </button>

--- a/src/components/dashboard/emergency-card.tsx
+++ b/src/components/dashboard/emergency-card.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useLiveQuery } from "dexie-react-hooks";
+import { useState } from "react";
 import { db } from "~/lib/db/dexie";
 import { useZoneStatus } from "~/hooks/use-zone-status";
 import { useLocale } from "~/hooks/use-translate";
-import { Phone, AlertOctagon, MapPin } from "lucide-react";
+import { Phone, AlertOctagon, MapPin, ChevronDown, ChevronUp } from "lucide-react";
 
 export function EmergencyCard() {
   const locale = useLocale();
@@ -17,33 +18,41 @@ export function EmergencyCard() {
     s?.managing_oncologist_phone ||
     s?.hospital_phone;
 
-  if (!hasAnyContact) return null;
+  // Default open whenever zone is warn/urgent; otherwise collapsed but
+  // still always reachable via the chevron.
+  const alertActive = zone === "red" || zone === "orange";
+  const [open, setOpen] = useState(alertActive);
 
-  const showExpanded = zone === "red" || zone === "orange";
+  if (!hasAnyContact) return null;
 
   return (
     <section
       className="rounded-[var(--r-md)] border"
       style={{
-        background: showExpanded ? "var(--warn-soft)" : "var(--paper-2)",
-        borderColor: showExpanded
+        background: alertActive ? "var(--warn-soft)" : "var(--paper-2)",
+        borderColor: alertActive
           ? "var(--warn)"
           : "color-mix(in oklch, var(--ink-900), transparent 92%)",
       }}
     >
-      <div className="flex items-center gap-3 px-4 py-3">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left"
+        aria-expanded={open}
+      >
         <div
           className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
           style={{
-            background: showExpanded ? "var(--warn)" : "var(--tide-soft)",
-            color: showExpanded ? "white" : "var(--tide-2)",
+            background: alertActive ? "var(--warn)" : "var(--tide-soft)",
+            color: alertActive ? "white" : "var(--tide-2)",
           }}
         >
           <AlertOctagon className="h-4 w-4" />
         </div>
         <div className="flex-1 min-w-0">
           <div className="text-[12.5px] font-semibold text-ink-900">
-            {showExpanded
+            {alertActive
               ? locale === "zh"
                 ? "警示激活 — 必要时拨打"
                 : "Alert active — call if needed"
@@ -57,9 +66,14 @@ export function EmergencyCard() {
               : "Temp ≥ 38 °C → hospital now"}
           </div>
         </div>
-      </div>
+        {open ? (
+          <ChevronUp className="h-4 w-4 shrink-0 text-ink-400" />
+        ) : (
+          <ChevronDown className="h-4 w-4 shrink-0 text-ink-400" />
+        )}
+      </button>
 
-      {showExpanded && (
+      {open && (
         <div className="border-t border-ink-100/70 px-4 py-3 space-y-1.5">
           {s?.oncall_phone && (
             <ContactLink


### PR DESCRIPTION
## Summary
Three small polish changes:
- **Treatment detail slate → ink**: section body copy, muted labels, phase description, snoozed-nudge pill now use Anchor tokens.
- **EmergencyCard is always reachable**: the contact list used to only expand in orange/red zones. Numbers should be one tap away regardless — the banner is now a toggle. Auto-opens when an alert is active, collapsible otherwise.
- **Tasks page**: leftover slate text/icons ported to ink tokens.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 103/103
- [x] `pnpm build` — clean
- [ ] Dashboard: tap the Emergency header — contacts expand even in green zone
- [ ] Settings → populate oncall/oncologist/hospital phones → dashboard card shows them
- [ ] `/tasks` list matches the rest of the ink/paper palette

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH