### PR TITLE
Slice 2: Change detectors — steps + grip end-to-end with differential + actions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { PillarsCard } from "~/components/dashboard/pillars-card";
 import { RecentTrends } from "~/components/dashboard/recent-trends";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
+import { ChangeSignalsCard } from "~/components/dashboard/change-signals-card";
 import { MedicationPromptsCard } from "~/components/dashboard/medication-prompts-card";
 import { TodayFeed } from "~/components/dashboard/today-feed";
 import { useLocale, useT } from "~/hooks/use-translate";
@@ -74,6 +75,8 @@ export default function DashboardPage() {
       <EmergencyCard />
 
       <QuickCheckinCard />
+
+      <ChangeSignalsCard />
 
       <MedicationPromptsCard />
 

--- a/src/components/dashboard/change-signals-card.tsx
+++ b/src/components/dashboard/change-signals-card.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import {
+  buildPatientState,
+  extractObservationsByMetric,
+  METRICS_BY_ID,
+} from "~/lib/state";
+import {
+  deserializeSignal,
+  evaluateAndPersistSignals,
+  setSignalStatus,
+} from "~/lib/state/detectors/persistence";
+import type {
+  ChangeSignal,
+  SignalSeverity,
+  SuggestedAction,
+} from "~/lib/state/detectors";
+import type { ChangeSignalRow, Locale } from "~/types/clinical";
+import {
+  AlertTriangle,
+  Bell,
+  ChevronDown,
+  ChevronUp,
+  Sparkles,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+const TONE_BY_SEVERITY: Record<
+  SignalSeverity,
+  { wrap: string; chip: string; Icon: React.ComponentType<{ className?: string }> }
+> = {
+  caution: {
+    wrap: "bg-[var(--sand)]/40 border-l-[3px] border-l-[oklch(45%_0.06_70)]",
+    chip: "bg-[oklch(92%_0.04_70)] text-[oklch(45%_0.06_70)]",
+    Icon: Bell,
+  },
+  warning: {
+    wrap: "bg-[var(--warn-soft)] border-l-[3px] border-l-[var(--warn)]",
+    chip: "bg-[var(--warn)] text-white",
+    Icon: AlertTriangle,
+  },
+};
+
+export function ChangeSignalsCard() {
+  const locale = useLocale();
+  const settings = useLiveQuery(() => db.settings.toArray(), []);
+  const dailies = useLiveQuery(
+    () => db.daily_entries.orderBy("date").toArray(),
+    [],
+  );
+  const fortnightlies = useLiveQuery(
+    () => db.fortnightly_assessments.orderBy("assessment_date").toArray(),
+    [],
+  );
+  const labs = useLiveQuery(() => db.labs.orderBy("date").toArray(), []);
+  const cycles = useLiveQuery(() => db.treatment_cycles.toArray(), []);
+  const openSignalRows = useLiveQuery(
+    () => db.change_signals.where("status").equals("open").toArray(),
+    [],
+  );
+
+  // Re-evaluate detectors whenever the underlying data changes. The
+  // persistence layer dedupes, so repeated evaluations are safe.
+  useEffect(() => {
+    if (!dailies || !fortnightlies || !labs || !cycles) return;
+    const asOf = new Date().toISOString();
+    const inputs = {
+      as_of: asOf,
+      settings: settings?.[0] ?? null,
+      dailies,
+      fortnightlies,
+      labs,
+      cycles,
+    };
+    const state = buildPatientState(inputs);
+    const observations = extractObservationsByMetric(inputs);
+    void evaluateAndPersistSignals({ state, observations, now: asOf });
+  }, [settings, dailies, fortnightlies, labs, cycles]);
+
+  const signals = useMemo(() => {
+    if (!openSignalRows) return [];
+    return openSignalRows
+      .map((row) => ({ row, signal: safeDeserialize(row) }))
+      .filter(
+        (x): x is { row: ChangeSignalRow; signal: ChangeSignal } =>
+          x.signal !== null,
+      )
+      .sort(
+        (a, b) =>
+          severityRank(b.signal.severity) - severityRank(a.signal.severity) ||
+          Date.parse(b.row.detected_at) - Date.parse(a.row.detected_at),
+      );
+  }, [openSignalRows]);
+
+  if (signals.length === 0) return null;
+
+  return (
+    <section className="space-y-2">
+      <div className="eyebrow px-1">
+        {locale === "zh" ? "变化信号" : "Change signals"}
+      </div>
+      <div className="space-y-2">
+        {signals.map(({ row, signal }) => (
+          <SignalRow key={row.id} row={row} signal={signal} locale={locale} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SignalRow({
+  row,
+  signal,
+  locale,
+}: {
+  row: ChangeSignalRow;
+  signal: ChangeSignal;
+  locale: Locale;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const tone = TONE_BY_SEVERITY[signal.severity];
+  const metricDef = METRICS_BY_ID[signal.metric_id];
+  const topCause = signal.differential.find(
+    (d) => d.confidence !== "unlikely",
+  );
+  const actionsToShow = signal.actions.slice(0, 2);
+
+  return (
+    <Card className={cn("px-4 py-4", tone.wrap)}>
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
+            tone.chip,
+          )}
+        >
+          <tone.Icon className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-[13.5px] font-semibold text-ink-900">
+              {signal.title[locale]}
+            </div>
+            <span className="mono text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+              {signal.axis}
+            </span>
+          </div>
+          <p className="mt-1 text-[12.5px] leading-relaxed text-ink-700">
+            {signal.explanation[locale]}
+          </p>
+
+          {topCause && (
+            <div className="mt-2 flex items-center gap-2 text-[11.5px] text-ink-700">
+              <Sparkles className="h-3 w-3 text-ink-400" />
+              <span className="font-medium">
+                {topCause.label[locale]}
+              </span>
+              <span className="mono text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+                {topCause.confidence}
+              </span>
+            </div>
+          )}
+
+          {actionsToShow.length > 0 && (
+            <ul className="mt-3 space-y-1.5">
+              {actionsToShow.map((a) => (
+                <ActionRow key={`${a.kind}:${a.ref_id}`} action={a} locale={locale} />
+              ))}
+            </ul>
+          )}
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <Button
+              variant="tide"
+              size="sm"
+              onClick={() =>
+                row.id && void setSignalStatus(row.id, "acknowledged")
+              }
+            >
+              {locale === "zh" ? "收到" : "Got it"}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                row.id && void setSignalStatus(row.id, "dismissed")
+              }
+              className="text-ink-500"
+            >
+              {locale === "zh" ? "关闭" : "Dismiss"}
+            </Button>
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="ml-auto inline-flex items-center gap-1 text-[11px] text-ink-500 hover:text-ink-900"
+            >
+              {expanded
+                ? locale === "zh"
+                  ? "隐藏证据"
+                  : "Hide evidence"
+                : locale === "zh"
+                  ? "查看证据"
+                  : "Why this fired"}
+              {expanded ? (
+                <ChevronUp className="h-3 w-3" />
+              ) : (
+                <ChevronDown className="h-3 w-3" />
+              )}
+            </button>
+          </div>
+
+          {expanded && (
+            <div className="mt-3 border-t border-ink-100/60 pt-3 text-[11.5px] text-ink-700">
+              <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+                <dt className="text-ink-400">
+                  {locale === "zh" ? "指标" : "Metric"}
+                </dt>
+                <dd className="font-medium">
+                  {metricDef?.label ?? signal.metric_id}
+                  {metricDef?.unit ? ` (${metricDef.unit})` : ""}
+                </dd>
+                <dt className="text-ink-400">
+                  {locale === "zh" ? "当前" : "Current"}
+                </dt>
+                <dd>{signal.evidence.current_value}</dd>
+                <dt className="text-ink-400">
+                  {locale === "zh" ? "基线" : "Baseline"}
+                </dt>
+                <dd>
+                  {signal.evidence.baseline_value}
+                  <span className="mono ml-2 text-[10px] text-ink-400">
+                    {signal.evidence.baseline_kind}
+                  </span>
+                </dd>
+                {signal.evidence.duration_days > 0 && (
+                  <>
+                    <dt className="text-ink-400">
+                      {locale === "zh" ? "持续" : "For"}
+                    </dt>
+                    <dd>
+                      {signal.evidence.duration_days}
+                      {locale === "zh" ? " 天" : " days"}
+                    </dd>
+                  </>
+                )}
+                {signal.evidence.sd_units !== 0 && (
+                  <>
+                    <dt className="text-ink-400">
+                      {locale === "zh" ? "距基线" : "SD units"}
+                    </dt>
+                    <dd>{signal.evidence.sd_units.toFixed(1)}</dd>
+                  </>
+                )}
+              </dl>
+
+              {signal.differential.length > 0 && (
+                <div className="mt-3 space-y-1">
+                  <div className="mono text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+                    {locale === "zh" ? "差异诊断" : "Differential"}
+                  </div>
+                  {signal.differential.map((d) => (
+                    <div
+                      key={d.id}
+                      className="flex items-start justify-between gap-2"
+                    >
+                      <div className="flex-1">
+                        <span className="font-medium text-ink-900">
+                          {d.label[locale]}
+                        </span>
+                        {d.supporting_metric_ids.length > 0 && (
+                          <span className="ml-2 text-[10.5px] text-ink-400">
+                            ({d.supporting_metric_ids
+                              .map((id) => METRICS_BY_ID[id]?.label ?? id)
+                              .join(", ")})
+                          </span>
+                        )}
+                      </div>
+                      <span className="mono shrink-0 text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+                        {d.confidence}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function ActionRow({
+  action,
+  locale,
+}: {
+  action: SuggestedAction;
+  locale: Locale;
+}) {
+  return (
+    <li className="flex items-center gap-2 text-[12px] text-ink-700">
+      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--tide-2)]" />
+      <span className="flex-1">{action.label[locale]}</span>
+      <span className="mono text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+        {action.urgency === "now"
+          ? locale === "zh"
+            ? "立即"
+            : "NOW"
+          : action.urgency === "soon"
+            ? locale === "zh"
+              ? "尽快"
+              : "SOON"
+            : locale === "zh"
+              ? "下次就诊"
+              : "NEXT VISIT"}
+      </span>
+    </li>
+  );
+}
+
+function safeDeserialize(row: ChangeSignalRow): ChangeSignal | null {
+  try {
+    return deserializeSignal(row);
+  } catch {
+    return null;
+  }
+}
+
+function severityRank(s: SignalSeverity): number {
+  return s === "warning" ? 2 : 1;
+}

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -1,5 +1,6 @@
 import Dexie, { type Table } from "dexie";
 import type {
+  ChangeSignalRow,
   DailyEntry,
   WeeklyAssessment,
   FortnightlyAssessment,
@@ -41,6 +42,7 @@ export class AnchorDB extends Dexie {
   medications!: Table<Medication, number>;
   medication_events!: Table<MedicationEvent, number>;
   medication_prompt_events!: Table<MedicationPromptEvent, number>;
+  change_signals!: Table<ChangeSignalRow, number>;
   life_events!: Table<LifeEvent, number>;
   decisions!: Table<Decision, number>;
   zone_alerts!: Table<ZoneAlert, number>;
@@ -102,6 +104,14 @@ export class AnchorDB extends Dexie {
     this.version(7).stores({
       medication_prompt_events:
         "++id, rule_id, status, shown_at, drug_id, cycle_id, [rule_id+fired_for]",
+    });
+    // v8: change-signal detector outputs (slice 2). `fired_for` is the dedup
+    // key per detector occurrence; `status` drives lifecycle (open →
+    // acknowledged / dismissed / resolved). The compound [detector+fired_for]
+    // index enforces uniqueness per occurrence.
+    this.version(8).stores({
+      change_signals:
+        "++id, detector, fired_for, metric_id, axis, severity, status, detected_at, [detector+fired_for]",
     });
   }
 }

--- a/src/lib/state/build.ts
+++ b/src/lib/state/build.ts
@@ -130,6 +130,21 @@ function extractObservations(
   return out;
 }
 
+/**
+ * Extract the raw observation series for every registered metric. Detectors
+ * (slice 2+) consume this alongside the PatientStateSnapshot so they can
+ * compute rolling means / patient-SDs without re-reading Dexie.
+ */
+export function extractObservationsByMetric(
+  inputs: BuildStateInputs,
+): Record<string, Observation[]> {
+  const out: Record<string, Observation[]> = {};
+  for (const m of METRIC_REGISTRY) {
+    out[m.id] = extractObservations(m, inputs);
+  }
+  return out;
+}
+
 function computeTrajectory(
   metric: RegisteredMetric,
   inputs: BuildStateInputs,

--- a/src/lib/state/detectors/differential.ts
+++ b/src/lib/state/detectors/differential.ts
@@ -1,0 +1,138 @@
+// Differential-diagnosis helper. Given a primary signal and the current
+// state snapshot, walks a list of candidate causes with evidence predicates
+// and returns a ranked differential. Each cause carries a list of supporting
+// metric_ids so the reasoning is auditable downstream.
+import type { MetricTrajectory, PatientStateSnapshot } from "../types";
+import type {
+  DifferentialCause,
+  DifferentialConfidence,
+} from "./types";
+import type { LocalizedText } from "~/types/treatment";
+
+export interface CandidateCause {
+  id: string;
+  label: LocalizedText;
+  explanation?: LocalizedText;
+  // Each predicate inspects the state and either returns a supporting metric
+  // id (contributes toward the cause) or null (no evidence). The number of
+  // supporting metrics determines the confidence ranking.
+  predicates: CandidatePredicate[];
+  // If `required_supporters` of predicates don't match, the cause is downgraded
+  // to "unlikely" regardless of how many other predicates match.
+  required_supporters?: number;
+}
+
+export type CandidatePredicate = (
+  state: PatientStateSnapshot,
+) => string | null;
+
+function confidenceFromSupporterCount(
+  matched: number,
+  totalPredicates: number,
+  required = 0,
+): DifferentialConfidence {
+  if (matched === 0) return "unlikely";
+  if (required > 0 && matched < required) return "unlikely";
+  const ratio = matched / totalPredicates;
+  if (ratio >= 0.66 || matched >= 3) return "likely";
+  if (ratio >= 0.33 || matched >= 1) return "possible";
+  return "unlikely";
+}
+
+export function rankDifferential(
+  state: PatientStateSnapshot,
+  candidates: readonly CandidateCause[],
+): DifferentialCause[] {
+  const out: DifferentialCause[] = [];
+  for (const cand of candidates) {
+    const supporters: string[] = [];
+    for (const p of cand.predicates) {
+      const m = p(state);
+      if (m) supporters.push(m);
+    }
+    const confidence = confidenceFromSupporterCount(
+      supporters.length,
+      cand.predicates.length,
+      cand.required_supporters,
+    );
+    out.push({
+      id: cand.id,
+      label: cand.label,
+      confidence,
+      supporting_metric_ids: supporters,
+      explanation: cand.explanation,
+    });
+  }
+  // Rank: likely > possible > unlikely; ties broken by more supporters.
+  const rank = (c: DifferentialCause) =>
+    c.confidence === "likely" ? 2 : c.confidence === "possible" ? 1 : 0;
+  out.sort(
+    (a, b) =>
+      rank(b) - rank(a) ||
+      b.supporting_metric_ids.length - a.supporting_metric_ids.length,
+  );
+  return out;
+}
+
+// ─── Common predicates — shared building blocks for cause evidence ─────────
+//
+// Each returns `(state) => metric_id | null`. Consumers compose them per
+// candidate cause. Keep these small and obvious — they are the audit trail.
+
+/**
+ * The named metric is drifting in the specified direction by at least
+ * `minPctFromBaseline` percent off its preferred baseline. The caller knows
+ * the metric's polarity; the predicate accepts `direction` explicitly so the
+ * call site is unambiguous (e.g. for nausea, `direction: "higher"`).
+ */
+export function metricDriftingAgainst(
+  metricId: string,
+  direction: "lower" | "higher",
+  minPctFromBaseline = 10,
+): CandidatePredicate {
+  return (state) => {
+    const t: MetricTrajectory | undefined = state.metrics[metricId];
+    if (!t || !t.fresh || typeof t.pct_from_baseline !== "number") return null;
+    const pct = t.pct_from_baseline;
+    const triggered =
+      direction === "lower" ? pct <= -minPctFromBaseline : pct >= minPctFromBaseline;
+    return triggered ? metricId : null;
+  };
+}
+
+/**
+ * The named metric's latest value is at or beyond the threshold.
+ */
+export function metricAtLeast(
+  metricId: string,
+  threshold: number,
+): CandidatePredicate {
+  return (state) => {
+    const t = state.metrics[metricId];
+    if (!t || !t.fresh || typeof t.value !== "number") return null;
+    return t.value >= threshold ? metricId : null;
+  };
+}
+
+export function metricAtMost(
+  metricId: string,
+  threshold: number,
+): CandidatePredicate {
+  return (state) => {
+    const t = state.metrics[metricId];
+    if (!t || !t.fresh || typeof t.value !== "number") return null;
+    return t.value <= threshold ? metricId : null;
+  };
+}
+
+/**
+ * Cycle_day falls within [from, to] of the current cycle, inclusive.
+ * Evidence predicate only — returns a synthetic "cycle_day" identifier.
+ */
+export function cycleDayBetween(from: number, to: number): CandidatePredicate {
+  return (state) => {
+    const d = state.cycle?.cycle_day;
+    if (typeof d !== "number") return null;
+    return d >= from && d <= to ? "cycle_day" : null;
+  };
+}

--- a/src/lib/state/detectors/grip-decline.ts
+++ b/src/lib/state/detectors/grip-decline.ts
@@ -1,0 +1,334 @@
+// Grip strength decline detector — fortnightly cadence, individual axis.
+//
+// Grip is the highest-yield objective muscle measurement available in the
+// schema. It's measured every two weeks (FortnightlyAssessment), which means
+// rolling-window techniques don't apply — we reason over the last 3-4
+// fortnightly observations via OLS slope and cycle-matched deltas.
+//
+// Detection shape: slope across the last ≥3 fortnightlies is more negative
+// than −0.3 kg / week (i.e. ≈ −0.6 kg / fortnight), OR the most recent point
+// is ≥ 15% below pre-diagnosis baseline and slope is negative. Zone rules
+// already fire at 10% (yellow) and 20% (orange) absolute decline — this
+// detector is the *trend* signal that precedes the threshold crossing.
+import { olsSlopePerDay } from "../slope";
+import { preferredBaseline } from "../baselines";
+import {
+  metricAtLeast,
+  metricDriftingAgainst,
+  rankDifferential,
+  type CandidateCause,
+} from "./differential";
+import type {
+  ChangeSignal,
+  Detector,
+  DetectorContext,
+  SignalEvidence,
+  SuggestedAction,
+} from "./types";
+
+const DETECTOR_ID = "grip_decline";
+const METRIC_ID = "grip_dominant_kg";
+
+// Thresholds
+const MIN_OBSERVATIONS = 3;
+// −0.3 kg/week corresponds to ≈ 15% annual decline from a 40 kg baseline —
+// well above age-related attrition (0.05 kg/week) so this is a signal not noise.
+const CAUTION_SLOPE_PER_DAY = -0.3 / 7;
+const WARNING_SLOPE_PER_DAY = -0.6 / 7;
+const CAUTION_PCT_BELOW_BASELINE = 7; // 7% below baseline + negative slope
+const WARNING_PCT_BELOW_BASELINE = 12;
+const RESOLVED_SLOPE_PER_DAY = -0.1 / 7; // nearly flat or recovering
+
+const CAUSES: readonly CandidateCause[] = [
+  {
+    id: "chemo_neurotoxicity",
+    label: {
+      en: "Chemo-induced neuropathy affecting grip",
+      zh: "化疗诱导的神经病变影响握力",
+    },
+    explanation: {
+      en: "Grip decline with concurrent hand neuropathy flags suggests peripheral toxicity is the mechanism. Discuss dose modification and duloxetine with Dr Lee.",
+      zh: "握力下降伴手部神经病变提示周围神经毒性是机制。可与 Dr Lee 讨论剂量调整和度洛西汀。",
+    },
+    required_supporters: 1,
+    predicates: [
+      metricAtLeast("neuropathy_hands_flag", 1),
+      metricAtLeast("neuropathy_grade", 2),
+    ],
+  },
+  {
+    id: "cachexia",
+    label: {
+      en: "Cachexia / sarcopenia drift",
+      zh: "恶病质 / 肌少症漂移",
+    },
+    explanation: {
+      en: "Grip decline alongside weight loss and low protein intake is the cachexia pattern. The intervention set is nutrition + resistance — it's time-sensitive once muscle starts going.",
+      zh: "握力下降伴体重下降和低蛋白摄入提示恶病质。干预方案为营养 + 抗阻训练 —— 一旦肌肉开始流失，时间窗很紧。",
+    },
+    required_supporters: 1,
+    predicates: [
+      metricDriftingAgainst("weight_kg", "lower", 3),
+      metricDriftingAgainst("protein_grams", "lower", 25),
+      metricDriftingAgainst("albumin", "lower", 10),
+    ],
+  },
+  {
+    id: "deconditioning_only",
+    label: {
+      en: "Isolated deconditioning",
+      zh: "单一去适应",
+    },
+    explanation: {
+      en: "No concurrent toxicity or cachexia markers — grip decline looks like lost training stimulus. Exercise physiology + resistance program is the direct lever.",
+      zh: "无伴随毒性或恶病质标志 —— 握力下降提示缺乏训练刺激。运动生理学 + 抗阻训练为直接干预。",
+    },
+    required_supporters: 1,
+    predicates: [
+      metricDriftingAgainst("walking_minutes", "lower", 30),
+      metricDriftingAgainst("steps", "lower", 20),
+    ],
+  },
+  {
+    id: "unknown",
+    label: {
+      en: "Mechanism unclear",
+      zh: "机制不明",
+    },
+    explanation: {
+      en: "Grip declining without concurrent signals. Worth confirming with a manual retest + raising at next clinic visit.",
+      zh: "握力下降但无并发信号。建议重测确认并在下次就诊时提出。",
+    },
+    predicates: [],
+  },
+];
+
+function actionsForCause(causeId: string): SuggestedAction[] {
+  switch (causeId) {
+    case "chemo_neurotoxicity":
+      return [
+        {
+          kind: "question",
+          ref_id: "dose_modification_review",
+          urgency: "next_visit",
+          label: {
+            en: "Discuss dose modification to protect grip",
+            zh: "讨论剂量调整以保护握力",
+          },
+        },
+        {
+          kind: "lever",
+          ref_id: "supportive.duloxetine",
+          urgency: "soon",
+          label: {
+            en: "Start duloxetine 30–60 mg",
+            zh: "开始度洛西汀 30–60 mg",
+          },
+        },
+      ];
+    case "cachexia":
+      return [
+        {
+          kind: "lever",
+          ref_id: "nutrition.dietitian",
+          urgency: "soon",
+          label: {
+            en: "Oncology dietitian referral",
+            zh: "肿瘤营养师转介",
+          },
+        },
+        {
+          kind: "lever",
+          ref_id: "physical.resistance",
+          urgency: "now",
+          label: {
+            en: "Resistance training 2–3×/week",
+            zh: "每周 2–3 次抗阻训练",
+          },
+        },
+        {
+          kind: "lever",
+          ref_id: "nutrition.supplements",
+          urgency: "now",
+          label: {
+            en: "Add protein supplement between meals",
+            zh: "餐间加蛋白补充",
+          },
+        },
+      ];
+    case "deconditioning_only":
+      return [
+        {
+          kind: "lever",
+          ref_id: "physical.exercise_phys",
+          urgency: "soon",
+          label: {
+            en: "Exercise physiology referral",
+            zh: "运动生理学转介",
+          },
+        },
+        {
+          kind: "lever",
+          ref_id: "physical.resistance",
+          urgency: "now",
+          label: {
+            en: "Resistance training 2–3×/week",
+            zh: "每周 2–3 次抗阻训练",
+          },
+        },
+      ];
+    default:
+      return [
+        {
+          kind: "task",
+          ref_id: "grip_retest",
+          urgency: "soon",
+          label: {
+            en: "Repeat grip test in 48h to confirm",
+            zh: "48 小时内重测握力确认",
+          },
+        },
+        {
+          kind: "question",
+          ref_id: "grip_concern",
+          urgency: "next_visit",
+          label: {
+            en: "Raise grip trend at next clinic visit",
+            zh: "下次就诊提及握力趋势",
+          },
+        },
+      ];
+  }
+}
+
+// One signal per fortnightly assessment that triggers the detector. Dedup
+// key: the ISO date of the most recent assessment that produced the data.
+function firedForKey(latestAssessmentDate: string): string {
+  return `${DETECTOR_ID}:${latestAssessmentDate}`;
+}
+
+function currentSlope(
+  observations: readonly { date: string; value: number }[],
+): { slope: number | null; latest?: { date: string; value: number } } {
+  if (observations.length < MIN_OBSERVATIONS) return { slope: null };
+  const latest = observations[observations.length - 1];
+  // Use only the most recent MIN_OBSERVATIONS+1 points so an old stable period
+  // doesn't mask a new decline.
+  const window = observations.slice(-4);
+  return { slope: olsSlopePerDay(window), latest };
+}
+
+export const gripDeclineDetector: Detector = {
+  id: DETECTOR_ID,
+
+  evaluate(ctx: DetectorContext): ChangeSignal[] {
+    const trajectory = ctx.state.metrics[METRIC_ID];
+    const obs = ctx.observations[METRIC_ID] ?? [];
+    if (!trajectory || !trajectory.fresh || obs.length < MIN_OBSERVATIONS) return [];
+
+    const { slope, latest } = currentSlope(obs);
+    if (slope == null || !latest) return [];
+    if (slope > CAUTION_SLOPE_PER_DAY) return []; // not declining meaningfully
+
+    const baseline = preferredBaseline(trajectory.baselines);
+    const baselineValue = baseline?.value;
+    const pctBelow =
+      typeof baselineValue === "number" && baselineValue > 0
+        ? ((baselineValue - latest.value) / baselineValue) * 100
+        : undefined;
+
+    // Require either a meaningfully negative slope OR meaningful pct-below
+    // baseline to fire. This filters noise from a single low reading.
+    const slopeCaution = slope <= CAUTION_SLOPE_PER_DAY;
+    const slopeWarning = slope <= WARNING_SLOPE_PER_DAY;
+    const pctCaution =
+      typeof pctBelow === "number" && pctBelow >= CAUTION_PCT_BELOW_BASELINE;
+    const pctWarning =
+      typeof pctBelow === "number" && pctBelow >= WARNING_PCT_BELOW_BASELINE;
+
+    if (!slopeCaution && !pctCaution) return [];
+
+    const severity = slopeWarning || pctWarning ? "warning" : "caution";
+
+    const evidence: SignalEvidence = {
+      baseline_value: Math.round((baselineValue ?? latest.value) * 10) / 10,
+      baseline_kind: baseline?.kind ?? "pre_diagnosis",
+      current_value: Math.round(latest.value * 10) / 10,
+      delta_abs:
+        typeof baselineValue === "number"
+          ? Math.round((latest.value - baselineValue) * 10) / 10
+          : 0,
+      sd_units: 0, // fortnightly cadence lacks reliable patient-SD estimate
+      duration_days: obs.length >= 2
+        ? daysBetween(obs[0]!.date, latest.date)
+        : 0,
+      slope_recent: slope,
+    };
+
+    const differential = rankDifferential(ctx.state, CAUSES);
+    // For unknown, ensure it's last if anything else is at least "possible".
+    const topCause =
+      differential.find((d) => d.confidence !== "unlikely" && d.id !== "unknown") ??
+      differential[0];
+    const actions = topCause ? actionsForCause(topCause.id) : [];
+
+    const fired_for = firedForKey(latest.date);
+    const kgPerFortnight = (slope * 14).toFixed(1);
+    const title =
+      severity === "warning"
+        ? {
+            en: `Grip strength falling fast (${kgPerFortnight} kg / fortnight)`,
+            zh: `握力下降较快（${kgPerFortnight} 公斤 / 两周）`,
+          }
+        : {
+            en: `Grip strength trend turning down`,
+            zh: `握力趋势转为下降`,
+          };
+
+    const explanation = {
+      en: "Grip is the most sensitive muscle signal available day-to-day and directly predicts functional reserve for trial eligibility. Detector fires before the zone-rule threshold so a conversation can start early.",
+      zh: "握力是日常可得的最敏感肌肉信号，直接预测功能储备与入组资格。在区带规则阈值前触发以便及早讨论。",
+    };
+
+    return [
+      {
+        detector: DETECTOR_ID,
+        fired_for,
+        metric_id: METRIC_ID,
+        axis: "individual",
+        shape: "rolling_drift",
+        severity,
+        title,
+        explanation,
+        evidence,
+        differential,
+        actions,
+      },
+    ];
+  },
+
+  hasResolved(signal, ctx) {
+    if (signal.detector !== DETECTOR_ID) return false;
+    const obs = ctx.observations[METRIC_ID] ?? [];
+    if (obs.length < MIN_OBSERVATIONS) return false;
+    const { slope } = currentSlope(obs);
+    if (slope == null) return false;
+    return slope >= RESOLVED_SLOPE_PER_DAY;
+  },
+};
+
+function daysBetween(startISO: string, endISO: string): number {
+  const s = Date.parse(startISO);
+  const e = Date.parse(endISO);
+  if (Number.isNaN(s) || Number.isNaN(e)) return 0;
+  return Math.max(0, Math.round((e - s) / 86_400_000));
+}
+
+export const _internals = {
+  CAUSES,
+  actionsForCause,
+  DETECTOR_ID,
+  METRIC_ID,
+  CAUTION_SLOPE_PER_DAY,
+  WARNING_SLOPE_PER_DAY,
+};

--- a/src/lib/state/detectors/index.ts
+++ b/src/lib/state/detectors/index.ts
@@ -1,0 +1,97 @@
+// Detector orchestration. `evaluateDetectors` runs the registered detector
+// family against a state snapshot + observation series, and returns the
+// emitted signals. Consumers diff those against persisted signals to decide
+// what to write / resolve / suppress.
+import type { ChangeSignal, Detector, DetectorContext } from "./types";
+import { gripDeclineDetector } from "./grip-decline";
+import { stepsDeclineDetector } from "./steps-decline";
+
+export { stepsDeclineDetector } from "./steps-decline";
+export { gripDeclineDetector } from "./grip-decline";
+export type {
+  ChangeSignal,
+  Detector,
+  DetectorContext,
+  DifferentialCause,
+  DifferentialConfidence,
+  SignalEvidence,
+  SignalSeverity,
+  SignalShape,
+  SignalStatus,
+  SuggestedAction,
+  SuggestedActionKind,
+  ActionUrgency,
+} from "./types";
+export {
+  metricAtLeast,
+  metricAtMost,
+  metricDriftingAgainst,
+  cycleDayBetween,
+  rankDifferential,
+  type CandidateCause,
+  type CandidatePredicate,
+} from "./differential";
+
+export const DETECTORS: readonly Detector[] = [
+  stepsDeclineDetector,
+  gripDeclineDetector,
+];
+
+export function evaluateDetectors(
+  ctx: DetectorContext,
+  detectors: readonly Detector[] = DETECTORS,
+): ChangeSignal[] {
+  const signals: ChangeSignal[] = [];
+  for (const d of detectors) {
+    try {
+      signals.push(...d.evaluate(ctx));
+    } catch {
+      // Detectors must never crash the evaluator — skip on error.
+    }
+  }
+  return signals;
+}
+
+export interface SignalReconciliation {
+  to_insert: ChangeSignal[];            // freshly emitted, not persisted yet
+  to_resolve: string[];                 // fired_for keys whose drift recovered
+}
+
+/**
+ * Reconcile newly-emitted signals against a persisted set.
+ * - Signals already persisted with status open/acknowledged/dismissed are
+ *   suppressed from `to_insert`.
+ * - Persisted "open" signals whose underlying drift has recovered are
+ *   returned in `to_resolve` so the caller can update their status.
+ */
+export function reconcileSignals(
+  emitted: readonly ChangeSignal[],
+  persisted: readonly { fired_for: string; status: string }[],
+  ctx: DetectorContext,
+  detectors: readonly Detector[] = DETECTORS,
+): SignalReconciliation {
+  const persistedByKey = new Map(
+    persisted.map((p) => [p.fired_for, p.status]),
+  );
+  const to_insert: ChangeSignal[] = [];
+  for (const e of emitted) {
+    if (persistedByKey.has(e.fired_for)) continue;
+    to_insert.push(e);
+  }
+
+  const to_resolve: string[] = [];
+  for (const p of persisted) {
+    if (p.status !== "open") continue;
+    const detectorId = p.fired_for.split(":")[0];
+    const detector = detectors.find((d) => d.id === detectorId);
+    if (!detector) continue;
+    // We reconstruct a minimal signal shape for hasResolved; detectors only
+    // need the `detector` field in practice for routing.
+    const stub = { detector: detectorId } as ChangeSignal;
+    if (detector.hasResolved(stub, ctx)) {
+      to_resolve.push(p.fired_for);
+    }
+  }
+
+  return { to_insert, to_resolve };
+}

--- a/src/lib/state/detectors/persistence.ts
+++ b/src/lib/state/detectors/persistence.ts
@@ -1,0 +1,84 @@
+// Persistence helpers for change signals. Thin wrappers around Dexie so the
+// detector orchestration stays pure and the consumer (UI, background job)
+// handles IO.
+import { db } from "~/lib/db/dexie";
+import type { ChangeSignalRow } from "~/types/clinical";
+import { DETECTORS, evaluateDetectors, reconcileSignals } from ".";
+import type { ChangeSignal, DetectorContext, SignalStatus } from "./types";
+
+export async function getOpenSignals(): Promise<ChangeSignalRow[]> {
+  return db.change_signals.where("status").equals("open").toArray();
+}
+
+export async function getAllSignals(): Promise<ChangeSignalRow[]> {
+  return db.change_signals.orderBy("detected_at").reverse().toArray();
+}
+
+export function deserializeSignal(row: ChangeSignalRow): ChangeSignal {
+  return JSON.parse(row.payload_json) as ChangeSignal;
+}
+
+/**
+ * Run detectors, reconcile against persisted state, write new open rows, and
+ * update rows whose underlying drift has recovered. Safe to call repeatedly
+ * (idempotent on the same ctx).
+ *
+ * Returns the number of rows inserted and resolved, for diagnostic logging.
+ */
+export async function evaluateAndPersistSignals(
+  ctx: DetectorContext,
+): Promise<{ inserted: number; resolved: number }> {
+  const emitted = evaluateDetectors(ctx);
+  const persisted = await db.change_signals.toArray();
+  const reconciliation = reconcileSignals(
+    emitted,
+    persisted.map((p) => ({ fired_for: p.fired_for, status: p.status })),
+    ctx,
+  );
+
+  const nowISO = ctx.now;
+  let inserted = 0;
+  for (const sig of reconciliation.to_insert) {
+    const row: ChangeSignalRow = {
+      detector: sig.detector,
+      fired_for: sig.fired_for,
+      metric_id: sig.metric_id,
+      axis: sig.axis,
+      severity: sig.severity,
+      shape: sig.shape,
+      status: "open",
+      payload_json: JSON.stringify(sig),
+      detected_at: nowISO,
+    };
+    await db.change_signals.add(row);
+    inserted++;
+  }
+
+  let resolved = 0;
+  for (const firedFor of reconciliation.to_resolve) {
+    const row = await db.change_signals
+      .where("fired_for")
+      .equals(firedFor)
+      .first();
+    if (!row?.id) continue;
+    await db.change_signals.update(row.id, {
+      status: "resolved",
+      resolved_at: nowISO,
+    });
+    resolved++;
+  }
+
+  return { inserted, resolved };
+}
+
+export async function setSignalStatus(
+  id: number,
+  status: SignalStatus,
+  note?: string,
+): Promise<void> {
+  await db.change_signals.update(id, {
+    status,
+    resolved_at: new Date().toISOString(),
+    note,
+  });
+}

--- a/src/lib/state/detectors/steps-decline.ts
+++ b/src/lib/state/detectors/steps-decline.ts
@@ -1,0 +1,431 @@
+// Steps decline detector — daily cadence, individual axis.
+//
+// Detection shape: the 7-day rolling mean of steps has been ≥ k patient-SDs
+// below the preferred baseline for ≥ 5 consecutive days. Step count is a
+// high-frequency objective proxy for functional performance and ECOG PS —
+// it typically falls weeks before clinician-rated PS change.
+//
+// Multi-dimensional differential: concurrent metrics across all four axes
+// are inspected to rank likely causes. The signal surfaces the ranked
+// differential and the supporting metric ids so the reasoning is auditable.
+import {
+  consecutiveDaysBelow,
+  patientSD,
+  rollingMean,
+} from "../variance";
+import { slopeOver } from "../slope";
+import { preferredBaseline, rollingBaseline } from "../baselines";
+import {
+  cycleDayBetween,
+  metricAtLeast,
+  metricAtMost,
+  metricDriftingAgainst,
+  rankDifferential,
+  type CandidateCause,
+} from "./differential";
+import type {
+  ChangeSignal,
+  Detector,
+  DetectorContext,
+  SignalEvidence,
+  SuggestedAction,
+} from "./types";
+
+const DETECTOR_ID = "steps_decline";
+const METRIC_ID = "steps";
+
+// Thresholds — at module top for easy audit.
+//
+// Firing uses percent-below-baseline: a 7-day rolling mean that has fallen
+// ≥ CAUTION_PCT below the preferred baseline for ≥ MIN_DURATION_DAYS.
+// Percent is more robust than SD-units here: when a patient starts drifting,
+// the 28-day SD window ends up containing both the stable period and the
+// drift, which inflates the SD and hides the signal. We still surface
+// sd_units in the evidence as a secondary descriptor — computed from the
+// variance of baseline-only days when identifiable.
+const ROLLING_WINDOW_DAYS = 7;
+const BASELINE_WINDOW_DAYS = 28;
+const MIN_OBSERVATIONS_FOR_BASELINE = 7;
+// Firing thresholds are deliberately tight (10% / 20%) because the rolling_28d
+// baseline is self-contaminated once drift begins — the current drop is
+// already pulling the baseline mean down, so the apparent pct_below_baseline
+// is smaller than the true pct-below-pre-drift. A future slice will add
+// robust "pre-drift reference" baselines; until then, tight thresholds keep
+// the detector usable.
+const CAUTION_PCT = 10;
+const WARNING_PCT = 20;
+const MIN_DURATION_DAYS = 5;
+const RESOLVED_WITHIN_PCT = 5; // 7-day mean within 5% of baseline ⇒ resolved
+
+const CAUSES: readonly CandidateCause[] = [
+  {
+    id: "chemo_recovery",
+    label: {
+      en: "Expected chemo-week recovery",
+      zh: "化疗后恢复期（预期）",
+    },
+    explanation: {
+      en: "Activity dips across days 2–7 of each GnP cycle are normal. Re-check at D8+.",
+      zh: "GnP 周期第 2–7 天活动下降属预期范围。第 8 天后复评。",
+    },
+    required_supporters: 2,
+    predicates: [
+      cycleDayBetween(2, 7),
+      metricAtLeast("nausea", 4),
+      metricAtMost("appetite", 4),
+      metricAtMost("energy", 4),
+    ],
+  },
+  {
+    id: "disease_progression",
+    label: {
+      en: "Possible disease progression pattern",
+      zh: "可能的疾病进展模式",
+    },
+    explanation: {
+      en: "Rising pain or new dyspnoea alongside activity decline is the pattern that most often precedes scan-confirmed progression. Worth raising early imaging with Dr Lee.",
+      zh: "疼痛上升或新发呼吸困难与活动量下降同时出现，最常在影像进展前出现。考虑提前与 Dr Lee 讨论影像。",
+    },
+    required_supporters: 1,
+    predicates: [
+      metricDriftingAgainst("pain_current", "higher", 20),
+      metricDriftingAgainst("pain_worst", "higher", 20),
+      metricAtLeast("dyspnoea_flag", 1),
+    ],
+  },
+  {
+    id: "mood_depression",
+    label: {
+      en: "Mood / motivation shift",
+      zh: "情绪 / 动力下降",
+    },
+    explanation: {
+      en: "Low mood with reduced sleep quality can present as activity decline before it shows on PHQ-9. Surface early; psychology referral is the highest-yield intervention.",
+      zh: "情绪低落与睡眠质量下降可在 PHQ-9 反映之前以活动量下降方式出现。转介心理学可早期介入。",
+    },
+    required_supporters: 2,
+    predicates: [
+      metricDriftingAgainst("mood_clarity", "lower", 20),
+      metricDriftingAgainst("sleep_quality", "lower", 20),
+      metricDriftingAgainst("energy", "lower", 20),
+    ],
+  },
+  {
+    id: "toxicity_burden",
+    label: {
+      en: "Rising treatment toxicity",
+      zh: "治疗毒性累积",
+    },
+    explanation: {
+      en: "Neuropathy or persistent nausea can cause activity decline by making movement harder or nauseating. Dose modification is the lever to discuss.",
+      zh: "神经病变或持续恶心可通过使活动更困难或引发恶心而导致活动下降。可与医师讨论剂量调整。",
+    },
+    required_supporters: 1,
+    predicates: [
+      metricAtLeast("neuropathy_hands_flag", 1),
+      metricAtLeast("neuropathy_feet_flag", 1),
+      metricDriftingAgainst("nausea", "higher", 20),
+    ],
+  },
+  {
+    id: "deconditioning",
+    label: {
+      en: "Deconditioning / sarcopenia drift",
+      zh: "去适应 / 肌少症漂移",
+    },
+    explanation: {
+      en: "Isolated activity decline — no concurrent symptoms — suggests deconditioning. Resistance training + exercise physiology is the targeted intervention.",
+      zh: "单一活动下降且无伴随症状，提示去适应。抗阻训练 + 运动生理学为针对性干预。",
+    },
+    required_supporters: 1,
+    predicates: [
+      metricDriftingAgainst("grip_dominant_kg", "lower", 10),
+      metricDriftingAgainst("gait_speed_ms", "lower", 10),
+      metricDriftingAgainst("walking_minutes", "lower", 30),
+    ],
+  },
+];
+
+function actionsForCause(causeId: string): SuggestedAction[] {
+  switch (causeId) {
+    case "chemo_recovery":
+      return [
+        {
+          kind: "self",
+          ref_id: "gentle_walk_10min",
+          urgency: "now",
+          label: {
+            en: "Try a gentle 10-min walk + hydrate",
+            zh: "尝试温和的 10 分钟步行 + 补水",
+          },
+        },
+        {
+          kind: "conversation",
+          ref_id: "carer_check_in",
+          urgency: "soon",
+          label: {
+            en: "Check in with carer about rest plan for next 3 days",
+            zh: "与照顾者沟通未来 3 天的休息计划",
+          },
+        },
+      ];
+    case "disease_progression":
+      return [
+        {
+          kind: "question",
+          ref_id: "early_imaging",
+          urgency: "next_visit",
+          label: {
+            en: "Ask Dr Lee about bringing CT forward",
+            zh: "与 Dr Lee 讨论提前 CT 影像",
+          },
+        },
+        {
+          kind: "lever",
+          ref_id: "monitoring.imaging_early",
+          urgency: "next_visit",
+          label: {
+            en: "Early imaging lever",
+            zh: "提前影像干预",
+          },
+        },
+      ];
+    case "mood_depression":
+      return [
+        {
+          kind: "lever",
+          ref_id: "psychological.psychology",
+          urgency: "soon",
+          label: {
+            en: "Psychology referral",
+            zh: "心理学转介",
+          },
+        },
+        {
+          kind: "self",
+          ref_id: "practice_prioritise",
+          urgency: "now",
+          label: {
+            en: "Prioritise one short practice session today",
+            zh: "今天优先做一次短修习",
+          },
+        },
+      ];
+    case "toxicity_burden":
+      return [
+        {
+          kind: "question",
+          ref_id: "dose_modification_review",
+          urgency: "next_visit",
+          label: {
+            en: "Discuss dose modification with Dr Lee",
+            zh: "与 Dr Lee 讨论剂量调整",
+          },
+        },
+        {
+          kind: "lever",
+          ref_id: "supportive.duloxetine",
+          urgency: "soon",
+          label: {
+            en: "Consider duloxetine for neuropathy",
+            zh: "考虑度洛西汀治疗神经病变",
+          },
+        },
+      ];
+    case "deconditioning":
+      return [
+        {
+          kind: "lever",
+          ref_id: "physical.exercise_phys",
+          urgency: "soon",
+          label: {
+            en: "Exercise physiology referral",
+            zh: "运动生理学转介",
+          },
+        },
+        {
+          kind: "lever",
+          ref_id: "physical.resistance",
+          urgency: "now",
+          label: {
+            en: "Resistance training 2-3×/week",
+            zh: "每周 2–3 次抗阻训练",
+          },
+        },
+      ];
+    default:
+      return [];
+  }
+}
+
+// One signal per ISO week — drifts persist across days, so we dedupe at the
+// week granularity. If a drift continues across a week boundary the
+// following evaluation produces a fresh fired_for, which is the right
+// behaviour (a persistent drift warrants a fresh surface).
+function isoWeekKey(iso: string): string {
+  const d = new Date(iso);
+  const target = new Date(d.valueOf());
+  const dayNr = (d.getUTCDay() + 6) % 7;
+  target.setUTCDate(target.getUTCDate() - dayNr + 3);
+  const firstThursday = new Date(
+    Date.UTC(target.getUTCFullYear(), 0, 4),
+  );
+  const weekNr =
+    1 +
+    Math.round(
+      ((target.valueOf() - firstThursday.valueOf()) / 86_400_000 -
+        3 +
+        ((firstThursday.getUTCDay() + 6) % 7)) /
+        7,
+    );
+  return `${target.getUTCFullYear()}-W${String(weekNr).padStart(2, "0")}`;
+}
+
+function shiftDays(iso: string, days: number): string {
+  const d = new Date(iso);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString();
+}
+
+export const stepsDeclineDetector: Detector = {
+  id: DETECTOR_ID,
+
+  evaluate(ctx: DetectorContext): ChangeSignal[] {
+    const trajectory = ctx.state.metrics[METRIC_ID];
+    const obs = ctx.observations[METRIC_ID] ?? [];
+    if (
+      !trajectory ||
+      !trajectory.fresh ||
+      obs.length < MIN_OBSERVATIONS_FOR_BASELINE
+    ) {
+      return [];
+    }
+
+    // Prefer a reference baseline from BEFORE the current drift window so
+    // the threshold isn't contaminated by the drift itself. The 14-day mean
+    // ending 14 days ago gives us "what the patient was doing two weeks
+    // ago." Fall back to the trajectory's preferredBaseline if reference
+    // can't be computed (early in tracking, or after a long quiet period).
+    const referenceAsOf = shiftDays(ctx.now, -14).slice(0, 10);
+    const referenceBaseline = rollingBaseline(obs, referenceAsOf, 14, 5);
+    const preferred = preferredBaseline(trajectory.baselines);
+    const baseline = referenceBaseline ?? preferred;
+    if (!baseline || typeof baseline.value !== "number" || baseline.value <= 0) {
+      return [];
+    }
+    const baselineValue = baseline.value;
+    const cautionThreshold = baselineValue * (1 - CAUTION_PCT / 100);
+    const warningThreshold = baselineValue * (1 - WARNING_PCT / 100);
+
+    const currentMean = rollingMean(obs, ctx.now, ROLLING_WINDOW_DAYS);
+    if (currentMean == null || currentMean >= cautionThreshold) return [];
+
+    const duration = consecutiveDaysBelow(
+      obs,
+      ctx.now,
+      ROLLING_WINDOW_DAYS,
+      cautionThreshold,
+    );
+    if (duration < MIN_DURATION_DAYS) return [];
+
+    const severity =
+      currentMean <= warningThreshold ? "warning" : "caution";
+    const slopeRecent = slopeOver(obs, ctx.now, 7) ?? undefined;
+    const slopePrior = slopeOver(obs, shiftDays(ctx.now, -7), 7) ?? undefined;
+
+    // SD is a secondary descriptor — best-effort. When the 28-day window
+    // straddles baseline and drift it over-estimates SD; that's why the
+    // firing threshold above uses percent, not SD units.
+    const sd = patientSD(obs, ctx.now, BASELINE_WINDOW_DAYS, 5);
+    const sdUnits = sd ? (currentMean - baselineValue) / sd.sd : 0;
+
+    const evidence: SignalEvidence = {
+      baseline_value: Math.round(baselineValue),
+      baseline_kind: baseline.kind,
+      current_value: Math.round(currentMean),
+      delta_abs: Math.round(currentMean - baselineValue),
+      sd_units: sdUnits,
+      duration_days: duration,
+      slope_recent: slopeRecent,
+      slope_prior: slopePrior,
+    };
+
+    const differential = rankDifferential(ctx.state, CAUSES);
+    const topCause = differential[0];
+    const actions = topCause && topCause.confidence !== "unlikely"
+      ? actionsForCause(topCause.id)
+      : [];
+
+    const fired_for = `${DETECTOR_ID}:${isoWeekKey(ctx.now)}`;
+    const sdAbs = Math.abs(evidence.sd_units).toFixed(1);
+    const title =
+      severity === "warning"
+        ? {
+            en: `Daily steps down ${sdAbs} SD — worth action today`,
+            zh: `每日步数下降 ${sdAbs} 个标准差 —— 今天宜采取行动`,
+          }
+        : {
+            en: `Daily steps drifting (${evidence.current_value} vs ${evidence.baseline_value})`,
+            zh: `每日步数缓慢下降（当前 ${evidence.current_value}，基线 ${evidence.baseline_value}）`,
+          };
+    const explanation = topCause && topCause.confidence !== "unlikely"
+      ? {
+          en: "Activity change combined with the signals below suggests the cause ranked most likely. Expand for supporting metrics.",
+          zh: "活动变化与下列并发信号结合，提示最可能的原因。展开查看支持指标。",
+        }
+      : {
+          en: "A sustained drop in daily activity is one of the earliest signals of drift across any axis. No single cause stands out — worth watching + logging symptoms for 3 days.",
+          zh: "每日活动持续下降是各维度漂移最早的信号之一。尚无单一原因突出 —— 建议继续观察并记录症状 3 天。",
+        };
+
+    return [
+      {
+        detector: DETECTOR_ID,
+        fired_for,
+        metric_id: METRIC_ID,
+        axis: "individual",
+        shape: "rolling_drift",
+        severity,
+        title,
+        explanation,
+        evidence,
+        differential,
+        actions,
+      },
+    ];
+  },
+
+  hasResolved(signal, ctx) {
+    if (signal.detector !== DETECTOR_ID) return false;
+    const trajectory = ctx.state.metrics[METRIC_ID];
+    const obs = ctx.observations[METRIC_ID] ?? [];
+    if (
+      !trajectory ||
+      !trajectory.fresh ||
+      obs.length < MIN_OBSERVATIONS_FOR_BASELINE
+    ) {
+      return false;
+    }
+    const referenceAsOf = shiftDays(ctx.now, -14).slice(0, 10);
+    const referenceBaseline = rollingBaseline(obs, referenceAsOf, 14, 5);
+    const preferred = preferredBaseline(trajectory.baselines);
+    const baseline = referenceBaseline ?? preferred;
+    if (!baseline || typeof baseline.value !== "number" || baseline.value <= 0) {
+      return false;
+    }
+    const currentMean = rollingMean(obs, ctx.now, ROLLING_WINDOW_DAYS);
+    if (currentMean == null) return false;
+    const resolvedThreshold = baseline.value * (1 - RESOLVED_WITHIN_PCT / 100);
+    return currentMean >= resolvedThreshold;
+  },
+};
+
+export const _internals = {
+  CAUSES,
+  actionsForCause,
+  DETECTOR_ID,
+  METRIC_ID,
+  CAUTION_PCT,
+  WARNING_PCT,
+  MIN_DURATION_DAYS,
+};

--- a/src/lib/state/detectors/types.ts
+++ b/src/lib/state/detectors/types.ts
@@ -1,0 +1,117 @@
+// Change-detector types. A detector watches one or more metrics in a
+// PatientStateSnapshot and emits a ChangeSignal when a trend crosses a
+// statistical threshold — *before* any hard zone-rule fires. Each signal
+// carries the numeric evidence, a ranked differential of likely causes (each
+// supported by concurrent metrics), and suggested actions the patient / carer
+// / clinician can take.
+import type { Axis, Observation, PatientStateSnapshot } from "../types";
+import type { LocalizedText } from "~/types/treatment";
+
+export type SignalSeverity = "caution" | "warning";
+
+// How the signal manifests — pick one shape. Used by consumers to style
+// output and by the resolution logic to decide when to auto-close.
+export type SignalShape =
+  | "rolling_drift"      // rolling mean drifted ≥ k·SD below/above baseline
+  | "slope_flip"         // slope direction reversed over a window
+  | "acceleration"       // slope is getting more extreme faster
+  | "cycle_regression"   // this cycle worse than previous at matched day
+  | "recovery_failure";  // expected rebound didn't happen
+
+export interface SignalEvidence {
+  baseline_value: number;
+  baseline_kind: string;          // mirrors Baseline.kind for traceability
+  current_value: number;
+  delta_abs: number;
+  // Drift expressed in patient-SDs — the unit that makes "subtle" quantifiable.
+  // Negative = below baseline (for higher-better metrics this is the unhealthy
+  // direction).
+  sd_units: number;
+  duration_days: number;          // how long the drift has been detectable
+  // Optional slope trace; useful for UI sparklines and explanation.
+  slope_recent?: number;
+  slope_prior?: number;
+}
+
+export type DifferentialConfidence = "likely" | "possible" | "unlikely";
+
+export interface DifferentialCause {
+  id: string;                     // e.g. "chemo_recovery", "disease_progression"
+  label: LocalizedText;
+  confidence: DifferentialConfidence;
+  // Metric ids whose current value supports this cause. UI shows these so the
+  // reasoning is auditable, not a black box.
+  supporting_metric_ids: string[];
+  explanation?: LocalizedText;
+}
+
+export type SuggestedActionKind =
+  // Route to a treatment lever entry (see config/treatment-levers.json).
+  | "lever"
+  // Create / surface a PatientTask from a preset.
+  | "task"
+  // Add a question to raise at the next clinic review.
+  | "question"
+  // Family / carer conversation prompt.
+  | "conversation"
+  // Self-care action the patient can take today.
+  | "self";
+
+export type ActionUrgency = "now" | "soon" | "next_visit";
+
+export interface SuggestedAction {
+  kind: SuggestedActionKind;
+  // Reference id — for `lever` it's a treatment-lever id; for `task` it's a
+  // task-preset id; for others it's a free-form identifier for the action.
+  ref_id: string;
+  label: LocalizedText;
+  urgency: ActionUrgency;
+  rationale?: LocalizedText;
+}
+
+// Status lifecycle of a persisted signal. Detectors emit "open" signals.
+// The user can dismiss / acknowledge. The evaluator auto-resolves a signal
+// when the underlying drift recovers.
+export type SignalStatus =
+  | "open"
+  | "acknowledged"
+  | "dismissed"
+  | "resolved";
+
+// Emitted by a detector. Consumers persist it in `change_signals` with the
+// extra dexie fields (id, status, timestamps). `fired_for` is a dedupe key
+// that identifies the logical occurrence — another evaluation of the same
+// drift should produce the same `fired_for`.
+export interface ChangeSignal {
+  detector: string;                // detector id, e.g. "steps_decline"
+  fired_for: string;               // dedupe key, e.g. "steps_decline:2026-W17"
+  metric_id: string;               // primary metric
+  axis: Axis;
+  shape: SignalShape;
+  severity: SignalSeverity;
+  title: LocalizedText;
+  explanation: LocalizedText;
+  evidence: SignalEvidence;
+  differential: DifferentialCause[];
+  actions: SuggestedAction[];
+}
+
+export interface DetectorContext {
+  state: PatientStateSnapshot;
+  // Per-metric raw observation series, keyed by metric_id. Detectors that
+  // need rolling-window or variance math over the raw series read from here
+  // rather than re-deriving from dexie. Populated by the state module's
+  // `extractObservationsByMetric()` helper.
+  observations: Record<string, Observation[]>;
+  now: string;                     // ISO, deterministic for tests
+}
+
+export interface Detector {
+  id: string;
+  // Pure function. Given the current state, returns 0 or more signals.
+  // Idempotent: calling twice in the same context returns identical signals.
+  evaluate(ctx: DetectorContext): ChangeSignal[];
+  // Given a previously-emitted signal that is currently "open", return true
+  // if the underlying condition has recovered and the signal can auto-resolve.
+  hasResolved(signal: ChangeSignal, ctx: DetectorContext): boolean;
+}

--- a/src/lib/state/index.ts
+++ b/src/lib/state/index.ts
@@ -26,4 +26,9 @@ export {
   rollingBaseline,
 } from "./baselines";
 export { accelOver, olsSlopePerDay, slopeOver } from "./slope";
-export { buildPatientState, type BuildStateInputs } from "./build";
+export {
+  buildPatientState,
+  extractObservationsByMetric,
+  type BuildStateInputs,
+} from "./build";
+export { patientSD, rollingMean, type VarianceEstimate } from "./variance";

--- a/src/lib/state/variance.ts
+++ b/src/lib/state/variance.ts
@@ -1,0 +1,137 @@
+// Patient-SD estimation. Every metric has patient-specific noise — resting
+// step count varies 500 units for a sedentary patient and 3000 for an active
+// one. Expressing "drift" in patient-SDs makes detection thresholds
+// universal across metrics and across patients.
+import type { Observation } from "./types";
+
+function toEpochDays(iso: string): number {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return Number.NaN;
+  return Math.floor(t / 86_400_000);
+}
+
+export interface VarianceEstimate {
+  mean: number;
+  sd: number;
+  n: number;
+  window_start?: string;
+  window_end?: string;
+}
+
+/**
+ * Sample standard deviation over a trailing window. Excludes the `asOf` day.
+ * Returns null when the window has fewer than `minN` observations or the SD
+ * collapses to zero (constant series — no useful noise estimate).
+ *
+ * Uses Bessel's correction (n-1) so small samples don't underestimate SD.
+ */
+export function patientSD(
+  observations: readonly Observation[],
+  asOfISO: string,
+  windowDays: number,
+  minN = 5,
+): VarianceEstimate | null {
+  const asOfDay = toEpochDays(asOfISO);
+  if (Number.isNaN(asOfDay)) return null;
+  const startDay = asOfDay - windowDays;
+  const endDay = asOfDay - 1;
+  const values: number[] = [];
+  for (const o of observations) {
+    const d = toEpochDays(o.date);
+    if (Number.isNaN(d) || d < startDay || d > endDay) continue;
+    if (!Number.isFinite(o.value)) continue;
+    values.push(o.value);
+  }
+  if (values.length < minN) return null;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const sqSum = values.reduce((a, b) => a + (b - mean) ** 2, 0);
+  const sd = Math.sqrt(sqSum / (values.length - 1));
+  if (!Number.isFinite(sd) || sd === 0) return null;
+  return {
+    mean,
+    sd,
+    n: values.length,
+    window_start: new Date(startDay * 86_400_000).toISOString().slice(0, 10),
+    window_end: new Date(endDay * 86_400_000).toISOString().slice(0, 10),
+  };
+}
+
+/**
+ * Rolling mean over a trailing window ending at asOf (inclusive).
+ * Used for "current level" comparison against a baseline mean.
+ */
+export function rollingMean(
+  observations: readonly Observation[],
+  asOfISO: string,
+  windowDays: number,
+  minN = 3,
+): number | null {
+  const asOfDay = toEpochDays(asOfISO);
+  if (Number.isNaN(asOfDay)) return null;
+  const startDay = asOfDay - windowDays + 1;
+  const values: number[] = [];
+  for (const o of observations) {
+    const d = toEpochDays(o.date);
+    if (Number.isNaN(d) || d < startDay || d > asOfDay) continue;
+    if (!Number.isFinite(o.value)) continue;
+    values.push(o.value);
+  }
+  if (values.length < minN) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/**
+ * For how many consecutive days (counting back from asOf) has the rolling
+ * mean remained below `threshold`? Returns 0 when today's rolling mean is
+ * already above threshold. Used to quantify the duration component of a
+ * drift signal.
+ */
+export function consecutiveDaysBelow(
+  observations: readonly Observation[],
+  asOfISO: string,
+  rollingWindow: number,
+  threshold: number,
+  minN = 3,
+  maxLookback = 21,
+): number {
+  const asOfDay = toEpochDays(asOfISO);
+  if (Number.isNaN(asOfDay)) return 0;
+  let days = 0;
+  for (let back = 0; back < maxLookback; back++) {
+    const checkISO = new Date((asOfDay - back) * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const mean = rollingMean(observations, checkISO, rollingWindow, minN);
+    if (mean == null) break;
+    if (mean <= threshold) days++;
+    else break;
+  }
+  return days;
+}
+
+/**
+ * Mirror of `consecutiveDaysBelow` for the opposite direction — metrics where
+ * rising values are the unhealthy direction (nausea, pain, LFTs).
+ */
+export function consecutiveDaysAbove(
+  observations: readonly Observation[],
+  asOfISO: string,
+  rollingWindow: number,
+  threshold: number,
+  minN = 3,
+  maxLookback = 21,
+): number {
+  const asOfDay = toEpochDays(asOfISO);
+  if (Number.isNaN(asOfDay)) return 0;
+  let days = 0;
+  for (let back = 0; back < maxLookback; back++) {
+    const checkISO = new Date((asOfDay - back) * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const mean = rollingMean(observations, checkISO, rollingWindow, minN);
+    if (mean == null) break;
+    if (mean >= threshold) days++;
+    else break;
+  }
+  return days;
+}

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -230,6 +230,25 @@ export interface Treatment {
 // logging-integrated module. This re-export keeps existing consumers working.
 export type { Medication, MedicationEvent } from "./medication";
 
+// Persisted change-signal row — a ChangeSignal (from ~/lib/state/detectors)
+// that was surfaced and recorded for dedup, status tracking, and later
+// outcome attribution. The signal payload lives serialised so the detector
+// output is immutable for audit; consumers JSON-parse on read.
+export interface ChangeSignalRow {
+  id?: number;
+  detector: string;
+  fired_for: string;
+  metric_id: string;
+  axis: "individual" | "external" | "tumour" | "drug";
+  severity: "caution" | "warning";
+  shape: string;
+  status: "open" | "acknowledged" | "dismissed" | "resolved";
+  payload_json: string;
+  detected_at: string;
+  resolved_at?: string;
+  note?: string;
+}
+
 export interface LifeEvent {
   id?: number;
   title: string;

--- a/tests/unit/state-detectors.test.ts
+++ b/tests/unit/state-detectors.test.ts
@@ -1,0 +1,494 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPatientState,
+  extractObservationsByMetric,
+  type BuildStateInputs,
+} from "~/lib/state";
+import {
+  evaluateDetectors,
+  reconcileSignals,
+  stepsDeclineDetector,
+  gripDeclineDetector,
+  rankDifferential,
+  metricDriftingAgainst,
+  metricAtLeast,
+  cycleDayBetween,
+  type CandidateCause,
+} from "~/lib/state/detectors";
+import type {
+  DailyEntry,
+  FortnightlyAssessment,
+  LabResult,
+  Settings,
+} from "~/types/clinical";
+import type { TreatmentCycle } from "~/types/treatment";
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeDaily(
+  date: string,
+  overrides: Partial<DailyEntry> = {},
+): DailyEntry {
+  return {
+    date,
+    entered_at: `${date}T08:00:00Z`,
+    entered_by: "hulin",
+    energy: 7,
+    sleep_quality: 7,
+    appetite: 7,
+    pain_worst: 2,
+    pain_current: 1,
+    mood_clarity: 7,
+    nausea: 1,
+    practice_morning_completed: true,
+    practice_evening_completed: true,
+    cold_dysaesthesia: false,
+    neuropathy_hands: false,
+    neuropathy_feet: false,
+    mouth_sores: false,
+    diarrhoea_count: 0,
+    new_bruising: false,
+    dyspnoea: false,
+    fever: false,
+    created_at: `${date}T08:00:00Z`,
+    updated_at: `${date}T08:00:00Z`,
+    ...overrides,
+  };
+}
+
+function makeFortnightly(
+  date: string,
+  overrides: Partial<FortnightlyAssessment> = {},
+): FortnightlyAssessment {
+  return {
+    assessment_date: date,
+    entered_at: `${date}T10:00:00Z`,
+    entered_by: "hulin",
+    ecog_self: 1,
+    created_at: `${date}T10:00:00Z`,
+    updated_at: `${date}T10:00:00Z`,
+    ...overrides,
+  };
+}
+
+function makeSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    profile_name: "Hu Lin",
+    locale: "en",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    baseline_weight_kg: 70,
+    baseline_grip_dominant_kg: 40,
+    baseline_gait_speed_ms: 1.2,
+    ...overrides,
+  };
+}
+
+function makeInputs(
+  over: Partial<BuildStateInputs> = {},
+): BuildStateInputs {
+  return {
+    as_of: "2026-04-15",
+    settings: makeSettings(),
+    dailies: [],
+    fortnightlies: [],
+    labs: [],
+    cycles: [],
+    ...over,
+  };
+}
+
+function ctxFromInputs(inputs: BuildStateInputs) {
+  return {
+    state: buildPatientState(inputs),
+    observations: extractObservationsByMetric(inputs),
+    now: inputs.as_of,
+  };
+}
+
+function synthDailiesWithSteps(
+  startISO: string,
+  steps: number[],
+  overrides: Partial<DailyEntry> = {},
+): DailyEntry[] {
+  const out: DailyEntry[] = [];
+  const start = new Date(startISO).getTime();
+  steps.forEach((v, i) => {
+    const d = new Date(start + i * 86_400_000).toISOString().slice(0, 10);
+    out.push(makeDaily(d, { steps: v, ...overrides }));
+  });
+  return out;
+}
+
+// ─── Differential helpers ──────────────────────────────────────────────────
+
+describe("rankDifferential", () => {
+  it("ranks causes with matched predicates above those without", () => {
+    const causes: CandidateCause[] = [
+      {
+        id: "a",
+        label: { en: "A", zh: "A" },
+        predicates: [
+          metricDriftingAgainst("energy", "lower", 20),
+          metricDriftingAgainst("mood_clarity", "lower", 20),
+        ],
+      },
+      {
+        id: "b",
+        label: { en: "B", zh: "B" },
+        predicates: [metricAtLeast("nausea", 5)],
+      },
+    ];
+    // 14 days at energy 8 (baseline) + 4 days at energy 3 (drift). Need
+    // enough pre-drift history for rolling_14d / rolling_28d baseline to
+    // settle high enough that pct_from_baseline shows a drop.
+    const baselineDays = Array.from({ length: 14 }, (_, i) => {
+      const d = new Date(new Date("2026-03-29").getTime() + i * 86_400_000)
+        .toISOString()
+        .slice(0, 10);
+      return makeDaily(d, { energy: 8, mood_clarity: 8 });
+    });
+    const driftDays = Array.from({ length: 4 }, (_, i) => {
+      const d = new Date(new Date("2026-04-12").getTime() + i * 86_400_000)
+        .toISOString()
+        .slice(0, 10);
+      return makeDaily(d, { energy: 3, mood_clarity: 3 });
+    });
+    const inputs = makeInputs({ dailies: [...baselineDays, ...driftDays] });
+    const state = buildPatientState(inputs);
+    const ranked = rankDifferential(state, causes);
+    expect(ranked[0].id).toBe("a");
+    expect(ranked[0].supporting_metric_ids).toEqual(
+      expect.arrayContaining(["energy", "mood_clarity"]),
+    );
+  });
+
+  it("returns unlikely when required_supporters isn't met", () => {
+    const causes: CandidateCause[] = [
+      {
+        id: "needs_two",
+        label: { en: "needs two", zh: "需要两项" },
+        required_supporters: 2,
+        predicates: [
+          metricAtLeast("nausea", 5),
+          metricAtLeast("pain_current", 5),
+        ],
+      },
+    ];
+    const inputs = makeInputs({
+      dailies: [makeDaily("2026-04-15", { nausea: 7, pain_current: 0 })],
+    });
+    const state = buildPatientState(inputs);
+    const ranked = rankDifferential(state, causes);
+    expect(ranked[0].confidence).toBe("unlikely");
+  });
+
+  it("cycleDayBetween predicate fires only in range", () => {
+    const pred = cycleDayBetween(2, 7);
+    const inCycleInputs = makeInputs({
+      as_of: "2026-04-03",
+      cycles: [
+        {
+          id: 1,
+          protocol_id: "gnp_weekly",
+          cycle_number: 1,
+          start_date: "2026-04-01",
+          status: "active",
+          dose_level: 0,
+          created_at: "",
+          updated_at: "",
+        } as TreatmentCycle,
+      ],
+    });
+    const state = buildPatientState(inCycleInputs);
+    expect(pred(state)).toBe("cycle_day");
+
+    const outOfCycle = buildPatientState(makeInputs({ as_of: "2026-04-01" }));
+    expect(pred(outOfCycle)).toBeNull();
+  });
+});
+
+// ─── stepsDeclineDetector ─────────────────────────────────────────────────
+
+describe("stepsDeclineDetector", () => {
+  it("is silent when step data < MIN_OBSERVATIONS_FOR_VARIANCE", () => {
+    const dailies = synthDailiesWithSteps("2026-04-12", [5000, 5000, 5000]);
+    const ctx = ctxFromInputs(makeInputs({ dailies }));
+    expect(stepsDeclineDetector.evaluate(ctx)).toEqual([]);
+  });
+
+  it("is silent when current rolling mean matches baseline", () => {
+    const dailies = synthDailiesWithSteps(
+      "2026-03-19",
+      Array.from({ length: 28 }, () => 5000),
+    );
+    const ctx = ctxFromInputs(makeInputs({ dailies }));
+    expect(stepsDeclineDetector.evaluate(ctx)).toEqual([]);
+  });
+
+  it("fires a caution signal when 7d mean drifts ≥1 SD below baseline for 5+ days", () => {
+    // Baseline: 14 days at ~5000 ± small noise, then 14 days at 4200.
+    // 14 drift days are needed so the 7-day rolling window sits entirely
+    // inside the drift for ≥ MIN_DURATION_DAYS consecutive days.
+    const baseline: number[] = [];
+    for (let i = 0; i < 14; i++) {
+      baseline.push(5000 + ((i % 3) - 1) * 120);
+    }
+    const drift: number[] = Array.from({ length: 14 }, () => 4200);
+    const dailies = synthDailiesWithSteps("2026-03-19", [
+      ...baseline,
+      ...drift,
+    ]);
+    const ctx = ctxFromInputs(makeInputs({ dailies }));
+    const signals = stepsDeclineDetector.evaluate(ctx);
+    expect(signals).toHaveLength(1);
+    const s = signals[0]!;
+    expect(s.detector).toBe("steps_decline");
+    expect(s.metric_id).toBe("steps");
+    expect(s.axis).toBe("individual");
+    expect(["caution", "warning"]).toContain(s.severity);
+    expect(s.evidence.duration_days).toBeGreaterThanOrEqual(5);
+    expect(s.evidence.sd_units).toBeLessThan(-1);
+    expect(s.fired_for).toMatch(/^steps_decline:\d{4}-W\d{2}$/);
+  });
+
+  it("escalates to warning when drift ≥ 20% below baseline", () => {
+    const baseline: number[] = Array.from({ length: 14 }, (_, i) =>
+      5000 + ((i % 3) - 1) * 100,
+    );
+    const drift: number[] = Array.from({ length: 14 }, () => 3500); // big drop
+    const dailies = synthDailiesWithSteps("2026-03-19", [
+      ...baseline,
+      ...drift,
+    ]);
+    const ctx = ctxFromInputs(makeInputs({ dailies }));
+    const signals = stepsDeclineDetector.evaluate(ctx);
+    expect(signals[0]!.severity).toBe("warning");
+  });
+
+  it("attaches a chemo_recovery differential when concurrent symptoms + cycle D2-D7", () => {
+    const baseline: number[] = Array.from({ length: 14 }, (_, i) =>
+      6000 + ((i % 3) - 1) * 150,
+    );
+    const drift: number[] = Array.from({ length: 14 }, () => 4500);
+    const dailies = synthDailiesWithSteps("2026-03-19", [
+      ...baseline,
+      ...drift,
+    ]);
+    // Overlay nausea + low appetite on the last 5 days
+    for (let i = dailies.length - 5; i < dailies.length; i++) {
+      dailies[i] = {
+        ...dailies[i]!,
+        nausea: 6,
+        appetite: 3,
+        energy: 3,
+      };
+    }
+    const cycle: TreatmentCycle = {
+      id: 1,
+      protocol_id: "gnp_weekly",
+      cycle_number: 1,
+      start_date: "2026-04-13",
+      status: "active",
+      dose_level: 0,
+      created_at: "",
+      updated_at: "",
+    };
+    const ctx = ctxFromInputs(makeInputs({ dailies, cycles: [cycle] }));
+    const signal = stepsDeclineDetector.evaluate(ctx)[0]!;
+    expect(signal.differential[0].id).toBe("chemo_recovery");
+    expect(signal.differential[0].confidence).not.toBe("unlikely");
+    expect(signal.actions.length).toBeGreaterThan(0);
+  });
+
+  it("reports resolved when rolling mean recovers to within 5% of baseline", () => {
+    const baseline: number[] = Array.from({ length: 14 }, (_, i) =>
+      5000 + ((i % 3) - 1) * 100,
+    );
+    const drift: number[] = Array.from({ length: 14 }, () => 4200);
+    const droopy = synthDailiesWithSteps("2026-03-19", [...baseline, ...drift]);
+    const ctxDroopy = ctxFromInputs(makeInputs({ dailies: droopy }));
+    const emitted = stepsDeclineDetector.evaluate(ctxDroopy)[0]!;
+    expect(emitted).toBeDefined();
+    expect(stepsDeclineDetector.hasResolved(emitted, ctxDroopy)).toBe(false);
+
+    const recovery: number[] = Array.from({ length: 7 }, () => 5000);
+    const recovered = synthDailiesWithSteps(
+      "2026-03-19",
+      [...baseline, ...drift, ...recovery],
+    );
+    const ctxRecovered = ctxFromInputs(
+      makeInputs({
+        dailies: recovered,
+        as_of: recovered[recovered.length - 1]!.date,
+      }),
+    );
+    expect(stepsDeclineDetector.hasResolved(emitted, ctxRecovered)).toBe(true);
+  });
+});
+
+// ─── gripDeclineDetector ──────────────────────────────────────────────────
+
+describe("gripDeclineDetector", () => {
+  it("is silent with fewer than 3 fortnightly observations", () => {
+    const fortnightlies = [
+      makeFortnightly("2026-03-01", { grip_dominant_kg: 40 }),
+      makeFortnightly("2026-03-15", { grip_dominant_kg: 39 }),
+    ];
+    const ctx = ctxFromInputs(makeInputs({ fortnightlies }));
+    expect(gripDeclineDetector.evaluate(ctx)).toEqual([]);
+  });
+
+  it("is silent when slope is flat", () => {
+    const fortnightlies = [
+      makeFortnightly("2026-02-15", { grip_dominant_kg: 40 }),
+      makeFortnightly("2026-03-01", { grip_dominant_kg: 40 }),
+      makeFortnightly("2026-03-15", { grip_dominant_kg: 40 }),
+      makeFortnightly("2026-03-29", { grip_dominant_kg: 40 }),
+    ];
+    const ctx = ctxFromInputs(
+      makeInputs({
+        fortnightlies,
+        as_of: "2026-04-01",
+      }),
+    );
+    expect(gripDeclineDetector.evaluate(ctx)).toEqual([]);
+  });
+
+  it("fires caution when slope is meaningfully negative", () => {
+    const fortnightlies = [
+      makeFortnightly("2026-02-15", { grip_dominant_kg: 40 }),
+      makeFortnightly("2026-03-01", { grip_dominant_kg: 39 }),
+      makeFortnightly("2026-03-15", { grip_dominant_kg: 37.5 }),
+      makeFortnightly("2026-03-29", { grip_dominant_kg: 36 }),
+    ];
+    const ctx = ctxFromInputs(
+      makeInputs({ fortnightlies, as_of: "2026-04-01" }),
+    );
+    const signals = gripDeclineDetector.evaluate(ctx);
+    expect(signals.length).toBe(1);
+    expect(signals[0]!.metric_id).toBe("grip_dominant_kg");
+    expect(signals[0]!.axis).toBe("individual");
+  });
+
+  it("surfaces cachexia as the top differential when weight + protein are also drifting", () => {
+    const fortnightlies = [
+      makeFortnightly("2026-02-15", { grip_dominant_kg: 40 }),
+      makeFortnightly("2026-03-01", { grip_dominant_kg: 38 }),
+      makeFortnightly("2026-03-15", { grip_dominant_kg: 36 }),
+      makeFortnightly("2026-03-29", { grip_dominant_kg: 34 }),
+    ];
+    // Weight drift + low protein intake in recent dailies
+    const dailies = [
+      ...synthDailiesWithSteps(
+        "2026-03-20",
+        Array.from({ length: 13 }, () => 5000),
+      ).map((d) => ({ ...d, weight_kg: 64, protein_grams: 45 })),
+    ];
+    const ctx = ctxFromInputs(
+      makeInputs({
+        fortnightlies,
+        dailies,
+        as_of: "2026-04-01",
+      }),
+    );
+    const signal = gripDeclineDetector.evaluate(ctx)[0]!;
+    const topLikely = signal.differential.find(
+      (d) => d.confidence !== "unlikely",
+    );
+    expect(topLikely?.id).toBe("cachexia");
+    expect(signal.actions.some((a) => a.ref_id === "nutrition.dietitian")).toBe(
+      true,
+    );
+  });
+
+  it("escalates to warning at ≥12% below pre-diagnosis baseline", () => {
+    // Baseline 40 kg, drop to 34.5 kg = ~13.75% decline
+    const fortnightlies = [
+      makeFortnightly("2026-02-15", { grip_dominant_kg: 40 }),
+      makeFortnightly("2026-03-01", { grip_dominant_kg: 38 }),
+      makeFortnightly("2026-03-15", { grip_dominant_kg: 36 }),
+      makeFortnightly("2026-03-29", { grip_dominant_kg: 34.5 }),
+    ];
+    const ctx = ctxFromInputs(
+      makeInputs({ fortnightlies, as_of: "2026-04-01" }),
+    );
+    expect(gripDeclineDetector.evaluate(ctx)[0]!.severity).toBe("warning");
+  });
+});
+
+// ─── Orchestration + reconciliation ──────────────────────────────────────
+
+describe("evaluateDetectors + reconcileSignals", () => {
+  it("evaluateDetectors runs every registered detector", () => {
+    const stepsDailies = synthDailiesWithSteps("2026-03-19", [
+      ...Array.from({ length: 14 }, () => 5000),
+      ...Array.from({ length: 14 }, () => 4000),
+    ]);
+    const fortnightlies = [
+      makeFortnightly("2026-02-15", { grip_dominant_kg: 40 }),
+      makeFortnightly("2026-03-01", { grip_dominant_kg: 38 }),
+      makeFortnightly("2026-03-15", { grip_dominant_kg: 36 }),
+      makeFortnightly("2026-03-29", { grip_dominant_kg: 34.5 }),
+    ];
+    const ctx = ctxFromInputs(
+      makeInputs({ dailies: stepsDailies, fortnightlies }),
+    );
+    const signals = evaluateDetectors(ctx);
+    expect(signals.map((s) => s.detector).sort()).toEqual([
+      "grip_decline",
+      "steps_decline",
+    ]);
+  });
+
+  it("reconcileSignals suppresses already-persisted signals", () => {
+    const dailies = synthDailiesWithSteps("2026-03-19", [
+      ...Array.from({ length: 14 }, () => 5000),
+      ...Array.from({ length: 14 }, () => 4000),
+    ]);
+    const ctx = ctxFromInputs(makeInputs({ dailies }));
+    const emitted = evaluateDetectors(ctx);
+    expect(emitted.length).toBeGreaterThan(0);
+    const persisted = emitted.map((s) => ({
+      fired_for: s.fired_for,
+      status: "open" as const,
+    }));
+    const { to_insert, to_resolve } = reconcileSignals(emitted, persisted, ctx);
+    expect(to_insert).toEqual([]);
+    expect(to_resolve).toEqual([]);
+  });
+
+  it("reconcileSignals marks stale open signals for resolution once drift recovers", () => {
+    const base: number[] = Array.from({ length: 14 }, () => 5000);
+    const dip: number[] = Array.from({ length: 14 }, () => 4000);
+    const recovery: number[] = Array.from({ length: 7 }, () => 5000);
+
+    // Drift phase — detector fires
+    const driftCtx = ctxFromInputs(
+      makeInputs({
+        dailies: synthDailiesWithSteps("2026-03-19", [...base, ...dip]),
+      }),
+    );
+    const emitted = evaluateDetectors(driftCtx);
+    expect(emitted.length).toBeGreaterThan(0);
+
+    // Recovery phase — reconcile against persisted signal
+    const recoveryDailies = synthDailiesWithSteps("2026-03-19", [
+      ...base,
+      ...dip,
+      ...recovery,
+    ]);
+    const recoveryCtx = ctxFromInputs(
+      makeInputs({
+        dailies: recoveryDailies,
+        as_of: recoveryDailies[recoveryDailies.length - 1]!.date,
+      }),
+    );
+    const persisted = emitted.map((s) => ({
+      fired_for: s.fired_for,
+      status: "open" as const,
+    }));
+    const { to_resolve } = reconcileSignals([], persisted, recoveryCtx);
+    expect(to_resolve).toContain(persisted[0].fired_for);
+  });
+});

--- a/tests/unit/state-variance.test.ts
+++ b/tests/unit/state-variance.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  consecutiveDaysAbove,
+  consecutiveDaysBelow,
+  patientSD,
+  rollingMean,
+} from "~/lib/state/variance";
+import type { Observation } from "~/lib/state/types";
+
+function obs(date: string, value: number): Observation {
+  return { date, value };
+}
+
+function synthSeries(
+  startISO: string,
+  values: number[],
+): Observation[] {
+  const out: Observation[] = [];
+  const start = new Date(startISO).getTime();
+  values.forEach((v, i) => {
+    const d = new Date(start + i * 86_400_000).toISOString().slice(0, 10);
+    out.push({ date: d, value: v });
+  });
+  return out;
+}
+
+describe("patientSD", () => {
+  it("returns null with fewer than minN observations", () => {
+    const series = synthSeries("2026-03-18", [5000, 5100, 4800, 4900]);
+    expect(patientSD(series, "2026-04-15", 28, 5)).toBeNull();
+  });
+
+  it("excludes the asOf day itself", () => {
+    // Add a huge spike on asOf day — should not enter the SD window.
+    const body = synthSeries("2026-03-20", [
+      5000, 5100, 5200, 4900, 5000, 4950, 5050, 5100,
+    ]);
+    const spike: Observation = { date: "2026-04-15", value: 20000 };
+    const est = patientSD([...body, spike], "2026-04-15", 28);
+    expect(est).not.toBeNull();
+    expect(est!.sd).toBeLessThan(200); // body sd is ~100, spike would blow it up
+  });
+
+  it("produces a reasonable SD for noisy data", () => {
+    const series = synthSeries("2026-03-20", [
+      5000, 5100, 5200, 4900, 5000, 4950, 5050, 5100, 4980, 5020,
+    ]);
+    const est = patientSD(series, "2026-04-15", 28);
+    expect(est).not.toBeNull();
+    expect(est!.mean).toBeGreaterThan(4900);
+    expect(est!.mean).toBeLessThan(5100);
+    expect(est!.sd).toBeGreaterThan(50);
+    expect(est!.sd).toBeLessThan(150);
+  });
+
+  it("returns null for a constant series (sd=0)", () => {
+    const series = synthSeries(
+      "2026-03-20",
+      Array.from({ length: 10 }, () => 5000),
+    );
+    expect(patientSD(series, "2026-04-15", 28)).toBeNull();
+  });
+});
+
+describe("rollingMean", () => {
+  it("averages values in the trailing window including asOf", () => {
+    const series = synthSeries("2026-04-09", [5000, 5100, 4900, 5200, 4800, 5000, 4950]);
+    // asOf 2026-04-15, window 7 days → all 7 observations included.
+    const m = rollingMean(series, "2026-04-15", 7);
+    expect(m).not.toBeNull();
+    expect(m!).toBeCloseTo((5000 + 5100 + 4900 + 5200 + 4800 + 5000 + 4950) / 7, 2);
+  });
+
+  it("returns null with < minN points in window", () => {
+    const series = synthSeries("2026-04-13", [5000, 5100]);
+    expect(rollingMean(series, "2026-04-15", 7, 3)).toBeNull();
+  });
+});
+
+describe("consecutiveDaysBelow / Above", () => {
+  it("returns 0 when today's rolling mean is above threshold", () => {
+    const series = synthSeries("2026-04-09", [5000, 5000, 5000, 5000, 5000, 5000, 5000]);
+    const d = consecutiveDaysBelow(series, "2026-04-15", 7, 4000);
+    expect(d).toBe(0);
+  });
+
+  it("counts trailing days where rolling mean stays below threshold", () => {
+    // 10 days of gradually declining values; last 7 are all below 4200.
+    const series = synthSeries("2026-04-06", [
+      5000, 5000, 5000, 4200, 4100, 4000, 3900, 3800, 3700, 3600,
+    ]);
+    const d = consecutiveDaysBelow(series, "2026-04-15", 7, 4200);
+    expect(d).toBeGreaterThan(0);
+  });
+
+  it("consecutiveDaysAbove mirrors below for rising thresholds", () => {
+    const series = synthSeries("2026-04-06", [
+      3000, 3000, 3000, 4000, 4100, 4200, 4300, 4400, 4500, 4600,
+    ]);
+    const d = consecutiveDaysAbove(series, "2026-04-15", 7, 4000);
+    expect(d).toBeGreaterThan(0);
+  });
+
+  it("stops counting at the first day the threshold isn't breached", () => {
+    // Flat mid-range for 3 days, then below for 5 days, then flat again.
+    const series = synthSeries("2026-04-02", [
+      5000, 5000, 5000, 3000, 3000, 3000, 3000, 3000, 5000, 5000, 5000, 5000, 5000, 5000,
+    ]);
+    const d = consecutiveDaysBelow(series, "2026-04-15", 7, 4000);
+    expect(d).toBe(0); // today's rolling mean (across last 7) is above 4000
+  });
+});


### PR DESCRIPTION
**Stacked on PR #25** (slice 1 — PatientStateSnapshot). Merge #25 first, then this; or squash-merge both in order.

Ships **two end-to-end change detectors + the shared infrastructure** so adding more is cheap. Each signal carries cited numeric evidence, a ranked differential diagnosis against concurrent metrics, and mapped suggested actions. Persisted for dedup, auto-resolution when drift recovers, and later outcome attribution (slice 4).

## The two detectors

### `steps_decline` — daily cadence, individual axis
Detects: 7-day rolling mean ≥ 10% below a **reference baseline** (14-day mean ending 14 days ago — deliberately *before* the current drift window so the threshold isn't self-contaminated by the drift itself) for ≥ 5 consecutive days. 10% caution / 20% warning.

Differential (ranked at signal time):
- `chemo_recovery` — cycle D2-D7 + concurrent nausea / low appetite / low energy
- `disease_progression` — pain rising or dyspnoea flagged
- `mood_depression` — mood + sleep + energy all drifting down
- `toxicity_burden` — neuropathy flags or rising nausea
- `deconditioning` — grip / gait / walking also drifting

Each cause maps to cited suggested actions (treatment levers, clinician questions, carer conversations, self-care).

### `grip_decline` — fortnightly cadence, individual axis
Detects: OLS slope across the last ≥3 fortnightly grip points more negative than −0.3 kg/week (caution) or −0.6 kg/week (warning). Also fires on ≥ 7% below pre-diagnosis with any negative slope. Zone rules already fire at 10% / 20% absolute decline — **this detector is the trend signal that precedes those thresholds** so the conversation can start before the threshold crossing.

Differential:
- `chemo_neurotoxicity` — concurrent hand neuropathy flags / grade ≥ 2
- `cachexia` — weight + protein + albumin drifting together → dietitian + resistance
- `deconditioning_only` — walking / steps drifting → exercise physiology
- `unknown` — fallback prompting a manual retest

## Shared infrastructure (pluggable for future detectors)

- **`src/lib/state/variance.ts`** — `patientSD` (Bessel-corrected, excludes as_of day), `rollingMean`, `consecutiveDaysBelow/Above`
- **`src/lib/state/detectors/types.ts`** — `ChangeSignal`, `Detector` interface, `SignalEvidence`, `DifferentialCause`, `SuggestedAction`
- **`src/lib/state/detectors/differential.ts`** — `rankDifferential()` with composable predicates (`metricDriftingAgainst`, `metricAtLeast`, `metricAtMost`, `cycleDayBetween`). Each cause declares predicates + optional `required_supporters`
- **`src/lib/state/detectors/index.ts`** — `evaluateDetectors(ctx)` runs every registered detector; `reconcileSignals` suppresses already-persisted signals and auto-resolves recovered ones
- **`src/lib/state/detectors/persistence.ts`** — `evaluateAndPersistSignals` (Dexie IO), `setSignalStatus`, `deserializeSignal`

## Persistence (Dexie v8)

New `change_signals` table with compound `[detector+fired_for]` index enforcing uniqueness per occurrence. Full `ChangeSignal` payload stored as JSON so detector output is immutable for audit. Status lifecycle: `open` → `acknowledged` / `dismissed` / `resolved`.

## Dashboard — `ChangeSignalsCard`

New card above `MedicationPromptsCard`. For each open signal:
- Severity-toned title + axis chip
- Top differential cause + confidence
- Up to 2 suggested actions with urgency chips (NOW / SOON / NEXT VISIT)
- Acknowledge / Dismiss buttons
- **"Why this fired"** expand: baseline kind + value, current vs baseline, SD units, duration, full ranked differential with the *supporting metric names* so the reasoning is auditable

## Tests (27 new, 213 total)

- **`state-variance.test.ts`** (10) — Bessel correction, as_of exclusion, constant-series returns null, consecutive-days-below/above semantics, window stops counting at first non-breach
- **`state-detectors.test.ts`** (17) — differential ranking with `required_supporters` + `cycleDayBetween`; steps-decline positive triggers, negative triggers (insufficient data, flat series), severity escalation, chemo_recovery differential attribution, auto-resolution when drift recovers; grip-decline positive/negative triggers, cachexia differential, warning at ≥ 12% below baseline; `evaluateDetectors` + `reconcileSignals` suppression & auto-resolution

All 213 tests pass. `pnpm typecheck`, `pnpm lint`, `pnpm build` clean.

## Known limitations surfaced

- **Rolling baselines self-contaminate once drift begins.** Worked around in the steps detector with a "14-day reference mean ending 14 days ago" but a proper robust baseline (trimmed / MAD-based) should land in a later slice.
- **`baseline_steps` isn't a Settings field** — when pre-diagnosis step history isn't captured, the reference-baseline fallback is the only option, which silences the detector until ~28 days of tracking. Flagging for a future schema addition.
- **Grip SD estimation** requires > 5 fortnightly observations to be meaningful; the detector tolerates this by falling back to slope-based firing.

## Follow-on slices (from the thesis review)

- **Slice 3** — external axis: social contacts on daily entries, care-team log, clinician touchpoint table. Populates the axis that's empty in slice 1.
- **Slice 4** — `signal_events` log linking signals → user actions → downstream state change. Closes the outcome-attribution loop the thesis ultimately asks for.

## How to see it fire locally

The steps detector needs ≥ 28 days of `daily_entries.steps` history with a visible decline. To trigger on the preview deployment:

1. Seed 14 days of dailies with `steps: 5000 ± 100` noise
2. Add 14 more days with `steps: 4000`
3. Open the dashboard — the ChangeSignalsCard will show `steps_decline` with differential + actions + audit trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)