### PR TITLE
Slice 3: External axis — social + clinician-gap detectors with data capture

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -18,7 +18,9 @@
     "decisions": "Decisions",
     "ingest": "Ingest",
     "reports": "Reports",
-    "settings": "Settings"
+    "settings": "Settings",
+    "history": "History",
+    "care_team": "Care team"
   },
   "zones": {
     "green": "Stable",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -18,7 +18,9 @@
     "decisions": "决策记录",
     "ingest": "导入",
     "reports": "报告",
-    "settings": "设置"
+    "settings": "设置",
+    "history": "历史记录",
+    "care_team": "医疗团队"
   },
   "zones": {
     "green": "稳定",

--- a/src/app/care-team/page.tsx
+++ b/src/app/care-team/page.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader, SectionHeader } from "~/components/ui/page-header";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import type {
+  CareTeamContact,
+  CareTeamContactKind,
+} from "~/types/clinical";
+import { differenceInCalendarDays, format, parseISO } from "date-fns";
+import { cn } from "~/lib/utils/cn";
+
+const KIND_LABELS: Record<CareTeamContactKind, { en: string; zh: string }> = {
+  clinic_visit: { en: "Clinic visit", zh: "门诊" },
+  clinician_call: { en: "Phone / telehealth", zh: "电话 / 远程医疗" },
+  specialist_visit: { en: "Specialist visit", zh: "专科门诊" },
+  community_nurse: { en: "Community nurse", zh: "社区护理" },
+  allied_health: { en: "Allied health", zh: "联合健康" },
+  hospital_admission: { en: "Hospital admission", zh: "住院" },
+  emergency_department: { en: "Emergency dept", zh: "急诊" },
+  pharmacist: { en: "Pharmacist", zh: "药剂师" },
+  other: { en: "Other", zh: "其他" },
+};
+
+const KIND_ORDER: CareTeamContactKind[] = [
+  "clinic_visit",
+  "clinician_call",
+  "specialist_visit",
+  "community_nurse",
+  "allied_health",
+  "hospital_admission",
+  "emergency_department",
+  "pharmacist",
+  "other",
+];
+
+export default function CareTeamPage() {
+  const locale = useLocale();
+  const contacts = useLiveQuery(
+    () => db.care_team_contacts.orderBy("date").reverse().toArray(),
+    [],
+  );
+  const [editing, setEditing] = useState<CareTeamContact | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const lastContact = useMemo(() => {
+    if (!contacts || contacts.length === 0) return null;
+    return contacts[0];
+  }, [contacts]);
+
+  const daysSince = useMemo(() => {
+    if (!lastContact) return null;
+    return differenceInCalendarDays(new Date(), parseISO(lastContact.date));
+  }, [lastContact]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "外部" : "External"}
+        title={locale === "zh" ? "医疗团队记录" : "Care team log"}
+      />
+
+      <Card className="p-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <div>
+            <div className="eyebrow">
+              {locale === "zh" ? "最近接触" : "Last contact"}
+            </div>
+            <div className="serif mt-1 text-[22px] text-ink-900">
+              {lastContact
+                ? `${daysSince ?? "?"} ${locale === "zh" ? "天前" : "days ago"}`
+                : locale === "zh"
+                  ? "尚无记录"
+                  : "No contacts logged"}
+            </div>
+            {lastContact && (
+              <div className="mt-1 text-sm text-ink-500">
+                {KIND_LABELS[lastContact.kind][locale]}
+                {lastContact.with_who ? ` · ${lastContact.with_who}` : ""}
+                {" · "}
+                {format(parseISO(lastContact.date), "d MMM yyyy")}
+              </div>
+            )}
+          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => {
+              setEditing(null);
+              setShowForm(true);
+            }}
+          >
+            {locale === "zh" ? "添加记录" : "Log contact"}
+          </Button>
+        </div>
+      </Card>
+
+      {showForm && (
+        <ContactForm
+          locale={locale}
+          editing={editing}
+          onSaved={() => {
+            setShowForm(false);
+            setEditing(null);
+          }}
+          onCancel={() => {
+            setShowForm(false);
+            setEditing(null);
+          }}
+        />
+      )}
+
+      <section className="space-y-2">
+        <SectionHeader title={locale === "zh" ? "历史" : "History"} />
+        {contacts && contacts.length > 0 ? (
+          <ul className="space-y-2">
+            {contacts.map((c) => (
+              <ContactRow
+                key={c.id}
+                contact={c}
+                locale={locale}
+                onEdit={() => {
+                  setEditing(c);
+                  setShowForm(true);
+                }}
+                onDelete={() => {
+                  if (c.id) void db.care_team_contacts.delete(c.id);
+                }}
+              />
+            ))}
+          </ul>
+        ) : (
+          <Card className="p-5 text-sm text-ink-500">
+            {locale === "zh"
+              ? "暂无记录。首次门诊 / 电话后添加一条，系统即可开始追踪接触节奏。"
+              : "No contacts yet. Add one after your next clinic call or visit so the app can track your support-network rhythm."}
+          </Card>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function ContactRow({
+  contact,
+  locale,
+  onEdit,
+  onDelete,
+}: {
+  contact: CareTeamContact;
+  locale: "en" | "zh";
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <li>
+      <Card className="flex items-start gap-3 px-4 py-3">
+        <div className="flex h-8 w-10 shrink-0 flex-col items-center justify-center rounded-md bg-paper-2 text-center">
+          <span className="mono text-[9px] uppercase tracking-[0.1em] text-ink-500">
+            {format(parseISO(contact.date), "MMM")}
+          </span>
+          <span className="text-[13px] font-semibold text-ink-900 leading-tight">
+            {format(parseISO(contact.date), "d")}
+          </span>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-[13px] font-semibold text-ink-900">
+              {KIND_LABELS[contact.kind][locale]}
+            </span>
+            {contact.with_who && (
+              <span className="text-[12px] text-ink-500">
+                · {contact.with_who}
+              </span>
+            )}
+            {contact.follow_up_needed && (
+              <span className="mono rounded-full bg-[var(--warn-soft)] px-2 py-0.5 text-[9.5px] uppercase tracking-[0.12em] text-[var(--warn)]">
+                {locale === "zh" ? "需随访" : "follow-up"}
+              </span>
+            )}
+          </div>
+          {contact.notes && (
+            <p className="mt-1 text-[12px] text-ink-700">{contact.notes}</p>
+          )}
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              onClick={onEdit}
+              className="text-[11px] text-ink-500 hover:text-ink-900"
+            >
+              {locale === "zh" ? "编辑" : "Edit"}
+            </button>
+            <button
+              type="button"
+              onClick={onDelete}
+              className="text-[11px] text-ink-400 hover:text-[var(--warn)]"
+            >
+              {locale === "zh" ? "删除" : "Delete"}
+            </button>
+          </div>
+        </div>
+      </Card>
+    </li>
+  );
+}
+
+function ContactForm({
+  locale,
+  editing,
+  onSaved,
+  onCancel,
+}: {
+  locale: "en" | "zh";
+  editing: CareTeamContact | null;
+  onSaved: () => void;
+  onCancel: () => void;
+}) {
+  const [date, setDate] = useState(
+    editing?.date ?? new Date().toISOString().slice(0, 10),
+  );
+  const [kind, setKind] = useState<CareTeamContactKind>(
+    editing?.kind ?? "clinic_visit",
+  );
+  const [withWho, setWithWho] = useState(editing?.with_who ?? "");
+  const [notes, setNotes] = useState(editing?.notes ?? "");
+  const [followUp, setFollowUp] = useState(editing?.follow_up_needed ?? false);
+
+  const save = async () => {
+    const nowISO = new Date().toISOString();
+    const payload: CareTeamContact = {
+      date,
+      kind,
+      with_who: withWho || undefined,
+      notes: notes || undefined,
+      follow_up_needed: followUp,
+      created_at: editing?.created_at ?? nowISO,
+      updated_at: nowISO,
+    };
+    if (editing?.id) {
+      await db.care_team_contacts.update(editing.id, payload);
+    } else {
+      await db.care_team_contacts.add(payload);
+    }
+    onSaved();
+  };
+
+  return (
+    <Card className="space-y-3 p-4">
+      <div className="eyebrow">
+        {editing
+          ? locale === "zh"
+            ? "编辑记录"
+            : "Edit contact"
+          : locale === "zh"
+            ? "新记录"
+            : "New contact"}
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <label className="flex flex-col gap-1 text-[12px]">
+          <span className="text-ink-500">
+            {locale === "zh" ? "日期" : "Date"}
+          </span>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="rounded-md border border-ink-200 bg-paper px-2 py-1.5 text-[13px]"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-[12px]">
+          <span className="text-ink-500">
+            {locale === "zh" ? "类型" : "Kind"}
+          </span>
+          <select
+            value={kind}
+            onChange={(e) => setKind(e.target.value as CareTeamContactKind)}
+            className="rounded-md border border-ink-200 bg-paper px-2 py-1.5 text-[13px]"
+          >
+            {KIND_ORDER.map((k) => (
+              <option key={k} value={k}>
+                {KIND_LABELS[k][locale]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-[12px] md:col-span-2">
+          <span className="text-ink-500">
+            {locale === "zh" ? "联系人 / 机构" : "Who / service"}
+          </span>
+          <input
+            type="text"
+            value={withWho}
+            onChange={(e) => setWithWho(e.target.value)}
+            placeholder={locale === "zh" ? "例如 Dr Lee" : "e.g. Dr Lee"}
+            className="rounded-md border border-ink-200 bg-paper px-2 py-1.5 text-[13px]"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-[12px] md:col-span-2">
+          <span className="text-ink-500">
+            {locale === "zh" ? "笔记" : "Notes"}
+          </span>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={3}
+            className="rounded-md border border-ink-200 bg-paper px-2 py-1.5 text-[13px]"
+          />
+        </label>
+        <label className="flex items-center gap-2 text-[12px] md:col-span-2">
+          <input
+            type="checkbox"
+            checked={followUp}
+            onChange={(e) => setFollowUp(e.target.checked)}
+          />
+          <span>
+            {locale === "zh" ? "需要后续跟进" : "Follow-up needed"}
+          </span>
+        </label>
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          {locale === "zh" ? "取消" : "Cancel"}
+        </Button>
+        <Button variant="primary" size="sm" onClick={() => void save()}>
+          {locale === "zh" ? "保存" : "Save"}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { format, parseISO } from "date-fns";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card } from "~/components/ui/card";
+import {
+  aggregateHistory,
+  groupByDate,
+  type HistoryCategory,
+  type HistoryEntry,
+  type HistoryTone,
+} from "~/lib/state/history";
+import {
+  Activity,
+  AlertTriangle,
+  Bell,
+  CheckCircle2,
+  Compass,
+  FlaskConical,
+  Heart,
+  Pill,
+  Scan,
+  Sparkles,
+  Syringe,
+  Users,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+type Filter = "all" | HistoryCategory;
+
+const FILTERS: { key: Filter; en: string; zh: string }[] = [
+  { key: "all", en: "All", zh: "全部" },
+  { key: "signal", en: "Signals", zh: "信号" },
+  { key: "action", en: "Actions", zh: "行动" },
+  { key: "medication", en: "Meds", zh: "用药" },
+  { key: "care_team", en: "Care team", zh: "医疗团队" },
+  { key: "lab", en: "Labs", zh: "化验" },
+  { key: "imaging", en: "Imaging", zh: "影像" },
+  { key: "treatment", en: "Treatment", zh: "治疗" },
+  { key: "check_in", en: "Check-ins", zh: "每日记录" },
+  { key: "decision", en: "Decisions", zh: "决策" },
+  { key: "life_event", en: "Life events", zh: "生活事件" },
+];
+
+const CATEGORY_ICON: Record<
+  HistoryCategory,
+  React.ComponentType<{ className?: string }>
+> = {
+  signal: AlertTriangle,
+  action: Sparkles,
+  medication: Pill,
+  care_team: Users,
+  lab: FlaskConical,
+  imaging: Scan,
+  treatment: Syringe,
+  check_in: Heart,
+  decision: Compass,
+  life_event: Activity,
+};
+
+const TONE_STYLE: Record<
+  HistoryTone,
+  { bg: string; fg: string; dot: string }
+> = {
+  info: {
+    bg: "bg-paper-2",
+    fg: "text-ink-700",
+    dot: "bg-ink-300",
+  },
+  positive: {
+    bg: "bg-[var(--ok-soft)]",
+    fg: "text-ink-900",
+    dot: "bg-[var(--ok)]",
+  },
+  caution: {
+    bg: "bg-[var(--sand)]/40",
+    fg: "text-ink-900",
+    dot: "bg-[oklch(45%_0.06_70)]",
+  },
+  warning: {
+    bg: "bg-[var(--warn-soft)]",
+    fg: "text-ink-900",
+    dot: "bg-[var(--warn)]",
+  },
+};
+
+export default function HistoryPage() {
+  const locale = useLocale();
+  const [filter, setFilter] = useState<Filter>("all");
+  const [windowDays, setWindowDays] = useState<number | null>(90);
+
+  const signals = useLiveQuery(
+    () => db.change_signals.toArray(),
+    [],
+  );
+  const signalEvents = useLiveQuery(
+    () => db.signal_events.toArray(),
+    [],
+  );
+  const medications = useLiveQuery(() => db.medications.toArray(), []);
+  const medicationEvents = useLiveQuery(
+    () => db.medication_events.toArray(),
+    [],
+  );
+  const careTeamContacts = useLiveQuery(
+    () => db.care_team_contacts.toArray(),
+    [],
+  );
+  const labs = useLiveQuery(() => db.labs.toArray(), []);
+  const imaging = useLiveQuery(() => db.imaging.toArray(), []);
+  const cycles = useLiveQuery(() => db.treatment_cycles.toArray(), []);
+  const dailies = useLiveQuery(() => db.daily_entries.toArray(), []);
+  const decisions = useLiveQuery(() => db.decisions.toArray(), []);
+  const lifeEvents = useLiveQuery(() => db.life_events.toArray(), []);
+
+  const allEntries = useMemo<HistoryEntry[]>(() => {
+    if (
+      !signals ||
+      !signalEvents ||
+      !medications ||
+      !medicationEvents ||
+      !careTeamContacts ||
+      !labs ||
+      !imaging ||
+      !cycles ||
+      !dailies ||
+      !decisions ||
+      !lifeEvents
+    ) {
+      return [];
+    }
+    return aggregateHistory({
+      signals,
+      signalEvents,
+      medications,
+      medicationEvents,
+      careTeamContacts,
+      labs,
+      imaging,
+      cycles,
+      dailyEntries: dailies,
+      decisions,
+      lifeEvents,
+      windowDays: windowDays ?? undefined,
+    });
+  }, [
+    signals,
+    signalEvents,
+    medications,
+    medicationEvents,
+    careTeamContacts,
+    labs,
+    imaging,
+    cycles,
+    dailies,
+    decisions,
+    lifeEvents,
+    windowDays,
+  ]);
+
+  const filtered = useMemo(
+    () =>
+      filter === "all"
+        ? allEntries
+        : allEntries.filter((e) => e.category === filter),
+    [allEntries, filter],
+  );
+
+  const groupedByDate = useMemo(() => groupByDate(filtered), [filtered]);
+
+  const countsByCategory = useMemo(() => {
+    const out: Partial<Record<Filter, number>> = { all: allEntries.length };
+    for (const e of allEntries) {
+      out[e.category] = (out[e.category] ?? 0) + 1;
+    }
+    return out;
+  }, [allEntries]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "全部" : "Everything"}
+        title={locale === "zh" ? "活动历史" : "Activity history"}
+      />
+
+      <div className="flex items-center gap-2">
+        <WindowButton
+          active={windowDays === 30}
+          onClick={() => setWindowDays(30)}
+        >
+          30d
+        </WindowButton>
+        <WindowButton
+          active={windowDays === 90}
+          onClick={() => setWindowDays(90)}
+        >
+          90d
+        </WindowButton>
+        <WindowButton
+          active={windowDays === 365}
+          onClick={() => setWindowDays(365)}
+        >
+          1y
+        </WindowButton>
+        <WindowButton
+          active={windowDays === null}
+          onClick={() => setWindowDays(null)}
+        >
+          {locale === "zh" ? "全部" : "All"}
+        </WindowButton>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {FILTERS.map((f) => {
+          const count = countsByCategory[f.key] ?? 0;
+          if (f.key !== "all" && count === 0) return null;
+          return (
+            <FilterChip
+              key={f.key}
+              active={filter === f.key}
+              onClick={() => setFilter(f.key)}
+              count={count}
+            >
+              {f.key === "all"
+                ? locale === "zh"
+                  ? f.zh
+                  : f.en
+                : locale === "zh"
+                  ? f.zh
+                  : f.en}
+            </FilterChip>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 ? (
+        <Card className="p-5 text-sm text-ink-500">
+          {locale === "zh"
+            ? "此过滤条件下暂无记录。"
+            : "No activity in this view."}
+        </Card>
+      ) : (
+        <div className="space-y-5">
+          {groupedByDate.map(({ date, entries }) => (
+            <DateGroup
+              key={date}
+              date={date}
+              entries={entries}
+              locale={locale}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WindowButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "mono rounded-full border px-3 py-1 text-[10.5px] uppercase tracking-[0.12em] transition-colors",
+        active
+          ? "border-ink-900 bg-ink-900 text-paper"
+          : "border-ink-200 bg-paper text-ink-500 hover:border-ink-400",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function FilterChip({
+  active,
+  onClick,
+  count,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  count?: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12px] transition-colors",
+        active
+          ? "border-[var(--tide-2)] bg-[var(--tide-2)] text-paper"
+          : "border-ink-200 bg-paper text-ink-600 hover:border-ink-400",
+      )}
+    >
+      <span>{children}</span>
+      {typeof count === "number" && count > 0 && (
+        <span
+          className={cn(
+            "mono text-[9.5px] tracking-wider",
+            active ? "text-paper/80" : "text-ink-400",
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function DateGroup({
+  date,
+  entries,
+  locale,
+}: {
+  date: string;
+  entries: HistoryEntry[];
+  locale: "en" | "zh";
+}) {
+  const d = parseISO(date);
+  const label =
+    locale === "zh"
+      ? format(d, "yyyy 年 M 月 d 日 · EEEE")
+      : format(d, "EEEE · d MMM yyyy");
+  return (
+    <section>
+      <div className="mono mb-2 text-[10px] uppercase tracking-[0.14em] text-ink-400">
+        {label}
+      </div>
+      <ul className="space-y-1.5">
+        {entries.map((e) => (
+          <li key={e.id}>
+            <HistoryRow entry={e} locale={locale} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function HistoryRow({
+  entry,
+  locale,
+}: {
+  entry: HistoryEntry;
+  locale: "en" | "zh";
+}) {
+  const Icon = CATEGORY_ICON[entry.category] ?? Bell;
+  const tone = TONE_STYLE[entry.tone];
+  const body = (
+    <div
+      className={cn(
+        "flex items-start gap-3 rounded-[var(--r-md)] px-3.5 py-3 transition-colors",
+        tone.bg,
+      )}
+    >
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-paper text-ink-700 ring-1 ring-ink-100">
+        <Icon className="h-3.5 w-3.5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-2">
+          <div className={cn("text-[13px] font-semibold", tone.fg)}>
+            {entry.title[locale]}
+          </div>
+          <time className="mono shrink-0 text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+            {format(parseISO(entry.at), "HH:mm")}
+          </time>
+        </div>
+        {entry.detail && (
+          <div className={cn("mt-0.5 truncate text-[12px]", tone.fg)}>
+            {entry.detail[locale]}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+  if (entry.href) {
+    return (
+      <Link href={entry.href} className="block">
+        {body}
+      </Link>
+    );
+  }
+  return body;
+}
+
+// Suppress unused-import warning for CheckCircle2 — kept for future use in
+// tone variations.
+void CheckCircle2;

--- a/src/components/daily/morning-checkin.tsx
+++ b/src/components/daily/morning-checkin.tsx
@@ -49,6 +49,8 @@ const INITIAL = {
   walking_minutes: undefined as number | undefined,
   resistance_training: false,
   other_exercise_minutes: undefined as number | undefined,
+  meaningful_interactions: undefined as number | undefined,
+  carer_present: false,
 };
 
 const STEPS = [
@@ -136,6 +138,8 @@ export function MorningCheckin({
         walking_minutes: existing.walking_minutes,
         resistance_training: existing.resistance_training ?? false,
         other_exercise_minutes: existing.other_exercise_minutes,
+        meaningful_interactions: existing.meaningful_interactions,
+        carer_present: existing.carer_present ?? false,
       });
     }
   }, [existing]);
@@ -386,6 +390,39 @@ export function MorningCheckin({
                 label={t("daily.exercise.resistance")}
                 checked={form.resistance_training}
                 onChange={(v) => update("resistance_training", v)}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                {locale === "zh" ? "联系 / 陪伴" : "Contact & company"}
+              </CardTitle>
+              <div className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                {locale === "zh"
+                  ? "有意义的社交接触 —— 当面、电话、视频都算。"
+                  : "Meaningful human contact — in-person, phone, or video all count."}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <NumberField
+                label={
+                  locale === "zh" ? "有意义的互动次数" : "Meaningful interactions"
+                }
+                suffix={locale === "zh" ? "次" : "today"}
+                value={form.meaningful_interactions}
+                step={1}
+                onChange={(v) => update("meaningful_interactions", v)}
+              />
+              <Toggle
+                label={
+                  locale === "zh"
+                    ? "今日有家人 / 照顾者陪伴"
+                    : "Carer or family present today"
+                }
+                checked={form.carer_present}
+                onChange={(v) => update("carer_present", v)}
               />
             </CardContent>
           </Card>

--- a/src/components/dashboard/change-signals-card.tsx
+++ b/src/components/dashboard/change-signals-card.tsx
@@ -66,6 +66,10 @@ export function ChangeSignalsCard() {
   );
   const labs = useLiveQuery(() => db.labs.orderBy("date").toArray(), []);
   const cycles = useLiveQuery(() => db.treatment_cycles.toArray(), []);
+  const careTeamContacts = useLiveQuery(
+    () => db.care_team_contacts.toArray(),
+    [],
+  );
   const openSignalRows = useLiveQuery(
     () => db.change_signals.where("status").equals("open").toArray(),
     [],
@@ -75,7 +79,9 @@ export function ChangeSignalsCard() {
   // Re-evaluate detectors whenever the underlying data changes. The
   // persistence layer dedupes, so repeated evaluations are safe.
   useEffect(() => {
-    if (!dailies || !fortnightlies || !labs || !cycles) return;
+    if (!dailies || !fortnightlies || !labs || !cycles || !careTeamContacts) {
+      return;
+    }
     const asOf = new Date().toISOString();
     const inputs = {
       as_of: asOf,
@@ -87,8 +93,13 @@ export function ChangeSignalsCard() {
     };
     const state = buildPatientState(inputs);
     const observations = extractObservationsByMetric(inputs);
-    void evaluateAndPersistSignals({ state, observations, now: asOf });
-  }, [settings, dailies, fortnightlies, labs, cycles]);
+    void evaluateAndPersistSignals({
+      state,
+      observations,
+      care_team_contacts: careTeamContacts,
+      now: asOf,
+    });
+  }, [settings, dailies, fortnightlies, labs, cycles, careTeamContacts]);
 
   const eventsBySignalId = useMemo(() => {
     const out = new Map<number, SignalEventRow[]>();

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -12,6 +12,8 @@ import {
   Compass,
   Syringe,
   ListTodo,
+  Users,
+  History as HistoryIcon,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { useT } from "~/hooks/use-translate";
@@ -25,7 +27,9 @@ const ITEMS = [
   { href: "/treatment", key: "nav.treatment", icon: Syringe },
   { href: "/labs", key: "nav.labs", icon: FlaskConical },
   { href: "/tasks", key: "nav.tasks", icon: ListTodo },
+  { href: "/care-team", key: "nav.care_team", icon: Users },
   { href: "/bridge", key: "nav.bridge", icon: Route },
+  { href: "/history", key: "nav.history", icon: HistoryIcon },
   { href: "/ingest", key: "nav.ingest", icon: ScanLine },
   { href: "/reports", key: "nav.reports", icon: FileText },
   { href: "/settings", key: "nav.settings", icon: SettingsIcon },

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -1,5 +1,6 @@
 import Dexie, { type Table } from "dexie";
 import type {
+  CareTeamContact,
   ChangeSignalRow,
   DailyEntry,
   WeeklyAssessment,
@@ -45,6 +46,7 @@ export class AnchorDB extends Dexie {
   medication_prompt_events!: Table<MedicationPromptEvent, number>;
   change_signals!: Table<ChangeSignalRow, number>;
   signal_events!: Table<SignalEventRow, number>;
+  care_team_contacts!: Table<CareTeamContact, number>;
   life_events!: Table<LifeEvent, number>;
   decisions!: Table<Decision, number>;
   zone_alerts!: Table<ZoneAlert, number>;
@@ -121,6 +123,13 @@ export class AnchorDB extends Dexie {
     this.version(9).stores({
       signal_events:
         "++id, signal_id, kind, action_ref_id, created_at, [signal_id+created_at]",
+    });
+    // v10: care-team touchpoint log (slice 3 — external axis). Populates
+    // the clinician-gap detector and renders a care-network view. Indexed
+    // by date for fast "last contact" lookups.
+    this.version(10).stores({
+      care_team_contacts:
+        "++id, date, kind, follow_up_needed, follow_up_by",
     });
   }
 }

--- a/src/lib/state/detectors/clinician-gap.ts
+++ b/src/lib/state/detectors/clinician-gap.ts
@@ -1,0 +1,180 @@
+// Clinician-gap detector — event-driven cadence, external axis.
+//
+// Detection shape: days since the most recent care-team touchpoint exceeds
+// an intensity-calibrated threshold. During active chemotherapy, contact
+// gaps > 14 days are anomalous; during maintenance > 28 days is the
+// threshold. The detector reads `care_team_contacts` directly from the
+// DetectorContext because the metric-registry / trajectory shape (rolling
+// means over continuous observations) doesn't fit event-driven data.
+import { rankDifferential, type CandidateCause } from "./differential";
+import type {
+  ChangeSignal,
+  Detector,
+  DetectorContext,
+  SignalEvidence,
+  SuggestedAction,
+} from "./types";
+
+const DETECTOR_ID = "clinician_gap";
+
+const DAYS_MS = 86_400_000;
+
+// Cycle-active thresholds (in days since last touchpoint).
+const ACTIVE_CAUTION_DAYS = 14;
+const ACTIVE_WARNING_DAYS = 21;
+// Maintenance / off-cycle thresholds.
+const MAINT_CAUTION_DAYS = 28;
+const MAINT_WARNING_DAYS = 42;
+
+const CAUSES: readonly CandidateCause[] = [
+  {
+    id: "scheduling_gap",
+    label: {
+      en: "Scheduling gap",
+      zh: "排期间隙",
+    },
+    explanation: {
+      en: "Normal follow-up appears to have slipped — not a clinical issue, but the loop breaks without touchpoints. One call or email re-establishes it.",
+      zh: "常规随访似乎被错过 —— 并非临床问题，但缺乏接触会中断沟通闭环。一次电话或邮件即可重建。",
+    },
+    predicates: [],
+  },
+];
+
+function actionsForSeverity(
+  severity: "caution" | "warning",
+): SuggestedAction[] {
+  const baseline: SuggestedAction[] = [
+    {
+      kind: "task",
+      ref_id: "book_clinic_review",
+      urgency: severity === "warning" ? "now" : "soon",
+      label: {
+        en: "Book next clinic review",
+        zh: "预约下次门诊",
+      },
+    },
+    {
+      kind: "self",
+      ref_id: "call_oncology_team",
+      urgency: severity === "warning" ? "now" : "soon",
+      label: {
+        en: "Call the oncology team to confirm plan",
+        zh: "致电肿瘤团队确认方案",
+      },
+    },
+  ];
+  return baseline;
+}
+
+function latestContact(
+  contacts: readonly { date: string }[],
+  nowISO: string,
+): { latest?: string; days_since: number | null } {
+  if (contacts.length === 0) return { days_since: null };
+  const nowMs = Date.parse(nowISO);
+  const dates = contacts
+    .map((c) => Date.parse(c.date))
+    .filter((t) => Number.isFinite(t))
+    .sort((a, b) => b - a);
+  const latest = dates[0];
+  if (latest == null) return { days_since: null };
+  const daysSince = Math.floor((nowMs - latest) / DAYS_MS);
+  return {
+    latest: new Date(latest).toISOString().slice(0, 10),
+    days_since: daysSince,
+  };
+}
+
+function fortnightKey(iso: string): string {
+  // Two-week dedup window — if a gap persists for longer than a fortnight
+  // a fresh signal should fire (the situation materially worsened).
+  const d = new Date(iso);
+  const days = Math.floor(d.valueOf() / DAYS_MS);
+  const fortnight = Math.floor(days / 14);
+  return `${DETECTOR_ID}:F${fortnight}`;
+}
+
+export const clinicianGapDetector: Detector = {
+  id: DETECTOR_ID,
+
+  evaluate(ctx: DetectorContext): ChangeSignal[] {
+    const contacts = ctx.care_team_contacts ?? [];
+    const cycleActive = !!ctx.state.cycle;
+    const cautionDays = cycleActive ? ACTIVE_CAUTION_DAYS : MAINT_CAUTION_DAYS;
+    const warningDays = cycleActive ? ACTIVE_WARNING_DAYS : MAINT_WARNING_DAYS;
+
+    const { latest, days_since } = latestContact(contacts, ctx.now);
+    if (days_since == null) return [];              // no contact log yet
+    if (days_since < cautionDays) return [];
+
+    const severity = days_since >= warningDays ? "warning" : "caution";
+
+    const evidence: SignalEvidence = {
+      baseline_value: cautionDays,
+      baseline_kind: cycleActive ? "fixed" : "fixed",
+      current_value: days_since,
+      delta_abs: days_since - cautionDays,
+      sd_units: 0,
+      duration_days: days_since,
+    };
+
+    const differential = rankDifferential(ctx.state, CAUSES);
+    const fired_for = fortnightKey(ctx.now);
+
+    const title =
+      severity === "warning"
+        ? {
+            en: `${days_since} days since a care-team contact — book now`,
+            zh: `已 ${days_since} 天未与医疗团队联系 —— 立即预约`,
+          }
+        : {
+            en: `${days_since} days since last care-team contact`,
+            zh: `距上次医疗团队接触已 ${days_since} 天`,
+          };
+    const explanation = cycleActive
+      ? {
+          en: `Active treatment cycles warrant touchpoints at least every ${cautionDays} days. Latest contact: ${latest ?? "—"}.`,
+          zh: `正在治疗周期期间，每 ${cautionDays} 天至少应有一次接触。最近接触：${latest ?? "—"}。`,
+        }
+      : {
+          en: `Maintenance follow-up rhythm is every ${cautionDays}–${warningDays} days. Latest contact: ${latest ?? "—"}.`,
+          zh: `维持期随访节奏约为每 ${cautionDays}–${warningDays} 天一次。最近接触：${latest ?? "—"}。`,
+        };
+
+    return [
+      {
+        detector: DETECTOR_ID,
+        fired_for,
+        metric_id: "days_since_clinician_touchpoint",
+        axis: "external",
+        shape: "rolling_drift",
+        severity,
+        title,
+        explanation,
+        evidence,
+        differential,
+        actions: actionsForSeverity(severity),
+      },
+    ];
+  },
+
+  hasResolved(signal, ctx) {
+    if (signal.detector !== DETECTOR_ID) return false;
+    const contacts = ctx.care_team_contacts ?? [];
+    const cycleActive = !!ctx.state.cycle;
+    const cautionDays = cycleActive ? ACTIVE_CAUTION_DAYS : MAINT_CAUTION_DAYS;
+    const { days_since } = latestContact(contacts, ctx.now);
+    if (days_since == null) return false;
+    return days_since < cautionDays;
+  },
+};
+
+export const _internals = {
+  DETECTOR_ID,
+  ACTIVE_CAUTION_DAYS,
+  ACTIVE_WARNING_DAYS,
+  MAINT_CAUTION_DAYS,
+  MAINT_WARNING_DAYS,
+  latestContact,
+};

--- a/src/lib/state/detectors/index.ts
+++ b/src/lib/state/detectors/index.ts
@@ -5,9 +5,13 @@
 import type { ChangeSignal, Detector, DetectorContext } from "./types";
 import { gripDeclineDetector } from "./grip-decline";
 import { stepsDeclineDetector } from "./steps-decline";
+import { socialIsolationDetector } from "./social-isolation";
+import { clinicianGapDetector } from "./clinician-gap";
 
 export { stepsDeclineDetector } from "./steps-decline";
 export { gripDeclineDetector } from "./grip-decline";
+export { socialIsolationDetector } from "./social-isolation";
+export { clinicianGapDetector } from "./clinician-gap";
 export {
   attributeSignal,
   eventsBySignalId,
@@ -50,6 +54,8 @@ export {
 export const DETECTORS: readonly Detector[] = [
   stepsDeclineDetector,
   gripDeclineDetector,
+  socialIsolationDetector,
+  clinicianGapDetector,
 ];
 
 export function evaluateDetectors(

--- a/src/lib/state/detectors/social-isolation.ts
+++ b/src/lib/state/detectors/social-isolation.ts
@@ -1,0 +1,319 @@
+// Social isolation detector — daily cadence, external axis.
+//
+// Detection shape: 7-day rolling mean of meaningful_interactions ≥ 40%
+// below a 14-day reference window ending 14 days ago, for ≥ 5 consecutive
+// days. Social drift is one of the most actionable external-axis signals
+// — it tracks the patient's support-network engagement independent of
+// disease or toxicity.
+import {
+  consecutiveDaysBelow,
+  rollingMean,
+} from "../variance";
+import { rollingBaseline, preferredBaseline } from "../baselines";
+import {
+  metricAtLeast,
+  metricAtMost,
+  metricDriftingAgainst,
+  rankDifferential,
+  type CandidateCause,
+} from "./differential";
+import type {
+  ChangeSignal,
+  Detector,
+  DetectorContext,
+  SignalEvidence,
+  SuggestedAction,
+} from "./types";
+
+const DETECTOR_ID = "social_isolation";
+const METRIC_ID = "meaningful_interactions";
+
+const ROLLING_WINDOW_DAYS = 7;
+const MIN_OBSERVATIONS_FOR_BASELINE = 7;
+const CAUTION_PCT = 30;
+const WARNING_PCT = 50;
+const MIN_DURATION_DAYS = 5;
+const RESOLVED_WITHIN_PCT = 10;
+
+const CAUSES: readonly CandidateCause[] = [
+  {
+    id: "carer_absence",
+    label: {
+      en: "Carer / family absence",
+      zh: "照顾者 / 家人不在身边",
+    },
+    explanation: {
+      en: "Low carer-present days alongside low interactions suggests the primary support structure has drifted. Worth flagging family / rota discussion.",
+      zh: "照顾者在场率下降与互动减少同时出现，提示主要支持结构发生变化。建议与家人讨论排班。",
+    },
+    required_supporters: 1,
+    predicates: [
+      metricAtMost("carer_present_flag", 0),
+      metricDriftingAgainst("carer_present_flag", "lower", 25),
+    ],
+  },
+  {
+    id: "chemo_exhaustion",
+    label: {
+      en: "Chemo exhaustion limiting contact",
+      zh: "化疗疲惫影响社交",
+    },
+    explanation: {
+      en: "Low energy + low mood alongside reduced interactions often means the patient is too tired to engage rather than socially disconnected. Shifting toward shorter visits or phone calls can help.",
+      zh: "精力与情绪同时下降伴随互动减少，常反映患者太累而非断联。可改为短暂探访或电话。",
+    },
+    required_supporters: 2,
+    predicates: [
+      metricDriftingAgainst("energy", "lower", 20),
+      metricDriftingAgainst("mood_clarity", "lower", 20),
+      metricAtLeast("nausea", 4),
+    ],
+  },
+  {
+    id: "mood_withdrawal",
+    label: {
+      en: "Mood-driven withdrawal",
+      zh: "情绪性回避社交",
+    },
+    explanation: {
+      en: "Low mood + sleep decline alongside low interactions is the depression-withdrawal pattern. Psychology referral is the highest-yield intervention.",
+      zh: "情绪低落、睡眠下降与互动减少 —— 抑郁性回避模式。转介心理学是最高产出干预。",
+    },
+    required_supporters: 2,
+    predicates: [
+      metricDriftingAgainst("mood_clarity", "lower", 20),
+      metricDriftingAgainst("sleep_quality", "lower", 20),
+    ],
+  },
+  {
+    id: "routine_drift",
+    label: {
+      en: "Routine drift — no obvious driver",
+      zh: "生活节奏漂移 —— 无明显原因",
+    },
+    explanation: {
+      en: "No concurrent drivers stand out. A single scheduled family visit or call can reset the trend before it becomes entrenched.",
+      zh: "无明显并发驱动因素。一次安排好的探访或电话可以在趋势变深前重置。",
+    },
+    predicates: [],
+  },
+];
+
+function actionsForCause(causeId: string): SuggestedAction[] {
+  switch (causeId) {
+    case "carer_absence":
+      return [
+        {
+          kind: "conversation",
+          ref_id: "family_rota_discussion",
+          urgency: "soon",
+          label: {
+            en: "Check in with family about carer rota",
+            zh: "与家人讨论照顾者排班",
+          },
+        },
+        {
+          kind: "lever",
+          ref_id: "community.support_services",
+          urgency: "soon",
+          label: {
+            en: "Community nurse / support referral",
+            zh: "社区护理 / 支援转介",
+          },
+        },
+      ];
+    case "chemo_exhaustion":
+      return [
+        {
+          kind: "self",
+          ref_id: "short_visit_preference",
+          urgency: "now",
+          label: {
+            en: "Switch to short visits or calls this week",
+            zh: "本周改为短暂探访或通话",
+          },
+        },
+        {
+          kind: "conversation",
+          ref_id: "family_pace_update",
+          urgency: "soon",
+          label: {
+            en: "Update family about current energy level",
+            zh: "向家人说明当前精力状况",
+          },
+        },
+      ];
+    case "mood_withdrawal":
+      return [
+        {
+          kind: "lever",
+          ref_id: "psychological.psychology",
+          urgency: "soon",
+          label: {
+            en: "Psychology referral",
+            zh: "心理学转介",
+          },
+        },
+        {
+          kind: "self",
+          ref_id: "one_planned_contact",
+          urgency: "now",
+          label: {
+            en: "Plan one specific contact this week",
+            zh: "本周安排一次具体的联系",
+          },
+        },
+      ];
+    case "routine_drift":
+    default:
+      return [
+        {
+          kind: "self",
+          ref_id: "one_planned_contact",
+          urgency: "now",
+          label: {
+            en: "Schedule one call or visit this week",
+            zh: "本周安排一次通话或探访",
+          },
+        },
+      ];
+  }
+}
+
+function isoWeekKey(iso: string): string {
+  const d = new Date(iso);
+  const target = new Date(d.valueOf());
+  const dayNr = (d.getUTCDay() + 6) % 7;
+  target.setUTCDate(target.getUTCDate() - dayNr + 3);
+  const firstThursday = new Date(
+    Date.UTC(target.getUTCFullYear(), 0, 4),
+  );
+  const weekNr =
+    1 +
+    Math.round(
+      ((target.valueOf() - firstThursday.valueOf()) / 86_400_000 -
+        3 +
+        ((firstThursday.getUTCDay() + 6) % 7)) /
+        7,
+    );
+  return `${target.getUTCFullYear()}-W${String(weekNr).padStart(2, "0")}`;
+}
+
+function shiftDays(iso: string, days: number): string {
+  const d = new Date(iso);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString();
+}
+
+export const socialIsolationDetector: Detector = {
+  id: DETECTOR_ID,
+
+  evaluate(ctx: DetectorContext): ChangeSignal[] {
+    const trajectory = ctx.state.metrics[METRIC_ID];
+    const obs = ctx.observations[METRIC_ID] ?? [];
+    if (
+      !trajectory ||
+      !trajectory.fresh ||
+      obs.length < MIN_OBSERVATIONS_FOR_BASELINE
+    ) {
+      return [];
+    }
+
+    const referenceAsOf = shiftDays(ctx.now, -14).slice(0, 10);
+    const referenceBaseline = rollingBaseline(obs, referenceAsOf, 14, 5);
+    const preferred = preferredBaseline(trajectory.baselines);
+    const baseline = referenceBaseline ?? preferred;
+    if (!baseline || typeof baseline.value !== "number" || baseline.value <= 0) {
+      return [];
+    }
+    const baselineValue = baseline.value;
+    const cautionThreshold = baselineValue * (1 - CAUTION_PCT / 100);
+    const warningThreshold = baselineValue * (1 - WARNING_PCT / 100);
+
+    const currentMean = rollingMean(obs, ctx.now, ROLLING_WINDOW_DAYS);
+    if (currentMean == null || currentMean >= cautionThreshold) return [];
+
+    const duration = consecutiveDaysBelow(
+      obs,
+      ctx.now,
+      ROLLING_WINDOW_DAYS,
+      cautionThreshold,
+    );
+    if (duration < MIN_DURATION_DAYS) return [];
+
+    const severity = currentMean <= warningThreshold ? "warning" : "caution";
+
+    const evidence: SignalEvidence = {
+      baseline_value: Math.round(baselineValue * 10) / 10,
+      baseline_kind: baseline.kind,
+      current_value: Math.round(currentMean * 10) / 10,
+      delta_abs: Math.round((currentMean - baselineValue) * 10) / 10,
+      sd_units: 0,
+      duration_days: duration,
+    };
+
+    const differential = rankDifferential(ctx.state, CAUSES);
+    const topCause =
+      differential.find((d) => d.confidence !== "unlikely") ??
+      differential[0];
+    const actions = topCause ? actionsForCause(topCause.id) : [];
+
+    const fired_for = `${DETECTOR_ID}:${isoWeekKey(ctx.now)}`;
+    const title =
+      severity === "warning"
+        ? {
+            en: `Social contact has halved (${evidence.current_value} vs ${evidence.baseline_value}/day)`,
+            zh: `社交联系减半（当前 ${evidence.current_value}，基线 ${evidence.baseline_value} 每日）`,
+          }
+        : {
+            en: `Social contact drifting down (${evidence.current_value} vs ${evidence.baseline_value}/day)`,
+            zh: `社交联系下降（当前 ${evidence.current_value}，基线 ${evidence.baseline_value} 每日）`,
+          };
+
+    const explanation = {
+      en: "Social connectedness is the external-axis signal with the most direct link to mood + motivation. Even one scheduled contact resets the trajectory.",
+      zh: "社交连接是外部维度中与情绪 / 动力最直接相关的信号。哪怕一次计划好的联系也能扭转趋势。",
+    };
+
+    return [
+      {
+        detector: DETECTOR_ID,
+        fired_for,
+        metric_id: METRIC_ID,
+        axis: "external",
+        shape: "rolling_drift",
+        severity,
+        title,
+        explanation,
+        evidence,
+        differential,
+        actions,
+      },
+    ];
+  },
+
+  hasResolved(signal, ctx) {
+    if (signal.detector !== DETECTOR_ID) return false;
+    const trajectory = ctx.state.metrics[METRIC_ID];
+    const obs = ctx.observations[METRIC_ID] ?? [];
+    if (
+      !trajectory ||
+      !trajectory.fresh ||
+      obs.length < MIN_OBSERVATIONS_FOR_BASELINE
+    ) {
+      return false;
+    }
+    const referenceAsOf = shiftDays(ctx.now, -14).slice(0, 10);
+    const referenceBaseline = rollingBaseline(obs, referenceAsOf, 14, 5);
+    const preferred = preferredBaseline(trajectory.baselines);
+    const baseline = referenceBaseline ?? preferred;
+    if (!baseline || typeof baseline.value !== "number" || baseline.value <= 0) {
+      return false;
+    }
+    const currentMean = rollingMean(obs, ctx.now, ROLLING_WINDOW_DAYS);
+    if (currentMean == null) return false;
+    return currentMean >= baseline.value * (1 - RESOLVED_WITHIN_PCT / 100);
+  },
+};
+
+export const _internals = { CAUSES, actionsForCause, DETECTOR_ID, METRIC_ID };

--- a/src/lib/state/detectors/types.ts
+++ b/src/lib/state/detectors/types.ts
@@ -6,6 +6,7 @@
 // / clinician can take.
 import type { Axis, Observation, PatientStateSnapshot } from "../types";
 import type { LocalizedText } from "~/types/treatment";
+import type { CareTeamContact } from "~/types/clinical";
 
 export type SignalSeverity = "caution" | "warning";
 
@@ -103,6 +104,10 @@ export interface DetectorContext {
   // rather than re-deriving from dexie. Populated by the state module's
   // `extractObservationsByMetric()` helper.
   observations: Record<string, Observation[]>;
+  // External-axis data that doesn't fit the metric-trajectory shape —
+  // currently just care-team contacts for the clinician-gap detector.
+  // Optional so existing callers / tests don't need to populate it.
+  care_team_contacts?: readonly CareTeamContact[];
   now: string;                     // ISO, deterministic for tests
 }
 

--- a/src/lib/state/history.ts
+++ b/src/lib/state/history.ts
@@ -1,0 +1,430 @@
+// Unified activity aggregator — pulls every time-stamped row from the
+// Dexie tables and produces a single chronological stream for the
+// /history view. Pure function: caller does the Dexie reads and passes
+// the rows in so this module is trivially testable and stays decoupled
+// from storage.
+import type {
+  CareTeamContact,
+  ChangeSignalRow,
+  DailyEntry,
+  Decision,
+  Imaging,
+  LabResult,
+  LifeEvent,
+  SignalEventRow,
+} from "~/types/clinical";
+import type { TreatmentCycle } from "~/types/treatment";
+import type { Medication, MedicationEvent } from "~/types/medication";
+
+export type HistoryCategory =
+  | "signal"
+  | "action"
+  | "medication"
+  | "care_team"
+  | "lab"
+  | "imaging"
+  | "treatment"
+  | "check_in"
+  | "decision"
+  | "life_event";
+
+export type HistoryTone = "info" | "positive" | "caution" | "warning";
+
+export interface LocalizedText {
+  en: string;
+  zh: string;
+}
+
+export interface HistoryEntry {
+  // Stable identifier composed from source table + id + variant, so the
+  // UI can key off it across re-renders even when new rows arrive.
+  id: string;
+  category: HistoryCategory;
+  at: string;              // ISO
+  title: LocalizedText;
+  detail?: LocalizedText;
+  tone: HistoryTone;
+  href?: string;
+}
+
+export interface AggregateInputs {
+  signals: readonly ChangeSignalRow[];
+  signalEvents: readonly SignalEventRow[];
+  medications: readonly Medication[];
+  medicationEvents: readonly MedicationEvent[];
+  careTeamContacts: readonly CareTeamContact[];
+  labs: readonly LabResult[];
+  imaging: readonly Imaging[];
+  cycles: readonly TreatmentCycle[];
+  dailyEntries: readonly DailyEntry[];
+  decisions: readonly Decision[];
+  lifeEvents: readonly LifeEvent[];
+  // Optional filter window — only include entries within the last N days.
+  // Undefined ⇒ include all.
+  windowDays?: number;
+  now?: string;            // for tests
+}
+
+const DAYS_MS = 86_400_000;
+
+function inWindow(iso: string | undefined, fromMs: number | null): boolean {
+  if (!iso) return false;
+  if (fromMs == null) return true;
+  const t = Date.parse(iso);
+  return !Number.isNaN(t) && t >= fromMs;
+}
+
+// ─── Entry builders ───────────────────────────────────────────────────────
+
+function signalEntries(
+  signals: readonly ChangeSignalRow[],
+): HistoryEntry[] {
+  const out: HistoryEntry[] = [];
+  for (const s of signals) {
+    out.push({
+      id: `signal-emitted-${s.id}`,
+      category: "signal",
+      at: s.detected_at,
+      title: {
+        en: titleFromSignal(s, "emitted"),
+        zh: titleFromSignalZh(s, "emitted"),
+      },
+      detail: {
+        en: `${s.detector} · ${s.axis}`,
+        zh: `${s.detector} · ${s.axis}`,
+      },
+      tone: s.severity === "warning" ? "warning" : "caution",
+      href: "/signals",
+    });
+    if (s.status === "resolved" && s.resolved_at) {
+      out.push({
+        id: `signal-resolved-${s.id}`,
+        category: "signal",
+        at: s.resolved_at,
+        title: {
+          en: titleFromSignal(s, "resolved"),
+          zh: titleFromSignalZh(s, "resolved"),
+        },
+        detail: {
+          en: `${s.detector} · ${s.axis}`,
+          zh: `${s.detector} · ${s.axis}`,
+        },
+        tone: "positive",
+        href: "/signals",
+      });
+    }
+  }
+  return out;
+}
+
+function titleFromSignal(
+  s: ChangeSignalRow,
+  kind: "emitted" | "resolved",
+): string {
+  const name = s.detector.replace(/_/g, " ");
+  return kind === "emitted"
+    ? `Signal: ${name}`
+    : `Signal resolved: ${name}`;
+}
+function titleFromSignalZh(
+  s: ChangeSignalRow,
+  kind: "emitted" | "resolved",
+): string {
+  return kind === "emitted"
+    ? `信号触发：${s.detector}`
+    : `信号解决：${s.detector}`;
+}
+
+function actionEntries(
+  signalEvents: readonly SignalEventRow[],
+): HistoryEntry[] {
+  return signalEvents
+    .filter((e) => e.kind === "action_taken" && e.action_ref_id)
+    .map((e) => ({
+      id: `action-${e.id}`,
+      category: "action" as const,
+      at: e.created_at,
+      title: {
+        en: `Action taken: ${e.action_ref_id}`,
+        zh: `采取行动：${e.action_ref_id}`,
+      },
+      detail: e.action_kind
+        ? { en: e.action_kind, zh: e.action_kind }
+        : undefined,
+      tone: "positive" as const,
+      href: "/signals",
+    }));
+}
+
+function medicationEntries(
+  events: readonly MedicationEvent[],
+  meds: readonly Medication[],
+): HistoryEntry[] {
+  const medById = new Map<number, Medication>();
+  for (const m of meds) {
+    if (m.id != null) medById.set(m.id, m);
+  }
+  return events.map((e) => {
+    const med = medById.get(e.medication_id);
+    const name = med?.display_name ?? e.drug_id;
+    const status =
+      e.event_type === "taken"
+        ? "taken"
+        : e.event_type === "missed"
+          ? "missed"
+          : "side effect";
+    return {
+      id: `med-${e.id}`,
+      category: "medication" as const,
+      at: e.logged_at,
+      title: {
+        en: `${name} — ${status}`,
+        zh: `${name} —— ${
+          e.event_type === "taken"
+            ? "已服用"
+            : e.event_type === "missed"
+              ? "漏服"
+              : "副作用"
+        }`,
+      },
+      detail: e.dose_taken
+        ? { en: e.dose_taken, zh: e.dose_taken }
+        : undefined,
+      tone:
+        e.event_type === "taken"
+          ? ("positive" as const)
+          : e.event_type === "missed"
+            ? ("caution" as const)
+            : ("info" as const),
+      href: med?.id ? `/medications/${med.id}` : "/medications",
+    };
+  });
+}
+
+function careTeamEntries(
+  contacts: readonly CareTeamContact[],
+): HistoryEntry[] {
+  return contacts
+    .filter((c) => c.id != null)
+    .map((c) => ({
+      id: `care-${c.id}`,
+      category: "care_team" as const,
+      at: `${c.date}T12:00:00Z`,
+      title: {
+        en: `Care team · ${c.kind.replace(/_/g, " ")}`,
+        zh: `医疗团队 · ${c.kind}`,
+      },
+      detail:
+        c.with_who || c.notes
+          ? {
+              en: [c.with_who, c.notes].filter(Boolean).join(" — "),
+              zh: [c.with_who, c.notes].filter(Boolean).join(" —— "),
+            }
+          : undefined,
+      tone: c.follow_up_needed ? ("caution" as const) : ("info" as const),
+      href: "/care-team",
+    }));
+}
+
+function labEntries(labs: readonly LabResult[]): HistoryEntry[] {
+  return labs
+    .filter((l) => l.id != null)
+    .map((l) => {
+      const flagged: string[] = [];
+      if (l.ca199) flagged.push(`CA19-9 ${l.ca199}`);
+      if (l.neutrophils != null) flagged.push(`ANC ${l.neutrophils}`);
+      if (l.hemoglobin != null) flagged.push(`Hb ${l.hemoglobin}`);
+      if (l.alt != null && l.alt >= 100) flagged.push(`ALT ${l.alt}↑`);
+      const detail = flagged.join(" · ");
+      return {
+        id: `lab-${l.id}`,
+        category: "lab" as const,
+        at: `${l.date}T08:00:00Z`,
+        title: {
+          en: `Labs received`,
+          zh: `化验结果`,
+        },
+        detail: detail ? { en: detail, zh: detail } : undefined,
+        tone: "info" as const,
+        href: "/labs",
+      };
+    });
+}
+
+function imagingEntries(imaging: readonly Imaging[]): HistoryEntry[] {
+  return imaging
+    .filter((i) => i.id != null)
+    .map((i) => ({
+      id: `img-${i.id}`,
+      category: "imaging" as const,
+      at: `${i.date}T08:00:00Z`,
+      title: {
+        en: `Imaging · ${i.modality}${i.recist_status ? ` · ${i.recist_status}` : ""}`,
+        zh: `影像 · ${i.modality}${i.recist_status ? ` · ${i.recist_status}` : ""}`,
+      },
+      detail: { en: i.findings_summary, zh: i.findings_summary },
+      tone:
+        i.recist_status === "PD"
+          ? ("warning" as const)
+          : i.recist_status === "PR" || i.recist_status === "CR"
+            ? ("positive" as const)
+            : ("info" as const),
+      href: "/labs",
+    }));
+}
+
+function cycleEntries(
+  cycles: readonly TreatmentCycle[],
+): HistoryEntry[] {
+  const out: HistoryEntry[] = [];
+  for (const c of cycles) {
+    if (c.id == null) continue;
+    out.push({
+      id: `cycle-start-${c.id}`,
+      category: "treatment",
+      at: `${c.start_date}T08:00:00Z`,
+      title: {
+        en: `Cycle ${c.cycle_number} started — ${c.protocol_id}`,
+        zh: `周期 ${c.cycle_number} 开始 — ${c.protocol_id}`,
+      },
+      tone: "info",
+      href: `/treatment/${c.id}`,
+    });
+    if (c.actual_end_date) {
+      out.push({
+        id: `cycle-end-${c.id}`,
+        category: "treatment",
+        at: `${c.actual_end_date}T18:00:00Z`,
+        title: {
+          en: `Cycle ${c.cycle_number} ended`,
+          zh: `周期 ${c.cycle_number} 结束`,
+        },
+        tone: "info",
+        href: `/treatment/${c.id}`,
+      });
+    }
+  }
+  return out;
+}
+
+function dailyCheckinEntries(
+  dailies: readonly DailyEntry[],
+): HistoryEntry[] {
+  return dailies
+    .filter((d) => d.id != null)
+    .map((d) => {
+      const flags: string[] = [];
+      if (d.fever) flags.push("fever");
+      if (d.nausea >= 5) flags.push(`nausea ${d.nausea}`);
+      if ((d.diarrhoea_count ?? 0) >= 3) flags.push(`diarrhoea ${d.diarrhoea_count}`);
+      if (d.neuropathy_hands) flags.push("neuropathy hands");
+      if (d.neuropathy_feet) flags.push("neuropathy feet");
+      if (d.cold_dysaesthesia) flags.push("cold dysaesthesia");
+      const weight =
+        typeof d.weight_kg === "number" ? `${d.weight_kg} kg` : null;
+      const parts = [
+        `energy ${d.energy}/10`,
+        `sleep ${d.sleep_quality}/10`,
+        weight,
+        ...flags,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+      const hasFlags = flags.length > 0;
+      return {
+        id: `daily-${d.id}`,
+        category: "check_in" as const,
+        at: d.entered_at ?? `${d.date}T08:00:00Z`,
+        title: {
+          en: `Daily check-in`,
+          zh: `每日记录`,
+        },
+        detail: parts ? { en: parts, zh: parts } : undefined,
+        tone: (d.fever ? "warning" : hasFlags ? "caution" : "info") as HistoryTone,
+        href: d.id ? `/daily/${d.id}` : "/daily",
+      };
+    });
+}
+
+function decisionEntries(
+  decisions: readonly Decision[],
+): HistoryEntry[] {
+  return decisions
+    .filter((d) => d.id != null)
+    .map((d) => ({
+      id: `decision-${d.id}`,
+      category: "decision" as const,
+      at: `${d.decision_date}T12:00:00Z`,
+      title: { en: `Decision: ${d.title}`, zh: `决策：${d.title}` },
+      detail: { en: d.decision, zh: d.decision },
+      tone: "info" as const,
+      href: `/decisions`,
+    }));
+}
+
+function lifeEventEntries(
+  events: readonly LifeEvent[],
+): HistoryEntry[] {
+  return events
+    .filter((e) => e.id != null)
+    .map((e) => ({
+      id: `life-${e.id}`,
+      category: "life_event" as const,
+      at: `${e.event_date}T12:00:00Z`,
+      title: { en: e.title, zh: e.title },
+      detail: e.notes ? { en: e.notes, zh: e.notes } : undefined,
+      tone: "info" as const,
+      href: "/events",
+    }));
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────
+
+export function aggregateHistory(
+  inputs: AggregateInputs,
+): HistoryEntry[] {
+  const nowMs = inputs.now
+    ? Date.parse(inputs.now)
+    : Date.now();
+  const fromMs =
+    typeof inputs.windowDays === "number"
+      ? nowMs - inputs.windowDays * DAYS_MS
+      : null;
+
+  const all: HistoryEntry[] = [
+    ...signalEntries(inputs.signals),
+    ...actionEntries(inputs.signalEvents),
+    ...medicationEntries(inputs.medicationEvents, inputs.medications),
+    ...careTeamEntries(inputs.careTeamContacts),
+    ...labEntries(inputs.labs),
+    ...imagingEntries(inputs.imaging),
+    ...cycleEntries(inputs.cycles),
+    ...dailyCheckinEntries(inputs.dailyEntries),
+    ...decisionEntries(inputs.decisions),
+    ...lifeEventEntries(inputs.lifeEvents),
+  ];
+
+  return all
+    .filter((e) => inWindow(e.at, fromMs))
+    .sort((a, b) => Date.parse(b.at) - Date.parse(a.at));
+}
+
+/**
+ * Group entries by calendar date (YYYY-MM-DD) in the order they appear.
+ * Useful for rendering date headers in the UI.
+ */
+export function groupByDate(
+  entries: readonly HistoryEntry[],
+): { date: string; entries: HistoryEntry[] }[] {
+  const out: { date: string; entries: HistoryEntry[] }[] = [];
+  let current: { date: string; entries: HistoryEntry[] } | null = null;
+  for (const e of entries) {
+    const day = e.at.slice(0, 10);
+    if (!current || current.date !== day) {
+      current = { date: day, entries: [] };
+      out.push(current);
+    }
+    current.entries.push(e);
+  }
+  return out;
+}

--- a/src/lib/state/metrics.ts
+++ b/src/lib/state/metrics.ts
@@ -403,10 +403,29 @@ const DRUG: RegisteredMetric[] = [
 ];
 
 // ─── External axis ─────────────────────────────────────────────────────────
-// Slice 1 scope: placeholder axis with no registered metrics yet.
-// Slice 2+ adds weather + social + care-team signals.
+// Slice 3 populates this with patient-reported social-connectedness signals.
+// Weather and care-team-contact metrics are derived at detector-time rather
+// than captured per day, so they don't appear here.
 
-const EXTERNAL: RegisteredMetric[] = [];
+const EXTERNAL: RegisteredMetric[] = [
+  {
+    id: "meaningful_interactions",
+    axis: "external",
+    polarity: "higher_better",
+    cadence_days: 1,
+    label: "Meaningful interactions",
+    unit: "count/day",
+    ...daily("meaningful_interactions", "meaningful_interactions"),
+  },
+  {
+    id: "carer_present_flag",
+    axis: "external",
+    polarity: "higher_better",
+    cadence_days: 1,
+    label: "Carer presence (daily flag)",
+    ...dailyBool("carer_present_flag", "carer_present"),
+  },
+];
 
 export const METRIC_REGISTRY: readonly RegisteredMetric[] = [
   ...INDIVIDUAL,

--- a/src/lib/validators/schemas.ts
+++ b/src/lib/validators/schemas.ts
@@ -36,6 +36,8 @@ export const dailyEntrySchema = z.object({
   walking_minutes: z.number().min(0).max(720).optional(),
   resistance_training: z.boolean().optional(),
   other_exercise_minutes: z.number().min(0).max(720).optional(),
+  meaningful_interactions: z.number().int().min(0).max(50).optional(),
+  carer_present: z.boolean().optional(),
 });
 
 export type DailyEntryInput = z.infer<typeof dailyEntrySchema>;

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -46,6 +46,15 @@ export interface DailyEntry {
   resistance_training?: boolean;
   other_exercise_minutes?: number;
   height_cm?: number;
+  // External-axis inputs (slice 3). Daily count of meaningful human
+  // interactions — in-person visits, phone calls, video calls that lasted
+  // long enough to matter. Deliberately patient-subjective, not raw call
+  // count, so it tracks social connectedness rather than phone activity.
+  meaningful_interactions?: number;
+  // True if a family member / carer was physically present for part of the
+  // day. A simpler binary that catches carer-absence drift independent of
+  // total-contacts count.
+  carer_present?: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -271,6 +280,35 @@ export interface SignalEventRow {
   action_kind?: string;             // "lever" | "task" | "question" | ...
   note?: string;
   created_at: string;
+}
+
+// External-axis: log of care-team touchpoints (clinician calls, clinic
+// visits, community nurse, allied health). Powers the clinician-gap
+// detector and lets the patient see their support-network activity over
+// time. Distinct from PatientTask (which is prospective / scheduling) —
+// this is retrospective / what actually happened.
+export type CareTeamContactKind =
+  | "clinic_visit"         // in-person visit with the oncologist / team
+  | "clinician_call"       // phone / telehealth with oncology team
+  | "specialist_visit"     // non-oncology specialist (HPB surgeon, etc.)
+  | "community_nurse"      // home or community nursing contact
+  | "allied_health"        // dietitian, physio, psychology, etc.
+  | "hospital_admission"   // inpatient stay
+  | "emergency_department"
+  | "pharmacist"
+  | "other";
+
+export interface CareTeamContact {
+  id?: number;
+  date: string;                      // ISO date
+  kind: CareTeamContactKind;
+  with_who?: string;                 // clinician / service name
+  duration_min?: number;
+  notes?: string;
+  follow_up_needed?: boolean;
+  follow_up_by?: string;             // ISO date for next action
+  created_at: string;
+  updated_at: string;
 }
 
 export interface LifeEvent {

--- a/tests/unit/external-detectors.test.ts
+++ b/tests/unit/external-detectors.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPatientState,
+  extractObservationsByMetric,
+  type BuildStateInputs,
+} from "~/lib/state";
+import {
+  socialIsolationDetector,
+  clinicianGapDetector,
+} from "~/lib/state/detectors";
+import type { CareTeamContact, DailyEntry } from "~/types/clinical";
+import type { TreatmentCycle } from "~/types/treatment";
+
+function makeDaily(
+  date: string,
+  overrides: Partial<DailyEntry> = {},
+): DailyEntry {
+  return {
+    date,
+    entered_at: `${date}T08:00:00Z`,
+    entered_by: "hulin",
+    energy: 7,
+    sleep_quality: 7,
+    appetite: 7,
+    pain_worst: 2,
+    pain_current: 1,
+    mood_clarity: 7,
+    nausea: 1,
+    practice_morning_completed: true,
+    practice_evening_completed: true,
+    cold_dysaesthesia: false,
+    neuropathy_hands: false,
+    neuropathy_feet: false,
+    mouth_sores: false,
+    diarrhoea_count: 0,
+    new_bruising: false,
+    dyspnoea: false,
+    fever: false,
+    created_at: `${date}T08:00:00Z`,
+    updated_at: `${date}T08:00:00Z`,
+    ...overrides,
+  };
+}
+
+function synthDaysWithInteractions(
+  startISO: string,
+  values: number[],
+  overrides: Partial<DailyEntry> = {},
+): DailyEntry[] {
+  const out: DailyEntry[] = [];
+  const start = new Date(startISO).getTime();
+  values.forEach((v, i) => {
+    const d = new Date(start + i * 86_400_000).toISOString().slice(0, 10);
+    out.push(
+      makeDaily(d, {
+        meaningful_interactions: v,
+        carer_present: v > 0,
+        ...overrides,
+      }),
+    );
+  });
+  return out;
+}
+
+function ctxFromInputs(
+  inputs: BuildStateInputs,
+  care_team_contacts: CareTeamContact[] = [],
+) {
+  return {
+    state: buildPatientState(inputs),
+    observations: extractObservationsByMetric(inputs),
+    care_team_contacts,
+    now: inputs.as_of,
+  };
+}
+
+const EMPTY_INPUTS: BuildStateInputs = {
+  as_of: "2026-04-15",
+  settings: null,
+  dailies: [],
+  fortnightlies: [],
+  labs: [],
+  cycles: [],
+};
+
+// ─── socialIsolationDetector ──────────────────────────────────────────────
+
+describe("socialIsolationDetector", () => {
+  it("is silent without enough history", () => {
+    const dailies = synthDaysWithInteractions("2026-04-10", [4, 4, 4]);
+    const ctx = ctxFromInputs({ ...EMPTY_INPUTS, dailies });
+    expect(socialIsolationDetector.evaluate(ctx)).toEqual([]);
+  });
+
+  it("fires when interactions drop ≥30% below reference for ≥5 consecutive days", () => {
+    // 14 days baseline at 5 interactions/day, then 14 days at 2 interactions/day
+    const dailies = synthDaysWithInteractions("2026-03-19", [
+      ...Array.from({ length: 14 }, () => 5),
+      ...Array.from({ length: 14 }, () => 2),
+    ]);
+    const ctx = ctxFromInputs({ ...EMPTY_INPUTS, dailies });
+    const signals = socialIsolationDetector.evaluate(ctx);
+    expect(signals).toHaveLength(1);
+    const s = signals[0]!;
+    expect(s.detector).toBe("social_isolation");
+    expect(s.axis).toBe("external");
+    expect(s.severity).toBe("warning"); // 2/5 = 60% drop
+    expect(s.fired_for).toMatch(/^social_isolation:\d{4}-W\d{2}$/);
+  });
+
+  it("escalates to warning when drop is ≥50%", () => {
+    const dailies = synthDaysWithInteractions("2026-03-19", [
+      ...Array.from({ length: 14 }, () => 6),
+      ...Array.from({ length: 14 }, () => 1),
+    ]);
+    const ctx = ctxFromInputs({ ...EMPTY_INPUTS, dailies });
+    expect(socialIsolationDetector.evaluate(ctx)[0]!.severity).toBe("warning");
+  });
+
+  it("attaches mood_withdrawal differential when concurrent mood + sleep drop", () => {
+    // Long clean baseline at high contact + mood + sleep
+    const baseline = synthDaysWithInteractions(
+      "2026-03-01",
+      Array.from({ length: 28 }, () => 5),
+      { mood_clarity: 8, sleep_quality: 8 },
+    );
+    // Recent drift in ALL three
+    const drift = synthDaysWithInteractions(
+      "2026-03-29",
+      Array.from({ length: 8 }, () => 2),
+      { mood_clarity: 3, sleep_quality: 3 },
+    );
+    const ctx = ctxFromInputs({
+      ...EMPTY_INPUTS,
+      as_of: "2026-04-05",
+      dailies: [...baseline, ...drift],
+    });
+    const signal = socialIsolationDetector.evaluate(ctx)[0]!;
+    const top = signal.differential.find((d) => d.confidence !== "unlikely");
+    expect(top?.id).toBe("mood_withdrawal");
+  });
+
+  it("auto-resolves when interactions recover", () => {
+    const dailies = synthDaysWithInteractions("2026-03-19", [
+      ...Array.from({ length: 14 }, () => 5),
+      ...Array.from({ length: 14 }, () => 2),
+    ]);
+    const ctxDroopy = ctxFromInputs({ ...EMPTY_INPUTS, dailies });
+    const emitted = socialIsolationDetector.evaluate(ctxDroopy)[0]!;
+    expect(socialIsolationDetector.hasResolved(emitted, ctxDroopy)).toBe(false);
+
+    const recovered = synthDaysWithInteractions("2026-03-19", [
+      ...Array.from({ length: 14 }, () => 5),
+      ...Array.from({ length: 14 }, () => 2),
+      ...Array.from({ length: 7 }, () => 5),
+    ]);
+    const ctxRecovered = ctxFromInputs({
+      ...EMPTY_INPUTS,
+      as_of: recovered[recovered.length - 1]!.date,
+      dailies: recovered,
+    });
+    expect(
+      socialIsolationDetector.hasResolved(emitted, ctxRecovered),
+    ).toBe(true);
+  });
+});
+
+// ─── clinicianGapDetector ─────────────────────────────────────────────────
+
+function contact(
+  date: string,
+  overrides: Partial<CareTeamContact> = {},
+): CareTeamContact {
+  return {
+    date,
+    kind: "clinic_visit",
+    created_at: `${date}T09:00:00Z`,
+    updated_at: `${date}T09:00:00Z`,
+    ...overrides,
+  };
+}
+
+function activeCycle(start_date = "2026-04-01"): TreatmentCycle {
+  return {
+    id: 1,
+    protocol_id: "gnp_weekly",
+    cycle_number: 1,
+    start_date,
+    status: "active",
+    dose_level: 0,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+describe("clinicianGapDetector", () => {
+  it("is silent when no contacts have been logged", () => {
+    const ctx = ctxFromInputs(EMPTY_INPUTS, []);
+    expect(clinicianGapDetector.evaluate(ctx)).toEqual([]);
+  });
+
+  it("is silent when last contact is within active-cycle caution window (14d)", () => {
+    const inputs = {
+      ...EMPTY_INPUTS,
+      as_of: "2026-04-15",
+      cycles: [activeCycle("2026-04-01")],
+    };
+    const ctx = ctxFromInputs(inputs, [contact("2026-04-10")]);
+    expect(clinicianGapDetector.evaluate(ctx)).toEqual([]);
+  });
+
+  it("fires caution at 14 days since last contact during active cycle", () => {
+    const inputs = {
+      ...EMPTY_INPUTS,
+      as_of: "2026-04-15",
+      cycles: [activeCycle("2026-04-01")],
+    };
+    const ctx = ctxFromInputs(inputs, [contact("2026-04-01")]);
+    const signals = clinicianGapDetector.evaluate(ctx);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.severity).toBe("caution");
+    expect(signals[0]!.axis).toBe("external");
+    expect(signals[0]!.evidence.current_value).toBe(14);
+  });
+
+  it("escalates to warning at 21+ days during active cycle", () => {
+    const inputs = {
+      ...EMPTY_INPUTS,
+      as_of: "2026-04-25",
+      cycles: [activeCycle("2026-04-01")],
+    };
+    const ctx = ctxFromInputs(inputs, [contact("2026-04-01")]);
+    expect(clinicianGapDetector.evaluate(ctx)[0]!.severity).toBe("warning");
+  });
+
+  it("uses a longer threshold when no active cycle (maintenance)", () => {
+    // 20 days gap + no cycle = below the 28d maintenance caution threshold.
+    const inputs = {
+      ...EMPTY_INPUTS,
+      as_of: "2026-04-21",
+    };
+    const ctx = ctxFromInputs(inputs, [contact("2026-04-01")]);
+    expect(clinicianGapDetector.evaluate(ctx)).toEqual([]);
+  });
+
+  it("fires at 28+ days without an active cycle", () => {
+    const inputs = {
+      ...EMPTY_INPUTS,
+      as_of: "2026-04-29",
+    };
+    const ctx = ctxFromInputs(inputs, [contact("2026-04-01")]);
+    const signals = clinicianGapDetector.evaluate(ctx);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.severity).toBe("caution");
+  });
+
+  it("auto-resolves once a new contact is logged within the caution window", () => {
+    const inputs = {
+      ...EMPTY_INPUTS,
+      as_of: "2026-04-15",
+      cycles: [activeCycle("2026-04-01")],
+    };
+    const ctxOpen = ctxFromInputs(inputs, [contact("2026-04-01")]);
+    const emitted = clinicianGapDetector.evaluate(ctxOpen)[0]!;
+
+    const ctxResolved = ctxFromInputs(inputs, [
+      contact("2026-04-01"),
+      contact("2026-04-14"),
+    ]);
+    expect(clinicianGapDetector.hasResolved(emitted, ctxResolved)).toBe(true);
+  });
+});

--- a/tests/unit/history.test.ts
+++ b/tests/unit/history.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { aggregateHistory, groupByDate } from "~/lib/state/history";
+import type {
+  CareTeamContact,
+  ChangeSignalRow,
+  DailyEntry,
+  LabResult,
+  SignalEventRow,
+} from "~/types/clinical";
+import type { TreatmentCycle } from "~/types/treatment";
+
+function signal(
+  over: Partial<ChangeSignalRow> = {},
+): ChangeSignalRow {
+  return {
+    id: 1,
+    detector: "steps_decline",
+    fired_for: "steps_decline:2026-W15",
+    metric_id: "steps",
+    axis: "individual",
+    severity: "caution",
+    shape: "rolling_drift",
+    status: "open",
+    payload_json: "{}",
+    detected_at: "2026-04-10T08:00:00Z",
+    ...over,
+  };
+}
+
+function signalEvent(
+  over: Partial<SignalEventRow> = {},
+): SignalEventRow {
+  return {
+    signal_id: 1,
+    kind: "emitted",
+    created_at: "2026-04-10T08:00:00Z",
+    ...over,
+  };
+}
+
+function careContact(
+  date: string,
+  over: Partial<CareTeamContact> = {},
+): CareTeamContact {
+  return {
+    date,
+    kind: "clinic_visit",
+    created_at: `${date}T09:00:00Z`,
+    updated_at: `${date}T09:00:00Z`,
+    ...over,
+    id: over.id ?? 10,
+  };
+}
+
+function daily(date: string, over: Partial<DailyEntry> = {}): DailyEntry {
+  return {
+    id: 99,
+    date,
+    entered_at: `${date}T09:00:00Z`,
+    entered_by: "hulin",
+    energy: 6,
+    sleep_quality: 6,
+    appetite: 6,
+    pain_worst: 2,
+    pain_current: 1,
+    mood_clarity: 6,
+    nausea: 1,
+    practice_morning_completed: true,
+    practice_evening_completed: true,
+    cold_dysaesthesia: false,
+    neuropathy_hands: false,
+    neuropathy_feet: false,
+    mouth_sores: false,
+    diarrhoea_count: 0,
+    new_bruising: false,
+    dyspnoea: false,
+    fever: false,
+    created_at: `${date}T09:00:00Z`,
+    updated_at: `${date}T09:00:00Z`,
+    ...over,
+  };
+}
+
+function lab(date: string, over: Partial<LabResult> = {}): LabResult {
+  return {
+    id: 50,
+    date,
+    source: "epworth",
+    created_at: `${date}T08:00:00Z`,
+    updated_at: `${date}T08:00:00Z`,
+    ...over,
+  };
+}
+
+function cycle(
+  over: Partial<TreatmentCycle> = {},
+): TreatmentCycle {
+  return {
+    id: 7,
+    protocol_id: "gnp_weekly",
+    cycle_number: 3,
+    start_date: "2026-04-01",
+    status: "active",
+    dose_level: 0,
+    created_at: "",
+    updated_at: "",
+    ...over,
+  };
+}
+
+const EMPTY = {
+  signals: [],
+  signalEvents: [],
+  medications: [],
+  medicationEvents: [],
+  careTeamContacts: [],
+  labs: [],
+  imaging: [],
+  cycles: [],
+  dailyEntries: [],
+  decisions: [],
+  lifeEvents: [],
+};
+
+describe("aggregateHistory", () => {
+  it("returns an empty list when all sources are empty", () => {
+    expect(aggregateHistory(EMPTY)).toEqual([]);
+  });
+
+  it("emits both an 'emitted' and a 'resolved' entry for a resolved signal", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      signals: [
+        signal({
+          id: 1,
+          status: "resolved",
+          detected_at: "2026-04-10T08:00:00Z",
+          resolved_at: "2026-04-17T08:00:00Z",
+        }),
+      ],
+    });
+    const kinds = entries.map((e) => e.id);
+    expect(kinds).toContain("signal-emitted-1");
+    expect(kinds).toContain("signal-resolved-1");
+    const resolved = entries.find((e) => e.id === "signal-resolved-1")!;
+    expect(resolved.tone).toBe("positive");
+  });
+
+  it("includes a care-team entry with follow-up tone when flagged", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      careTeamContacts: [
+        careContact("2026-04-05", {
+          id: 10,
+          follow_up_needed: true,
+          with_who: "Dr Lee",
+        }),
+      ],
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.category).toBe("care_team");
+    expect(entries[0]!.tone).toBe("caution");
+  });
+
+  it("flags fever dailies as warning tone", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      dailyEntries: [daily("2026-04-10", { id: 1, fever: true })],
+    });
+    expect(entries[0]!.tone).toBe("warning");
+    expect(entries[0]!.category).toBe("check_in");
+  });
+
+  it("marks imaging PD as warning and PR/CR as positive", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      imaging: [
+        {
+          id: 1,
+          date: "2026-04-08",
+          modality: "CT",
+          findings_summary: "Progressive disease",
+          recist_status: "PD",
+          created_at: "",
+          updated_at: "",
+        },
+        {
+          id: 2,
+          date: "2026-04-09",
+          modality: "CT",
+          findings_summary: "Partial response",
+          recist_status: "PR",
+          created_at: "",
+          updated_at: "",
+        },
+      ],
+    });
+    const byId = Object.fromEntries(entries.map((e) => [e.id, e]));
+    expect(byId["img-1"].tone).toBe("warning");
+    expect(byId["img-2"].tone).toBe("positive");
+  });
+
+  it("filters entries to the specified windowDays", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      now: "2026-04-30T00:00:00Z",
+      windowDays: 14,
+      labs: [
+        lab("2026-04-01", { id: 1 }),  // 29 days before — excluded
+        lab("2026-04-20", { id: 2 }),  // 10 days before — included
+      ],
+    });
+    expect(entries.map((e) => e.id)).toEqual(["lab-2"]);
+  });
+
+  it("sorts entries chronologically descending", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      labs: [
+        lab("2026-04-01", { id: 1 }),
+        lab("2026-04-20", { id: 2 }),
+        lab("2026-04-10", { id: 3 }),
+      ],
+    });
+    const ids = entries.map((e) => e.id);
+    expect(ids).toEqual(["lab-2", "lab-3", "lab-1"]);
+  });
+
+  it("generates a treatment entry per cycle start", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      cycles: [cycle({ id: 1, start_date: "2026-03-01" })],
+    });
+    expect(entries.some((e) => e.id === "cycle-start-1")).toBe(true);
+  });
+
+  it("surfaces only action_taken events as actions, not emitted/etc", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      signalEvents: [
+        signalEvent({ id: 1, kind: "emitted" }),
+        signalEvent({
+          id: 2,
+          kind: "action_taken",
+          action_ref_id: "gentle_walk_10min",
+        }),
+        signalEvent({ id: 3, kind: "resolved_auto" }),
+      ],
+    });
+    const actionEntries = entries.filter((e) => e.category === "action");
+    expect(actionEntries).toHaveLength(1);
+    expect(actionEntries[0]!.title.en).toContain("gentle_walk_10min");
+  });
+});
+
+describe("groupByDate", () => {
+  it("groups already-sorted entries into contiguous date buckets", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      labs: [
+        lab("2026-04-10", { id: 1 }),
+        lab("2026-04-10", { id: 2 }),
+        lab("2026-04-09", { id: 3 }),
+      ],
+    });
+    const groups = groupByDate(entries);
+    expect(groups.map((g) => g.date)).toEqual(["2026-04-10", "2026-04-09"]);
+    expect(groups[0]!.entries).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
**Stacked on PR #27** (slice 4 — attribution) which stacks on #26 (slice 2 — detectors) which stacks on #25 (slice 1 — state model). Merge order: **#25 → #26 → #27 → this**.

Populates the `external` axis that slice 1 left empty. Ships two detectors end-to-end plus the data-capture surfaces needed to feed them.

## Data model

### DailyEntry (two new fields)
- **`meaningful_interactions`** — daily count of meaningful contacts (in-person, phone, video). Patient-subjective; tracks connectedness, not raw call volume.
- **`carer_present`** — boolean for "family / carer was physically present part of the day". Catches carer-absence drift independent of interaction count.

Zod schema updated to match.

### `care_team_contacts` table (Dexie v10)
Retrospective log of clinical touchpoints — clinic visits, phone / telehealth, specialist, community nurse, allied health, hospital admission, ED, pharmacist, other. Distinct from `patient_tasks` (prospective) — this records what actually happened, when, with whom.

### Metric registry
Two new metrics on the external axis:
- `meaningful_interactions` (daily, higher_better)
- `carer_present_flag` (daily, higher_better 0/1)

## Detectors

### `social_isolation` — daily cadence
7-day rolling mean of meaningful_interactions ≥ 30% below a 14-day reference window (ending 14 days ago) for ≥ 5 consecutive days. 30% caution / 50% warning.

Differential:
- **`carer_absence`** — carer_present dropping alongside interactions
- **`chemo_exhaustion`** — low energy + mood + rising nausea
- **`mood_withdrawal`** — mood + sleep drift (depression-withdrawal pattern)
- **`routine_drift`** — no concurrent driver; one scheduled contact often resets

Actions mapped per cause: family-rota discussion, community nurse referral, psychology referral, short-visit preference shift, one-planned-contact self-action.

### `clinician_gap` — event-driven cadence
Fires when days-since-last-care-team-contact exceeds an intensity-calibrated threshold:
- **Active cycle:** 14d caution / 21d warning
- **Maintenance:** 28d caution / 42d warning

Reads `care_team_contacts` directly from `DetectorContext` (event-driven data doesn't fit the metric-trajectory shape). Fortnightly dedup.

Actions: book clinic review + call oncology team, urgency scales with severity.

### `DetectorContext` gains `care_team_contacts?`
Optional, so existing detectors / tests are unaffected.

## UI

- **Daily check-in** — new "Contact & company" card in the body step: interactions count + carer-present toggle
- **`/care-team` page** — last-contact summary with days-since, inline add/edit/delete form, chronological history list with kind chips + follow-up flags
- **`ChangeSignalsCard`** — evaluator loop now reads `care_team_contacts` live and passes through to `evaluateAndPersistSignals` so clinician-gap fires on the dashboard

## Tests (12 new, 220 total)

`external-detectors.test.ts`:
- **socialIsolation** — silent on insufficient data; caution at ≥30% drop for ≥5 days; warning at ≥50%; mood_withdrawal differential when mood + sleep drop with it; auto-resolves on recovery
- **clinicianGap** — silent without contacts; silent within active-cycle caution window; caution at 14d active / 28d maintenance; warning at 21d/42d; auto-resolves after new contact in caution window

All 220 tests pass. typecheck / lint / build clean.

## What's left

**Polish pass (follow-up PR):**
- Unified `/history` view accessible from side menu: all activity logged chronologically — medications, signals, interventions, care-team contacts, daily entries, treatment cycles. Requested in-session so the patient / carer can see the whole picture in one place.
- UI / copy tighten across the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)