### PR TITLE
Onboarding baseline fields + custom behavioural practices

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -18,7 +18,8 @@
     "decisions": "Decisions",
     "ingest": "Ingest",
     "reports": "Reports",
-    "settings": "Settings"
+    "settings": "Settings",
+    "practices": "Practices"
   },
   "zones": {
     "green": "Stable",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -18,7 +18,8 @@
     "decisions": "决策记录",
     "ingest": "导入",
     "reports": "报告",
-    "settings": "设置"
+    "settings": "设置",
+    "practices": "修习"
   },
   "zones": {
     "green": "稳定",

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -69,6 +69,9 @@ interface FormState {
   baseline_weight_kg: string;
   baseline_grip_dominant_kg: string;
   baseline_gait_speed_ms: string;
+  baseline_sit_to_stand: string;       // 30-second count
+  baseline_sts_5x_seconds: string;     // 5× STS time
+  baseline_tug_seconds: string;        // Timed Up-and-Go seconds
   baseline_muac_cm: string;
   baseline_calf_cm: string;
   start_cycle: boolean;
@@ -94,6 +97,9 @@ const EMPTY: FormState = {
   baseline_weight_kg: "",
   baseline_grip_dominant_kg: "",
   baseline_gait_speed_ms: "",
+  baseline_sit_to_stand: "",
+  baseline_sts_5x_seconds: "",
+  baseline_tug_seconds: "",
   baseline_muac_cm: "",
   baseline_calf_cm: "",
   start_cycle: false,
@@ -149,6 +155,15 @@ export default function OnboardingPage() {
           : "",
         baseline_gait_speed_ms: s.baseline_gait_speed_ms
           ? String(s.baseline_gait_speed_ms)
+          : "",
+        baseline_sit_to_stand: s.baseline_sit_to_stand
+          ? String(s.baseline_sit_to_stand)
+          : "",
+        baseline_sts_5x_seconds: s.baseline_sts_5x_seconds
+          ? String(s.baseline_sts_5x_seconds)
+          : "",
+        baseline_tug_seconds: s.baseline_tug_seconds
+          ? String(s.baseline_tug_seconds)
           : "",
         baseline_muac_cm: s.baseline_muac_cm ? String(s.baseline_muac_cm) : "",
         baseline_calf_cm: s.baseline_calf_cm ? String(s.baseline_calf_cm) : "",
@@ -217,6 +232,9 @@ export default function OnboardingPage() {
         baseline_date: form.baseline_weight_kg ? todayISO() : undefined,
         baseline_grip_dominant_kg: toNum(form.baseline_grip_dominant_kg),
         baseline_gait_speed_ms: toNum(form.baseline_gait_speed_ms),
+        baseline_sit_to_stand: toNum(form.baseline_sit_to_stand),
+        baseline_sts_5x_seconds: toNum(form.baseline_sts_5x_seconds),
+        baseline_tug_seconds: toNum(form.baseline_tug_seconds),
         baseline_muac_cm: toNum(form.baseline_muac_cm),
         baseline_calf_cm: toNum(form.baseline_calf_cm),
         locale: form.locale,
@@ -584,6 +602,46 @@ function BaselinesStep({
             step="0.05"
             value={form.baseline_gait_speed_ms}
             onChange={(e) => update("baseline_gait_speed_ms", e.target.value)}
+          />
+        </Field>
+        <Field
+          label={
+            locale === "zh"
+              ? "30 秒坐立次数"
+              : "30 s sit-to-stand (count)"
+          }
+        >
+          <TextInput
+            type="number"
+            step="1"
+            value={form.baseline_sit_to_stand}
+            onChange={(e) => update("baseline_sit_to_stand", e.target.value)}
+          />
+        </Field>
+        <Field
+          label={
+            locale === "zh" ? "5 次坐立 (秒)" : "5× sit-to-stand (s)"
+          }
+        >
+          <TextInput
+            type="number"
+            step="0.1"
+            value={form.baseline_sts_5x_seconds}
+            onChange={(e) =>
+              update("baseline_sts_5x_seconds", e.target.value)
+            }
+          />
+        </Field>
+        <Field
+          label={
+            locale === "zh" ? "起立行走 TUG (秒)" : "Timed Up-and-Go (s)"
+          }
+        >
+          <TextInput
+            type="number"
+            step="0.1"
+            value={form.baseline_tug_seconds}
+            onChange={(e) => update("baseline_tug_seconds", e.target.value)}
           />
         </Field>
         <Field

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { RecentTrends } from "~/components/dashboard/recent-trends";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
 import { MedicationPromptsCard } from "~/components/dashboard/medication-prompts-card";
+import { PracticesCard } from "~/components/dashboard/practices-card";
 import { TodayFeed } from "~/components/dashboard/today-feed";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { PageHeader, SectionHeader } from "~/components/ui/page-header";
@@ -76,6 +77,8 @@ export default function DashboardPage() {
       <QuickCheckinCard />
 
       <MedicationPromptsCard />
+
+      <PracticesCard />
 
       <TodayFeed excludeIds={["checkin_today"]} />
 

--- a/src/app/practices/[id]/page.tsx
+++ b/src/app/practices/[id]/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { PracticeForm } from "~/components/practices/practice-form";
+import { Card } from "~/components/ui/card";
+
+export default function EditPracticePage() {
+  const locale = useLocale();
+  const params = useParams<{ id: string }>();
+  const id = Number(params.id);
+  const med = useLiveQuery(
+    () => (Number.isFinite(id) ? db.medications.get(id) : undefined),
+    [id],
+  );
+
+  if (!Number.isFinite(id)) {
+    return (
+      <div className="mx-auto max-w-xl p-6">
+        <Card className="p-5 text-sm text-ink-500">
+          {locale === "zh" ? "无效链接" : "Invalid link"}
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "编辑" : "Edit"}
+        title={med?.display_name ?? (locale === "zh" ? "修习" : "Practice")}
+      />
+      {med ? (
+        <PracticeForm existing={med} />
+      ) : (
+        <Card className="p-5 text-sm text-ink-500">
+          {locale === "zh" ? "加载中…" : "Loading…"}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/practices/new/page.tsx
+++ b/src/app/practices/new/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { PracticeForm } from "~/components/practices/practice-form";
+
+export default function NewPracticePage() {
+  const locale = useLocale();
+  return (
+    <div className="mx-auto max-w-xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "新建修习" : "New practice"}
+        title={
+          locale === "zh"
+            ? "添加行为干预"
+            : "Add a behavioural intervention"
+        }
+      />
+      <PracticeForm />
+    </div>
+  );
+}

--- a/src/app/practices/page.tsx
+++ b/src/app/practices/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import {
+  deactivateCustomPractice,
+  deleteCustomPractice,
+  isCustomPractice,
+  scheduleSummary,
+} from "~/lib/medication/practices";
+import { DRUGS_BY_ID } from "~/config/drug-registry";
+import type { Medication } from "~/types/medication";
+import { Plus, Sparkles } from "lucide-react";
+import { format, parseISO } from "date-fns";
+
+export default function PracticesPage() {
+  const locale = useLocale();
+  const rows = useLiveQuery(
+    () => db.medications.where("category").equals("behavioural").toArray(),
+    [],
+  );
+
+  const [active, archived] = useMemo(() => {
+    const a: Medication[] = [];
+    const x: Medication[] = [];
+    for (const m of rows ?? []) (m.active ? a : x).push(m);
+    return [a, x];
+  }, [rows]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "行为干预" : "Behavioural"}
+        title={locale === "zh" ? "修习" : "Practices"}
+      />
+
+      <Card className="p-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <div>
+            <div className="serif text-[18px] text-ink-900">
+              {locale === "zh"
+                ? "每日修习与身心干预"
+                : "Daily practices and mind-body interventions"}
+            </div>
+            <p className="mt-1 text-[13px] text-ink-600">
+              {locale === "zh"
+                ? "添加呼吸练习、冥想、走路、阻力训练 —— 每日记录形成节奏。"
+                : "Add breathing exercises, meditation, walking, resistance training. Logging daily builds the rhythm."}
+            </p>
+          </div>
+          <Link href="/practices/new">
+            <Button variant="primary" size="sm" className="gap-1">
+              <Plus className="h-4 w-4" />
+              {locale === "zh" ? "新建" : "Add"}
+            </Button>
+          </Link>
+        </div>
+      </Card>
+
+      {active.length === 0 ? (
+        <Card className="p-5 text-sm text-ink-500">
+          {locale === "zh"
+            ? "暂无修习。点击右上角新建第一项。"
+            : "No practices yet. Add your first above."}
+        </Card>
+      ) : (
+        <ul className="space-y-2">
+          {active.map((m) => (
+            <PracticeRow key={m.id} med={m} locale={locale} />
+          ))}
+        </ul>
+      )}
+
+      {archived.length > 0 && (
+        <section className="space-y-2">
+          <div className="eyebrow px-1">
+            {locale === "zh" ? "已存档" : "Archived"}
+          </div>
+          <ul className="space-y-2 opacity-70">
+            {archived.map((m) => (
+              <PracticeRow key={m.id} med={m} locale={locale} />
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function PracticeRow({
+  med,
+  locale,
+}: {
+  med: Medication;
+  locale: "en" | "zh";
+}) {
+  const catalogue = DRUGS_BY_ID[med.drug_id];
+  const name =
+    (locale === "zh" ? catalogue?.name.zh : catalogue?.name.en) ??
+    med.display_name ??
+    med.drug_id;
+  const custom = isCustomPractice(med);
+  const started = med.started_on
+    ? format(parseISO(med.started_on), "d MMM yyyy")
+    : "";
+
+  return (
+    <li>
+      <Card className="flex items-start gap-3 px-4 py-3">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-paper-2 text-ink-700">
+          <Sparkles className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-[13.5px] font-semibold text-ink-900">
+              {name}
+            </span>
+            {custom && (
+              <span className="mono rounded-full bg-[var(--tide-soft)] px-2 py-0.5 text-[9.5px] uppercase tracking-[0.12em] text-[var(--tide-2)]">
+                {locale === "zh" ? "自定义" : "custom"}
+              </span>
+            )}
+          </div>
+          <div className="mt-1 text-[12px] text-ink-600">
+            {med.dose} · {scheduleSummary(med.schedule, locale)}
+          </div>
+          {started && (
+            <div className="mt-0.5 text-[11px] text-ink-400">
+              {locale === "zh" ? "开始：" : "Since "}
+              {started}
+            </div>
+          )}
+          {med.notes && (
+            <p className="mt-1 text-[12px] text-ink-700">{med.notes}</p>
+          )}
+          {custom && med.active && med.id !== undefined && (
+            <div className="mt-2 flex gap-2">
+              <Link
+                href={`/practices/${med.id}`}
+                className="text-[11px] text-ink-500 hover:text-ink-900"
+              >
+                {locale === "zh" ? "编辑" : "Edit"}
+              </Link>
+              <button
+                type="button"
+                onClick={() => {
+                  if (med.id) void deactivateCustomPractice(med.id);
+                }}
+                className="text-[11px] text-ink-500 hover:text-ink-900"
+              >
+                {locale === "zh" ? "存档" : "Archive"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  if (med.id && confirm("Delete this practice and its logs?"))
+                    void deleteCustomPractice(med.id);
+                }}
+                className="text-[11px] text-ink-400 hover:text-[var(--warn)]"
+              >
+                {locale === "zh" ? "删除" : "Delete"}
+              </button>
+            </div>
+          )}
+        </div>
+      </Card>
+    </li>
+  );
+}

--- a/src/components/dashboard/practices-card.tsx
+++ b/src/components/dashboard/practices-card.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { DRUGS_BY_ID } from "~/config/drug-registry";
+import {
+  isCustomPractice,
+  scheduleSummary,
+} from "~/lib/medication/practices";
+import { logMedicationEvent } from "~/lib/medication/log";
+import { expectedDosesToday } from "~/lib/medication/log";
+import type { Medication } from "~/types/medication";
+import { Check, ChevronRight, Plus, Sparkles } from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+import { todayISO } from "~/lib/utils/date";
+
+/**
+ * Dashboard card for daily behavioural practices — breathing, meditation,
+ * walking, resistance training. Shows every active behavioural-category
+ * medication expected today (incl. catalogue items like qigong + custom
+ * user-added) and supports tap-to-log.
+ *
+ * Runs independent of treatment cycle so practices stay visible on rest
+ * weeks and off-cycle intervals.
+ */
+export function PracticesCard() {
+  const locale = useLocale();
+  const meds = useLiveQuery(
+    () =>
+      db.medications
+        .where("category")
+        .equals("behavioural")
+        .filter((m) => m.active)
+        .toArray(),
+    [],
+  );
+  const today = todayISO();
+  const todaysEvents = useLiveQuery(
+    () =>
+      db.medication_events
+        .where("logged_at")
+        .startsWith(today)
+        .toArray(),
+    [today],
+  );
+
+  const rows = useMemo(() => {
+    return (meds ?? [])
+      .map((m) => {
+        const due = expectedDosesToday(m.schedule);
+        const logged = (todaysEvents ?? []).filter(
+          (e) => e.medication_id === m.id && e.event_type === "taken",
+        ).length;
+        return { med: m, due, logged };
+      })
+      .filter((r) => r.due > 0 || r.logged > 0)
+      .sort(
+        (a, b) =>
+          (a.logged < a.due ? 0 : 1) - (b.logged < b.due ? 0 : 1),
+      );
+  }, [meds, todaysEvents]);
+
+  // Hide the card entirely when nothing is scheduled or logged today — keeps
+  // the dashboard quiet until the user has set up at least one practice.
+  if (meds === undefined || todaysEvents === undefined) return null;
+  if ((meds?.length ?? 0) === 0) return null;
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <div>
+          <div className="eyebrow">
+            {locale === "zh" ? "今日修习" : "Practices today"}
+          </div>
+          <div className="serif mt-1 text-[16px] text-ink-900">
+            {locale === "zh"
+              ? "每日行为节奏"
+              : "Your daily rhythm"}
+          </div>
+        </div>
+        <Link
+          href="/practices"
+          className="inline-flex items-center gap-1 text-[11px] text-ink-500 hover:text-ink-900"
+        >
+          {locale === "zh" ? "管理" : "Manage"}
+          <ChevronRight className="h-3 w-3" />
+        </Link>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="mt-3 flex items-center justify-between rounded-[var(--r-md)] bg-paper-2 p-3 text-[12px] text-ink-600">
+          <span>
+            {locale === "zh"
+              ? "今日没有已排程的修习。"
+              : "No practices scheduled for today."}
+          </span>
+          <Link href="/practices/new">
+            <Button variant="ghost" size="sm" className="gap-1">
+              <Plus className="h-3.5 w-3.5" />
+              {locale === "zh" ? "添加" : "Add"}
+            </Button>
+          </Link>
+        </div>
+      ) : (
+        <ul className="mt-3 space-y-1.5">
+          {rows.map(({ med, due, logged }) => (
+            <PracticeRow
+              key={med.id}
+              med={med}
+              due={due}
+              logged={logged}
+              locale={locale}
+            />
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+function PracticeRow({
+  med,
+  due,
+  logged,
+  locale,
+}: {
+  med: Medication;
+  due: number;
+  logged: number;
+  locale: "en" | "zh";
+}) {
+  const catalogue = DRUGS_BY_ID[med.drug_id];
+  const name =
+    (locale === "zh" ? catalogue?.name.zh : catalogue?.name.en) ??
+    med.display_name ??
+    med.drug_id;
+  const complete = due > 0 && logged >= due;
+  const count = `${logged}/${Math.max(due, 1)}`;
+  const custom = isCustomPractice(med);
+
+  const onLog = async () => {
+    if (!med.id) return;
+    await logMedicationEvent({
+      medication: med,
+      event_type: "taken",
+      source: "daily_checkin",
+    });
+  };
+
+  return (
+    <li className="flex items-center gap-3 rounded-[var(--r-md)] bg-paper-2 px-3 py-2">
+      <button
+        type="button"
+        onClick={onLog}
+        disabled={complete}
+        aria-label={complete ? "Done" : "Log practice"}
+        className={cn(
+          "flex h-6 w-6 shrink-0 items-center justify-center rounded-md border transition-colors",
+          complete
+            ? "border-[var(--ok)] bg-[var(--ok)] text-white"
+            : "border-ink-300 bg-paper hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]",
+        )}
+      >
+        {complete ? (
+          <Check className="h-3.5 w-3.5" strokeWidth={3} />
+        ) : (
+          <Sparkles className="h-3.5 w-3.5" />
+        )}
+      </button>
+      <div className="min-w-0 flex-1">
+        <div
+          className={cn(
+            "truncate text-[13px] font-medium",
+            complete ? "text-ink-500 line-through" : "text-ink-900",
+          )}
+        >
+          {name}
+          {custom && (
+            <span className="mono ml-2 text-[9px] uppercase tracking-[0.12em] text-ink-400">
+              custom
+            </span>
+          )}
+        </div>
+        <div className="text-[11px] text-ink-500">
+          {med.dose} · {scheduleSummary(med.schedule, locale)}
+        </div>
+      </div>
+      <span className="mono shrink-0 text-[10px] uppercase tracking-[0.12em] text-ink-400">
+        {count}
+      </span>
+    </li>
+  );
+}

--- a/src/components/practices/practice-form.tsx
+++ b/src/components/practices/practice-form.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, TextInput, Textarea } from "~/components/ui/field";
+import { useLocale } from "~/hooks/use-translate";
+import {
+  createCustomPractice,
+  updateCustomPractice,
+  type CustomPracticeInput,
+} from "~/lib/medication/practices";
+import type { Medication, ScheduleKind } from "~/types/medication";
+import { todayISO } from "~/lib/utils/date";
+import { cn } from "~/lib/utils/cn";
+
+type Cadence = "daily" | "multiple_daily" | "mwf" | "weekdays" | "as_needed";
+
+const CADENCES: { key: Cadence; en: string; zh: string; hint: string }[] = [
+  {
+    key: "daily",
+    en: "Once daily",
+    zh: "每日一次",
+    hint: "e.g. morning breathing, evening meditation",
+  },
+  {
+    key: "multiple_daily",
+    en: "Multiple times daily",
+    zh: "每日多次",
+    hint: "e.g. 4 × breathing breaks",
+  },
+  {
+    key: "mwf",
+    en: "Mon / Wed / Fri",
+    zh: "周一 / 三 / 五",
+    hint: "resistance training on recovery days",
+  },
+  {
+    key: "weekdays",
+    en: "Weekdays",
+    zh: "工作日",
+    hint: "structured weekday routine",
+  },
+  {
+    key: "as_needed",
+    en: "As needed",
+    zh: "按需",
+    hint: "not scheduled — log whenever you do it",
+  },
+];
+
+interface FormState {
+  name: string;
+  duration: string;
+  cadence: Cadence;
+  times_per_day: string;
+  clock_time: string;
+  notes: string;
+}
+
+function cadenceToSchedule(form: FormState): {
+  kind: ScheduleKind;
+  times_per_day?: number;
+  clock_times?: string[];
+  rrule?: string;
+} {
+  switch (form.cadence) {
+    case "daily":
+      return {
+        kind: "fixed",
+        times_per_day: 1,
+        clock_times: form.clock_time ? [form.clock_time] : undefined,
+      };
+    case "multiple_daily":
+      return {
+        kind: "fixed",
+        times_per_day: Number(form.times_per_day) || 2,
+      };
+    case "mwf":
+      return { kind: "custom", rrule: "FREQ=WEEKLY;BYDAY=MO,WE,FR" };
+    case "weekdays":
+      return { kind: "custom", rrule: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR" };
+    case "as_needed":
+      return { kind: "prn" };
+  }
+}
+
+function scheduleToFormCadence(med?: Medication): FormState["cadence"] {
+  if (!med) return "daily";
+  const s = med.schedule;
+  if (s.kind === "prn") return "as_needed";
+  if (s.kind === "custom" && s.rrule) {
+    if (s.rrule.includes("BYDAY=MO,WE,FR")) return "mwf";
+    if (s.rrule.includes("BYDAY=MO,TU,WE,TH,FR")) return "weekdays";
+  }
+  if (s.kind === "fixed" || s.kind === "with_meals") {
+    if ((s.times_per_day ?? 1) > 1) return "multiple_daily";
+    return "daily";
+  }
+  return "daily";
+}
+
+export function PracticeForm({ existing }: { existing?: Medication }) {
+  const locale = useLocale();
+  const router = useRouter();
+  const [form, setForm] = useState<FormState>({
+    name: "",
+    duration: "",
+    cadence: "daily",
+    times_per_day: "2",
+    clock_time: "",
+    notes: "",
+  });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!existing) return;
+    setForm({
+      name: existing.display_name ?? "",
+      duration: existing.dose ?? "",
+      cadence: scheduleToFormCadence(existing),
+      times_per_day: String(existing.schedule.times_per_day ?? 2),
+      clock_time: existing.schedule.clock_times?.[0] ?? "",
+      notes: existing.notes ?? "",
+    });
+  }, [existing]);
+
+  function update<K extends keyof FormState>(k: K, v: FormState[K]) {
+    setForm((f) => ({ ...f, [k]: v }));
+  }
+
+  const canSave = form.name.trim().length > 0 && form.duration.trim().length > 0;
+
+  async function save() {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const schedule = cadenceToSchedule(form);
+      const input: CustomPracticeInput = {
+        name: form.name.trim(),
+        duration: form.duration.trim(),
+        schedule_kind: schedule.kind,
+        times_per_day: schedule.times_per_day,
+        clock_times: schedule.clock_times,
+        rrule: schedule.rrule,
+        notes: form.notes.trim() || undefined,
+        started_on: existing?.started_on ?? todayISO(),
+      };
+      if (existing?.id) {
+        await updateCustomPractice(existing.id, input);
+      } else {
+        await createCustomPractice(input);
+      }
+      router.push("/practices");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card className="space-y-4 p-5">
+        <Field label={locale === "zh" ? "名称" : "Name"}>
+          <TextInput
+            value={form.name}
+            onChange={(e) => update("name", e.target.value)}
+            placeholder={
+              locale === "zh"
+                ? "例如：晨间呼吸"
+                : "e.g. Morning breathing"
+            }
+            autoFocus
+          />
+        </Field>
+        <Field
+          label={locale === "zh" ? "单次时长 / 次数" : "Duration / dose"}
+          hint={
+            locale === "zh"
+              ? "例如：10 分钟、20 次呼吸、3 组"
+              : "e.g. 10 min, 20 breaths, 3 sets"
+          }
+        >
+          <TextInput
+            value={form.duration}
+            onChange={(e) => update("duration", e.target.value)}
+            placeholder={locale === "zh" ? "10 分钟" : "10 min"}
+          />
+        </Field>
+
+        <Field
+          label={locale === "zh" ? "频率" : "How often"}
+        >
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {CADENCES.map((c) => {
+              const active = form.cadence === c.key;
+              return (
+                <button
+                  key={c.key}
+                  type="button"
+                  onClick={() => update("cadence", c.key)}
+                  className={cn(
+                    "rounded-[var(--r-md)] border p-3 text-left transition-colors",
+                    active
+                      ? "border-ink-900 bg-ink-900 text-paper"
+                      : "border-ink-200 bg-paper-2 text-ink-700 hover:border-ink-400",
+                  )}
+                >
+                  <div className="text-[13px] font-medium">
+                    {locale === "zh" ? c.zh : c.en}
+                  </div>
+                  <div
+                    className={cn(
+                      "text-[11px]",
+                      active ? "text-paper/80" : "text-ink-500",
+                    )}
+                  >
+                    {c.hint}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </Field>
+
+        {form.cadence === "daily" && (
+          <Field
+            label={
+              locale === "zh" ? "时间（可选）" : "Clock time (optional)"
+            }
+          >
+            <TextInput
+              type="time"
+              value={form.clock_time}
+              onChange={(e) => update("clock_time", e.target.value)}
+            />
+          </Field>
+        )}
+        {form.cadence === "multiple_daily" && (
+          <Field label={locale === "zh" ? "每日次数" : "Times per day"}>
+            <TextInput
+              type="number"
+              min={1}
+              max={12}
+              step={1}
+              value={form.times_per_day}
+              onChange={(e) => update("times_per_day", e.target.value)}
+            />
+          </Field>
+        )}
+
+        <Field
+          label={locale === "zh" ? "笔记（可选）" : "Notes (optional)"}
+        >
+          <Textarea
+            rows={3}
+            value={form.notes}
+            onChange={(e) => update("notes", e.target.value)}
+            placeholder={
+              locale === "zh"
+                ? "任何具体形式、目标或提醒"
+                : "Any specifics, goals, or reminders"
+            }
+          />
+        </Field>
+      </Card>
+
+      <CardContent className="flex items-center justify-end gap-2 p-0">
+        <Button variant="ghost" onClick={() => router.back()}>
+          {locale === "zh" ? "取消" : "Cancel"}
+        </Button>
+        <Button onClick={() => void save()} disabled={!canSave || saving}>
+          {saving
+            ? locale === "zh"
+              ? "保存中…"
+              : "Saving…"
+            : locale === "zh"
+              ? "保存"
+              : "Save"}
+        </Button>
+      </CardContent>
+    </div>
+  );
+}

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -12,6 +12,7 @@ import {
   Compass,
   Syringe,
   ListTodo,
+  Sparkles,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { useT } from "~/hooks/use-translate";
@@ -25,6 +26,7 @@ const ITEMS = [
   { href: "/treatment", key: "nav.treatment", icon: Syringe },
   { href: "/labs", key: "nav.labs", icon: FlaskConical },
   { href: "/tasks", key: "nav.tasks", icon: ListTodo },
+  { href: "/practices", key: "nav.practices", icon: Sparkles },
   { href: "/bridge", key: "nav.bridge", icon: Route },
   { href: "/ingest", key: "nav.ingest", icon: ScanLine },
   { href: "/reports", key: "nav.reports", icon: FileText },

--- a/src/lib/medication/practices.ts
+++ b/src/lib/medication/practices.ts
@@ -1,0 +1,162 @@
+// Custom behavioural practices — Hu Lin's breathing exercises, meditation,
+// walking, etc. Stored in the same `medications` table with
+// `category: "behavioural"` and `source: "user_added"`. Drug_id uses a
+// `custom:<slug>` namespace per docs/MEDICATIONS.md so they don't collide
+// with the curated DRUG_REGISTRY.
+import { db, now } from "~/lib/db/dexie";
+import type {
+  DoseSchedule,
+  Medication,
+  MedicationRoute,
+  ScheduleKind,
+} from "~/types/medication";
+import type { LocalizedText } from "~/types/treatment";
+
+export interface CustomPracticeInput {
+  name: string;                        // display name, e.g. "Morning breathing"
+  name_zh?: string;
+  duration: string;                    // "20 min" / "10 breaths"
+  schedule_kind: ScheduleKind;         // typically "fixed" or "custom"
+  clock_times?: string[];              // ["07:00"] for fixed-schedule
+  times_per_day?: number;
+  rrule?: string;                      // e.g. FREQ=WEEKLY;BYDAY=MO,WE,FR
+  notes?: string;
+  started_on?: string;                 // defaults to today
+}
+
+// Produce a URL-safe slug for the drug_id. Keeps it deterministic so editing
+// a practice by name doesn't create orphan rows.
+export function practiceSlug(name: string): string {
+  const base = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s-]+/g, "")
+    .replace(/\s+/g, "_")
+    .replace(/-+/g, "_")
+    .slice(0, 40);
+  return `custom:${base || "practice"}`;
+}
+
+function scheduleFromInput(input: CustomPracticeInput): DoseSchedule {
+  const schedule: DoseSchedule = {
+    kind: input.schedule_kind,
+    start_date: input.started_on,
+  };
+  if (input.schedule_kind === "fixed" || input.schedule_kind === "with_meals") {
+    schedule.times_per_day = input.times_per_day ?? 1;
+    if (input.clock_times?.length) schedule.clock_times = input.clock_times;
+  }
+  if (input.schedule_kind === "custom" && input.rrule) {
+    schedule.rrule = input.rrule;
+  }
+  // Attach a human-readable label for display.
+  schedule.label = {
+    en: scheduleLabelEn(input),
+    zh: scheduleLabelZh(input),
+  };
+  return schedule;
+}
+
+function scheduleLabelEn(input: CustomPracticeInput): string {
+  if (input.schedule_kind === "fixed") {
+    const n = input.times_per_day ?? 1;
+    const times = input.clock_times?.join(", ");
+    return times
+      ? `${n}× daily at ${times}`
+      : `${n}× daily`;
+  }
+  if (input.schedule_kind === "with_meals") {
+    return `${input.times_per_day ?? 3}× daily with meals`;
+  }
+  if (input.schedule_kind === "custom") {
+    return input.rrule ?? "Custom schedule";
+  }
+  return input.schedule_kind;
+}
+
+function scheduleLabelZh(input: CustomPracticeInput): string {
+  if (input.schedule_kind === "fixed") {
+    const n = input.times_per_day ?? 1;
+    const times = input.clock_times?.join(", ");
+    return times ? `每日 ${n} 次，于 ${times}` : `每日 ${n} 次`;
+  }
+  if (input.schedule_kind === "with_meals") {
+    return `每日 ${input.times_per_day ?? 3} 次与餐同服`;
+  }
+  if (input.schedule_kind === "custom") {
+    return input.rrule ?? "自定义计划";
+  }
+  return input.schedule_kind;
+}
+
+export async function createCustomPractice(
+  input: CustomPracticeInput,
+): Promise<number> {
+  const ts = now();
+  const med: Medication = {
+    drug_id: practiceSlug(input.name),
+    display_name: input.name,
+    category: "behavioural",
+    dose: input.duration,
+    route: "practice" as MedicationRoute,
+    schedule: scheduleFromInput(input),
+    source: "user_added",
+    active: true,
+    notes: input.notes,
+    started_on: input.started_on ?? ts.slice(0, 10),
+    created_at: ts,
+    updated_at: ts,
+  };
+  return (await db.medications.add(med)) as number;
+}
+
+export async function updateCustomPractice(
+  id: number,
+  input: CustomPracticeInput,
+): Promise<void> {
+  await db.medications.update(id, {
+    drug_id: practiceSlug(input.name),
+    display_name: input.name,
+    dose: input.duration,
+    schedule: scheduleFromInput(input),
+    notes: input.notes,
+    updated_at: now(),
+  });
+}
+
+export async function deactivateCustomPractice(id: number): Promise<void> {
+  await db.medications.update(id, {
+    active: false,
+    stopped_on: now(),
+    updated_at: now(),
+  });
+}
+
+export async function deleteCustomPractice(id: number): Promise<void> {
+  await db.medications.delete(id);
+}
+
+/**
+ * All active behavioural-category medications — both catalogued (qigong,
+ * resistance_training) and user-added custom ones.
+ */
+export async function listActivePractices(): Promise<Medication[]> {
+  const all = await db.medications.toArray();
+  return all.filter((m) => m.category === "behavioural" && m.active);
+}
+
+export function isCustomPractice(med: Medication): boolean {
+  return med.drug_id.startsWith("custom:");
+}
+
+export function scheduleSummary(
+  schedule: DoseSchedule,
+  locale: "en" | "zh",
+): string {
+  const label = schedule.label?.[locale];
+  if (label) return label;
+  return schedule.kind;
+}
+
+// Re-export for components that want a typed label accessor.
+export type CustomPracticeLabel = LocalizedText;

--- a/src/lib/validators/schemas.ts
+++ b/src/lib/validators/schemas.ts
@@ -51,6 +51,8 @@ export const settingsSchema = z.object({
   baseline_grip_nondominant_kg: z.number().min(0).max(100).optional(),
   baseline_gait_speed_ms: z.number().min(0).max(3).optional(),
   baseline_sit_to_stand: z.number().int().min(0).max(50).optional(),
+  baseline_sts_5x_seconds: z.number().min(0).max(120).optional(),
+  baseline_tug_seconds: z.number().min(0).max(120).optional(),
   baseline_muac_cm: z.number().min(15).max(50).optional(),
   baseline_calf_cm: z.number().min(20).max(60).optional(),
   locale: z.enum(["en", "zh"]),

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -291,7 +291,9 @@ export interface Settings {
   baseline_grip_dominant_kg?: number;
   baseline_grip_nondominant_kg?: number;
   baseline_gait_speed_ms?: number;
-  baseline_sit_to_stand?: number;
+  baseline_sit_to_stand?: number;     // 30-second sit-to-stand count
+  baseline_sts_5x_seconds?: number;   // 5× sit-to-stand time (seconds)
+  baseline_tug_seconds?: number;      // Timed Up-and-Go (seconds)
   baseline_muac_cm?: number;
   baseline_calf_cm?: number;
   height_cm?: number;

--- a/tests/unit/practices.test.ts
+++ b/tests/unit/practices.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  isCustomPractice,
+  practiceSlug,
+  scheduleSummary,
+} from "~/lib/medication/practices";
+import type { DoseSchedule, Medication } from "~/types/medication";
+
+function med(overrides: Partial<Medication> = {}): Medication {
+  return {
+    drug_id: "custom:morning_breathing",
+    display_name: "Morning breathing",
+    category: "behavioural",
+    dose: "10 min",
+    route: "practice",
+    schedule: { kind: "fixed", times_per_day: 1 },
+    source: "user_added",
+    active: true,
+    started_on: "2026-04-01",
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+describe("practiceSlug", () => {
+  it("produces a url-safe, custom-namespaced slug", () => {
+    expect(practiceSlug("Morning Breathing")).toBe("custom:morning_breathing");
+    expect(practiceSlug("Qigong — 15 min")).toBe("custom:qigong_15_min");
+  });
+
+  it("falls back to 'practice' on empty input", () => {
+    expect(practiceSlug("   ")).toBe("custom:practice");
+    expect(practiceSlug("")).toBe("custom:practice");
+  });
+
+  it("truncates overly long names", () => {
+    const slug = practiceSlug("a".repeat(80));
+    expect(slug.length).toBeLessThanOrEqual("custom:".length + 40);
+  });
+});
+
+describe("isCustomPractice", () => {
+  it("returns true for drug_ids prefixed with custom:", () => {
+    expect(isCustomPractice(med({ drug_id: "custom:walk" }))).toBe(true);
+  });
+  it("returns false for catalogue drugs like qigong", () => {
+    expect(isCustomPractice(med({ drug_id: "qigong" }))).toBe(false);
+    expect(isCustomPractice(med({ drug_id: "resistance_training" }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("scheduleSummary", () => {
+  it("prefers the schedule's localised label when present", () => {
+    const s: DoseSchedule = {
+      kind: "fixed",
+      label: { en: "Once daily at 07:00", zh: "每日 07:00 一次" },
+    };
+    expect(scheduleSummary(s, "en")).toBe("Once daily at 07:00");
+    expect(scheduleSummary(s, "zh")).toBe("每日 07:00 一次");
+  });
+
+  it("falls back to the kind when no label", () => {
+    expect(scheduleSummary({ kind: "prn" }, "en")).toBe("prn");
+  });
+});


### PR DESCRIPTION
Step-1 enablement for real data flowing. Closes two of the three gaps identified in the onboarding audit and adds the custom-practice flow Hu Lin needs for breathing exercises, meditation, walking, etc.

### Onboarding (src/app/onboarding/page.tsx)

Baselines step now captures the three objective functional measures the slice-2 detectors lean on:
- 30-second sit-to-stand (count)
- 5× sit-to-stand (seconds)
- Timed Up-and-Go (seconds)

Corresponding Settings fields added: `baseline_sts_5x_seconds`, `baseline_tug_seconds`. Zod validator updated. All three are optional — skip what hasn't been measured.

### Custom behavioural practices

New module `src/lib/medication/practices.ts`:
- `createCustomPractice`, `updateCustomPractice`, `deactivateCustomPractice`, `deleteCustomPractice`, `listActivePractices`
- `practiceSlug(name)` → `"custom:<slug>"` namespace (per docs/MEDICATIONS.md) so they don't collide with DRUG_REGISTRY
- Reuses the existing `medications` Dexie table (category=behavioural, source=user_added) — no new schema needed.

Pages:
- `/practices` — list all behavioural meds (catalogue + custom), with edit / archive / delete affordances per custom entry
- `/practices/new` + `/practices/[id]` — shared `PracticeForm` component. Cadence presets: daily, multiple-daily, MWF, weekdays, as-needed. Per-preset follow-up inputs (clock time, times/day).

Dashboard:
- New `PracticesCard` below MedicationPromptsCard. Lists today's scheduled behavioural items with tap-to-log checkboxes. Hidden when no practices are configured. Runs independent of treatment cycle so practices stay visible on rest weeks and off-cycle intervals.

Side menu + mobile-nav eligibility: `/practices` added with Sparkles icon. i18n keys `nav.practices` in EN + ZH.

### Tests

`tests/unit/practices.test.ts` (7 tests): slug generation (url-safe, length-limited, empty fallback), custom-vs-catalogue discrimination, schedule summary localisation + fallback.

166 tests pass. typecheck / lint / build clean.

### Next

PR 2 (stacked): backfill importer for labs CSV + weight history + prior cycles so Hu Lin's existing data pre-populates the trend model, plus a data-coverage chip on the dashboard.

https://claude.ai/code/session_01754ihnx36senmjkTiJxAP3