### PR TITLE
Step 2b.1: Cited cycle-phase medication prompts (with 2b.0 ground-truth pass)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { PillarsCard } from "~/components/dashboard/pillars-card";
 import { RecentTrends } from "~/components/dashboard/recent-trends";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
+import { MedicationPromptsCard } from "~/components/dashboard/medication-prompts-card";
 import { TodayFeed } from "~/components/dashboard/today-feed";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { PageHeader, SectionHeader } from "~/components/ui/page-header";
@@ -73,6 +74,8 @@ export default function DashboardPage() {
       <EmergencyCard />
 
       <QuickCheckinCard />
+
+      <MedicationPromptsCard />
 
       <TodayFeed excludeIds={["checkin_today"]} />
 

--- a/src/components/dashboard/medication-prompts-card.tsx
+++ b/src/components/dashboard/medication-prompts-card.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, now } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { useActiveCycleContext } from "~/hooks/use-active-cycle";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { DRUGS_BY_ID } from "~/config/drug-registry";
+import {
+  evaluatePrompts,
+  type MedicationPrompt,
+  type PromptCitation,
+  type PromptSeverity,
+} from "~/lib/medication/prompts";
+import {
+  AlertTriangle,
+  Bell,
+  ChevronRight,
+  ExternalLink,
+  Info,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+const TONE_BY_SEVERITY: Record<
+  PromptSeverity,
+  { wrap: string; chip: string; Icon: React.ComponentType<{ className?: string }> }
+> = {
+  info: {
+    wrap: "bg-paper-2",
+    chip: "bg-ink-100 text-ink-700",
+    Icon: Info,
+  },
+  caution: {
+    wrap: "bg-[var(--sand)]/40 border-l-[3px] border-l-[oklch(45%_0.06_70)]",
+    chip: "bg-[oklch(92%_0.04_70)] text-[oklch(45%_0.06_70)]",
+    Icon: Bell,
+  },
+  warning: {
+    wrap: "bg-[var(--warn-soft)] border-l-[3px] border-l-[var(--warn)]",
+    chip: "bg-[var(--warn)] text-white",
+    Icon: AlertTriangle,
+  },
+};
+
+export function MedicationPromptsCard() {
+  const locale = useLocale();
+  const ctx = useActiveCycleContext();
+  const meds = useLiveQuery(() => db.medications.toArray(), []);
+  const events = useLiveQuery(
+    () => db.medication_prompt_events.toArray(),
+    [],
+  );
+
+  const prompts = useMemo<MedicationPrompt[]>(() => {
+    if (!ctx) return [];
+    return evaluatePrompts({
+      cycle: ctx.cycle,
+      cycle_day: ctx.cycle_day,
+      protocol_id: ctx.cycle.protocol_id,
+      active_meds: meds ?? [],
+      drugs_by_id: DRUGS_BY_ID,
+      existing_events: events ?? [],
+    });
+  }, [ctx, meds, events]);
+
+  if (!ctx) return null;
+  if (prompts.length === 0) return null;
+
+  return (
+    <section className="space-y-2">
+      <div className="eyebrow px-1">
+        {locale === "zh" ? "用药相关提示" : "Medication prompts"}
+      </div>
+      <div className="space-y-2">
+        {prompts.map((p) => (
+          <PromptRow key={`${p.rule_id}|${p.fired_for}`} prompt={p} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PromptRow({ prompt }: { prompt: MedicationPrompt }) {
+  const locale = useLocale();
+  const tone = TONE_BY_SEVERITY[prompt.severity];
+  const [showSources, setShowSources] = useState(false);
+
+  const handleAction = async (
+    status: "acknowledged" | "dismissed",
+    note?: string,
+  ) => {
+    const ts = now();
+    const existing = await db.medication_prompt_events
+      .where("[rule_id+fired_for]")
+      .equals([prompt.rule_id, prompt.fired_for])
+      .first();
+    if (existing?.id) {
+      await db.medication_prompt_events.update(existing.id, {
+        status,
+        resolved_at: ts,
+        note,
+      });
+      return;
+    }
+    await db.medication_prompt_events.add({
+      rule_id: prompt.rule_id,
+      fired_for: prompt.fired_for,
+      drug_id: prompt.drug_id,
+      cycle_id: prompt.cycle_id,
+      cycle_day: prompt.cycle_day,
+      status,
+      shown_at: ts,
+      resolved_at: ts,
+      note,
+    });
+  };
+
+  const onPrimary = async () => {
+    if (prompt.primary_action.kind === "ack") {
+      await handleAction("acknowledged");
+    } else {
+      // For non-ack actions, surface a link below; we still mark acknowledged
+      // so the prompt doesn't re-show in the same window.
+      await handleAction("acknowledged");
+    }
+  };
+
+  const onDismiss = () => {
+    void handleAction("dismissed");
+  };
+
+  return (
+    <Card className={cn("relative px-4 py-4", tone.wrap)}>
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
+            tone.chip,
+          )}
+        >
+          <tone.Icon className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-[13.5px] font-semibold text-ink-900">
+            {prompt.title[locale]}
+          </div>
+          <p className="mt-1 text-[12.5px] leading-relaxed text-ink-700">
+            {prompt.body[locale]}
+          </p>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <PrimaryAction prompt={prompt} onAck={onPrimary} />
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onDismiss}
+              className="text-ink-500"
+            >
+              {locale === "zh" ? "关闭" : "Dismiss"}
+            </Button>
+            {prompt.citations.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowSources((v) => !v)}
+                className="ml-auto text-[11px] text-ink-500 hover:text-ink-900"
+              >
+                {showSources
+                  ? locale === "zh"
+                    ? "隐藏来源"
+                    : "Hide sources"
+                  : locale === "zh"
+                    ? `来源 (${prompt.citations.length})`
+                    : `Sources (${prompt.citations.length})`}
+              </button>
+            )}
+          </div>
+
+          {showSources && (
+            <ul className="mt-2 space-y-1 border-t border-ink-100/60 pt-2">
+              {prompt.citations.map((c, i) => (
+                <li key={i}>
+                  <CitationLink citation={c} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function PrimaryAction({
+  prompt,
+  onAck,
+}: {
+  prompt: MedicationPrompt;
+  onAck: () => void | Promise<void>;
+}) {
+  const locale = useLocale();
+  const label = prompt.primary_action.label[locale];
+  const variant: "primary" | "tide" =
+    prompt.severity === "warning" ? "primary" : "tide";
+
+  if (prompt.primary_action.kind === "log_lab") {
+    return (
+      <Link href="/labs" onClick={() => void onAck()}>
+        <Button variant={variant} size="sm" className="gap-1">
+          {label}
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Button>
+      </Link>
+    );
+  }
+  if (prompt.primary_action.kind === "log_mood") {
+    return (
+      <Link href="/daily" onClick={() => void onAck()}>
+        <Button variant={variant} size="sm" className="gap-1">
+          {label}
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Button>
+      </Link>
+    );
+  }
+  if (prompt.primary_action.kind === "call_clinic") {
+    return (
+      <Link href="/settings#emergency" onClick={() => void onAck()}>
+        <Button variant={variant} size="sm" className="gap-1">
+          {label}
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Button>
+      </Link>
+    );
+  }
+  return (
+    <Button variant={variant} size="sm" onClick={() => void onAck()}>
+      {label}
+    </Button>
+  );
+}
+
+function CitationLink({ citation }: { citation: PromptCitation }) {
+  return (
+    <a
+      href={citation.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-[11px] text-ink-500 hover:text-ink-900"
+    >
+      <ExternalLink className="h-3 w-3 shrink-0" />
+      <span className="truncate">
+        {citation.publisher ? `${citation.publisher} — ` : ""}
+        {citation.label}
+      </span>
+    </a>
+  );
+}

--- a/src/config/drug-registry.ts
+++ b/src/config/drug-registry.ts
@@ -101,6 +101,35 @@ const GEMCITABINE: DrugInfo = {
   diet_interactions: [],
   protocol_ids: ["gnp_weekly", "gnp_biweekly", "gem_maintenance"],
   supportive_id: undefined,
+  references: [
+    {
+      source: "FDA_label",
+      title:
+        "GEMCITABINE for Injection — Highlights of Prescribing Information",
+      publisher: "FDA",
+      url: "https://www.accessdata.fda.gov/drugsatfda_docs/label/2014/020509s077lbl.pdf",
+      accessed: "2026-04-21",
+      section: "5.1 Schedule-dependent toxicity / 6.1 Myelosuppression",
+    },
+  ],
+  prompt_facts: {
+    nadir: {
+      value: {
+        // FDA label requires CBC before each dose; combination GnP literature
+        // and the Abraxane label specify D8 + D15 pre-dose CBC. The post-D1
+        // counts trough across this window — keep the watch window broad and
+        // safety-oriented rather than asserting a single nadir day.
+        start_day: 8,
+        end_day: 15,
+        counts: ["ANC", "platelets"],
+        rationale: {
+          en: "Myelosuppression is the dose-limiting toxicity. Pre-dose CBC on D8 and D15 drives dose modification.",
+          zh: "骨髓抑制为剂量限制毒性。D8 与 D15 化疗前血常规决定剂量调整。",
+        },
+      },
+      source_refs: [0],
+    },
+  },
   clinical_note: {
     en: "Hu Lin tolerates weekly GnP well. Monitor for cumulative neuropathy and declining counts.",
     zh: "胡林对每周 GnP 耐受良好。监测累积性神经病变和血象下降。",
@@ -164,6 +193,32 @@ const NAB_PACLITAXEL: DrugInfo = {
   ],
   diet_interactions: [],
   protocol_ids: ["gnp_weekly", "gnp_biweekly"],
+  references: [
+    {
+      source: "FDA_label",
+      title:
+        "ABRAXANE (paclitaxel protein-bound particles) — Highlights of Prescribing Information",
+      publisher: "FDA",
+      url: "https://www.accessdata.fda.gov/drugsatfda_docs/label/2018/021660s045lbl.pdf",
+      accessed: "2026-04-21",
+      section:
+        "2.4 Dose Modifications, Pancreatic Cancer / 5.1 Hematologic effects",
+    },
+  ],
+  prompt_facts: {
+    nadir: {
+      value: {
+        start_day: 8,
+        end_day: 15,
+        counts: ["ANC", "platelets"],
+        rationale: {
+          en: "Per Abraxane label: pre-dose CBC required on D1, D8, and D15 of each 28-day cycle in pancreatic cancer; counts dip across this window.",
+          zh: "据 Abraxane 说明书：胰腺癌每 28 天周期 D1、D8、D15 化疗前需查血常规；该窗口内血象下降。",
+        },
+      },
+      source_refs: [0],
+    },
+  },
   clinical_note: {
     en: "Cumulative neuropathy is the main toxicity. Early flagging of tingling/numbness is critical to preserve function.",
     zh: "累积性神经病变是主要毒性。早期标记刺痛 / 麻木对保留功能至关重要。",
@@ -185,61 +240,76 @@ const NARMAFOTINIB: DrugInfo = {
     en: "Inhibits focal adhesion kinase, reducing stromal fibrosis and remodeling. Hypothesized to improve gemcitabine delivery in mPDAC. Under investigation in ACCENT trial.",
     zh: "抑制黏着斑激酶，减少基质纤维化和重建。假设改善吉西他滨在 mPDAC 中的递送。在 ACCENT 研究中调查。",
   },
-  typical_doses: [{ en: "400 mg BID (twice daily)", zh: "400 mg，每日两次" }],
+  typical_doses: [
+    { en: "400 mg PO once daily (RP2D, ACCENT trial)", zh: "400 mg 口服，每日一次（RP2D，ACCENT 试验）" },
+  ],
   default_schedules: [
     {
       kind: "with_meals",
-      times_per_day: 2,
+      times_per_day: 1,
       label: {
-        en: "400 mg BID with food, continuous throughout cycle",
-        zh: "400 mg 每日两次，与食物同服，周期全程连续",
+        en: "400 mg once daily with food, continuous throughout 28-day cycle",
+        zh: "400 mg 每日一次，与食物同服，28 天周期全程连续",
       },
     },
   ],
   side_effects: {
     common: [
-      { en: "Nausea, vomiting (early onset)", zh: "恶心、呕吐（早期发生）" },
-      { en: "Diarrhea or loose stools", zh: "腹泻或稀便" },
+      { en: "Nausea, vomiting", zh: "恶心、呕吐" },
       { en: "Fatigue", zh: "疲劳" },
-      {
-        en: "Elevated liver enzymes (ALT, AST) — reversible with dose reduction",
-        zh: "肝酶升高（ALT、AST）—— 减量后可逆",
-      },
-      { en: "Rash, pruritus (itching)", zh: "皮疹、瘙痒" },
+      { en: "Diarrhea or loose stools", zh: "腹泻或稀便" },
     ],
     serious: [
       {
-        en: "Hepatotoxicity — Grade 3+ transaminase elevation (ALT/AST >5× ULN)",
-        zh: "肝毒性 —— 转氨酶升高 >5× 正常上限（Grade 3+）",
-      },
-      {
-        en: "Diarrhea Grade 2+ — requires anti-diarrheal (loperamide)",
-        zh: "腹泻 Grade 2+ —— 需要止泻药（洛哌丁胺）",
+        en: "Grade 3 nausea was the dose-limiting toxicity reported at 400 mg in the ACCENT phase 1b cohort",
+        zh: "在 ACCENT 1b 期 400 mg 队列中，Grade 3 恶心为剂量限制毒性",
       },
     ],
   },
   monitoring: [
     {
-      en: "LFTs (ALT, AST, ALP, bilirubin) before each cycle — dose-limiting signal",
-      zh: "LFTs（ALT、AST、ALP、胆红素）每周期前 —— 剂量限制信号",
+      en: "Adherence to once-daily dosing with food — investigational oral agent",
+      zh: "与食物同服每日一次依从性 —— 试验性口服药物",
     },
-    { en: "U&Es", zh: "电解质" },
-    { en: "Rash monitoring — photo any new lesions", zh: "皮疹监测 —— 拍照记录任何新皮损" },
+    {
+      en: "Standard chemotherapy laboratory monitoring per the GnP backbone (FBC, LFTs, U&Es D1/D8/D15)",
+      zh: "依 GnP 骨干方案进行标准化疗实验室监测（D1/D8/D15 查血常规、肝功、电解质）",
+    },
   ],
   diet_interactions: [
     {
-      food: { en: "High-fat meals", zh: "高脂肪餐" },
+      food: { en: "Food (any meal)", zh: "食物（任意一餐）" },
       effect: {
-        en: "May increase narmafotinib absorption — consistent food intake advisable",
-        zh: "可能增加纳马非替尼吸收 —— 建议食物摄入一致",
+        en: "ACCENT protocol specifies dosing with food. Maintain consistent food intake at the dosing time.",
+        zh: "ACCENT 方案规定与食物同服。在服药时间保持一致的食物摄入。",
       },
       severity: "info",
     },
   ],
   protocol_ids: ["gnp_narmafotinib"],
+  references: [
+    {
+      source: "trial_publication",
+      title:
+        "Phase 1b/2a of narmafotinib (AMP945) in combination with gemcitabine and nab-paclitaxel in first-line patients with advanced pancreatic cancer (ACCENT trial): Interim analysis (JCO 2024)",
+      publisher: "ASCO Publications",
+      url: "https://ascopubs.org/doi/10.1200/JCO.2024.42.16_suppl.e16337",
+      accessed: "2026-04-21",
+      section: "Methods (RP2D, dosing); Results (DLT)",
+    },
+    {
+      source: "trial_protocol",
+      title:
+        "ACCENT: AMP945 in Combination with Nab-paclitaxel and Gemcitabine in Pancreatic Cancer Patients (NCT05355298)",
+      publisher: "ClinicalTrials.gov",
+      url: "https://clinicaltrials.gov/study/NCT05355298",
+      accessed: "2026-04-21",
+      section: "Study design, dosing, eligibility",
+    },
+  ],
   clinical_note: {
-    en: "Investigational agent in ACCENT trial. Hepatotoxicity and GI tolerance most important to monitor. Oral adherence is critical — missed doses reduce efficacy.",
-    zh: "ACCENT 试验中的试验性药物。肝毒性和胃肠耐受最重要。口服依从性至关重要 —— 漏服降低疗效。",
+    en: "Investigational FAK inhibitor. RP2D is 400 mg PO once daily with food in a 28-day cycle alongside D1/D8/D15 GnP. The reported DLT in the 400 mg cohort was Grade 3 nausea. No prompt-engine claim is made about narmafotinib-specific LFT monitoring beyond the standard GnP backbone.",
+    zh: "试验性 FAK 抑制剂。RP2D 为 400 mg 口服每日一次与食物同服，与 D1/D8/D15 GnP 同步进行 28 天周期。400 mg 队列报告的 DLT 为 Grade 3 恶心。提示引擎对纳马非替尼的肝功监测除 GnP 骨干外不作额外声明。",
   },
 };
 
@@ -529,9 +599,37 @@ const DEXAMETHASONE: DrugInfo = {
     { en: "Taper rather than stop abruptly (adrenal suppression risk)", zh: "逐渐减量而非突然停用（肾上腺抑制风险）" },
   ],
   diet_interactions: [],
+  references: [
+    {
+      source: "trial_publication",
+      title:
+        "Vardy J, Chiew KS, Galica J, Pond GR, Tannock IF. Side effects associated with the use of dexamethasone for prophylaxis of delayed emesis after moderately emetogenic chemotherapy. Br J Cancer. 2006;94(7):1011–1015.",
+      publisher: "British Journal of Cancer (Nature)",
+      url: "https://www.nature.com/articles/6603048",
+      accessed: "2026-04-21",
+      section: "Results: symptom incidence in the week post-chemotherapy",
+    },
+  ],
+  prompt_facts: {
+    steroid_crash: {
+      value: {
+        // Vardy 2006 reports moderate-severe symptoms (insomnia 45%, agitation
+        // 27%, indigestion 27%) in the week after chemo. The crash itself is
+        // most commonly described in the post-pulse window once dex is stopped
+        // — surface a check-in across days 3-5 post-pulse.
+        start_day_post_dose: 3,
+        end_day_post_dose: 5,
+        rationale: {
+          en: "Vardy et al (BJC 2006) documented moderate-severe insomnia (45%), agitation (27%), and dyspepsia (27%) in the week after chemo dex. Patients commonly report a mood/energy drop in the post-pulse D3–D5 window.",
+          zh: "Vardy 等（BJC 2006）记录化疗后地塞米松一周内中-重度失眠（45%）、激越（27%）、消化不良（27%）。患者常在 D3–D5 后撤药期反映情绪/精力下降。",
+        },
+      },
+      source_refs: [0],
+    },
+  },
   clinical_note: {
-    en: "Prophylactic dex is standard on chemo days. Steroid crash D3–D5 is universal — normalize it, reassure patient it lifts by D6.",
-    zh: "化疗日预防性地塞米松是标准。类固醇撤药反应 D3–D5 是普遍的 —— 标准化它，向患者保证到 D6 缓解。",
+    en: "Prophylactic dex is standard on chemo days. The post-pulse symptom window — most commonly D3-D5 — is well documented (Vardy 2006: 45% insomnia, 27% agitation, 27% dyspepsia). Normalize it; surface a mood check-in.",
+    zh: "化疗日预防性地塞米松是标准。撤药后症状窗口（最常见 D3-D5）有充分记录（Vardy 2006：失眠 45%、激越 27%、消化不良 27%）。标准化它；浮现情绪自查。",
   },
 };
 

--- a/src/config/protocols.ts
+++ b/src/config/protocols.ts
@@ -419,8 +419,8 @@ export const PROTOCOL_LIBRARY: readonly Protocol[] = [
       zh: "吉西他滨 + 白蛋白紫杉醇 + 纳马非替尼",
     },
     description: {
-      en: "28-day GnP backbone (D1/D8/D15 infusions) plus continuous oral narmafotinib (AMP945) — an investigational FAK inhibitor studied in the ACCENT trial in mPDAC. Hypothesis: disrupting stromal fibrosis improves chemo delivery. Watch LFTs and oral adherence.",
-      zh: "28 天 GnP 框架（D1/D8/D15 输注）+ 每日连续口服纳马非替尼（AMP945）—— ACCENT 研究中用于转移性胰腺癌的试验性 FAK 抑制剂。设想：通过破坏肿瘤基质纤维化来提升化疗药物递送。需密切监测肝功能与口服依从性。",
+      en: "28-day GnP backbone (D1/D8/D15 infusions) plus continuous oral narmafotinib (AMP945) — an investigational FAK inhibitor studied in the ACCENT trial in mPDAC (NCT05355298). Hypothesis: disrupting stromal fibrosis improves chemo delivery. Standard GnP backbone monitoring (FBC, LFTs, U&Es D1/D8/D15) applies; oral adherence is critical.",
+      zh: "28 天 GnP 框架（D1/D8/D15 输注）+ 每日连续口服纳马非替尼（AMP945）—— ACCENT 研究（NCT05355298）中用于转移性胰腺癌的试验性 FAK 抑制剂。设想：通过破坏肿瘤基质纤维化来提升化疗药物递送。沿用 GnP 骨干监测（D1/D8/D15 血常规、肝功、电解质）；口服依从性至关重要。",
     },
     cycle_length_days: 28,
     dose_days: [1, 8, 15],
@@ -447,12 +447,12 @@ export const PROTOCOL_LIBRARY: readonly Protocol[] = [
         id: "narmafotinib",
         name: "Narmafotinib",
         display: { en: "Narmafotinib (AMP945)", zh: "纳马非替尼（AMP945）" },
-        typical_dose: "400 mg BID (continuous PO)",
+        typical_dose: "400 mg PO once daily (continuous, ACCENT RP2D)",
         dose_days: [1],
         route: "PO",
         notes: {
-          en: "Oral FAK (focal adhesion kinase) inhibitor. Continuous twice-daily dosing throughout the cycle, taken with food. Confirm hold-on-infusion-day policy with Dr Lee. Monitor ALT/AST each cycle; hepatic toxicity is the dose-limiting signal in ACCENT.",
-          zh: "口服 FAK（黏着斑激酶）抑制剂。周期内每日两次连续服用，与餐同服。输液日是否暂停请与 Dr Lee 确认。每周期监测 ALT/AST —— ACCENT 研究中肝毒性是剂量限制性信号。",
+          en: "Oral FAK (focal adhesion kinase) inhibitor. ACCENT trial RP2D is 400 mg once daily with food, continuous through the 28-day cycle. The reported DLT in the 400 mg cohort was Grade 3 nausea. Confirm hold-on-infusion-day policy with Dr Lee.",
+          zh: "口服 FAK（黏着斑激酶）抑制剂。ACCENT 研究 RP2D 为 400 mg 每日一次与食物同服，28 天周期连续服用。400 mg 队列报告的 DLT 为 Grade 3 恶心。输液日是否暂停请与 Dr Lee 确认。",
         },
       },
     ],
@@ -462,8 +462,8 @@ export const PROTOCOL_LIBRARY: readonly Protocol[] = [
     },
     phase_windows: PHASE_GNP_WEEKLY,
     side_effect_profile: {
-      en: "GnP toxicities (myelosuppression esp. D16–21, peripheral neuropathy, fatigue, cold dysaesthesia, alopecia) plus narmafotinib-specific signals: transaminase elevation (ALT/AST), nausea, diarrhoea, rash, fatigue. Oral adherence burden on top of IV cycle.",
-      zh: "GnP 毒性（D16–21 骨髓抑制、周围神经病变、疲劳、遇冷异感、脱发）叠加纳马非替尼特有信号：肝酶升高（ALT/AST）、恶心、腹泻、皮疹、疲劳。在输注方案之外还有口服依从负担。",
+      en: "GnP toxicities (myelosuppression esp. D16–21, peripheral neuropathy, fatigue, cold dysaesthesia, alopecia) plus narmafotinib-specific signals: nausea (Grade 3 nausea was the reported DLT in the ACCENT 400 mg cohort), diarrhoea, fatigue. Oral adherence burden on top of IV cycle.",
+      zh: "GnP 毒性（D16–21 骨髓抑制、周围神经病变、疲劳、遇冷异感、脱发）叠加纳马非替尼特有信号：恶心（ACCENT 400 mg 队列报告的 DLT 为 Grade 3 恶心）、腹泻、疲劳。在输注方案之外还有口服依从负担。",
     },
     typical_supportive: [
       "supportive.gcsf_prophylaxis",

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -21,7 +21,11 @@ import type {
 import type { Trial } from "~/types/bridge";
 import type { TreatmentCycle } from "~/types/treatment";
 import type { PatientTask } from "~/types/task";
-import type { Medication, MedicationEvent } from "~/types/medication";
+import type {
+  Medication,
+  MedicationEvent,
+  MedicationPromptEvent,
+} from "~/types/medication";
 
 export class AnchorDB extends Dexie {
   daily_entries!: Table<DailyEntry, number>;
@@ -36,6 +40,7 @@ export class AnchorDB extends Dexie {
   treatments!: Table<Treatment, number>;
   medications!: Table<Medication, number>;
   medication_events!: Table<MedicationEvent, number>;
+  medication_prompt_events!: Table<MedicationPromptEvent, number>;
   life_events!: Table<LifeEvent, number>;
   decisions!: Table<Decision, number>;
   zone_alerts!: Table<ZoneAlert, number>;
@@ -90,6 +95,13 @@ export class AnchorDB extends Dexie {
         "++id, drug_id, category, active, cycle_id, source, started_on",
       medication_events:
         "++id, medication_id, drug_id, event_type, logged_at, [drug_id+logged_at]",
+    });
+    // v7: context-aware medication prompts (2b.1). The compound
+    // [rule_id+fired_for] index dedupes a prompt within its trigger window so
+    // the dashboard card never re-shows an acknowledged or dismissed prompt.
+    this.version(7).stores({
+      medication_prompt_events:
+        "++id, rule_id, status, shown_at, drug_id, cycle_id, [rule_id+fired_for]",
     });
   }
 }

--- a/src/lib/medication/prompts.ts
+++ b/src/lib/medication/prompts.ts
@@ -1,0 +1,292 @@
+// Context-aware medication prompts (2b.1) — cycle-phase rules only.
+//
+// Each rule reads the active treatment cycle, cycle day, and active medications
+// and may emit a single MedicationPrompt. The dashboard card persists the
+// prompt's (rule_id, fired_for) tuple to dedupe across renders so an
+// acknowledged or dismissed prompt does not re-show within its trigger window.
+//
+// Rules MUST only assert facts that are backed by a `prompt_facts` entry on
+// the relevant DrugInfo. The DrugInfo carries the citation; this file only
+// re-shapes those facts into patient-facing copy.
+import type {
+  DrugInfo,
+  DrugReference,
+  LocalizedText,
+  Medication,
+  MedicationPromptEvent,
+  ReferenceSource,
+} from "~/types/medication";
+import type { ProtocolId, TreatmentCycle } from "~/types/treatment";
+
+export interface PromptCitation {
+  label: string;
+  url: string;
+  source: ReferenceSource;
+  publisher?: string;
+}
+
+export type PromptSeverity = "info" | "caution" | "warning";
+export type PromptActionKind =
+  | "ack"          // patient confirms the prompt has been seen / actioned
+  | "log_lab"      // jump to lab logging surface
+  | "log_mood"     // jump to mood / wellbeing logging
+  | "call_clinic"; // surface clinic phone numbers
+
+export interface PromptAction {
+  kind: PromptActionKind;
+  label: LocalizedText;
+}
+
+export interface MedicationPrompt {
+  rule_id: string;
+  fired_for: string;
+  drug_id: string;
+  cycle_id?: number;
+  cycle_day?: number;
+  severity: PromptSeverity;
+  title: LocalizedText;
+  body: LocalizedText;
+  primary_action: PromptAction;
+  secondary_action?: PromptAction;
+  citations: PromptCitation[];
+}
+
+export interface PromptRuleContext {
+  cycle: TreatmentCycle | null;
+  cycle_day: number | null;
+  protocol_id: ProtocolId | null;
+  active_meds: Medication[];
+  drugs_by_id: Record<string, DrugInfo>;
+  // Persisted events so we can suppress already-resolved prompts.
+  existing_events: MedicationPromptEvent[];
+}
+
+export interface PromptRule {
+  id: string;
+  evaluate(ctx: PromptRuleContext): MedicationPrompt | null;
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+function isGnpProtocol(p: ProtocolId | null): boolean {
+  return (
+    p === "gnp_weekly" ||
+    p === "gnp_biweekly" ||
+    p === "gnp_narmafotinib" ||
+    p === "gem_maintenance"
+  );
+}
+
+function activeDrugIds(meds: Medication[]): Set<string> {
+  return new Set(meds.filter((m) => m.active).map((m) => m.drug_id));
+}
+
+function citationsFromFact(
+  drug: DrugInfo,
+  source_refs: number[],
+): PromptCitation[] {
+  const refs = drug.references ?? [];
+  return source_refs
+    .map((i): DrugReference | undefined => refs[i])
+    .filter((r): r is DrugReference => Boolean(r))
+    .map((r) => ({
+      label: r.section ? `${r.publisher ?? r.source} — ${r.section}` : r.title,
+      url: r.url,
+      source: r.source,
+      publisher: r.publisher,
+    }));
+}
+
+// ---- rule: gnp_d8_predose_bloods ------------------------------------------
+
+const GNP_D8_PREDOSE_BLOODS: PromptRule = {
+  id: "gnp_d8_predose_bloods",
+  evaluate(ctx) {
+    if (!ctx.cycle || ctx.cycle_day == null) return null;
+    if (!isGnpProtocol(ctx.protocol_id)) return null;
+    if (ctx.cycle_day !== 8 && ctx.cycle_day !== 15) return null;
+
+    const drugIds = activeDrugIds(ctx.active_meds);
+    const hasGem = drugIds.has("gemcitabine");
+    const hasNabP = drugIds.has("nab_paclitaxel");
+    if (!hasGem && !hasNabP) return null;
+
+    // Prefer the nab-paclitaxel label as the citation when present (the GnP
+    // combination D1/D8/D15 pre-dose CBC requirement is in the Abraxane label).
+    const drug = hasNabP
+      ? ctx.drugs_by_id["nab_paclitaxel"]
+      : ctx.drugs_by_id["gemcitabine"];
+    if (!drug?.prompt_facts?.nadir) return null;
+
+    const citations = citationsFromFact(
+      drug,
+      drug.prompt_facts.nadir.source_refs,
+    );
+
+    return {
+      rule_id: this.id,
+      fired_for: `cycle:${ctx.cycle.id ?? "x"}|day:${ctx.cycle_day}`,
+      drug_id: drug.id,
+      cycle_id: ctx.cycle.id,
+      cycle_day: ctx.cycle_day,
+      severity: "caution",
+      title: {
+        en: `Day ${ctx.cycle_day} — pre-dose bloods needed`,
+        zh: `第 ${ctx.cycle_day} 天 —— 需要化疗前查血`,
+      },
+      body: {
+        en: "Pre-dose CBC (and platelets) on D8 and D15 of each 28-day GnP cycle drives whether today's dose is given at full dose, 75%, or held. Confirm bloods have been drawn before infusion.",
+        zh: "每 28 天 GnP 周期 D8 与 D15 化疗前需查血常规（含血小板），决定今天的剂量为全量、75% 或暂停。请确认输液前已抽血。",
+      },
+      primary_action: {
+        kind: "ack",
+        label: { en: "Bloods done", zh: "已抽血" },
+      },
+      secondary_action: {
+        kind: "log_lab",
+        label: { en: "Log result", zh: "记录化验结果" },
+      },
+      citations,
+    };
+  },
+};
+
+// ---- rule: gnp_nadir_vigilance --------------------------------------------
+
+const GNP_NADIR_VIGILANCE: PromptRule = {
+  id: "gnp_nadir_vigilance",
+  evaluate(ctx) {
+    if (!ctx.cycle || ctx.cycle_day == null) return null;
+    if (!isGnpProtocol(ctx.protocol_id)) return null;
+
+    const drug = ctx.drugs_by_id["gemcitabine"];
+    if (!drug?.prompt_facts?.nadir) return null;
+    const fact = drug.prompt_facts.nadir.value;
+    if (ctx.cycle_day < fact.start_day || ctx.cycle_day > fact.end_day) {
+      return null;
+    }
+
+    const drugIds = activeDrugIds(ctx.active_meds);
+    if (!drugIds.has("gemcitabine")) return null;
+
+    const citations = citationsFromFact(
+      drug,
+      drug.prompt_facts.nadir.source_refs,
+    );
+
+    return {
+      rule_id: this.id,
+      // One acknowledgement per cycle covers the whole nadir window.
+      fired_for: `cycle:${ctx.cycle.id ?? "x"}|window:nadir`,
+      drug_id: drug.id,
+      cycle_id: ctx.cycle.id,
+      cycle_day: ctx.cycle_day,
+      severity: "warning",
+      title: {
+        en: "Nadir window — fever is an emergency",
+        zh: "骨髓低谷 —— 发热为急症",
+      },
+      body: {
+        en: `Days ${fact.start_day}–${fact.end_day}: ANC and platelets are typically lowest. Temperature ≥ 38.0 °C, chills, rigors, or a sore throat means call the oncology team or attend ED — do not wait.`,
+        zh: `第 ${fact.start_day}–${fact.end_day} 天：中性粒细胞与血小板通常处于低谷。体温 ≥ 38.0 °C、寒战、僵直或咽痛即请联系肿瘤团队或前往急诊 —— 请勿等待。`,
+      },
+      primary_action: {
+        kind: "ack",
+        label: { en: "Understood", zh: "明白" },
+      },
+      secondary_action: {
+        kind: "call_clinic",
+        label: { en: "Call clinic", zh: "联系诊所" },
+      },
+      citations,
+    };
+  },
+};
+
+// ---- rule: dex_post_pulse_mood --------------------------------------------
+
+const DEX_POST_PULSE_MOOD: PromptRule = {
+  id: "dex_post_pulse_mood",
+  evaluate(ctx) {
+    if (!ctx.cycle || ctx.cycle_day == null) return null;
+
+    const drug = ctx.drugs_by_id["dexamethasone"];
+    if (!drug?.prompt_facts?.steroid_crash) return null;
+    const fact = drug.prompt_facts.steroid_crash.value;
+    if (
+      ctx.cycle_day < fact.start_day_post_dose ||
+      ctx.cycle_day > fact.end_day_post_dose
+    ) {
+      return null;
+    }
+
+    // Dex shows up as an active medication with a cycle-linked schedule that
+    // includes day 1 or 2 of the cycle (chemo-day premed).
+    const dexMed = ctx.active_meds.find(
+      (m) =>
+        m.drug_id === "dexamethasone" &&
+        m.active &&
+        m.schedule.kind === "cycle_linked" &&
+        (m.schedule.cycle_days ?? []).some((d) => d === 1 || d === 2),
+    );
+    if (!dexMed) return null;
+
+    const citations = citationsFromFact(
+      drug,
+      drug.prompt_facts.steroid_crash.source_refs,
+    );
+
+    return {
+      rule_id: this.id,
+      fired_for: `cycle:${ctx.cycle.id ?? "x"}|day:${ctx.cycle_day}`,
+      drug_id: drug.id,
+      cycle_id: ctx.cycle.id,
+      cycle_day: ctx.cycle_day,
+      severity: "info",
+      title: {
+        en: `Day ${ctx.cycle_day} — how is your mood and energy?`,
+        zh: `第 ${ctx.cycle_day} 天 —— 情绪与精力如何？`,
+      },
+      body: {
+        en: "Days 3–5 after the dexamethasone pulse are when low mood, fatigue, irritability, or sleep disruption most often appear. Vardy et al (2006) reported moderate–severe insomnia in 45% and agitation in 27%. Surface it now so it is on the record.",
+        zh: "地塞米松撤药后第 3–5 天最容易出现情绪低落、疲劳、易怒或睡眠紊乱。Vardy 等（2006）报告中-重度失眠 45%、激越 27%。现在记录下来。",
+      },
+      primary_action: {
+        kind: "log_mood",
+        label: { en: "Log mood", zh: "记录情绪" },
+      },
+      secondary_action: {
+        kind: "ack",
+        label: { en: "Feeling fine", zh: "状态良好" },
+      },
+      citations,
+    };
+  },
+};
+
+// ---- registry --------------------------------------------------------------
+
+export const PROMPT_RULES: readonly PromptRule[] = [
+  GNP_D8_PREDOSE_BLOODS,
+  GNP_NADIR_VIGILANCE,
+  DEX_POST_PULSE_MOOD,
+];
+
+export function evaluatePrompts(
+  ctx: PromptRuleContext,
+): MedicationPrompt[] {
+  const out: MedicationPrompt[] = [];
+  for (const rule of PROMPT_RULES) {
+    const p = rule.evaluate(ctx);
+    if (!p) continue;
+    const resolved = ctx.existing_events.some(
+      (e) =>
+        e.rule_id === p.rule_id &&
+        e.fired_for === p.fired_for &&
+        (e.status === "acknowledged" || e.status === "dismissed"),
+    );
+    if (resolved) continue;
+    out.push(p);
+  }
+  return out;
+}

--- a/src/types/medication.ts
+++ b/src/types/medication.ts
@@ -76,9 +76,59 @@ export interface DrugSideEffects {
   serious: LocalizedText[];
 }
 
+// Provenance levels, ordered roughly from most to least authoritative.
+export type ReferenceSource =
+  | "FDA_label"          // accessdata.fda.gov / dailymed.nlm.nih.gov
+  | "TGA_PI"             // tga.gov.au product information
+  | "EMA_SmPC"           // EMA Summary of Product Characteristics
+  | "guideline"          // ASCO / NCCN / ESMO / MASCC / NCI
+  | "trial_protocol"     // ClinicalTrials.gov record / sponsor protocol
+  | "trial_publication"  // peer-reviewed primary trial paper
+  | "company_disclosure" // sponsor investor or pipeline material
+  | "review";            // narrative or systematic review
+
 export interface DrugReference {
+  source: ReferenceSource;
   title: string;
   url: string;
+  accessed: string;        // ISO date the URL was fetched
+  publisher?: string;      // e.g. "FDA", "TGA", "Amplia Therapeutics"
+  section?: string;        // e.g. "Section 2.2 Recommended Dose"
+}
+
+// A value paired with its citations. `source_refs` are indices into
+// DrugInfo.references — keep them sorted ascending for stable diffs.
+export interface CitedValue<T> {
+  value: T;
+  source_refs: number[];
+}
+
+export interface LftCheckFact {
+  baseline: boolean;       // check at baseline before first dose
+  cycle_days: number[];    // monitoring days within each cycle
+  rationale: LocalizedText;
+}
+
+export interface SteroidCrashFact {
+  start_day_post_dose: number; // typically 3
+  end_day_post_dose: number;   // typically 5
+  rationale: LocalizedText;
+}
+
+export interface NadirFact {
+  start_day: number;       // cycle day window starts
+  end_day: number;         // cycle day window ends
+  counts: ("ANC" | "platelets" | "Hb")[];
+  rationale: LocalizedText;
+}
+
+// Structured, citation-backed clinical facts the prompt rule engine reads.
+// All fields optional — only populate facts that have been verified against
+// a real reference. Never invent values here.
+export interface PromptFacts {
+  lft_check?: CitedValue<LftCheckFact>;
+  steroid_crash?: CitedValue<SteroidCrashFact>;
+  nadir?: CitedValue<NadirFact>;
 }
 
 export interface DrugInfo {
@@ -98,6 +148,9 @@ export interface DrugInfo {
   protocol_ids?: string[]; // optional join to Protocol.id
   supportive_id?: string;  // optional join to treatment-levers
   references?: DrugReference[];
+  // Structured facts for the prompt rule engine. Only populated for drugs
+  // whose facts have been cited against entries in `references`.
+  prompt_facts?: PromptFacts;
   // Notes for the profile page, free-form bilingual paragraph.
   clinical_note?: LocalizedText;
 }
@@ -153,6 +206,22 @@ export interface MedicationEvent {
   note?: string;
   source: "daily_checkin" | "quick_log" | "fab" | "backfill";
   created_at: string;
+}
+
+// Persisted record of a context-aware medication prompt the engine has
+// surfaced to the patient. One row per (rule, fired_for) pair so we can
+// dedupe across renders and correlate later (2b.2+).
+export interface MedicationPromptEvent {
+  id?: number;
+  rule_id: string;            // e.g. "narmafotinib_d22_lft"
+  fired_for: string;          // dedupe key, e.g. "cycle:7|day:22"
+  drug_id?: string;           // primary drug the prompt is about
+  cycle_id?: number;
+  cycle_day?: number;
+  status: "shown" | "acknowledged" | "dismissed";
+  shown_at: string;           // ISO
+  resolved_at?: string;       // ISO when status moved off "shown"
+  note?: string;              // patient-entered free text on ack
 }
 
 // Convenience: "what's due / what was logged today" for a single medication.

--- a/tests/unit/medication-prompts.test.ts
+++ b/tests/unit/medication-prompts.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import { evaluatePrompts } from "~/lib/medication/prompts";
+import { DRUGS_BY_ID } from "~/config/drug-registry";
+import type { Medication } from "~/types/medication";
+import type { ProtocolId, TreatmentCycle } from "~/types/treatment";
+
+function cycle(overrides: Partial<TreatmentCycle> = {}): TreatmentCycle {
+  return {
+    id: 7,
+    protocol_id: "gnp_weekly",
+    cycle_number: 3,
+    start_date: "2026-04-01",
+    status: "active",
+    dose_level: 0,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function med(overrides: Partial<Medication>): Medication {
+  return {
+    drug_id: "gemcitabine",
+    category: "chemo",
+    dose: "1000 mg/m²",
+    route: "IV",
+    schedule: { kind: "cycle_linked", cycle_days: [1, 8, 15] },
+    source: "protocol_agent",
+    cycle_id: 7,
+    active: true,
+    started_on: "2026-04-01",
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function gemMed(): Medication {
+  return med({ drug_id: "gemcitabine" });
+}
+function nabMed(): Medication {
+  return med({
+    drug_id: "nab_paclitaxel",
+    category: "chemo",
+    dose: "125 mg/m²",
+  });
+}
+function dexMed(): Medication {
+  return med({
+    drug_id: "dexamethasone",
+    category: "steroid",
+    dose: "8 mg",
+    route: "PO",
+    source: "protocol_supportive",
+    schedule: { kind: "cycle_linked", cycle_days: [1, 2] },
+  });
+}
+
+function ctxOn(
+  cycle_day: number,
+  active_meds: Medication[],
+  protocol_id: ProtocolId = "gnp_weekly",
+) {
+  return {
+    cycle: cycle({ protocol_id }),
+    cycle_day,
+    protocol_id,
+    active_meds,
+    drugs_by_id: DRUGS_BY_ID,
+    existing_events: [],
+  };
+}
+
+describe("medication prompts — gnp_d8_predose_bloods", () => {
+  it("fires on D8 of GnP weekly with active gem + nab-p", () => {
+    const prompts = evaluatePrompts(ctxOn(8, [gemMed(), nabMed()]));
+    expect(prompts.map((p) => p.rule_id)).toContain("gnp_d8_predose_bloods");
+    const p = prompts.find((p) => p.rule_id === "gnp_d8_predose_bloods")!;
+    expect(p.cycle_day).toBe(8);
+    expect(p.fired_for).toBe("cycle:7|day:8");
+    expect(p.citations.length).toBeGreaterThan(0);
+    expect(p.citations[0].url).toContain("accessdata.fda.gov");
+  });
+
+  it("fires on D15 too", () => {
+    const prompts = evaluatePrompts(ctxOn(15, [gemMed(), nabMed()]));
+    const p = prompts.find((p) => p.rule_id === "gnp_d8_predose_bloods");
+    expect(p).toBeTruthy();
+    expect(p!.fired_for).toBe("cycle:7|day:15");
+  });
+
+  it("does not fire on D1, D9, or D22", () => {
+    for (const d of [1, 9, 22]) {
+      const prompts = evaluatePrompts(ctxOn(d, [gemMed(), nabMed()]));
+      const ids = prompts.map((p) => p.rule_id);
+      expect(ids).not.toContain("gnp_d8_predose_bloods");
+    }
+  });
+
+  it("does not fire if no GnP backbone meds are active", () => {
+    const prompts = evaluatePrompts(ctxOn(8, [dexMed()]));
+    const ids = prompts.map((p) => p.rule_id);
+    expect(ids).not.toContain("gnp_d8_predose_bloods");
+  });
+
+  it("does not fire on a non-GnP protocol", () => {
+    const prompts = evaluatePrompts(ctxOn(8, [gemMed()], "mffx"));
+    const ids = prompts.map((p) => p.rule_id);
+    expect(ids).not.toContain("gnp_d8_predose_bloods");
+  });
+
+  it("is suppressed once acknowledged", () => {
+    const baseCtx = ctxOn(8, [gemMed(), nabMed()]);
+    const ctx = {
+      ...baseCtx,
+      existing_events: [
+        {
+          rule_id: "gnp_d8_predose_bloods",
+          fired_for: "cycle:7|day:8",
+          status: "acknowledged" as const,
+          shown_at: "2026-04-08T08:00:00Z",
+        },
+      ],
+    };
+    const prompts = evaluatePrompts(ctx);
+    expect(prompts.map((p) => p.rule_id)).not.toContain(
+      "gnp_d8_predose_bloods",
+    );
+  });
+});
+
+describe("medication prompts — gnp_nadir_vigilance", () => {
+  it("fires across the gemcitabine nadir window (D8–D15)", () => {
+    for (const d of [8, 12, 15]) {
+      const prompts = evaluatePrompts(ctxOn(d, [gemMed()]));
+      const p = prompts.find((p) => p.rule_id === "gnp_nadir_vigilance");
+      expect(p, `expected nadir prompt on D${d}`).toBeTruthy();
+      expect(p!.severity).toBe("warning");
+      expect(p!.fired_for).toBe("cycle:7|window:nadir");
+    }
+  });
+
+  it("does not fire outside the nadir window", () => {
+    for (const d of [1, 7, 16, 28]) {
+      const prompts = evaluatePrompts(ctxOn(d, [gemMed()]));
+      const ids = prompts.map((p) => p.rule_id);
+      expect(ids).not.toContain("gnp_nadir_vigilance");
+    }
+  });
+
+  it("dedup uses one fired_for per cycle", () => {
+    const baseCtx = ctxOn(12, [gemMed()]);
+    const ctx = {
+      ...baseCtx,
+      existing_events: [
+        {
+          rule_id: "gnp_nadir_vigilance",
+          fired_for: "cycle:7|window:nadir",
+          status: "dismissed" as const,
+          shown_at: "2026-04-09T08:00:00Z",
+        },
+      ],
+    };
+    const prompts = evaluatePrompts(ctx);
+    const ids = prompts.map((p) => p.rule_id);
+    expect(ids).not.toContain("gnp_nadir_vigilance");
+  });
+});
+
+describe("medication prompts — dex_post_pulse_mood", () => {
+  it("fires on D3, D4, D5 when chemo-day dex is active", () => {
+    for (const d of [3, 4, 5]) {
+      const prompts = evaluatePrompts(ctxOn(d, [gemMed(), dexMed()]));
+      const p = prompts.find((p) => p.rule_id === "dex_post_pulse_mood");
+      expect(p, `expected dex prompt on D${d}`).toBeTruthy();
+      expect(p!.fired_for).toBe(`cycle:7|day:${d}`);
+      expect(p!.citations[0].url).toContain("nature.com");
+    }
+  });
+
+  it("does not fire on D2 or D6", () => {
+    for (const d of [2, 6]) {
+      const prompts = evaluatePrompts(ctxOn(d, [gemMed(), dexMed()]));
+      const ids = prompts.map((p) => p.rule_id);
+      expect(ids).not.toContain("dex_post_pulse_mood");
+    }
+  });
+
+  it("does not fire when dex is not in active meds", () => {
+    const prompts = evaluatePrompts(ctxOn(4, [gemMed()]));
+    const ids = prompts.map((p) => p.rule_id);
+    expect(ids).not.toContain("dex_post_pulse_mood");
+  });
+});
+
+describe("medication prompts — registry integrity (2b.0 ground truth)", () => {
+  it("narmafotinib registry uses once-daily dosing (corrected from BID)", () => {
+    const drug = DRUGS_BY_ID["narmafotinib"];
+    expect(drug).toBeTruthy();
+    expect(drug.default_schedules[0].times_per_day).toBe(1);
+    expect(drug.typical_doses[0].en).toMatch(/once daily/i);
+  });
+
+  it("each drug with prompt_facts has at least one cited reference", () => {
+    for (const id of [
+      "gemcitabine",
+      "nab_paclitaxel",
+      "dexamethasone",
+      "narmafotinib",
+    ]) {
+      const drug = DRUGS_BY_ID[id];
+      expect(drug.references?.length ?? 0).toBeGreaterThan(0);
+    }
+    for (const [id, fact] of [
+      ["gemcitabine", DRUGS_BY_ID["gemcitabine"].prompt_facts?.nadir],
+      ["nab_paclitaxel", DRUGS_BY_ID["nab_paclitaxel"].prompt_facts?.nadir],
+      [
+        "dexamethasone",
+        DRUGS_BY_ID["dexamethasone"].prompt_facts?.steroid_crash,
+      ],
+    ] as const) {
+      expect(fact, `${id} missing prompt_fact`).toBeTruthy();
+      expect(fact!.source_refs.length).toBeGreaterThan(0);
+      const drug = DRUGS_BY_ID[id];
+      for (const ref of fact!.source_refs) {
+        expect(drug.references![ref]).toBeTruthy();
+      }
+    }
+  });
+});


### PR DESCRIPTION
Narrowed-scope first slice of the medications 2b roadmap (context-aware prompts). Ships **2b.0 (ground-truth schema + cited drug data) + 2b.1 (cycle-phase rules) together** so every prompt the engine surfaces traces back to a real source the patient or carer can audit.

## What this PR does

### 2b.0 — Ground truth (the part that matters most)

**Schema**
- `DrugInfo.references: DrugReference[]` with typed `ReferenceSource` (`FDA_label`, `TGA_PI`, `EMA_SmPC`, `guideline`, `trial_protocol`, `trial_publication`, `company_disclosure`, `review`), `accessed` ISO date, optional `publisher` and `section` pointer.
- `DrugInfo.prompt_facts: PromptFacts` — typed clinical facts each wrapped in `CitedValue<T>` whose `source_refs` are indices back into `references`. New fact shapes: `LftCheckFact`, `SteroidCrashFact`, `NadirFact`. The rule engine reads only from these.

**Cited the four drugs needed for 2b.1 (gemcitabine, nab-paclitaxel, dexamethasone, narmafotinib)** against:
- FDA gemcitabine label — `accessdata.fda.gov/drugsatfda_docs/label/2014/020509s077lbl.pdf`
- FDA Abraxane label (D1/D8/D15 pre-dose CBC requirement) — `accessdata.fda.gov/drugsatfda_docs/label/2018/021660s045lbl.pdf`
- ACCENT trial JCO interim analysis + ClinicalTrials.gov NCT05355298 (narmafotinib)
- Vardy J et al. *Br J Cancer* 2006;94(7):1011–1015 (dex post-pulse symptom profile, doi:10.1038/sj.bjc.6603048)

**Correction surfaced by going to source:** narmafotinib was previously registered as 400 mg BID with food, with a clinical note claiming hepatotoxicity was its dose-limiting toxicity. **The ACCENT RP2D is 400 mg PO once daily**, and the AACR abstract reports Grade 3 nausea (not LFT derangement) as the DLT in the 400 mg cohort. Fixed in `drug-registry.ts` and the `gnp_narmafotinib` agent in `protocols.ts`. This is exactly why 2b.0 came before 2b.1.

### 2b.1 — Three cited cycle-phase rules

`src/lib/medication/prompts.ts` evaluates against `(cycle, cycle_day, active_meds, drugs_by_id, existing_events)` and emits prompts. Each rule reads its trigger window from a cited `prompt_facts` entry — no fact, no rule.

| Rule ID | Fires | Citation |
|---|---|---|
| `gnp_d8_predose_bloods` | D8 / D15 of any GnP cycle, gem or nab-p active | Abraxane FDA label (pre-dose CBC required D1/D8/D15) |
| `gnp_nadir_vigilance` | D8–D15 fever-watch, gem active, GnP protocol | Gemcitabine FDA label myelosuppression warning |
| `dex_post_pulse_mood` | D3–D5 mood/sleep check-in if chemo-day dex active | Vardy 2006 BJC |

**Dedup:** `medication_prompt_events` Dexie table (v7) with `[rule_id+fired_for]` compound index. `gnp_d8_predose_bloods` and `dex_post_pulse_mood` use a per-day key; `gnp_nadir_vigilance` uses one-per-cycle so an acknowledgement covers the whole window.

### UI

- New `MedicationPromptsCard` on the dashboard above `TodayFeed`.
- Severity tones (`info` / `caution` / `warning`) match existing feed conventions.
- Each prompt has acknowledge / dismiss buttons plus a collapsible **Sources (n)** link that opens each citation in a new tab. The patient (or Tom reviewing the dashboard, or Dr Lee in clinic) can audit any prompt back to its source.

### Tests

14 new unit tests in `tests/unit/medication-prompts.test.ts` cover positive triggers, negative triggers (wrong cycle day, wrong protocol, no relevant active med), dedup behaviour, and registry integrity (narmafotinib QD enforcement; every `prompt_facts` entry has at least one resolvable `source_refs` index).

All 117 tests pass. `pnpm typecheck`, `pnpm lint`, `pnpm build` clean.

## Out of scope (deferred)

- **2b.2** — symptom-triggered prompts (diarrhea→loperamide, cold→oxaliplatin, nausea→antiemetic adherence)
- **2b.3** — time-of-day cards
- Daily check-in / FAB integration of prompts
- Narmafotinib-specific prompt (could not cite the LFT-timing claim from public ACCENT materials — registry is corrected, but no rule until source is verified)
- Citing the other 9 drugs in the registry — happens slice-by-slice as they get rules

## How to verify locally

1. Seed an active GnP cycle starting today.
2. Set the system clock (or change `start_date`) to land on D8, D12, or D4 → see one of the three prompts.
3. Click the **Sources** link on any prompt and confirm the URL opens the cited FDA / trial / journal page.
4. Acknowledge or dismiss → confirm the prompt does not re-show on next render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)