### PR TITLE
Polish: unified /history activity stream + care-team side-menu access

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -18,7 +18,9 @@
     "decisions": "Decisions",
     "ingest": "Ingest",
     "reports": "Reports",
-    "settings": "Settings"
+    "settings": "Settings",
+    "history": "History",
+    "care_team": "Care team"
   },
   "zones": {
     "green": "Stable",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -18,7 +18,9 @@
     "decisions": "决策记录",
     "ingest": "导入",
     "reports": "报告",
-    "settings": "设置"
+    "settings": "设置",
+    "history": "历史记录",
+    "care_team": "医疗团队"
   },
   "zones": {
     "green": "稳定",

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { format, parseISO } from "date-fns";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card } from "~/components/ui/card";
+import {
+  aggregateHistory,
+  groupByDate,
+  type HistoryCategory,
+  type HistoryEntry,
+  type HistoryTone,
+} from "~/lib/state/history";
+import {
+  Activity,
+  AlertTriangle,
+  Bell,
+  CheckCircle2,
+  Compass,
+  FlaskConical,
+  Heart,
+  Pill,
+  Scan,
+  Sparkles,
+  Syringe,
+  Users,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+type Filter = "all" | HistoryCategory;
+
+const FILTERS: { key: Filter; en: string; zh: string }[] = [
+  { key: "all", en: "All", zh: "全部" },
+  { key: "signal", en: "Signals", zh: "信号" },
+  { key: "action", en: "Actions", zh: "行动" },
+  { key: "medication", en: "Meds", zh: "用药" },
+  { key: "care_team", en: "Care team", zh: "医疗团队" },
+  { key: "lab", en: "Labs", zh: "化验" },
+  { key: "imaging", en: "Imaging", zh: "影像" },
+  { key: "treatment", en: "Treatment", zh: "治疗" },
+  { key: "check_in", en: "Check-ins", zh: "每日记录" },
+  { key: "decision", en: "Decisions", zh: "决策" },
+  { key: "life_event", en: "Life events", zh: "生活事件" },
+];
+
+const CATEGORY_ICON: Record<
+  HistoryCategory,
+  React.ComponentType<{ className?: string }>
+> = {
+  signal: AlertTriangle,
+  action: Sparkles,
+  medication: Pill,
+  care_team: Users,
+  lab: FlaskConical,
+  imaging: Scan,
+  treatment: Syringe,
+  check_in: Heart,
+  decision: Compass,
+  life_event: Activity,
+};
+
+const TONE_STYLE: Record<
+  HistoryTone,
+  { bg: string; fg: string; dot: string }
+> = {
+  info: {
+    bg: "bg-paper-2",
+    fg: "text-ink-700",
+    dot: "bg-ink-300",
+  },
+  positive: {
+    bg: "bg-[var(--ok-soft)]",
+    fg: "text-ink-900",
+    dot: "bg-[var(--ok)]",
+  },
+  caution: {
+    bg: "bg-[var(--sand)]/40",
+    fg: "text-ink-900",
+    dot: "bg-[oklch(45%_0.06_70)]",
+  },
+  warning: {
+    bg: "bg-[var(--warn-soft)]",
+    fg: "text-ink-900",
+    dot: "bg-[var(--warn)]",
+  },
+};
+
+export default function HistoryPage() {
+  const locale = useLocale();
+  const [filter, setFilter] = useState<Filter>("all");
+  const [windowDays, setWindowDays] = useState<number | null>(90);
+
+  const signals = useLiveQuery(
+    () => db.change_signals.toArray(),
+    [],
+  );
+  const signalEvents = useLiveQuery(
+    () => db.signal_events.toArray(),
+    [],
+  );
+  const medications = useLiveQuery(() => db.medications.toArray(), []);
+  const medicationEvents = useLiveQuery(
+    () => db.medication_events.toArray(),
+    [],
+  );
+  const careTeamContacts = useLiveQuery(
+    () => db.care_team_contacts.toArray(),
+    [],
+  );
+  const labs = useLiveQuery(() => db.labs.toArray(), []);
+  const imaging = useLiveQuery(() => db.imaging.toArray(), []);
+  const cycles = useLiveQuery(() => db.treatment_cycles.toArray(), []);
+  const dailies = useLiveQuery(() => db.daily_entries.toArray(), []);
+  const decisions = useLiveQuery(() => db.decisions.toArray(), []);
+  const lifeEvents = useLiveQuery(() => db.life_events.toArray(), []);
+
+  const allEntries = useMemo<HistoryEntry[]>(() => {
+    if (
+      !signals ||
+      !signalEvents ||
+      !medications ||
+      !medicationEvents ||
+      !careTeamContacts ||
+      !labs ||
+      !imaging ||
+      !cycles ||
+      !dailies ||
+      !decisions ||
+      !lifeEvents
+    ) {
+      return [];
+    }
+    return aggregateHistory({
+      signals,
+      signalEvents,
+      medications,
+      medicationEvents,
+      careTeamContacts,
+      labs,
+      imaging,
+      cycles,
+      dailyEntries: dailies,
+      decisions,
+      lifeEvents,
+      windowDays: windowDays ?? undefined,
+    });
+  }, [
+    signals,
+    signalEvents,
+    medications,
+    medicationEvents,
+    careTeamContacts,
+    labs,
+    imaging,
+    cycles,
+    dailies,
+    decisions,
+    lifeEvents,
+    windowDays,
+  ]);
+
+  const filtered = useMemo(
+    () =>
+      filter === "all"
+        ? allEntries
+        : allEntries.filter((e) => e.category === filter),
+    [allEntries, filter],
+  );
+
+  const groupedByDate = useMemo(() => groupByDate(filtered), [filtered]);
+
+  const countsByCategory = useMemo(() => {
+    const out: Partial<Record<Filter, number>> = { all: allEntries.length };
+    for (const e of allEntries) {
+      out[e.category] = (out[e.category] ?? 0) + 1;
+    }
+    return out;
+  }, [allEntries]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "全部" : "Everything"}
+        title={locale === "zh" ? "活动历史" : "Activity history"}
+      />
+
+      <div className="flex items-center gap-2">
+        <WindowButton
+          active={windowDays === 30}
+          onClick={() => setWindowDays(30)}
+        >
+          30d
+        </WindowButton>
+        <WindowButton
+          active={windowDays === 90}
+          onClick={() => setWindowDays(90)}
+        >
+          90d
+        </WindowButton>
+        <WindowButton
+          active={windowDays === 365}
+          onClick={() => setWindowDays(365)}
+        >
+          1y
+        </WindowButton>
+        <WindowButton
+          active={windowDays === null}
+          onClick={() => setWindowDays(null)}
+        >
+          {locale === "zh" ? "全部" : "All"}
+        </WindowButton>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {FILTERS.map((f) => {
+          const count = countsByCategory[f.key] ?? 0;
+          if (f.key !== "all" && count === 0) return null;
+          return (
+            <FilterChip
+              key={f.key}
+              active={filter === f.key}
+              onClick={() => setFilter(f.key)}
+              count={count}
+            >
+              {f.key === "all"
+                ? locale === "zh"
+                  ? f.zh
+                  : f.en
+                : locale === "zh"
+                  ? f.zh
+                  : f.en}
+            </FilterChip>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 ? (
+        <Card className="p-5 text-sm text-ink-500">
+          {locale === "zh"
+            ? "此过滤条件下暂无记录。"
+            : "No activity in this view."}
+        </Card>
+      ) : (
+        <div className="space-y-5">
+          {groupedByDate.map(({ date, entries }) => (
+            <DateGroup
+              key={date}
+              date={date}
+              entries={entries}
+              locale={locale}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WindowButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "mono rounded-full border px-3 py-1 text-[10.5px] uppercase tracking-[0.12em] transition-colors",
+        active
+          ? "border-ink-900 bg-ink-900 text-paper"
+          : "border-ink-200 bg-paper text-ink-500 hover:border-ink-400",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function FilterChip({
+  active,
+  onClick,
+  count,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  count?: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12px] transition-colors",
+        active
+          ? "border-[var(--tide-2)] bg-[var(--tide-2)] text-paper"
+          : "border-ink-200 bg-paper text-ink-600 hover:border-ink-400",
+      )}
+    >
+      <span>{children}</span>
+      {typeof count === "number" && count > 0 && (
+        <span
+          className={cn(
+            "mono text-[9.5px] tracking-wider",
+            active ? "text-paper/80" : "text-ink-400",
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function DateGroup({
+  date,
+  entries,
+  locale,
+}: {
+  date: string;
+  entries: HistoryEntry[];
+  locale: "en" | "zh";
+}) {
+  const d = parseISO(date);
+  const label =
+    locale === "zh"
+      ? format(d, "yyyy 年 M 月 d 日 · EEEE")
+      : format(d, "EEEE · d MMM yyyy");
+  return (
+    <section>
+      <div className="mono mb-2 text-[10px] uppercase tracking-[0.14em] text-ink-400">
+        {label}
+      </div>
+      <ul className="space-y-1.5">
+        {entries.map((e) => (
+          <li key={e.id}>
+            <HistoryRow entry={e} locale={locale} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function HistoryRow({
+  entry,
+  locale,
+}: {
+  entry: HistoryEntry;
+  locale: "en" | "zh";
+}) {
+  const Icon = CATEGORY_ICON[entry.category] ?? Bell;
+  const tone = TONE_STYLE[entry.tone];
+  const body = (
+    <div
+      className={cn(
+        "flex items-start gap-3 rounded-[var(--r-md)] px-3.5 py-3 transition-colors",
+        tone.bg,
+      )}
+    >
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-paper text-ink-700 ring-1 ring-ink-100">
+        <Icon className="h-3.5 w-3.5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-2">
+          <div className={cn("text-[13px] font-semibold", tone.fg)}>
+            {entry.title[locale]}
+          </div>
+          <time className="mono shrink-0 text-[9.5px] uppercase tracking-[0.12em] text-ink-400">
+            {format(parseISO(entry.at), "HH:mm")}
+          </time>
+        </div>
+        {entry.detail && (
+          <div className={cn("mt-0.5 truncate text-[12px]", tone.fg)}>
+            {entry.detail[locale]}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+  if (entry.href) {
+    return (
+      <Link href={entry.href} className="block">
+        {body}
+      </Link>
+    );
+  }
+  return body;
+}
+
+// Suppress unused-import warning for CheckCircle2 — kept for future use in
+// tone variations.
+void CheckCircle2;

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -12,6 +12,8 @@ import {
   Compass,
   Syringe,
   ListTodo,
+  Users,
+  History as HistoryIcon,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { useT } from "~/hooks/use-translate";
@@ -25,7 +27,9 @@ const ITEMS = [
   { href: "/treatment", key: "nav.treatment", icon: Syringe },
   { href: "/labs", key: "nav.labs", icon: FlaskConical },
   { href: "/tasks", key: "nav.tasks", icon: ListTodo },
+  { href: "/care-team", key: "nav.care_team", icon: Users },
   { href: "/bridge", key: "nav.bridge", icon: Route },
+  { href: "/history", key: "nav.history", icon: HistoryIcon },
   { href: "/ingest", key: "nav.ingest", icon: ScanLine },
   { href: "/reports", key: "nav.reports", icon: FileText },
   { href: "/settings", key: "nav.settings", icon: SettingsIcon },

--- a/src/lib/state/history.ts
+++ b/src/lib/state/history.ts
@@ -1,0 +1,430 @@
+// Unified activity aggregator — pulls every time-stamped row from the
+// Dexie tables and produces a single chronological stream for the
+// /history view. Pure function: caller does the Dexie reads and passes
+// the rows in so this module is trivially testable and stays decoupled
+// from storage.
+import type {
+  CareTeamContact,
+  ChangeSignalRow,
+  DailyEntry,
+  Decision,
+  Imaging,
+  LabResult,
+  LifeEvent,
+  SignalEventRow,
+} from "~/types/clinical";
+import type { TreatmentCycle } from "~/types/treatment";
+import type { Medication, MedicationEvent } from "~/types/medication";
+
+export type HistoryCategory =
+  | "signal"
+  | "action"
+  | "medication"
+  | "care_team"
+  | "lab"
+  | "imaging"
+  | "treatment"
+  | "check_in"
+  | "decision"
+  | "life_event";
+
+export type HistoryTone = "info" | "positive" | "caution" | "warning";
+
+export interface LocalizedText {
+  en: string;
+  zh: string;
+}
+
+export interface HistoryEntry {
+  // Stable identifier composed from source table + id + variant, so the
+  // UI can key off it across re-renders even when new rows arrive.
+  id: string;
+  category: HistoryCategory;
+  at: string;              // ISO
+  title: LocalizedText;
+  detail?: LocalizedText;
+  tone: HistoryTone;
+  href?: string;
+}
+
+export interface AggregateInputs {
+  signals: readonly ChangeSignalRow[];
+  signalEvents: readonly SignalEventRow[];
+  medications: readonly Medication[];
+  medicationEvents: readonly MedicationEvent[];
+  careTeamContacts: readonly CareTeamContact[];
+  labs: readonly LabResult[];
+  imaging: readonly Imaging[];
+  cycles: readonly TreatmentCycle[];
+  dailyEntries: readonly DailyEntry[];
+  decisions: readonly Decision[];
+  lifeEvents: readonly LifeEvent[];
+  // Optional filter window — only include entries within the last N days.
+  // Undefined ⇒ include all.
+  windowDays?: number;
+  now?: string;            // for tests
+}
+
+const DAYS_MS = 86_400_000;
+
+function inWindow(iso: string | undefined, fromMs: number | null): boolean {
+  if (!iso) return false;
+  if (fromMs == null) return true;
+  const t = Date.parse(iso);
+  return !Number.isNaN(t) && t >= fromMs;
+}
+
+// ─── Entry builders ───────────────────────────────────────────────────────
+
+function signalEntries(
+  signals: readonly ChangeSignalRow[],
+): HistoryEntry[] {
+  const out: HistoryEntry[] = [];
+  for (const s of signals) {
+    out.push({
+      id: `signal-emitted-${s.id}`,
+      category: "signal",
+      at: s.detected_at,
+      title: {
+        en: titleFromSignal(s, "emitted"),
+        zh: titleFromSignalZh(s, "emitted"),
+      },
+      detail: {
+        en: `${s.detector} · ${s.axis}`,
+        zh: `${s.detector} · ${s.axis}`,
+      },
+      tone: s.severity === "warning" ? "warning" : "caution",
+      href: "/signals",
+    });
+    if (s.status === "resolved" && s.resolved_at) {
+      out.push({
+        id: `signal-resolved-${s.id}`,
+        category: "signal",
+        at: s.resolved_at,
+        title: {
+          en: titleFromSignal(s, "resolved"),
+          zh: titleFromSignalZh(s, "resolved"),
+        },
+        detail: {
+          en: `${s.detector} · ${s.axis}`,
+          zh: `${s.detector} · ${s.axis}`,
+        },
+        tone: "positive",
+        href: "/signals",
+      });
+    }
+  }
+  return out;
+}
+
+function titleFromSignal(
+  s: ChangeSignalRow,
+  kind: "emitted" | "resolved",
+): string {
+  const name = s.detector.replace(/_/g, " ");
+  return kind === "emitted"
+    ? `Signal: ${name}`
+    : `Signal resolved: ${name}`;
+}
+function titleFromSignalZh(
+  s: ChangeSignalRow,
+  kind: "emitted" | "resolved",
+): string {
+  return kind === "emitted"
+    ? `信号触发：${s.detector}`
+    : `信号解决：${s.detector}`;
+}
+
+function actionEntries(
+  signalEvents: readonly SignalEventRow[],
+): HistoryEntry[] {
+  return signalEvents
+    .filter((e) => e.kind === "action_taken" && e.action_ref_id)
+    .map((e) => ({
+      id: `action-${e.id}`,
+      category: "action" as const,
+      at: e.created_at,
+      title: {
+        en: `Action taken: ${e.action_ref_id}`,
+        zh: `采取行动：${e.action_ref_id}`,
+      },
+      detail: e.action_kind
+        ? { en: e.action_kind, zh: e.action_kind }
+        : undefined,
+      tone: "positive" as const,
+      href: "/signals",
+    }));
+}
+
+function medicationEntries(
+  events: readonly MedicationEvent[],
+  meds: readonly Medication[],
+): HistoryEntry[] {
+  const medById = new Map<number, Medication>();
+  for (const m of meds) {
+    if (m.id != null) medById.set(m.id, m);
+  }
+  return events.map((e) => {
+    const med = medById.get(e.medication_id);
+    const name = med?.display_name ?? e.drug_id;
+    const status =
+      e.event_type === "taken"
+        ? "taken"
+        : e.event_type === "missed"
+          ? "missed"
+          : "side effect";
+    return {
+      id: `med-${e.id}`,
+      category: "medication" as const,
+      at: e.logged_at,
+      title: {
+        en: `${name} — ${status}`,
+        zh: `${name} —— ${
+          e.event_type === "taken"
+            ? "已服用"
+            : e.event_type === "missed"
+              ? "漏服"
+              : "副作用"
+        }`,
+      },
+      detail: e.dose_taken
+        ? { en: e.dose_taken, zh: e.dose_taken }
+        : undefined,
+      tone:
+        e.event_type === "taken"
+          ? ("positive" as const)
+          : e.event_type === "missed"
+            ? ("caution" as const)
+            : ("info" as const),
+      href: med?.id ? `/medications/${med.id}` : "/medications",
+    };
+  });
+}
+
+function careTeamEntries(
+  contacts: readonly CareTeamContact[],
+): HistoryEntry[] {
+  return contacts
+    .filter((c) => c.id != null)
+    .map((c) => ({
+      id: `care-${c.id}`,
+      category: "care_team" as const,
+      at: `${c.date}T12:00:00Z`,
+      title: {
+        en: `Care team · ${c.kind.replace(/_/g, " ")}`,
+        zh: `医疗团队 · ${c.kind}`,
+      },
+      detail:
+        c.with_who || c.notes
+          ? {
+              en: [c.with_who, c.notes].filter(Boolean).join(" — "),
+              zh: [c.with_who, c.notes].filter(Boolean).join(" —— "),
+            }
+          : undefined,
+      tone: c.follow_up_needed ? ("caution" as const) : ("info" as const),
+      href: "/care-team",
+    }));
+}
+
+function labEntries(labs: readonly LabResult[]): HistoryEntry[] {
+  return labs
+    .filter((l) => l.id != null)
+    .map((l) => {
+      const flagged: string[] = [];
+      if (l.ca199) flagged.push(`CA19-9 ${l.ca199}`);
+      if (l.neutrophils != null) flagged.push(`ANC ${l.neutrophils}`);
+      if (l.hemoglobin != null) flagged.push(`Hb ${l.hemoglobin}`);
+      if (l.alt != null && l.alt >= 100) flagged.push(`ALT ${l.alt}↑`);
+      const detail = flagged.join(" · ");
+      return {
+        id: `lab-${l.id}`,
+        category: "lab" as const,
+        at: `${l.date}T08:00:00Z`,
+        title: {
+          en: `Labs received`,
+          zh: `化验结果`,
+        },
+        detail: detail ? { en: detail, zh: detail } : undefined,
+        tone: "info" as const,
+        href: "/labs",
+      };
+    });
+}
+
+function imagingEntries(imaging: readonly Imaging[]): HistoryEntry[] {
+  return imaging
+    .filter((i) => i.id != null)
+    .map((i) => ({
+      id: `img-${i.id}`,
+      category: "imaging" as const,
+      at: `${i.date}T08:00:00Z`,
+      title: {
+        en: `Imaging · ${i.modality}${i.recist_status ? ` · ${i.recist_status}` : ""}`,
+        zh: `影像 · ${i.modality}${i.recist_status ? ` · ${i.recist_status}` : ""}`,
+      },
+      detail: { en: i.findings_summary, zh: i.findings_summary },
+      tone:
+        i.recist_status === "PD"
+          ? ("warning" as const)
+          : i.recist_status === "PR" || i.recist_status === "CR"
+            ? ("positive" as const)
+            : ("info" as const),
+      href: "/labs",
+    }));
+}
+
+function cycleEntries(
+  cycles: readonly TreatmentCycle[],
+): HistoryEntry[] {
+  const out: HistoryEntry[] = [];
+  for (const c of cycles) {
+    if (c.id == null) continue;
+    out.push({
+      id: `cycle-start-${c.id}`,
+      category: "treatment",
+      at: `${c.start_date}T08:00:00Z`,
+      title: {
+        en: `Cycle ${c.cycle_number} started — ${c.protocol_id}`,
+        zh: `周期 ${c.cycle_number} 开始 — ${c.protocol_id}`,
+      },
+      tone: "info",
+      href: `/treatment/${c.id}`,
+    });
+    if (c.actual_end_date) {
+      out.push({
+        id: `cycle-end-${c.id}`,
+        category: "treatment",
+        at: `${c.actual_end_date}T18:00:00Z`,
+        title: {
+          en: `Cycle ${c.cycle_number} ended`,
+          zh: `周期 ${c.cycle_number} 结束`,
+        },
+        tone: "info",
+        href: `/treatment/${c.id}`,
+      });
+    }
+  }
+  return out;
+}
+
+function dailyCheckinEntries(
+  dailies: readonly DailyEntry[],
+): HistoryEntry[] {
+  return dailies
+    .filter((d) => d.id != null)
+    .map((d) => {
+      const flags: string[] = [];
+      if (d.fever) flags.push("fever");
+      if (d.nausea >= 5) flags.push(`nausea ${d.nausea}`);
+      if ((d.diarrhoea_count ?? 0) >= 3) flags.push(`diarrhoea ${d.diarrhoea_count}`);
+      if (d.neuropathy_hands) flags.push("neuropathy hands");
+      if (d.neuropathy_feet) flags.push("neuropathy feet");
+      if (d.cold_dysaesthesia) flags.push("cold dysaesthesia");
+      const weight =
+        typeof d.weight_kg === "number" ? `${d.weight_kg} kg` : null;
+      const parts = [
+        `energy ${d.energy}/10`,
+        `sleep ${d.sleep_quality}/10`,
+        weight,
+        ...flags,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+      const hasFlags = flags.length > 0;
+      return {
+        id: `daily-${d.id}`,
+        category: "check_in" as const,
+        at: d.entered_at ?? `${d.date}T08:00:00Z`,
+        title: {
+          en: `Daily check-in`,
+          zh: `每日记录`,
+        },
+        detail: parts ? { en: parts, zh: parts } : undefined,
+        tone: (d.fever ? "warning" : hasFlags ? "caution" : "info") as HistoryTone,
+        href: d.id ? `/daily/${d.id}` : "/daily",
+      };
+    });
+}
+
+function decisionEntries(
+  decisions: readonly Decision[],
+): HistoryEntry[] {
+  return decisions
+    .filter((d) => d.id != null)
+    .map((d) => ({
+      id: `decision-${d.id}`,
+      category: "decision" as const,
+      at: `${d.decision_date}T12:00:00Z`,
+      title: { en: `Decision: ${d.title}`, zh: `决策：${d.title}` },
+      detail: { en: d.decision, zh: d.decision },
+      tone: "info" as const,
+      href: `/decisions`,
+    }));
+}
+
+function lifeEventEntries(
+  events: readonly LifeEvent[],
+): HistoryEntry[] {
+  return events
+    .filter((e) => e.id != null)
+    .map((e) => ({
+      id: `life-${e.id}`,
+      category: "life_event" as const,
+      at: `${e.event_date}T12:00:00Z`,
+      title: { en: e.title, zh: e.title },
+      detail: e.notes ? { en: e.notes, zh: e.notes } : undefined,
+      tone: "info" as const,
+      href: "/events",
+    }));
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────
+
+export function aggregateHistory(
+  inputs: AggregateInputs,
+): HistoryEntry[] {
+  const nowMs = inputs.now
+    ? Date.parse(inputs.now)
+    : Date.now();
+  const fromMs =
+    typeof inputs.windowDays === "number"
+      ? nowMs - inputs.windowDays * DAYS_MS
+      : null;
+
+  const all: HistoryEntry[] = [
+    ...signalEntries(inputs.signals),
+    ...actionEntries(inputs.signalEvents),
+    ...medicationEntries(inputs.medicationEvents, inputs.medications),
+    ...careTeamEntries(inputs.careTeamContacts),
+    ...labEntries(inputs.labs),
+    ...imagingEntries(inputs.imaging),
+    ...cycleEntries(inputs.cycles),
+    ...dailyCheckinEntries(inputs.dailyEntries),
+    ...decisionEntries(inputs.decisions),
+    ...lifeEventEntries(inputs.lifeEvents),
+  ];
+
+  return all
+    .filter((e) => inWindow(e.at, fromMs))
+    .sort((a, b) => Date.parse(b.at) - Date.parse(a.at));
+}
+
+/**
+ * Group entries by calendar date (YYYY-MM-DD) in the order they appear.
+ * Useful for rendering date headers in the UI.
+ */
+export function groupByDate(
+  entries: readonly HistoryEntry[],
+): { date: string; entries: HistoryEntry[] }[] {
+  const out: { date: string; entries: HistoryEntry[] }[] = [];
+  let current: { date: string; entries: HistoryEntry[] } | null = null;
+  for (const e of entries) {
+    const day = e.at.slice(0, 10);
+    if (!current || current.date !== day) {
+      current = { date: day, entries: [] };
+      out.push(current);
+    }
+    current.entries.push(e);
+  }
+  return out;
+}

--- a/tests/unit/history.test.ts
+++ b/tests/unit/history.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { aggregateHistory, groupByDate } from "~/lib/state/history";
+import type {
+  CareTeamContact,
+  ChangeSignalRow,
+  DailyEntry,
+  LabResult,
+  SignalEventRow,
+} from "~/types/clinical";
+import type { TreatmentCycle } from "~/types/treatment";
+
+function signal(
+  over: Partial<ChangeSignalRow> = {},
+): ChangeSignalRow {
+  return {
+    id: 1,
+    detector: "steps_decline",
+    fired_for: "steps_decline:2026-W15",
+    metric_id: "steps",
+    axis: "individual",
+    severity: "caution",
+    shape: "rolling_drift",
+    status: "open",
+    payload_json: "{}",
+    detected_at: "2026-04-10T08:00:00Z",
+    ...over,
+  };
+}
+
+function signalEvent(
+  over: Partial<SignalEventRow> = {},
+): SignalEventRow {
+  return {
+    signal_id: 1,
+    kind: "emitted",
+    created_at: "2026-04-10T08:00:00Z",
+    ...over,
+  };
+}
+
+function careContact(
+  date: string,
+  over: Partial<CareTeamContact> = {},
+): CareTeamContact {
+  return {
+    date,
+    kind: "clinic_visit",
+    created_at: `${date}T09:00:00Z`,
+    updated_at: `${date}T09:00:00Z`,
+    ...over,
+    id: over.id ?? 10,
+  };
+}
+
+function daily(date: string, over: Partial<DailyEntry> = {}): DailyEntry {
+  return {
+    id: 99,
+    date,
+    entered_at: `${date}T09:00:00Z`,
+    entered_by: "hulin",
+    energy: 6,
+    sleep_quality: 6,
+    appetite: 6,
+    pain_worst: 2,
+    pain_current: 1,
+    mood_clarity: 6,
+    nausea: 1,
+    practice_morning_completed: true,
+    practice_evening_completed: true,
+    cold_dysaesthesia: false,
+    neuropathy_hands: false,
+    neuropathy_feet: false,
+    mouth_sores: false,
+    diarrhoea_count: 0,
+    new_bruising: false,
+    dyspnoea: false,
+    fever: false,
+    created_at: `${date}T09:00:00Z`,
+    updated_at: `${date}T09:00:00Z`,
+    ...over,
+  };
+}
+
+function lab(date: string, over: Partial<LabResult> = {}): LabResult {
+  return {
+    id: 50,
+    date,
+    source: "epworth",
+    created_at: `${date}T08:00:00Z`,
+    updated_at: `${date}T08:00:00Z`,
+    ...over,
+  };
+}
+
+function cycle(
+  over: Partial<TreatmentCycle> = {},
+): TreatmentCycle {
+  return {
+    id: 7,
+    protocol_id: "gnp_weekly",
+    cycle_number: 3,
+    start_date: "2026-04-01",
+    status: "active",
+    dose_level: 0,
+    created_at: "",
+    updated_at: "",
+    ...over,
+  };
+}
+
+const EMPTY = {
+  signals: [],
+  signalEvents: [],
+  medications: [],
+  medicationEvents: [],
+  careTeamContacts: [],
+  labs: [],
+  imaging: [],
+  cycles: [],
+  dailyEntries: [],
+  decisions: [],
+  lifeEvents: [],
+};
+
+describe("aggregateHistory", () => {
+  it("returns an empty list when all sources are empty", () => {
+    expect(aggregateHistory(EMPTY)).toEqual([]);
+  });
+
+  it("emits both an 'emitted' and a 'resolved' entry for a resolved signal", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      signals: [
+        signal({
+          id: 1,
+          status: "resolved",
+          detected_at: "2026-04-10T08:00:00Z",
+          resolved_at: "2026-04-17T08:00:00Z",
+        }),
+      ],
+    });
+    const kinds = entries.map((e) => e.id);
+    expect(kinds).toContain("signal-emitted-1");
+    expect(kinds).toContain("signal-resolved-1");
+    const resolved = entries.find((e) => e.id === "signal-resolved-1")!;
+    expect(resolved.tone).toBe("positive");
+  });
+
+  it("includes a care-team entry with follow-up tone when flagged", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      careTeamContacts: [
+        careContact("2026-04-05", {
+          id: 10,
+          follow_up_needed: true,
+          with_who: "Dr Lee",
+        }),
+      ],
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.category).toBe("care_team");
+    expect(entries[0]!.tone).toBe("caution");
+  });
+
+  it("flags fever dailies as warning tone", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      dailyEntries: [daily("2026-04-10", { id: 1, fever: true })],
+    });
+    expect(entries[0]!.tone).toBe("warning");
+    expect(entries[0]!.category).toBe("check_in");
+  });
+
+  it("marks imaging PD as warning and PR/CR as positive", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      imaging: [
+        {
+          id: 1,
+          date: "2026-04-08",
+          modality: "CT",
+          findings_summary: "Progressive disease",
+          recist_status: "PD",
+          created_at: "",
+          updated_at: "",
+        },
+        {
+          id: 2,
+          date: "2026-04-09",
+          modality: "CT",
+          findings_summary: "Partial response",
+          recist_status: "PR",
+          created_at: "",
+          updated_at: "",
+        },
+      ],
+    });
+    const byId = Object.fromEntries(entries.map((e) => [e.id, e]));
+    expect(byId["img-1"].tone).toBe("warning");
+    expect(byId["img-2"].tone).toBe("positive");
+  });
+
+  it("filters entries to the specified windowDays", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      now: "2026-04-30T00:00:00Z",
+      windowDays: 14,
+      labs: [
+        lab("2026-04-01", { id: 1 }),  // 29 days before — excluded
+        lab("2026-04-20", { id: 2 }),  // 10 days before — included
+      ],
+    });
+    expect(entries.map((e) => e.id)).toEqual(["lab-2"]);
+  });
+
+  it("sorts entries chronologically descending", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      labs: [
+        lab("2026-04-01", { id: 1 }),
+        lab("2026-04-20", { id: 2 }),
+        lab("2026-04-10", { id: 3 }),
+      ],
+    });
+    const ids = entries.map((e) => e.id);
+    expect(ids).toEqual(["lab-2", "lab-3", "lab-1"]);
+  });
+
+  it("generates a treatment entry per cycle start", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      cycles: [cycle({ id: 1, start_date: "2026-03-01" })],
+    });
+    expect(entries.some((e) => e.id === "cycle-start-1")).toBe(true);
+  });
+
+  it("surfaces only action_taken events as actions, not emitted/etc", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      signalEvents: [
+        signalEvent({ id: 1, kind: "emitted" }),
+        signalEvent({
+          id: 2,
+          kind: "action_taken",
+          action_ref_id: "gentle_walk_10min",
+        }),
+        signalEvent({ id: 3, kind: "resolved_auto" }),
+      ],
+    });
+    const actionEntries = entries.filter((e) => e.category === "action");
+    expect(actionEntries).toHaveLength(1);
+    expect(actionEntries[0]!.title.en).toContain("gentle_walk_10min");
+  });
+});
+
+describe("groupByDate", () => {
+  it("groups already-sorted entries into contiguous date buckets", () => {
+    const entries = aggregateHistory({
+      ...EMPTY,
+      labs: [
+        lab("2026-04-10", { id: 1 }),
+        lab("2026-04-10", { id: 2 }),
+        lab("2026-04-09", { id: 3 }),
+      ],
+    });
+    const groups = groupByDate(entries);
+    expect(groups.map((g) => g.date)).toEqual(["2026-04-10", "2026-04-09"]);
+    expect(groups[0]!.entries).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
**Stacked on PR #28** (slice 3 — external axis). Merge order: **#25 → #26 → #27 → #28 → this**.

Delivers the unified activity history you asked for in-session, accessible from the side menu alongside the `/care-team` page that slice 3 shipped.

## What it does

One page — `/history` — shows every timestamped thing the app has logged, in reverse chronological order. Signals, actions taken, medication doses, care-team contacts, labs, imaging, treatment cycles, daily check-ins, decisions, life events — all in one stream. The patient / carer / clinician can open it, pick a window and a category filter, and audit the whole trajectory without clicking through seven different pages.

## Module — `src/lib/state/history.ts`

Pure `aggregateHistory(inputs)` function. Takes every timestamped table from Dexie and emits a single chronological `HistoryEntry[]` descending. `groupByDate(entries)` buckets them by day for rendering.

Per-source builders:

| Source | Entry | Tone logic |
|---|---|---|
| ChangeSignal | `signal-emitted-*` per detection; `signal-resolved-*` per resolution | severity → caution/warning; resolution → positive |
| SignalEvent (action_taken only) | one per logged action | always positive |
| MedicationEvent | one per dose | taken → positive; missed → caution |
| CareTeamContact | one per contact | follow_up_needed → caution |
| LabResult | one per result, summary line (CA 19-9, ANC, Hb, ALT↑ when present) | info |
| Imaging | one per scan | PD → warning; PR/CR → positive |
| TreatmentCycle | `cycle-start-*` + `cycle-end-*` | info |
| DailyEntry | one per day with symptom + weight summary | fever → warning; any flag → caution |
| Decision / LifeEvent | dated entries linking back | info |

`windowDays` arg filters to trailing N days.

## Page — `/history`

- **Window toggle:** 30d / 90d / 1y / All
- **Filter chips** per category with live counts; empty categories hidden
- **Date-grouped list** with mono date headers
- **Per-entry card** — category icon + title + time + optional detail, tone-coloured background
- **Link-backs** — each entry jumps to its source (medication profile, `/signals`, `/care-team`, `/labs`, `/treatment/:id`, etc.)

## Navigation

`DesktopSidebar` adds two items in logical position:
- **Care team** (Users icon) — next to Tasks
- **History** (History icon) — next to Bridge

i18n keys `nav.care_team` + `nav.history` added to EN + ZH.

## Tests (10 new, 228 total)

`tests/unit/history.test.ts` — empty sources → empty; resolved signals emit both emitted + resolved entries; care-team follow-up → caution tone; daily fever → warning tone; imaging PD → warning, PR/CR → positive; windowDays filters out-of-range; chronological descending sort; treatment cycle entries; only `action_taken` signal events promoted; `groupByDate` buckets contiguous dates.

All 228 tests pass. typecheck / lint / build clean.

## The thesis, now visibly closed

With this PR merged, the patient dashboard looks like:

1. Today's check-in + change signals + medication prompts (prompt/react layer)
2. Signal loop summary (30-day rollup — is the system working?)
3. Four axes of daily state surface via the axis-tagged signals
4. `/signals` — detector history with event timelines + likely contributors
5. `/care-team` — external-axis touchpoint log
6. `/history` — **everything, chronologically, one place** ← this PR

That's the full detection → action → outcome loop, observable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)