### PR TITLE
Medications step 2a: Logging integration (cycle-derived, daily check-in, quick-log, FAB)

### DIFF
--- a/src/app/medications/log/page.tsx
+++ b/src/app/medications/log/page.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { useActiveCycleContext } from "~/hooks/use-active-cycle";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import {
+  ensureCycleMedications,
+  getActiveMedications,
+} from "~/lib/medication/active";
+import {
+  compileTodayStatuses,
+  logMedicationEvent,
+} from "~/lib/medication/log";
+import type { Medication, MedicationTodayStatus } from "~/types/medication";
+import { DRUGS_BY_ID } from "~/config/drug-registry";
+import { Check, X, AlertCircle, Pill, ChevronRight } from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+const COMMON_SIDE_EFFECTS = [
+  { id: "nausea", en: "Nausea", zh: "恶心" },
+  { id: "fatigue", en: "Fatigue", zh: "疲劳" },
+  { id: "diarrhea", en: "Diarrhea", zh: "腹泻" },
+  { id: "constipation", en: "Constipation", zh: "便秘" },
+  { id: "headache", en: "Headache", zh: "头痛" },
+  { id: "dizziness", en: "Dizziness", zh: "头晕" },
+  { id: "neuropathy", en: "Tingling / numbness", zh: "刺痛 / 麻木" },
+  { id: "rash", en: "Rash / itching", zh: "皮疹 / 瘙痒" },
+  { id: "insomnia", en: "Insomnia", zh: "失眠" },
+];
+
+export default function MedicationLogPage() {
+  const locale = useLocale();
+  const ctx = useActiveCycleContext();
+  const cycleId = ctx?.cycle.id;
+  const cycleDay = ctx?.cycle_day;
+  const [statuses, setStatuses] = useState<MedicationTodayStatus[]>([]);
+  const [sheetFor, setSheetFor] = useState<Medication | null>(null);
+
+  // Auto-seed protocol-derived meds when a cycle is active
+  useEffect(() => {
+    if (ctx?.cycle) {
+      void ensureCycleMedications(ctx.cycle);
+    }
+  }, [ctx?.cycle]);
+
+  // Reactive reload of today's statuses whenever events change
+  const allEvents = useLiveQuery(() => db.medication_events.toArray(), []);
+  useEffect(() => {
+    void (async () => {
+      const meds = await getActiveMedications(cycleId);
+      const s = await compileTodayStatuses(meds, cycleDay);
+      setStatuses(s);
+    })();
+  }, [cycleId, cycleDay, allEvents?.length]);
+
+  const dueNow = useMemo(
+    () => statuses.filter((s) => s.is_due_now),
+    [statuses],
+  );
+  const otherActive = useMemo(
+    () => statuses.filter((s) => !s.is_due_now),
+    [statuses],
+  );
+
+  const handleQuickLog = async (
+    med: Medication,
+    event_type: "taken" | "missed",
+  ) => {
+    await logMedicationEvent({
+      medication: med,
+      event_type,
+      source: "quick_log",
+    });
+  };
+
+  const cycleLabel = ctx
+    ? locale === "zh"
+      ? `周期 ${ctx.cycle.cycle_number} · 第 ${cycleDay} 天 · ${ctx.protocol.short_name}`
+      : `Cycle ${ctx.cycle.cycle_number} · Day ${cycleDay} · ${ctx.protocol.short_name}`
+    : locale === "zh"
+      ? "当前无活动治疗周期"
+      : "No active treatment cycle";
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-8">
+      <PageHeader
+        title={locale === "zh" ? "今日用药记录" : "Today's medication log"}
+        subtitle={cycleLabel}
+      />
+
+      {!ctx && (
+        <Card>
+          <CardContent className="p-6 text-sm text-ink-500">
+            {locale === "zh"
+              ? "开始一个治疗周期后，系统将自动填充今日应服用的药物。"
+              : "Start an active treatment cycle and this page will auto-populate today's medications."}
+            <div className="mt-4">
+              <Link href="/treatment/new">
+                <Button variant="secondary">
+                  {locale === "zh" ? "开始新周期" : "Start a cycle"}
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {ctx && dueNow.length > 0 && (
+        <section>
+          <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-ink-500">
+            <AlertCircle className="h-4 w-4" />
+            {locale === "zh" ? "待服药" : "Due now"}
+          </h2>
+          <div className="space-y-2">
+            {dueNow.map((s) => (
+              <MedRow
+                key={s.medication.id}
+                status={s}
+                locale={locale}
+                onTaken={() => handleQuickLog(s.medication, "taken")}
+                onMissed={() => handleQuickLog(s.medication, "missed")}
+                onDetails={() => setSheetFor(s.medication)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {ctx && otherActive.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-ink-500">
+            {locale === "zh" ? "其他活动药物" : "Other active medications"}
+          </h2>
+          <div className="space-y-2">
+            {otherActive.map((s) => (
+              <MedRow
+                key={s.medication.id}
+                status={s}
+                locale={locale}
+                onTaken={() => handleQuickLog(s.medication, "taken")}
+                onMissed={() => handleQuickLog(s.medication, "missed")}
+                onDetails={() => setSheetFor(s.medication)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {ctx && statuses.length === 0 && (
+        <Card>
+          <CardContent className="p-6 text-sm text-ink-500">
+            {locale === "zh"
+              ? "没有找到药物。正在从方案中填充 …"
+              : "No medications registered yet. Protocol-derived meds are being seeded…"}
+          </CardContent>
+        </Card>
+      )}
+
+      {sheetFor && (
+        <SideEffectSheet
+          medication={sheetFor}
+          locale={locale}
+          onClose={() => setSheetFor(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function MedRow({
+  status,
+  locale,
+  onTaken,
+  onMissed,
+  onDetails,
+}: {
+  status: MedicationTodayStatus;
+  locale: "en" | "zh";
+  onTaken: () => void;
+  onMissed: () => void;
+  onDetails: () => void;
+}) {
+  const { medication, drug_name_en, drug_name_zh, due_count, logged_count } =
+    status;
+  const name = locale === "zh" ? drug_name_zh : drug_name_en;
+  const allLogged = due_count > 0 && logged_count >= due_count;
+
+  return (
+    <Card
+      className={cn(
+        "transition-colors",
+        allLogged && "bg-paper-1 opacity-80",
+      )}
+    >
+      <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex flex-1 items-center gap-3">
+          <Pill className="h-5 w-5 text-ink-400" />
+          <div className="flex-1">
+            <div className="font-medium text-ink-900">{name}</div>
+            <div className="text-xs text-ink-500">
+              {medication.dose}
+              {due_count > 0 && (
+                <>
+                  {" · "}
+                  <span
+                    className={cn(
+                      logged_count >= due_count
+                        ? "text-green-600"
+                        : "text-ink-600",
+                    )}
+                  >
+                    {locale === "zh"
+                      ? `今日 ${logged_count}/${due_count}`
+                      : `${logged_count}/${due_count} logged today`}
+                  </span>
+                </>
+              )}
+              {due_count === 0 && (
+                <> · {locale === "zh" ? "按需" : "as needed"}</>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            onClick={onTaken}
+            size="sm"
+            variant={allLogged ? "ghost" : "primary"}
+            className="gap-1"
+          >
+            <Check className="h-3.5 w-3.5" />
+            {locale === "zh" ? "已服" : "Taken"}
+          </Button>
+          <Button
+            onClick={onMissed}
+            size="sm"
+            variant="secondary"
+            className="gap-1"
+          >
+            <X className="h-3.5 w-3.5" />
+            {locale === "zh" ? "漏服" : "Missed"}
+          </Button>
+          <Button
+            onClick={onDetails}
+            size="sm"
+            variant="ghost"
+            className="gap-1"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SideEffectSheet({
+  medication,
+  locale,
+  onClose,
+}: {
+  medication: Medication;
+  locale: "en" | "zh";
+  onClose: () => void;
+}) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [severity, setSeverity] = useState<1 | 2 | 3 | 4 | 5>(3);
+  const [note, setNote] = useState("");
+  const drug = DRUGS_BY_ID[medication.drug_id];
+
+  const toggle = (id: string) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setSelected(next);
+  };
+
+  const submit = async () => {
+    const hasSelections = selected.size > 0 || note.trim().length > 0;
+    await logMedicationEvent({
+      medication,
+      event_type: hasSelections ? "side_effect_only" : "taken",
+      side_effects: selected.size > 0 ? Array.from(selected) : undefined,
+      side_effect_severity: selected.size > 0 ? severity : undefined,
+      note: note.trim() || undefined,
+      source: "quick_log",
+    });
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-t-2xl bg-paper p-5 shadow-xl sm:rounded-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="serif text-lg text-ink-900">
+            {locale === "zh"
+              ? drug?.name.zh ?? medication.display_name
+              : drug?.name.en ?? medication.display_name}
+          </h3>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <p className="mb-3 text-xs text-ink-500">
+          {locale === "zh"
+            ? "如有不良反应，请勾选。这会记录带注释的用药事件。"
+            : "Tick any side effects you're experiencing. This logs an annotated medication event."}
+        </p>
+
+        <div className="mb-4 flex flex-wrap gap-2">
+          {COMMON_SIDE_EFFECTS.map((se) => (
+            <button
+              key={se.id}
+              type="button"
+              onClick={() => toggle(se.id)}
+              className={cn(
+                "rounded-full border px-3 py-1 text-xs transition-colors",
+                selected.has(se.id)
+                  ? "border-[var(--warn)] bg-[var(--warn)]/10 text-[var(--warn)]"
+                  : "border-ink-200 text-ink-600 hover:border-ink-300",
+              )}
+            >
+              {locale === "zh" ? se.zh : se.en}
+            </button>
+          ))}
+        </div>
+
+        {selected.size > 0 && (
+          <div className="mb-4">
+            <div className="mb-2 text-xs font-medium text-ink-600">
+              {locale === "zh" ? "严重度" : "Severity"}
+            </div>
+            <div className="flex gap-1">
+              {[1, 2, 3, 4, 5].map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => setSeverity(n as 1 | 2 | 3 | 4 | 5)}
+                  className={cn(
+                    "h-9 flex-1 rounded border text-sm transition-colors",
+                    severity === n
+                      ? "border-ink-900 bg-ink-900 text-paper"
+                      : "border-ink-200 text-ink-600",
+                  )}
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder={locale === "zh" ? "备注（可选）" : "Note (optional)"}
+          className="mb-4 w-full rounded border border-ink-200 bg-paper-1 p-2 text-sm"
+          rows={2}
+        />
+
+        <div className="flex gap-2">
+          <Button onClick={submit} className="flex-1">
+            {locale === "zh" ? "记录" : "Log"}
+          </Button>
+          <Button variant="secondary" onClick={onClose}>
+            {locale === "zh" ? "取消" : "Cancel"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/daily/medications-step.tsx
+++ b/src/components/daily/medications-step.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { useActiveCycleContext } from "~/hooks/use-active-cycle";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import {
+  ensureCycleMedications,
+  getActiveMedications,
+} from "~/lib/medication/active";
+import {
+  compileTodayStatuses,
+  logMedicationEvent,
+} from "~/lib/medication/log";
+import type { MedicationTodayStatus } from "~/types/medication";
+import { Check, X, Pill } from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+/**
+ * Daily check-in step: lists today's active medications and lets the user
+ * batch-log them. Only rendered when there's an active treatment cycle.
+ */
+export function MedicationsStep() {
+  const locale = useLocale();
+  const ctx = useActiveCycleContext();
+  const cycleId = ctx?.cycle.id;
+  const cycleDay = ctx?.cycle_day;
+  const [statuses, setStatuses] = useState<MedicationTodayStatus[]>([]);
+  const allEvents = useLiveQuery(() => db.medication_events.toArray(), []);
+
+  useEffect(() => {
+    if (ctx?.cycle) void ensureCycleMedications(ctx.cycle);
+  }, [ctx?.cycle]);
+
+  useEffect(() => {
+    void (async () => {
+      const meds = await getActiveMedications(cycleId);
+      const s = await compileTodayStatuses(meds, cycleDay);
+      setStatuses(s);
+    })();
+  }, [cycleId, cycleDay, allEvents?.length]);
+
+  if (!ctx) {
+    return (
+      <Card>
+        <CardContent className="p-5 text-sm text-ink-500">
+          {locale === "zh"
+            ? "当前没有活动治疗周期 —— 跳过用药记录。"
+            : "No active treatment cycle — skip medication logging."}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (statuses.length === 0) {
+    return (
+      <Card>
+        <CardContent className="p-5 text-sm text-ink-500">
+          {locale === "zh"
+            ? "正在加载药物清单 …"
+            : "Loading medication list…"}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const handleLog = async (
+    status: MedicationTodayStatus,
+    event_type: "taken" | "missed",
+  ) => {
+    await logMedicationEvent({
+      medication: status.medication,
+      event_type,
+      source: "daily_checkin",
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-ink-500">
+        {locale === "zh"
+          ? `周期 ${ctx.cycle.cycle_number}·D${cycleDay} · ${ctx.protocol.short_name} — 记录今日是否服用。`
+          : `Cycle ${ctx.cycle.cycle_number}·D${cycleDay} · ${ctx.protocol.short_name} — mark each as taken or missed today.`}
+      </p>
+
+      {statuses.map((s) => {
+        const name = locale === "zh" ? s.drug_name_zh : s.drug_name_en;
+        const allLogged = s.due_count > 0 && s.logged_count >= s.due_count;
+        const isPrn = s.due_count === 0;
+        return (
+          <Card
+            key={s.medication.id}
+            className={cn("transition-colors", allLogged && "bg-paper-1")}
+          >
+            <CardContent className="flex items-center justify-between gap-3 p-3">
+              <div className="flex flex-1 items-center gap-2">
+                <Pill className="h-4 w-4 text-ink-400" />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-ink-900">
+                    {name}
+                  </div>
+                  <div className="text-[11px] text-ink-500">
+                    {s.medication.dose}
+                    {!isPrn && (
+                      <>
+                        {" · "}
+                        <span
+                          className={cn(
+                            allLogged
+                              ? "text-green-600"
+                              : s.logged_count > 0
+                                ? "text-amber-600"
+                                : "text-ink-500",
+                          )}
+                        >
+                          {s.logged_count}/{s.due_count}
+                        </span>
+                      </>
+                    )}
+                    {isPrn && (
+                      <> · {locale === "zh" ? "按需" : "PRN"}</>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="flex shrink-0 gap-1">
+                <Button
+                  onClick={() => handleLog(s, "taken")}
+                  size="sm"
+                  variant={allLogged ? "ghost" : "primary"}
+                  className="gap-1 px-2"
+                >
+                  <Check className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  onClick={() => handleLog(s, "missed")}
+                  size="sm"
+                  variant="secondary"
+                  className="gap-1 px-2"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/daily/morning-checkin.tsx
+++ b/src/components/daily/morning-checkin.tsx
@@ -15,6 +15,7 @@ import { SectionHeader } from "~/components/ui/page-header";
 import { ScaleInput } from "./scale-input";
 import { Toggle } from "./toggle";
 import { CycleBanner } from "./cycle-banner";
+import { MedicationsStep } from "./medications-step";
 
 const INITIAL = {
   date: todayISO(),
@@ -55,6 +56,7 @@ const STEPS = [
   "objective",
   "body",
   "symptoms",
+  "medications",
   "reflection",
 ] as const;
 
@@ -66,6 +68,7 @@ const STEP_LABELS: Record<"en" | "zh", Record<StepKey, string>> = {
     objective: "Weight & practice",
     body: "Food & movement",
     symptoms: "Symptom flags",
+    medications: "Today's medications",
     reflection: "Reflection",
   },
   zh: {
@@ -73,6 +76,7 @@ const STEP_LABELS: Record<"en" | "zh", Record<StepKey, string>> = {
     objective: "体重与修习",
     body: "饮食与运动",
     symptoms: "症状",
+    medications: "今日用药",
     reflection: "反思",
   },
 };
@@ -443,6 +447,8 @@ export function MorningCheckin({
           </CardContent>
         </Card>
       )}
+
+      {currentStep === "medications" && <MedicationsStep />}
 
       {currentStep === "reflection" && (
         <Card>

--- a/src/components/shared/add-fab.tsx
+++ b/src/components/shared/add-fab.tsx
@@ -15,6 +15,7 @@ import {
   FileText,
   ListTodo,
   Camera,
+  Pill,
 } from "lucide-react";
 
 interface FabItem {
@@ -31,6 +32,16 @@ const ITEMS: FabItem[] = [
     label: { en: "Today's check-in", zh: "今日记录" },
     hint: { en: "Symptoms, weight, practice", zh: "症状、体重、修习" },
     icon: CalendarDays,
+    tone: "tide",
+  },
+  {
+    href: "/medications/log",
+    label: { en: "Log medication", zh: "记录服药" },
+    hint: {
+      en: "Taken, missed, side effects",
+      zh: "已服、漏服、副作用",
+    },
+    icon: Pill,
     tone: "tide",
   },
   {

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -9,7 +9,6 @@ import type {
   CtdnaResult,
   MolecularProfile,
   Treatment,
-  Medication,
   LifeEvent,
   Decision,
   ZoneAlert,
@@ -22,6 +21,7 @@ import type {
 import type { Trial } from "~/types/bridge";
 import type { TreatmentCycle } from "~/types/treatment";
 import type { PatientTask } from "~/types/task";
+import type { Medication, MedicationEvent } from "~/types/medication";
 
 export class AnchorDB extends Dexie {
   daily_entries!: Table<DailyEntry, number>;
@@ -35,6 +35,7 @@ export class AnchorDB extends Dexie {
   trials!: Table<Trial, number>;
   treatments!: Table<Treatment, number>;
   medications!: Table<Medication, number>;
+  medication_events!: Table<MedicationEvent, number>;
   life_events!: Table<LifeEvent, number>;
   decisions!: Table<Decision, number>;
   zone_alerts!: Table<ZoneAlert, number>;
@@ -81,6 +82,14 @@ export class AnchorDB extends Dexie {
     this.version(5).stores({
       patient_tasks:
         "++id, due_date, active, category, schedule_kind, preset_id",
+    });
+    // v6: reshape medications table for logging-integrated module + add events.
+    // The v1 medications table was unused; safe to redefine indexes.
+    this.version(6).stores({
+      medications:
+        "++id, drug_id, category, active, cycle_id, source, started_on",
+      medication_events:
+        "++id, medication_id, drug_id, event_type, logged_at, [drug_id+logged_at]",
     });
   }
 }

--- a/src/lib/medication/active.ts
+++ b/src/lib/medication/active.ts
@@ -1,0 +1,135 @@
+import { db, now } from "~/lib/db/dexie";
+import { DRUGS_BY_ID } from "~/config/drug-registry";
+import { PROTOCOL_BY_ID } from "~/config/protocols";
+import type {
+  Medication,
+  MedicationCategory,
+  MedicationSource,
+  DoseSchedule,
+} from "~/types/medication";
+import type { TreatmentCycle } from "~/types/treatment";
+
+// Map supportive lever ID to a drug_id in DRUG_REGISTRY.
+// Protocol's typical_supportive uses IDs like "supportive.pert" — we map each
+// to the corresponding registered drug (or skip if unmapped).
+const SUPPORTIVE_TO_DRUG: Record<string, string> = {
+  "supportive.gcsf_prophylaxis": "pegfilgrastim",
+  "supportive.olanzapine": "olanzapine",
+  "supportive.duloxetine": "duloxetine",
+  "supportive.pert": "pancrelipase",
+  "supportive.vte_prophylaxis": "apixaban",
+};
+
+/**
+ * Derive the full list of medications for a given cycle from its protocol.
+ * Idempotent: re-running will not create duplicates.
+ */
+export async function ensureCycleMedications(
+  cycle: TreatmentCycle,
+): Promise<void> {
+  if (!cycle.id) return;
+  const protocol = cycle.protocol_id === "custom" && cycle.custom_protocol
+    ? cycle.custom_protocol
+    : PROTOCOL_BY_ID[cycle.protocol_id];
+  if (!protocol) return;
+
+  const existing = await db.medications
+    .where("cycle_id")
+    .equals(cycle.id)
+    .toArray();
+  const existingKey = (m: Medication) => `${m.drug_id}:${m.source}`;
+  const existingSet = new Set(existing.map(existingKey));
+
+  const toInsert: Medication[] = [];
+
+  // Protocol agents (chemo)
+  for (const agent of protocol.agents) {
+    const key = `${agent.id}:protocol_agent`;
+    if (existingSet.has(key)) continue;
+    const drug = DRUGS_BY_ID[agent.id];
+    toInsert.push({
+      drug_id: agent.id,
+      display_name: drug?.name.en ?? agent.name,
+      category: (drug?.category ?? "chemo") as MedicationCategory,
+      dose: agent.typical_dose,
+      route: agent.route,
+      schedule: {
+        kind: "cycle_linked",
+        cycle_days: agent.dose_days,
+      } as DoseSchedule,
+      source: "protocol_agent" as MedicationSource,
+      cycle_id: cycle.id,
+      active: true,
+      started_on: cycle.start_date,
+      created_at: now(),
+      updated_at: now(),
+    });
+  }
+
+  // Supportive meds mapped from protocol.typical_supportive
+  for (const supportiveId of protocol.typical_supportive) {
+    const drugId = SUPPORTIVE_TO_DRUG[supportiveId];
+    if (!drugId) continue;
+    const key = `${drugId}:protocol_supportive`;
+    if (existingSet.has(key)) continue;
+    const drug = DRUGS_BY_ID[drugId];
+    if (!drug) continue;
+    toInsert.push({
+      drug_id: drugId,
+      display_name: drug.name.en,
+      category: drug.category,
+      dose: drug.typical_doses[0]
+        ? drug.typical_doses[0].en
+        : "See protocol",
+      route: drug.default_route,
+      schedule: drug.default_schedules[0] ?? { kind: "prn" },
+      source: "protocol_supportive" as MedicationSource,
+      cycle_id: cycle.id,
+      active: true,
+      started_on: cycle.start_date,
+      created_at: now(),
+      updated_at: now(),
+    });
+  }
+
+  if (toInsert.length > 0) {
+    await db.medications.bulkAdd(toInsert);
+  }
+}
+
+/**
+ * Fetch active medications for the current treatment context.
+ * - If a cycle is provided, returns meds for that cycle plus user-added (cycle_id null).
+ * - If no cycle, returns only user-added active meds.
+ */
+export async function getActiveMedications(
+  cycleId?: number,
+): Promise<Medication[]> {
+  const all = await db.medications.toArray();
+  return all.filter(
+    (m) => m.active && (m.cycle_id === cycleId || m.cycle_id == null),
+  );
+}
+
+/**
+ * When a cycle is stopped/cancelled, deactivate its protocol-derived meds.
+ * User-added meds (source: "user_added") are left alone — they may continue
+ * between cycles.
+ */
+export async function deactivateCycleMedications(
+  cycleId: number,
+): Promise<void> {
+  const meds = await db.medications
+    .where("cycle_id")
+    .equals(cycleId)
+    .toArray();
+  for (const m of meds) {
+    if (m.source !== "user_added" && m.id) {
+      await db.medications.update(m.id, {
+        active: false,
+        stopped_on: now(),
+        updated_at: now(),
+      });
+    }
+  }
+}

--- a/src/lib/medication/log.ts
+++ b/src/lib/medication/log.ts
@@ -1,0 +1,146 @@
+import { db, now } from "~/lib/db/dexie";
+import type {
+  Medication,
+  MedicationEvent,
+  MedicationTodayStatus,
+  DoseSchedule,
+} from "~/types/medication";
+import { DRUGS_BY_ID } from "~/config/drug-registry";
+
+/**
+ * Log a single medication event (dose taken, missed, or a side-effect-only note).
+ */
+export async function logMedicationEvent(
+  params: {
+    medication: Medication;
+    event_type: "taken" | "missed" | "side_effect_only";
+    dose_taken?: string;
+    side_effects?: string[];
+    side_effect_severity?: 1 | 2 | 3 | 4 | 5;
+    note?: string;
+    source: "daily_checkin" | "quick_log" | "fab" | "backfill";
+    logged_at?: string; // defaults to now
+  },
+): Promise<number> {
+  if (!params.medication.id) throw new Error("medication.id required");
+  const event: MedicationEvent = {
+    medication_id: params.medication.id,
+    drug_id: params.medication.drug_id,
+    event_type: params.event_type,
+    logged_at: params.logged_at ?? now(),
+    dose_taken: params.dose_taken,
+    side_effects: params.side_effects,
+    side_effect_severity: params.side_effect_severity,
+    note: params.note,
+    source: params.source,
+    created_at: now(),
+  };
+  return (await db.medication_events.add(event)) as number;
+}
+
+/**
+ * Count how many scheduled doses are expected today for this medication.
+ * Rules:
+ *  - kind "fixed" / "with_meals"     — times_per_day (default 1)
+ *  - kind "cycle_linked"            — 1 if today's cycle_day is in cycle_days
+ *  - kind "prn"                     — 0 (on-demand)
+ *  - kind "taper"                   — 1 per day during current taper step
+ *  - kind "custom"                  — 1 (best-effort; rrule parser comes later)
+ */
+export function expectedDosesToday(
+  schedule: DoseSchedule,
+  cycleDay?: number,
+): number {
+  switch (schedule.kind) {
+    case "fixed":
+    case "with_meals":
+      return schedule.times_per_day ?? 1;
+    case "cycle_linked":
+      if (!cycleDay || !schedule.cycle_days) return 0;
+      return schedule.cycle_days.includes(cycleDay) ? 1 : 0;
+    case "prn":
+      return 0;
+    case "taper":
+    case "custom":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Next due clock time today for a fixed-schedule med (ISO), or undefined.
+ */
+export function nextDueTimeToday(
+  schedule: DoseSchedule,
+  nowDate: Date,
+): string | undefined {
+  if (
+    (schedule.kind !== "fixed" && schedule.kind !== "with_meals") ||
+    !schedule.clock_times ||
+    schedule.clock_times.length === 0
+  ) {
+    return undefined;
+  }
+  const today = nowDate.toISOString().slice(0, 10);
+  for (const t of schedule.clock_times) {
+    const iso = `${today}T${t}:00`;
+    if (new Date(iso).getTime() > nowDate.getTime()) return iso;
+  }
+  return undefined;
+}
+
+/**
+ * Compile MedicationTodayStatus for every active med, given the current cycle day.
+ * Consumes: all active meds + today's events.
+ */
+export async function compileTodayStatuses(
+  medications: Medication[],
+  cycleDay?: number,
+  nowDate: Date = new Date(),
+): Promise<MedicationTodayStatus[]> {
+  const today = nowDate.toISOString().slice(0, 10);
+
+  const todaysEvents = await db.medication_events
+    .where("logged_at")
+    .startsWith(today)
+    .toArray();
+
+  return medications.map((med) => {
+    const drug = DRUGS_BY_ID[med.drug_id];
+    const due = expectedDosesToday(med.schedule, cycleDay);
+    const loggedEvents = todaysEvents.filter(
+      (e) => e.medication_id === med.id && e.event_type === "taken",
+    );
+    const nextDue = nextDueTimeToday(med.schedule, nowDate);
+    const withinNextHour = nextDue
+      ? new Date(nextDue).getTime() - nowDate.getTime() <= 60 * 60 * 1000
+      : false;
+
+    return {
+      medication: med,
+      drug_name_en: drug?.name.en ?? med.display_name ?? med.drug_id,
+      drug_name_zh: drug?.name.zh ?? med.display_name ?? med.drug_id,
+      due_count: due,
+      logged_count: loggedEvents.length,
+      last_logged_at: loggedEvents[loggedEvents.length - 1]?.logged_at,
+      is_due_now: due > 0 && (withinNextHour || loggedEvents.length < due),
+      next_due_at: nextDue,
+    };
+  });
+}
+
+/**
+ * Fetch recent events for a medication (newest first, limit N).
+ */
+export async function getRecentEvents(
+  medicationId: number,
+  limit = 20,
+): Promise<MedicationEvent[]> {
+  const all = await db.medication_events
+    .where("medication_id")
+    .equals(medicationId)
+    .reverse()
+    .sortBy("logged_at");
+  return all.slice(0, limit);
+}

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -226,18 +226,9 @@ export interface Treatment {
   updated_at: string;
 }
 
-export interface Medication {
-  id?: number;
-  name: string;
-  dose?: string;
-  frequency?: string;
-  start_date: string;
-  stop_date?: string;
-  active: boolean;
-  notes?: string;
-  created_at: string;
-  updated_at: string;
-}
+// NOTE: Medication and MedicationEvent moved to ~/types/medication for the
+// logging-integrated module. This re-export keeps existing consumers working.
+export type { Medication, MedicationEvent } from "./medication";
 
 export interface LifeEvent {
   id?: number;

--- a/src/types/medication.ts
+++ b/src/types/medication.ts
@@ -109,31 +109,60 @@ export interface DrugInteraction {
   management: LocalizedText;
 }
 
-// ---- Runtime persistence shapes (step 2 will write these) ------------------
+// ---- Runtime persistence shapes --------------------------------------------
 
-export interface MedicationRecord {
+// Source of the medication in the patient's active list.
+// - "protocol_agent"  — chemo agent auto-derived from the active cycle's protocol
+// - "protocol_supportive" — typical_supportive from the protocol (auto-derived)
+// - "user_added"     — patient or carer added manually (e.g. PRN symptomatic)
+export type MedicationSource =
+  | "protocol_agent"
+  | "protocol_supportive"
+  | "user_added";
+
+export interface Medication {
   id?: number;
-  drug_id: string;
-  display_name?: string;
+  drug_id: string;            // joins to DRUG_REGISTRY; "custom:<slug>" for freeform
+  display_name?: string;      // override when drug_id is custom or user wants a tag
   category: MedicationCategory;
-  dose: string;
+  dose: string;               // e.g. "400 mg", "1000 mg/m²"
   route: MedicationRoute;
   schedule: DoseSchedule;
+  source: MedicationSource;
+  cycle_id?: number;          // for protocol-derived meds, link to TreatmentCycle.id
   active: boolean;
   notes?: string;
-  started_on: string;
+  started_on: string;         // ISO date
   stopped_on?: string;
   created_at: string;
   updated_at: string;
 }
 
-export interface DoseLogEntry {
+// A single logged dose (taken, skipped, or side-effect observation).
+export interface MedicationEvent {
   id?: number;
   medication_id: number;
-  scheduled_at?: string;
-  logged_at: string;
-  taken: boolean;
-  dose_taken?: string;
+  drug_id: string;            // denormalized for queries without joins
+  event_type: "taken" | "missed" | "side_effect_only";
+  logged_at: string;          // ISO timestamp
+  scheduled_at?: string;      // if the med had a scheduled time
+  dose_taken?: string;        // override of schedule dose
+  // Side-effect flags observed at or near this log
+  side_effects?: string[];    // e.g. ["nausea", "fatigue", "diarrhea"]
+  side_effect_severity?: 1 | 2 | 3 | 4 | 5; // 1=mild, 5=severe (patient self-report)
   note?: string;
-  source: "check_in" | "quick_log" | "backfill";
+  source: "daily_checkin" | "quick_log" | "fab" | "backfill";
+  created_at: string;
+}
+
+// Convenience: "what's due / what was logged today" for a single medication.
+export interface MedicationTodayStatus {
+  medication: Medication;
+  drug_name_en: string;
+  drug_name_zh: string;
+  due_count: number;          // expected doses today from schedule
+  logged_count: number;       // actual dose events today
+  last_logged_at?: string;
+  is_due_now: boolean;        // within the next scheduled-time window
+  next_due_at?: string;       // ISO timestamp of the next scheduled dose today
 }


### PR DESCRIPTION
## Summary

**Step 2a** of the medications logging module — the first vertical slice of "logging integrated into treatment". Builds on PR #22.

### Data model

- **Reshape `Medication` type** into a logging-ready shape (drug_id, schedule, source, cycle_id) in `~/types/medication` (moved out of `clinical.ts` with a re-export for back-compat).
- **New `MedicationEvent` type** — one row per logged dose with event_type, timestamp, optional side effects + severity, source.
- **Dexie v6 migration** — reshapes `medications` table indexes + adds `medication_events` table.

### Derivation (`src/lib/medication/active.ts`)

- `ensureCycleMedications(cycle)` — idempotently seeds protocol-derived meds for a cycle. Takes `protocol.agents` (chemo) + `typical_supportive` (mapped via `SUPPORTIVE_TO_DRUG` to drug_ids) and writes them as active medication records linked to the cycle.
- `getActiveMedications(cycleId?)` — returns meds for the cycle + any cycle-agnostic user-added meds.
- `deactivateCycleMedications(cycleId)` — when a cycle ends.

### Logging helpers (`src/lib/medication/log.ts`)

- `logMedicationEvent({ medication, event_type, side_effects, severity, note, source })` — unified logging entry point.
- `expectedDosesToday(schedule, cycleDay)` — resolves schedule kind (fixed/with_meals/cycle_linked/prn/taper/custom) to today's expected dose count.
- `nextDueTimeToday(schedule, now)` — next scheduled clock time today.
- `compileTodayStatuses(medications, cycleDay)` — full today view (due, logged, next-due, is-due-now) for the whole med list.

### UI

- **`/medications/log`** — dedicated quick-log surface. Grouped "Due now" / "Other active". One-tap Taken/Missed. Side-effect annotation sheet with 9 common flags + 1–5 severity + free-text note.
- **Daily check-in** — new "Today's medications" step (step 5 of 6, between symptoms and reflection). Conditional on active cycle; auto-seeds protocol meds on render. Batch-log with taken/missed chips.
- **FAB** — new "Log medication" entry (tide tone, pill icon).

### What's NOT in this PR (deferred to step 2b / 3+)

- Context-aware prompts (time-of-day, cycle-phase, symptom-flag popups) — the logging surface is there; the trigger engine comes next.
- Correlation analysis (symptom ↔ med timing patterns).
- Adherence drift alerts (missed-dose streaks feeding zone engine).
- Drug-drug interaction matrix.
- Custom recurrence UI for user-added meds (current default: `kind: "prn"`).

## Test plan

- [ ] Dexie v6 migration runs clean on existing profiles (medications table was empty pre-v6, so no data loss risk)
- [ ] Start a GnP cycle → `/medications/log` auto-populates with gemcitabine, nab-paclitaxel, PERT, olanzapine, duloxetine, apixaban, pegfilgrastim
- [ ] Tap "Taken" on a med → event logged, count updates
- [ ] Tap the chevron → side-effect sheet opens, log with 2+ flags + severity 4 → appears as `side_effect_only` event
- [ ] Daily check-in `/daily/new` → reach "Today's medications" step → same batch-log UI works
- [ ] FAB → "Log medication" → lands on `/medications/log`
- [ ] zh locale: all labels render bilingually
- [ ] Without an active cycle: `/medications/log` shows "Start a cycle" prompt; daily step shows "skip" message

https://claude.ai/code/session_01WttF8prFRyQjW2H1wuqRP3