### PR TITLE
Slice 4: Signal event log + outcome attribution (detection → action → resolution loop)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { RecentTrends } from "~/components/dashboard/recent-trends";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
 import { ChangeSignalsCard } from "~/components/dashboard/change-signals-card";
+import { SignalLoopSummaryCard } from "~/components/dashboard/signal-loop-summary-card";
 import { MedicationPromptsCard } from "~/components/dashboard/medication-prompts-card";
 import { TodayFeed } from "~/components/dashboard/today-feed";
 import { useLocale, useT } from "~/hooks/use-translate";
@@ -77,6 +78,8 @@ export default function DashboardPage() {
       <QuickCheckinCard />
 
       <ChangeSignalsCard />
+
+      <SignalLoopSummaryCard />
 
       <MedicationPromptsCard />
 

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { METRICS_BY_ID } from "~/lib/state";
+import {
+  attributeSignal,
+  eventsBySignalId,
+} from "~/lib/state/detectors";
+import { deserializeSignal } from "~/lib/state/detectors/persistence";
+import type {
+  ChangeSignal,
+  SignalSeverity,
+} from "~/lib/state/detectors";
+import type {
+  ChangeSignalRow,
+  SignalEventKind,
+  SignalEventRow,
+} from "~/types/clinical";
+import {
+  AlertTriangle,
+  Bell,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Circle,
+  XCircle,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+import { format, parseISO } from "date-fns";
+
+type Filter = "all" | "open" | "resolved";
+
+export default function SignalsPage() {
+  const locale = useLocale();
+  const [filter, setFilter] = useState<Filter>("all");
+  const signals = useLiveQuery(
+    () =>
+      db.change_signals
+        .orderBy("detected_at")
+        .reverse()
+        .toArray(),
+    [],
+  );
+  const events = useLiveQuery(
+    () => db.signal_events.orderBy("created_at").toArray(),
+    [],
+  );
+
+  const indexed = useMemo(() => {
+    if (!events) return new Map<number, SignalEventRow[]>();
+    return eventsBySignalId(events);
+  }, [events]);
+
+  const rows = useMemo(() => {
+    if (!signals) return [];
+    return signals.filter((s) => {
+      if (filter === "open") return s.status === "open";
+      if (filter === "resolved") return s.status === "resolved";
+      return true;
+    });
+  }, [signals, filter]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "历史" : "History"}
+        title={
+          locale === "zh"
+            ? "变化信号与行动"
+            : "Change signals and actions"
+        }
+      />
+
+      <div className="flex items-center gap-2">
+        <FilterButton
+          active={filter === "all"}
+          onClick={() => setFilter("all")}
+        >
+          {locale === "zh" ? "全部" : "All"}
+        </FilterButton>
+        <FilterButton
+          active={filter === "open"}
+          onClick={() => setFilter("open")}
+        >
+          {locale === "zh" ? "未结" : "Open"}
+        </FilterButton>
+        <FilterButton
+          active={filter === "resolved"}
+          onClick={() => setFilter("resolved")}
+        >
+          {locale === "zh" ? "已解决" : "Resolved"}
+        </FilterButton>
+      </div>
+
+      {rows.length === 0 ? (
+        <Card className="p-5 text-sm text-ink-500">
+          {locale === "zh"
+            ? "目前没有变化信号。"
+            : "No change signals yet."}
+        </Card>
+      ) : (
+        <ul className="space-y-3">
+          {rows.map((row) => (
+            <SignalHistoryRow
+              key={row.id}
+              row={row}
+              events={row.id ? (indexed.get(row.id) ?? []) : []}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function FilterButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "mono rounded-full border px-3 py-1 text-[10.5px] uppercase tracking-[0.12em] transition-colors",
+        active
+          ? "border-ink-900 bg-ink-900 text-paper"
+          : "border-ink-200 bg-paper text-ink-500 hover:border-ink-400",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+const STATUS_TONE: Record<
+  ChangeSignalRow["status"],
+  { wrap: string; Icon: React.ComponentType<{ className?: string }> }
+> = {
+  open: { wrap: "bg-paper-2", Icon: Circle },
+  acknowledged: { wrap: "bg-paper-2", Icon: CheckCircle2 },
+  dismissed: { wrap: "bg-paper-2 opacity-60", Icon: XCircle },
+  resolved: {
+    wrap: "bg-[var(--ok-soft)] border-l-[3px] border-l-[var(--ok)]",
+    Icon: CheckCircle2,
+  },
+};
+
+const SEV_ICON: Record<
+  SignalSeverity,
+  React.ComponentType<{ className?: string }>
+> = {
+  caution: Bell,
+  warning: AlertTriangle,
+};
+
+function SignalHistoryRow({
+  row,
+  events,
+}: {
+  row: ChangeSignalRow;
+  events: SignalEventRow[];
+}) {
+  const locale = useLocale();
+  const [expanded, setExpanded] = useState(false);
+  const signal = useMemo<ChangeSignal | null>(() => {
+    try {
+      return deserializeSignal(row);
+    } catch {
+      return null;
+    }
+  }, [row]);
+  const attribution = useMemo(
+    () => attributeSignal(row, events),
+    [row, events],
+  );
+  if (!signal) return null;
+  const tone = STATUS_TONE[row.status];
+  const SevIcon = SEV_ICON[signal.severity];
+  const metricDef = METRICS_BY_ID[signal.metric_id];
+
+  return (
+    <li>
+      <Card className={cn("px-4 py-3.5", tone.wrap)}>
+        <div className="flex items-start gap-3">
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-paper text-ink-700 ring-1 ring-ink-200">
+            <SevIcon className="h-3.5 w-3.5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-[13px] font-semibold text-ink-900">
+                {signal.title[locale]}
+              </div>
+              <StatusBadge status={row.status} />
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-ink-500">
+              <span>{format(parseISO(row.detected_at), "d MMM yyyy")}</span>
+              <span>·</span>
+              <span>{signal.axis}</span>
+              <span>·</span>
+              <span>
+                {metricDef?.label ?? signal.metric_id}
+              </span>
+              {attribution.duration_days != null && (
+                <>
+                  <span>·</span>
+                  <span>
+                    {locale === "zh"
+                      ? `${attribution.duration_days} 天解决`
+                      : `resolved in ${attribution.duration_days}d`}
+                  </span>
+                </>
+              )}
+            </div>
+
+            {attribution.likely_contributors.length > 0 && (
+              <div className="mt-2 rounded-md bg-paper-2 px-2.5 py-2 text-[11.5px] text-ink-700">
+                <div className="mono text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+                  {locale === "zh"
+                    ? "可能的促进因素"
+                    : "Likely contributors"}
+                </div>
+                <ul className="mt-1 space-y-0.5">
+                  {attribution.likely_contributors.map((a, i) => (
+                    <li key={i}>
+                      {a.action_ref_id}
+                      {typeof a.days_before_resolution === "number" && (
+                        <span className="ml-1 text-ink-400">
+                          ({a.days_before_resolution}
+                          {locale === "zh" ? " 天前" : "d before"})
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-1 text-[10.5px] text-ink-400">
+                  {locale === "zh"
+                    ? "相关性，非因果。"
+                    : "Correlational, not causal."}
+                </div>
+              </div>
+            )}
+
+            {attribution.spontaneous && (
+              <div className="mt-2 rounded-md bg-paper-2 px-2.5 py-2 text-[11.5px] text-ink-600">
+                {locale === "zh"
+                  ? "该信号自行解决 —— 未记录任何行动。可能为噪声或自发恢复。"
+                  : "Resolved with no logged actions — may be noise or spontaneous recovery."}
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="mt-2 inline-flex items-center gap-1 text-[11px] text-ink-500 hover:text-ink-900"
+            >
+              {expanded
+                ? locale === "zh"
+                  ? "收起时间线"
+                  : "Hide timeline"
+                : locale === "zh"
+                  ? `查看时间线 (${events.length})`
+                  : `Timeline (${events.length})`}
+              {expanded ? (
+                <ChevronUp className="h-3 w-3" />
+              ) : (
+                <ChevronDown className="h-3 w-3" />
+              )}
+            </button>
+
+            {expanded && events.length > 0 && (
+              <Timeline events={events} />
+            )}
+          </div>
+        </div>
+      </Card>
+    </li>
+  );
+}
+
+function StatusBadge({ status }: { status: ChangeSignalRow["status"] }) {
+  const locale = useLocale();
+  const labels: Record<ChangeSignalRow["status"], { en: string; zh: string }> = {
+    open: { en: "OPEN", zh: "未结" },
+    acknowledged: { en: "ACK", zh: "已知" },
+    dismissed: { en: "DISMISSED", zh: "关闭" },
+    resolved: { en: "RESOLVED", zh: "已解决" },
+  };
+  return (
+    <span
+      className={cn(
+        "mono shrink-0 rounded-full px-2 py-0.5 text-[9.5px] uppercase tracking-[0.12em]",
+        status === "resolved"
+          ? "bg-[var(--ok)] text-white"
+          : status === "dismissed"
+            ? "bg-ink-200 text-ink-500"
+            : status === "open"
+              ? "bg-ink-900 text-paper"
+              : "bg-paper-2 text-ink-600",
+      )}
+    >
+      {labels[status][locale]}
+    </span>
+  );
+}
+
+const EVENT_KIND_LABEL: Record<
+  SignalEventKind,
+  { en: string; zh: string }
+> = {
+  emitted: { en: "signal emitted", zh: "信号触发" },
+  acknowledged: { en: "acknowledged", zh: "已知" },
+  dismissed: { en: "dismissed", zh: "关闭" },
+  action_taken: { en: "action taken", zh: "采取行动" },
+  resolved_auto: { en: "auto-resolved", zh: "自动解决" },
+  resolved_manual: { en: "marked resolved", zh: "手动解决" },
+  reopened: { en: "reopened", zh: "重新打开" },
+};
+
+function Timeline({ events }: { events: SignalEventRow[] }) {
+  const locale = useLocale();
+  return (
+    <ol className="mt-3 space-y-1.5 border-l-2 border-ink-100 pl-3">
+      {events.map((e) => (
+        <li key={e.id} className="text-[11.5px] text-ink-700">
+          <div className="flex items-baseline gap-2">
+            <span className="mono text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+              {format(parseISO(e.created_at), "d MMM HH:mm")}
+            </span>
+            <span className="font-medium text-ink-900">
+              {EVENT_KIND_LABEL[e.kind][locale]}
+            </span>
+            {e.action_ref_id && (
+              <span className="text-ink-500">— {e.action_ref_id}</span>
+            )}
+          </div>
+          {e.note && <div className="mt-0.5 text-ink-500">{e.note}</div>}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/components/dashboard/change-signals-card.tsx
+++ b/src/components/dashboard/change-signals-card.tsx
@@ -14,6 +14,7 @@ import {
 import {
   deserializeSignal,
   evaluateAndPersistSignals,
+  markActionTaken,
   setSignalStatus,
 } from "~/lib/state/detectors/persistence";
 import type {
@@ -21,10 +22,15 @@ import type {
   SignalSeverity,
   SuggestedAction,
 } from "~/lib/state/detectors";
-import type { ChangeSignalRow, Locale } from "~/types/clinical";
+import type {
+  ChangeSignalRow,
+  Locale,
+  SignalEventRow,
+} from "~/types/clinical";
 import {
   AlertTriangle,
   Bell,
+  Check,
   ChevronDown,
   ChevronUp,
   Sparkles,
@@ -64,6 +70,7 @@ export function ChangeSignalsCard() {
     () => db.change_signals.where("status").equals("open").toArray(),
     [],
   );
+  const eventRows = useLiveQuery(() => db.signal_events.toArray(), []);
 
   // Re-evaluate detectors whenever the underlying data changes. The
   // persistence layer dedupes, so repeated evaluations are safe.
@@ -82,6 +89,16 @@ export function ChangeSignalsCard() {
     const observations = extractObservationsByMetric(inputs);
     void evaluateAndPersistSignals({ state, observations, now: asOf });
   }, [settings, dailies, fortnightlies, labs, cycles]);
+
+  const eventsBySignalId = useMemo(() => {
+    const out = new Map<number, SignalEventRow[]>();
+    for (const e of eventRows ?? []) {
+      const arr = out.get(e.signal_id) ?? [];
+      arr.push(e);
+      out.set(e.signal_id, arr);
+    }
+    return out;
+  }, [eventRows]);
 
   const signals = useMemo(() => {
     if (!openSignalRows) return [];
@@ -107,7 +124,13 @@ export function ChangeSignalsCard() {
       </div>
       <div className="space-y-2">
         {signals.map(({ row, signal }) => (
-          <SignalRow key={row.id} row={row} signal={signal} locale={locale} />
+          <SignalRow
+            key={row.id}
+            row={row}
+            signal={signal}
+            locale={locale}
+            events={row.id ? (eventsBySignalId.get(row.id) ?? []) : []}
+          />
         ))}
       </div>
     </section>
@@ -118,10 +141,12 @@ function SignalRow({
   row,
   signal,
   locale,
+  events,
 }: {
   row: ChangeSignalRow;
   signal: ChangeSignal;
   locale: Locale;
+  events: SignalEventRow[];
 }) {
   const [expanded, setExpanded] = useState(false);
   const tone = TONE_BY_SEVERITY[signal.severity];
@@ -130,6 +155,11 @@ function SignalRow({
     (d) => d.confidence !== "unlikely",
   );
   const actionsToShow = signal.actions.slice(0, 2);
+  const actionsTaken = new Set(
+    events
+      .filter((e) => e.kind === "action_taken" && e.action_ref_id)
+      .map((e) => e.action_ref_id!),
+  );
 
   return (
     <Card className={cn("px-4 py-4", tone.wrap)}>
@@ -170,7 +200,13 @@ function SignalRow({
           {actionsToShow.length > 0 && (
             <ul className="mt-3 space-y-1.5">
               {actionsToShow.map((a) => (
-                <ActionRow key={`${a.kind}:${a.ref_id}`} action={a} locale={locale} />
+                <ActionRow
+                  key={`${a.kind}:${a.ref_id}`}
+                  action={a}
+                  locale={locale}
+                  signalId={row.id}
+                  done={actionsTaken.has(a.ref_id)}
+                />
               ))}
             </ul>
           )}
@@ -299,14 +335,54 @@ function SignalRow({
 function ActionRow({
   action,
   locale,
+  signalId,
+  done,
 }: {
   action: SuggestedAction;
   locale: Locale;
+  signalId?: number;
+  done: boolean;
 }) {
+  const onMarkDone = () => {
+    if (!signalId || done) return;
+    void markActionTaken({
+      signal_id: signalId,
+      action_ref_id: action.ref_id,
+      action_kind: action.kind,
+    });
+  };
   return (
     <li className="flex items-center gap-2 text-[12px] text-ink-700">
-      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--tide-2)]" />
-      <span className="flex-1">{action.label[locale]}</span>
+      <button
+        type="button"
+        onClick={onMarkDone}
+        disabled={done || !signalId}
+        aria-label={
+          done
+            ? locale === "zh"
+              ? "已完成"
+              : "Done"
+            : locale === "zh"
+              ? "标记为已完成"
+              : "Mark as done"
+        }
+        className={cn(
+          "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
+          done
+            ? "border-[var(--ok)] bg-[var(--ok)] text-white"
+            : "border-ink-300 bg-paper hover:border-ink-500",
+        )}
+      >
+        {done && <Check className="h-3 w-3" strokeWidth={3} />}
+      </button>
+      <span
+        className={cn(
+          "flex-1",
+          done && "text-ink-400 line-through decoration-[1px]",
+        )}
+      >
+        {action.label[locale]}
+      </span>
       <span className="mono text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
         {action.urgency === "now"
           ? locale === "zh"

--- a/src/components/dashboard/signal-loop-summary-card.tsx
+++ b/src/components/dashboard/signal-loop-summary-card.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { Card } from "~/components/ui/card";
+import { computeLoopSummary } from "~/lib/state/detectors";
+import { ChevronRight, Activity } from "lucide-react";
+
+// Lightweight rollup of signal-loop activity over the last 30 days. Shows up
+// on the dashboard as feedback that the detection → action → resolution
+// loop is actually running. Hidden until at least one signal has ever fired.
+export function SignalLoopSummaryCard() {
+  const locale = useLocale();
+  const signals = useLiveQuery(() => db.change_signals.toArray(), []);
+  const events = useLiveQuery(() => db.signal_events.toArray(), []);
+
+  const summary = useMemo(() => {
+    if (!signals || !events) return null;
+    const asOf = new Date().toISOString();
+    return computeLoopSummary(signals, events, asOf, 30);
+  }, [signals, events]);
+
+  if (!signals || signals.length === 0) return null;
+  if (!summary) return null;
+  if (
+    summary.signals_emitted === 0 &&
+    summary.signals_open === 0 &&
+    summary.signals_resolved === 0
+  ) {
+    return null;
+  }
+
+  const resolutionLabel = (() => {
+    if (summary.median_resolution_days == null) {
+      return locale === "zh" ? "暂无解决数据" : "no resolutions yet";
+    }
+    const d = summary.median_resolution_days;
+    return locale === "zh"
+      ? `中位 ${d.toFixed(1)} 天`
+      : `median ${d.toFixed(1)} days`;
+  })();
+
+  const actionFractionLabel = (() => {
+    if (summary.fraction_with_action == null) return null;
+    const pct = Math.round(summary.fraction_with_action * 100);
+    return locale === "zh"
+      ? `${pct}% 有记录行动`
+      : `${pct}% with a logged action`;
+  })();
+
+  return (
+    <Link href="/signals" className="block">
+      <Card className="px-4 py-3 transition-colors hover:border-ink-300">
+        <div className="flex items-center gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-paper-2 text-ink-700">
+            <Activity className="h-4 w-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-[13px] font-semibold text-ink-900">
+                {locale === "zh"
+                  ? "信号环路（30 天）"
+                  : "Signal loop · 30 days"}
+              </div>
+              <ChevronRight className="h-3.5 w-3.5 shrink-0 text-ink-400" />
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11.5px] text-ink-600">
+              <Stat
+                label={locale === "zh" ? "触发" : "emitted"}
+                value={summary.signals_emitted}
+              />
+              <Stat
+                label={locale === "zh" ? "解决" : "resolved"}
+                value={summary.signals_resolved}
+              />
+              <Stat
+                label={locale === "zh" ? "未结" : "open"}
+                value={summary.signals_open}
+              />
+              <Stat
+                label={locale === "zh" ? "行动" : "actions"}
+                value={summary.actions_taken}
+              />
+              <span className="text-ink-400">· {resolutionLabel}</span>
+              {actionFractionLabel && (
+                <span className="text-ink-400">· {actionFractionLabel}</span>
+              )}
+            </div>
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="inline-flex items-baseline gap-1">
+      <span className="mono num text-[13px] font-semibold text-ink-900">
+        {value}
+      </span>
+      <span className="mono text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+        {label}
+      </span>
+    </span>
+  );
+}

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -18,6 +18,7 @@ import type {
   PendingResult,
   IngestedDocument,
   ComprehensiveAssessment,
+  SignalEventRow,
 } from "~/types/clinical";
 import type { Trial } from "~/types/bridge";
 import type { TreatmentCycle } from "~/types/treatment";
@@ -43,6 +44,7 @@ export class AnchorDB extends Dexie {
   medication_events!: Table<MedicationEvent, number>;
   medication_prompt_events!: Table<MedicationPromptEvent, number>;
   change_signals!: Table<ChangeSignalRow, number>;
+  signal_events!: Table<SignalEventRow, number>;
   life_events!: Table<LifeEvent, number>;
   decisions!: Table<Decision, number>;
   zone_alerts!: Table<ZoneAlert, number>;
@@ -112,6 +114,13 @@ export class AnchorDB extends Dexie {
     this.version(8).stores({
       change_signals:
         "++id, detector, fired_for, metric_id, axis, severity, status, detected_at, [detector+fired_for]",
+    });
+    // v9: per-signal event log for outcome attribution (slice 4). One row
+    // per lifecycle transition or user-logged action. Index on signal_id so
+    // the attribution helper can walk events for a given signal cheaply.
+    this.version(9).stores({
+      signal_events:
+        "++id, signal_id, kind, action_ref_id, created_at, [signal_id+created_at]",
     });
   }
 }

--- a/src/lib/state/detectors/attribution.ts
+++ b/src/lib/state/detectors/attribution.ts
@@ -1,0 +1,128 @@
+// Outcome attribution — given a resolved signal and its event log, produce
+// a structured summary of what actions were logged during the signal's open
+// window and rank them by plausibility of contribution.
+//
+// This is correlational, not causal. The UI must label it as such. Over many
+// signals the correlation pattern may become informative (e.g. "steps
+// decline signals consistently resolved within 7 days of a logged walk
+// action" is a real useful insight; "consistently resolved without any
+// logged action" tells us the signal is noisy).
+import type {
+  ChangeSignalRow,
+  SignalEventRow,
+} from "~/types/clinical";
+
+export type AttributionConfidence = "likely" | "possible" | "unknown";
+
+export interface AttributedAction {
+  action_ref_id: string;
+  action_kind?: string;
+  taken_at: string;
+  days_before_resolution?: number;
+  confidence: AttributionConfidence;
+}
+
+export interface SignalAttribution {
+  signal_id: number;
+  detected_at: string;
+  resolved_at?: string;
+  duration_days?: number;
+  status: ChangeSignalRow["status"];
+  // All action_taken events logged during the signal's lifetime, in
+  // chronological order.
+  actions_taken: AttributedAction[];
+  // Shortcut: any action_taken within LIKELY_WINDOW days before resolution.
+  likely_contributors: AttributedAction[];
+  // True when signal resolved and no actions were logged — either the drift
+  // was noise, spontaneous recovery, or the intervention happened off-app.
+  spontaneous: boolean;
+}
+
+// If an action was logged within LIKELY_WINDOW days before resolution,
+// we classify it as a likely contributor. Within POSSIBLE_WINDOW but
+// outside LIKELY_WINDOW it's still a possible contributor. Beyond that it
+// was early in the signal's life and likely didn't drive resolution.
+const LIKELY_WINDOW_DAYS = 5;
+const POSSIBLE_WINDOW_DAYS = 14;
+
+export function attributeSignal(
+  signal: ChangeSignalRow,
+  events: readonly SignalEventRow[],
+): SignalAttribution {
+  const detected = Date.parse(signal.detected_at);
+  const resolved = signal.resolved_at
+    ? Date.parse(signal.resolved_at)
+    : null;
+  const duration_days =
+    resolved != null && !Number.isNaN(resolved)
+      ? Math.round(((resolved - detected) / 86_400_000) * 10) / 10
+      : undefined;
+
+  const actionEvents = events.filter(
+    (e) => e.kind === "action_taken" && e.action_ref_id,
+  );
+
+  const actions_taken: AttributedAction[] = actionEvents
+    .map((e) => {
+      const taken = Date.parse(e.created_at);
+      let daysBefore: number | undefined;
+      let confidence: AttributionConfidence = "unknown";
+      if (resolved != null && !Number.isNaN(resolved)) {
+        const diff = (resolved - taken) / 86_400_000;
+        daysBefore = Math.round(diff * 10) / 10;
+        if (diff < 0) {
+          // action logged after resolution — ignore for contribution
+          confidence = "unknown";
+        } else if (diff <= LIKELY_WINDOW_DAYS) {
+          confidence = "likely";
+        } else if (diff <= POSSIBLE_WINDOW_DAYS) {
+          confidence = "possible";
+        } else {
+          confidence = "unknown";
+        }
+      } else {
+        // signal still open — any action is "possible" contribution.
+        confidence = "possible";
+      }
+      return {
+        action_ref_id: e.action_ref_id!,
+        action_kind: e.action_kind,
+        taken_at: e.created_at,
+        days_before_resolution: daysBefore,
+        confidence,
+      };
+    })
+    .sort((a, b) => Date.parse(a.taken_at) - Date.parse(b.taken_at));
+
+  const likely_contributors = actions_taken.filter(
+    (a) => a.confidence === "likely",
+  );
+  const spontaneous =
+    signal.status === "resolved" && actions_taken.length === 0;
+
+  return {
+    signal_id: signal.id ?? 0,
+    detected_at: signal.detected_at,
+    resolved_at: signal.resolved_at,
+    duration_days,
+    status: signal.status,
+    actions_taken,
+    likely_contributors,
+    spontaneous,
+  };
+}
+
+/**
+ * Index events by signal id for bulk attribution over many signals.
+ */
+export function eventsBySignalId(
+  events: readonly SignalEventRow[],
+): Map<number, SignalEventRow[]> {
+  const out = new Map<number, SignalEventRow[]>();
+  for (const e of events) {
+    const arr = out.get(e.signal_id) ?? [];
+    arr.push(e);
+    out.set(e.signal_id, arr);
+  }
+  return out;
+}

--- a/src/lib/state/detectors/events.ts
+++ b/src/lib/state/detectors/events.ts
@@ -1,0 +1,146 @@
+// Signal event log — Dexie IO for the per-signal lifecycle trail.
+//
+// Every state transition of a ChangeSignalRow plus every action the user
+// marks as done writes one row here. The attribution layer consumes this
+// log to answer "was this signal's resolution preceded by any of the
+// suggested actions?" — the core loop of the app.
+import { db } from "~/lib/db/dexie";
+import type {
+  ChangeSignalRow,
+  SignalEventKind,
+  SignalEventRow,
+} from "~/types/clinical";
+
+export interface LogSignalEventInput {
+  signal_id: number;
+  kind: SignalEventKind;
+  action_ref_id?: string;
+  action_kind?: string;
+  note?: string;
+  at?: string;                  // override timestamp (tests)
+}
+
+/**
+ * Append an event to the signal's timeline. Single-writer: no dedup logic
+ * here — callers decide when to log (e.g. logging `acknowledged` twice is
+ * allowed, though typically suppressed at the UI layer).
+ */
+export async function logSignalEvent(
+  input: LogSignalEventInput,
+): Promise<number> {
+  const row: SignalEventRow = {
+    signal_id: input.signal_id,
+    kind: input.kind,
+    action_ref_id: input.action_ref_id,
+    action_kind: input.action_kind,
+    note: input.note,
+    created_at: input.at ?? new Date().toISOString(),
+  };
+  return (await db.signal_events.add(row)) as number;
+}
+
+export async function getEventsForSignal(
+  signal_id: number,
+): Promise<SignalEventRow[]> {
+  return db.signal_events
+    .where("signal_id")
+    .equals(signal_id)
+    .sortBy("created_at");
+}
+
+export async function getAllSignalEvents(): Promise<SignalEventRow[]> {
+  return db.signal_events.orderBy("created_at").toArray();
+}
+
+// ─── Loop summary ─────────────────────────────────────────────────────────
+
+export interface SignalLoopSummary {
+  range_days: number;
+  signals_emitted: number;
+  signals_resolved: number;
+  signals_open: number;
+  actions_taken: number;
+  // Median days between emitted → resolved, across signals resolved in range.
+  median_resolution_days: number | null;
+  // Fraction of resolved signals in range that had at least one
+  // `action_taken` event in their lifetime. Not causal — correlational only.
+  fraction_with_action: number | null;
+}
+
+/**
+ * Compute a rollup of signal-loop activity within the trailing `rangeDays`
+ * ending at `asOfISO`. Pure function — caller fetches rows from Dexie.
+ */
+export function computeLoopSummary(
+  signals: readonly ChangeSignalRow[],
+  events: readonly SignalEventRow[],
+  asOfISO: string,
+  rangeDays = 30,
+): SignalLoopSummary {
+  const asOf = Date.parse(asOfISO);
+  const from = asOf - rangeDays * 86_400_000;
+  const inRange = (iso?: string | null) => {
+    if (!iso) return false;
+    const t = Date.parse(iso);
+    return !Number.isNaN(t) && t >= from && t <= asOf;
+  };
+
+  const emitted = signals.filter((s) => inRange(s.detected_at));
+  const resolvedInRange = signals.filter(
+    (s) => s.status === "resolved" && inRange(s.resolved_at),
+  );
+  const open = signals.filter((s) => s.status === "open").length;
+
+  const eventsBySignal = new Map<number, SignalEventRow[]>();
+  for (const e of events) {
+    const arr = eventsBySignal.get(e.signal_id) ?? [];
+    arr.push(e);
+    eventsBySignal.set(e.signal_id, arr);
+  }
+
+  const actions_taken = events.filter(
+    (e) => e.kind === "action_taken" && inRange(e.created_at),
+  ).length;
+
+  const resolutionDurations: number[] = [];
+  let resolvedWithAction = 0;
+  for (const sig of resolvedInRange) {
+    if (!sig.id || !sig.resolved_at) continue;
+    const dur =
+      (Date.parse(sig.resolved_at) - Date.parse(sig.detected_at)) /
+      86_400_000;
+    if (Number.isFinite(dur) && dur >= 0) resolutionDurations.push(dur);
+    const sigEvents = eventsBySignal.get(sig.id) ?? [];
+    if (sigEvents.some((e) => e.kind === "action_taken")) {
+      resolvedWithAction++;
+    }
+  }
+
+  const median_resolution_days =
+    resolutionDurations.length > 0
+      ? median(resolutionDurations)
+      : null;
+  const fraction_with_action =
+    resolvedInRange.length > 0
+      ? resolvedWithAction / resolvedInRange.length
+      : null;
+
+  return {
+    range_days: rangeDays,
+    signals_emitted: emitted.length,
+    signals_resolved: resolvedInRange.length,
+    signals_open: open,
+    actions_taken,
+    median_resolution_days,
+    fraction_with_action,
+  };
+}
+
+function median(nums: readonly number[]): number {
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1]! + sorted[mid]!) / 2;
+  }
+  return sorted[mid]!;
+}

--- a/src/lib/state/detectors/index.ts
+++ b/src/lib/state/detectors/index.ts
@@ -8,6 +8,21 @@ import { stepsDeclineDetector } from "./steps-decline";
 
 export { stepsDeclineDetector } from "./steps-decline";
 export { gripDeclineDetector } from "./grip-decline";
+export {
+  attributeSignal,
+  eventsBySignalId,
+  type AttributedAction,
+  type AttributionConfidence,
+  type SignalAttribution,
+} from "./attribution";
+export {
+  logSignalEvent,
+  getEventsForSignal,
+  getAllSignalEvents,
+  computeLoopSummary,
+  type LogSignalEventInput,
+  type SignalLoopSummary,
+} from "./events";
 export type {
   ChangeSignal,
   Detector,

--- a/src/lib/state/detectors/persistence.ts
+++ b/src/lib/state/detectors/persistence.ts
@@ -1,10 +1,12 @@
 // Persistence helpers for change signals. Thin wrappers around Dexie so the
 // detector orchestration stays pure and the consumer (UI, background job)
-// handles IO.
+// handles IO. Writes to signal_events on every lifecycle transition so the
+// attribution layer (slice 4) can walk the timeline.
 import { db } from "~/lib/db/dexie";
-import type { ChangeSignalRow } from "~/types/clinical";
-import { DETECTORS, evaluateDetectors, reconcileSignals } from ".";
+import type { ChangeSignalRow, SignalEventKind } from "~/types/clinical";
+import { evaluateDetectors, reconcileSignals } from ".";
 import type { ChangeSignal, DetectorContext, SignalStatus } from "./types";
+import { logSignalEvent } from "./events";
 
 export async function getOpenSignals(): Promise<ChangeSignalRow[]> {
   return db.change_signals.where("status").equals("open").toArray();
@@ -21,9 +23,8 @@ export function deserializeSignal(row: ChangeSignalRow): ChangeSignal {
 /**
  * Run detectors, reconcile against persisted state, write new open rows, and
  * update rows whose underlying drift has recovered. Safe to call repeatedly
- * (idempotent on the same ctx).
- *
- * Returns the number of rows inserted and resolved, for diagnostic logging.
+ * (idempotent on the same ctx). Emits `emitted` and `resolved_auto` events
+ * so the attribution layer can reconstruct the lifecycle.
  */
 export async function evaluateAndPersistSignals(
   ctx: DetectorContext,
@@ -50,7 +51,12 @@ export async function evaluateAndPersistSignals(
       payload_json: JSON.stringify(sig),
       detected_at: nowISO,
     };
-    await db.change_signals.add(row);
+    const id = (await db.change_signals.add(row)) as number;
+    await logSignalEvent({
+      signal_id: id,
+      kind: "emitted",
+      at: nowISO,
+    });
     inserted++;
   }
 
@@ -65,20 +71,83 @@ export async function evaluateAndPersistSignals(
       status: "resolved",
       resolved_at: nowISO,
     });
+    await logSignalEvent({
+      signal_id: row.id,
+      kind: "resolved_auto",
+      at: nowISO,
+    });
     resolved++;
   }
 
   return { inserted, resolved };
 }
 
+/**
+ * Map a user-driven status change to the event kind that should be logged.
+ * Centralised so UI components never have to decide the event taxonomy.
+ */
+function statusToEventKind(
+  status: SignalStatus,
+): SignalEventKind | null {
+  switch (status) {
+    case "acknowledged":
+      return "acknowledged";
+    case "dismissed":
+      return "dismissed";
+    case "resolved":
+      return "resolved_manual";
+    case "open":
+      return "reopened";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Update a signal's status and write the corresponding lifecycle event.
+ * Single source of truth for user-driven lifecycle transitions — components
+ * should call this rather than Dexie directly.
+ */
 export async function setSignalStatus(
   id: number,
   status: SignalStatus,
   note?: string,
 ): Promise<void> {
+  const nowISO = new Date().toISOString();
   await db.change_signals.update(id, {
     status,
-    resolved_at: new Date().toISOString(),
+    resolved_at:
+      status === "resolved" || status === "dismissed" ? nowISO : undefined,
     note,
+  });
+  const kind = statusToEventKind(status);
+  if (kind) {
+    await logSignalEvent({
+      signal_id: id,
+      kind,
+      note,
+      at: nowISO,
+    });
+  }
+}
+
+/**
+ * Log that the user has taken one of the signal's suggested actions. This
+ * is the core action-attribution hook — keep the call site simple
+ * (`<MarkDoneButton action={a} signalId={id} />`) because every tap here is
+ * a data point the attribution layer later relies on.
+ */
+export async function markActionTaken(input: {
+  signal_id: number;
+  action_ref_id: string;
+  action_kind?: string;
+  note?: string;
+}): Promise<void> {
+  await logSignalEvent({
+    signal_id: input.signal_id,
+    kind: "action_taken",
+    action_ref_id: input.action_ref_id,
+    action_kind: input.action_kind,
+    note: input.note,
   });
 }

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -249,6 +249,30 @@ export interface ChangeSignalRow {
   note?: string;
 }
 
+// Every lifecycle transition of a signal + every action the user takes in
+// response is written here. The table exists so slice 4's attribution layer
+// can reason about "was this signal's resolution preceded by any of the
+// suggested actions?" — the loop the app is ultimately built around.
+export type SignalEventKind =
+  | "emitted"           // detector first fired, ChangeSignalRow created
+  | "acknowledged"      // user tapped "Got it"
+  | "dismissed"         // user tapped "Dismiss"
+  | "action_taken"      // user marked a suggested action done
+  | "resolved_auto"     // detector.hasResolved returned true
+  | "resolved_manual"   // user marked the signal resolved
+  | "reopened";         // detector re-fired after a prior resolution
+
+export interface SignalEventRow {
+  id?: number;
+  signal_id: number;                // fk → change_signals.id
+  kind: SignalEventKind;
+  // For kind=action_taken — which SuggestedAction was marked done.
+  action_ref_id?: string;
+  action_kind?: string;             // "lever" | "task" | "question" | ...
+  note?: string;
+  created_at: string;
+}
+
 export interface LifeEvent {
   id?: number;
   title: string;

--- a/tests/unit/signal-attribution.test.ts
+++ b/tests/unit/signal-attribution.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+import {
+  attributeSignal,
+  eventsBySignalId,
+  computeLoopSummary,
+} from "~/lib/state/detectors";
+import type {
+  ChangeSignalRow,
+  SignalEventRow,
+} from "~/types/clinical";
+
+function signal(
+  over: Partial<ChangeSignalRow> = {},
+): ChangeSignalRow {
+  return {
+    id: 1,
+    detector: "steps_decline",
+    fired_for: "steps_decline:2026-W15",
+    metric_id: "steps",
+    axis: "individual",
+    severity: "caution",
+    shape: "rolling_drift",
+    status: "open",
+    payload_json: "{}",
+    detected_at: "2026-04-01T08:00:00Z",
+    ...over,
+  };
+}
+
+function event(over: Partial<SignalEventRow> = {}): SignalEventRow {
+  return {
+    signal_id: 1,
+    kind: "emitted",
+    created_at: "2026-04-01T08:00:00Z",
+    ...over,
+  };
+}
+
+describe("attributeSignal", () => {
+  it("lists no actions when events contain only lifecycle transitions", () => {
+    const sig = signal({ status: "resolved", resolved_at: "2026-04-08T08:00:00Z" });
+    const events = [
+      event({ kind: "emitted" }),
+      event({ kind: "resolved_auto", created_at: "2026-04-08T08:00:00Z" }),
+    ];
+    const attr = attributeSignal(sig, events);
+    expect(attr.actions_taken).toEqual([]);
+    expect(attr.spontaneous).toBe(true);
+    expect(attr.duration_days).toBeCloseTo(7, 0);
+  });
+
+  it("marks an action as 'likely' when taken within 5 days before resolution", () => {
+    const sig = signal({ status: "resolved", resolved_at: "2026-04-08T08:00:00Z" });
+    const events = [
+      event({ kind: "emitted" }),
+      event({
+        kind: "action_taken",
+        action_ref_id: "gentle_walk_10min",
+        action_kind: "self",
+        created_at: "2026-04-05T10:00:00Z",
+      }),
+      event({ kind: "resolved_auto", created_at: "2026-04-08T08:00:00Z" }),
+    ];
+    const attr = attributeSignal(sig, events);
+    expect(attr.actions_taken).toHaveLength(1);
+    expect(attr.actions_taken[0].confidence).toBe("likely");
+    expect(attr.likely_contributors).toHaveLength(1);
+    expect(attr.spontaneous).toBe(false);
+  });
+
+  it("classifies actions 5-14 days before resolution as 'possible'", () => {
+    const sig = signal({ status: "resolved", resolved_at: "2026-04-20T08:00:00Z" });
+    const events = [
+      event({ kind: "emitted", created_at: "2026-04-01T08:00:00Z" }),
+      event({
+        kind: "action_taken",
+        action_ref_id: "nutrition.dietitian",
+        created_at: "2026-04-10T09:00:00Z", // 10 days before resolution
+      }),
+      event({ kind: "resolved_auto", created_at: "2026-04-20T08:00:00Z" }),
+    ];
+    const attr = attributeSignal(sig, events);
+    expect(attr.actions_taken[0].confidence).toBe("possible");
+    expect(attr.likely_contributors).toHaveLength(0);
+  });
+
+  it("classifies actions >14 days before resolution as 'unknown'", () => {
+    const sig = signal({ status: "resolved", resolved_at: "2026-05-01T08:00:00Z" });
+    const events = [
+      event({ kind: "emitted", created_at: "2026-04-01T08:00:00Z" }),
+      event({
+        kind: "action_taken",
+        action_ref_id: "physical.resistance",
+        created_at: "2026-04-10T09:00:00Z", // 21 days before resolution
+      }),
+      event({ kind: "resolved_auto", created_at: "2026-05-01T08:00:00Z" }),
+    ];
+    const attr = attributeSignal(sig, events);
+    expect(attr.actions_taken[0].confidence).toBe("unknown");
+  });
+
+  it("treats all actions on an open signal as 'possible'", () => {
+    const sig = signal({ status: "open" });
+    const events = [
+      event({ kind: "emitted" }),
+      event({
+        kind: "action_taken",
+        action_ref_id: "gentle_walk_10min",
+        created_at: "2026-04-05T10:00:00Z",
+      }),
+    ];
+    const attr = attributeSignal(sig, events);
+    expect(attr.actions_taken[0].confidence).toBe("possible");
+    expect(attr.spontaneous).toBe(false);
+    expect(attr.duration_days).toBeUndefined();
+  });
+
+  it("sorts actions chronologically", () => {
+    const sig = signal({ status: "resolved", resolved_at: "2026-04-20T08:00:00Z" });
+    const events = [
+      event({
+        kind: "action_taken",
+        action_ref_id: "second",
+        created_at: "2026-04-16T08:00:00Z",
+      }),
+      event({
+        kind: "action_taken",
+        action_ref_id: "first",
+        created_at: "2026-04-10T08:00:00Z",
+      }),
+      event({ kind: "emitted", created_at: "2026-04-01T08:00:00Z" }),
+    ];
+    const attr = attributeSignal(sig, events);
+    expect(attr.actions_taken.map((a) => a.action_ref_id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+});
+
+describe("eventsBySignalId", () => {
+  it("groups events by their signal_id", () => {
+    const events = [
+      event({ signal_id: 1, kind: "emitted" }),
+      event({ signal_id: 2, kind: "emitted" }),
+      event({ signal_id: 1, kind: "acknowledged" }),
+    ];
+    const grouped = eventsBySignalId(events);
+    expect(grouped.get(1)).toHaveLength(2);
+    expect(grouped.get(2)).toHaveLength(1);
+  });
+});
+
+describe("computeLoopSummary", () => {
+  const asOf = "2026-04-30T12:00:00Z";
+
+  it("counts signals emitted and resolved within the range", () => {
+    const signals = [
+      signal({ id: 1, detected_at: "2026-04-10T00:00:00Z" }),
+      signal({
+        id: 2,
+        detected_at: "2026-04-15T00:00:00Z",
+        status: "resolved",
+        resolved_at: "2026-04-22T00:00:00Z",
+      }),
+      // Out of range — ignored
+      signal({ id: 3, detected_at: "2025-12-01T00:00:00Z" }),
+    ];
+    const events: SignalEventRow[] = [];
+    const s = computeLoopSummary(signals, events, asOf, 30);
+    expect(s.signals_emitted).toBe(2);
+    expect(s.signals_resolved).toBe(1);
+  });
+
+  it("computes median resolution duration + fraction with action", () => {
+    const signals = [
+      signal({
+        id: 1,
+        detected_at: "2026-04-01T00:00:00Z",
+        status: "resolved",
+        resolved_at: "2026-04-08T00:00:00Z",
+      }),
+      signal({
+        id: 2,
+        detected_at: "2026-04-10T00:00:00Z",
+        status: "resolved",
+        resolved_at: "2026-04-18T00:00:00Z",
+      }),
+      signal({
+        id: 3,
+        detected_at: "2026-04-15T00:00:00Z",
+        status: "resolved",
+        resolved_at: "2026-04-25T00:00:00Z",
+      }),
+    ];
+    const events: SignalEventRow[] = [
+      event({
+        signal_id: 1,
+        kind: "action_taken",
+        action_ref_id: "x",
+        created_at: "2026-04-05T00:00:00Z",
+      }),
+      event({
+        signal_id: 3,
+        kind: "action_taken",
+        action_ref_id: "y",
+        created_at: "2026-04-20T00:00:00Z",
+      }),
+    ];
+    const s = computeLoopSummary(signals, events, asOf, 30);
+    expect(s.signals_resolved).toBe(3);
+    // Durations: 7, 8, 10 → median 8
+    expect(s.median_resolution_days).toBe(8);
+    // 2 of 3 had an action
+    expect(s.fraction_with_action).toBeCloseTo(2 / 3, 3);
+    expect(s.actions_taken).toBe(2);
+  });
+
+  it("returns null resolution-stats when nothing resolved in range", () => {
+    const signals = [signal({ id: 1, detected_at: "2026-04-10T00:00:00Z" })];
+    const s = computeLoopSummary(signals, [], asOf, 30);
+    expect(s.median_resolution_days).toBeNull();
+    expect(s.fraction_with_action).toBeNull();
+  });
+});


### PR DESCRIPTION
**Stacked on PR #26** (slice 2 — change detectors), which stacks on PR #25 (slice 1). Merge order: **#25 → #26 → this**.

Closes the **detection → action → outcome** loop the thesis asks for. Every lifecycle transition of every signal is now recorded, and the user can mark suggested actions as done right from the signal card. When a signal resolves, the system can reason about whether any of the logged actions likely contributed.

## The loop, end to end

1. Detector fires → `emitted` event logged, ChangeSignalRow inserted.
2. User sees the signal on the dashboard, taps **✓** next to a suggested action → `action_taken` event logged with the action's ref_id + kind.
3. User may acknowledge / dismiss → `acknowledged` / `dismissed` event.
4. Drift recovers → `detector.hasResolved()` → `resolved_auto` event + status → `resolved`.
5. On `/signals`, the resolved signal shows its timeline + likely contributors (actions taken within 5 days of resolution) + a correlational-not-causal disclaimer.

## Schema (Dexie v9)

New `signal_events` table. One row per lifecycle transition or logged action. Kinds:
- `emitted` / `acknowledged` / `dismissed`
- `action_taken` (carries `action_ref_id` + `action_kind`)
- `resolved_auto` / `resolved_manual` / `reopened`

Compound index `[signal_id+created_at]` so per-signal timeline reads are cheap.

## Modules

- **`src/lib/state/detectors/events.ts`** — `logSignalEvent`, `getEventsForSignal`, `computeLoopSummary(signals, events, asOf, rangeDays)` returning `{ signals_emitted, signals_resolved, signals_open, actions_taken, median_resolution_days, fraction_with_action }`.
- **`src/lib/state/detectors/attribution.ts`** — `attributeSignal(sig, events)` returning ordered `actions_taken[]` with per-action confidence:
  - `likely` — taken within 5 days before resolution
  - `possible` — 5–14 days before resolution, or any action while signal is still open
  - `unknown` — >14 days before resolution
  - `spontaneous: true` when a signal resolved with zero logged actions
- **`src/lib/state/detectors/persistence.ts`** — updated to write `emitted` on new signals and `resolved_auto` on reconciled resolutions. `setSignalStatus` now also writes the matching lifecycle event. New `markActionTaken` helper for the mark-done UI.

## UI

### `ChangeSignalsCard` (updated)
Every suggested action now has a checkbox that writes `action_taken` when tapped. Taken actions visibly strike through and disable the checkbox. Reads events via live query so the state is synchronised across tabs.

### `SignalLoopSummaryCard` (new — dashboard)
Last-30d rollup below ChangeSignalsCard:
- signals emitted / resolved / open / actions
- median resolution days
- percent of resolutions with a logged action
Links through to `/signals`. Hidden until there's been at least one signal ever.

### `/signals` history page (new)
Full list with filters (all / open / resolved). Each row expands to the chronological event timeline. Resolved signals with likely contributors show a green panel:

> **Likely contributors:** gentle_walk_10min (3d before)
> Correlational, not causal.

Resolved signals with no actions logged show a "may be noise or spontaneous recovery" note — this is itself informative over time.

## Tests (10 new, 206 total)

`signal-attribution.test.ts`:
- `attributeSignal` — no actions ⇒ `spontaneous: true`; action within 5d ⇒ `likely`; 5–14d ⇒ `possible`; >14d ⇒ `unknown`; open signals treat any action as `possible`; actions sorted chronologically
- `eventsBySignalId` — groups correctly
- `computeLoopSummary` — in-range counting, median resolution duration, fraction_with_action, null stats when nothing resolved in range

All 206 tests pass. typecheck / lint / build clean.

## Design notes

- **Attribution is deliberately correlational.** The UI labels it as such. Over many signals the pattern may become informative (systematic post-action resolution vs. systematic spontaneous resolution tells the patient/carer whether the app is actually driving outcomes vs. logging noise).
- **Confidence windows (5d likely, 14d possible)** are conservative defaults; per-detector tuning is possible once there's real data.
- **`markActionTaken` only writes to the event log** — it doesn't change the signal's status. Deliberate: the user may take an action but the drift continues, and the signal should stay open until the detector's `hasResolved` actually fires.

## Up next

- **Slice 3** — external axis (social contacts, care-team log, clinician touchpoints). Populates the empty axis from slice 1 so cross-axis detection actually spans all four pillars.
- **Polish** — tighten UI, consolidate copy, prune stale bits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)