### PR TITLE
Reports + ingest-pending: ink tokens

### DIFF
--- a/src/app/ingest/pending/page.tsx
+++ b/src/app/ingest/pending/page.tsx
@@ -105,7 +105,7 @@ export default function PendingResultsPage() {
               onChange={(e) =>
                 setCategory(e.target.value as PendingResultCategory)
               }
-              className="h-11 w-full rounded-lg border border-slate-300 bg-white px-3 text-sm focus:border-slate-900 focus:outline-none dark:border-slate-700 dark:bg-slate-900"
+              className="h-11 w-full rounded-lg border border-ink-200 bg-paper-2 px-3 text-sm focus:border-ink-900 focus:outline-none focus:ring-2 focus:ring-ink-900/10"
             >
               {CATEGORIES.map((c) => (
                 <option key={c} value={c}>
@@ -143,11 +143,11 @@ export default function PendingResultsPage() {
       </Card>
 
       <section className="space-y-3">
-        <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
           {locale === "zh" ? "未收到" : "Open"} ({open.length})
         </h2>
         {open.length === 0 && (
-          <div className="rounded-lg border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500 dark:border-slate-700">
+          <div className="rounded-lg border border-dashed border-ink-200 p-6 text-center text-sm text-ink-500">
             {locale === "zh" ? "没有待出结果。" : "Nothing pending."}
           </div>
         )}
@@ -158,15 +158,15 @@ export default function PendingResultsPage() {
               <li
                 key={r.id}
                 className={cn(
-                  "flex items-center justify-between rounded-xl border bg-white p-4 dark:bg-slate-900",
+                  "flex items-center justify-between rounded-xl border bg-paper-2 p-4",
                   overdue
-                    ? "border-amber-400 dark:border-amber-800"
-                    : "border-slate-200 dark:border-slate-800",
+                    ? "border-[oklch(75%_0.13_70)]"
+                    : "border-ink-100/70",
                 )}
               >
                 <div className="space-y-1">
                   <div className="text-sm font-medium">{r.test_name}</div>
-                  <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500">
+                  <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-ink-500">
                     <span>{r.category}</span>
                     <span>
                       {locale === "zh" ? "下单" : "ordered"}{" "}
@@ -213,14 +213,14 @@ export default function PendingResultsPage() {
 
       {done.length > 0 && (
         <section className="space-y-3">
-          <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
             {locale === "zh" ? "已收到" : "Received"} ({done.length})
           </h2>
           <ul className="space-y-2">
             {done.map((r) => (
               <li
                 key={r.id}
-                className="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs dark:border-slate-800 dark:bg-slate-900/60"
+                className="flex items-center justify-between rounded-xl border border-ink-100/70 bg-paper p-3 text-xs"
               >
                 <span>
                   {r.test_name} ·{" "}

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -111,7 +111,7 @@ export default function ReportsPage() {
           <CardTitle>
             {locale === "zh" ? "就诊前小结" : "Pre-clinic summary"}
           </CardTitle>
-          <div className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          <div className="mt-1 text-sm text-ink-500">
             {locale === "zh"
               ? "包含当前区间、活动警示、功能轨迹、两周日均值、本周反思、近期化验、以及自动生成的提问清单。"
               : "Includes current zone, active alerts, functional trajectory, 14-day averages, latest weekly, recent labs, and auto-generated questions for the oncologist."}
@@ -143,7 +143,7 @@ export default function ReportsPage() {
                 : "Generate PDF"}
           </Button>
           {settings && settings.length === 0 && (
-            <div className="mt-3 text-xs text-amber-700 dark:text-amber-300">
+            <div className="mt-3 text-xs text-[oklch(45%_0.09_70)]">
               {locale === "zh"
                 ? "先在设置里填写基本信息，生成的小结会更完整。"
                 : "Fill in Settings first — the summary uses those to compute baselines and deltas."}
@@ -157,7 +157,7 @@ export default function ReportsPage() {
           <CardTitle>
             {locale === "zh" ? "数据备份" : "Data backup"}
           </CardTitle>
-          <div className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          <div className="mt-1 text-sm text-ink-500">
             {locale === "zh"
               ? "全部数据导出为 JSON。保存到加密 U 盘或密码保护的云盘。清除浏览器数据前务必先导出。"
               : "Export everything as JSON. Save to encrypted storage. Always export before clearing site data or changing browser."}
@@ -174,14 +174,14 @@ export default function ReportsPage() {
                 ? "导出 JSON 备份"
                 : "Export JSON backup"}
           </Button>
-          <div className="mt-2 text-xs text-slate-500">
+          <div className="mt-2 text-xs text-ink-500">
             {locale === "zh" ? "今天：" : "Today: "}
             {formatDate(todayISO(), locale)}
           </div>
         </CardContent>
       </Card>
 
-      <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white p-3 text-xs text-slate-500 dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex items-center gap-2 rounded-lg border border-ink-100/70 bg-paper-2 p-3 text-xs text-ink-500">
         <Database className="h-4 w-4" />
         <span>
           {locale === "zh"
@@ -195,8 +195,8 @@ export default function ReportsPage() {
 
 function Stat({ label, value }: { label: string; value: number }) {
   return (
-    <div className="rounded-lg border border-slate-200 bg-slate-50 p-2 text-center dark:border-slate-800 dark:bg-slate-900/40">
-      <div className="text-xs text-slate-500">{label}</div>
+    <div className="rounded-lg border border-ink-100/70 bg-paper-2 p-2 text-center">
+      <div className="text-xs text-ink-500">{label}</div>
       <div className="mt-1 text-lg font-semibold tabular-nums">{value}</div>
     </div>
   );


### PR DESCRIPTION
## Summary
- `/reports` — subtitle copy, stat cards, export blurb, and the IndexedDB footer all move to ink/paper.
- `/ingest/pending` — category select, pending rows, and the resolved section use ink tokens. Overdue rows keep an attention colour via a sand oklch border.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean

https://claude.ai/code/session_01N63eFHsacHn97GE2Zyz9aH