### PR TITLE
Bridge + assessment list: ink tokens

### DIFF
--- a/src/app/assessment/page.tsx
+++ b/src/app/assessment/page.tsx
@@ -50,11 +50,11 @@ export default function AssessmentListPage() {
 
       {(!assessments || assessments.length === 0) && (
         <Card className="p-10 text-center">
-          <Stethoscope className="mx-auto mb-3 h-8 w-8 text-slate-400" />
+          <Stethoscope className="mx-auto mb-3 h-8 w-8 text-ink-400" />
           <div className="text-sm font-medium">
             {locale === "zh" ? "尚未做过综合评估" : "No comprehensive assessment yet"}
           </div>
-          <div className="mx-auto mt-1 max-w-sm text-sm text-slate-500">
+          <div className="mx-auto mt-1 max-w-sm text-sm text-ink-500">
             {locale === "zh"
               ? "第一次评估会建立基线，后续的变化都以此为参照。"
               : "Your first assessment becomes the baseline. Everything after compares against it."}
@@ -70,21 +70,21 @@ export default function AssessmentListPage() {
           <li key={a.id}>
             <Link
               href={a.status === "draft" ? `/assessment/run/${a.id}` : `/assessment/${a.id}`}
-              className="group flex items-center gap-4 rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-slate-400 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-600"
+              className="group flex items-center gap-4 rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300"
             >
               {typeof a.anchor_index === "number" ? (
                 <PillarRing score={a.anchor_index} size={56} />
               ) : (
-                <div className="flex h-14 w-14 items-center justify-center rounded-full border border-dashed border-slate-300 dark:border-slate-700">
-                  <Clock className="h-5 w-5 text-slate-400" />
+                <div className="flex h-14 w-14 items-center justify-center rounded-full border border-dashed border-ink-200">
+                  <Clock className="h-5 w-5 text-ink-400" />
                 </div>
               )}
               <div className="flex-1 space-y-1">
-                <div className="text-sm font-semibold">
+                <div className="text-sm font-semibold text-ink-900">
                   {formatDate(a.assessment_date, locale)} ·{" "}
                   {a.trigger === "baseline" ? (locale === "zh" ? "基线" : "Baseline") : a.trigger}
                 </div>
-                <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500">
+                <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-ink-500">
                   <span>
                     {(a.tests_completed?.length ?? 0)} /{" "}
                     {(a.tests_included?.length ?? 0)}{" "}
@@ -102,8 +102,8 @@ export default function AssessmentListPage() {
                   <span
                     className={
                       a.status === "complete"
-                        ? "text-emerald-600 dark:text-emerald-400"
-                        : "text-amber-600 dark:text-amber-400"
+                        ? "text-[var(--ok)]"
+                        : "text-[oklch(55%_0.1_70)]"
                     }
                   >
                     {a.status === "complete"
@@ -116,7 +116,7 @@ export default function AssessmentListPage() {
                   </span>
                 </div>
               </div>
-              <ChevronRight className="h-4 w-4 text-slate-400 group-hover:text-slate-700 dark:group-hover:text-slate-200" />
+              <ChevronRight className="h-4 w-4 text-ink-400 group-hover:text-ink-700" />
             </Link>
           </li>
         ))}

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -2,32 +2,45 @@
 
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
-import { useT } from "~/hooks/use-translate";
+import { useLocale, useT } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
 
 export default function BridgePage() {
   const t = useT();
+  const locale = useLocale();
   const trials = useLiveQuery(() =>
     db.trials.orderBy("priority").toArray(),
   );
 
   return (
     <div className="max-w-4xl mx-auto p-4 md:p-8 space-y-6">
-      <h1 className="text-2xl font-semibold">{t("nav.bridge")}</h1>
+      <PageHeader
+        title={t("nav.bridge")}
+        subtitle={
+          locale === "zh"
+            ? "daraxonrasib 的桥接策略 —— 维持功能，等待机会。"
+            : "Bridge strategy to daraxonrasib — preserve function while the window opens."
+        }
+      />
       <div className="grid gap-4 md:grid-cols-2">
         {(trials ?? []).map((trial) => (
           <div
             key={trial.trial_id}
-            className="rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4"
+            className="rounded-[var(--r-md)] border border-ink-100/70 bg-paper-2 p-4"
           >
             <div className="flex items-baseline justify-between gap-2">
-              <h2 className="font-semibold">{trial.name}</h2>
-              <span className="text-xs text-slate-500">{trial.phase}</span>
+              <h2 className="font-semibold text-ink-900">{trial.name}</h2>
+              <span className="mono text-[10px] uppercase tracking-wider text-ink-400">
+                {trial.phase}
+              </span>
             </div>
-            <div className="text-xs text-slate-500 mt-1">{trial.trial_id}</div>
-            <div className="mt-2 text-sm text-slate-700 dark:text-slate-300">
+            <div className="mono mt-1 text-[10px] uppercase tracking-wider text-ink-500">
+              {trial.trial_id}
+            </div>
+            <div className="mt-3 text-sm text-ink-700">
               {trial.eligibility_summary}
             </div>
-            <div className="mt-3 inline-flex items-center rounded-full border border-slate-300 dark:border-slate-700 px-2 py-0.5 text-xs">
+            <div className="mt-3 inline-flex items-center rounded-full border border-ink-200 px-2 py-0.5 text-xs capitalize text-ink-600">
               {trial.status}
             </div>
           </div>


### PR DESCRIPTION
## Summary
Last couple of patient-facing surfaces still on slate:
- `/bridge` — PageHeader added, trial cards use paper/ink tokens with mono eyebrow on trial id/phase.
- `/assessment` list — card borders, empty state, "complete" / "draft" status text all move to ink + `var(--ok)` / sand-amber.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [ ] `/bridge` trial cards match the rest of the app
- [ ] `/assessment` list rows match paper/ink

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH