### PR TITLE
Consolidate duplicated date/error/settings helpers

### DIFF
--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useLiveQuery } from "dexie-react-hooks";
 import { format } from "date-fns";
 import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -19,13 +19,14 @@ import {
   type MealEstimate,
 } from "~/lib/ingest/meal-vision";
 import { todayISO } from "~/lib/utils/date";
+import { getErrorMessage } from "~/lib/utils/error";
 import { Sparkles, Check, Loader2, AlertCircle } from "lucide-react";
 
 export default function MealIngestPage() {
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
-  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+  const settings = useSettings();
+  const apiKey = settings?.anthropic_api_key;
+  const model = settings?.default_ai_model ?? "claude-opus-4-7";
 
   const [prepared, setPrepared] = useState<PreparedImage | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
@@ -44,7 +45,7 @@ export default function MealIngestPage() {
       const blob = new Blob([Uint8Array.from(atob(p.base64), (c) => c.charCodeAt(0))]);
       setPreview(URL.createObjectURL(blob));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(null);
     }
@@ -58,7 +59,7 @@ export default function MealIngestPage() {
       const result = await estimateMeal({ apiKey, model, image: prepared });
       setEstimate(result);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(null);
     }

--- a/src/app/ingest/notes/page.tsx
+++ b/src/app/ingest/notes/page.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -18,15 +18,16 @@ import {
   type NotesStructure,
 } from "~/lib/ingest/notes-vision";
 import { todayISO } from "~/lib/utils/date";
+import { getErrorMessage } from "~/lib/utils/error";
 import { Sparkles, Check, Loader2, AlertCircle } from "lucide-react";
 
 type DailyPatch = NonNullable<NotesStructure["daily_patch"]>;
 
 export default function NotesIngestPage() {
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
-  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+  const settings = useSettings();
+  const apiKey = settings?.anthropic_api_key;
+  const model = settings?.default_ai_model ?? "claude-opus-4-7";
 
   const [prepared, setPrepared] = useState<PreparedImage | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
@@ -45,7 +46,7 @@ export default function NotesIngestPage() {
       const blob = new Blob([Uint8Array.from(atob(p.base64), (c) => c.charCodeAt(0))]);
       setPreview(URL.createObjectURL(blob));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(null);
     }
@@ -59,7 +60,7 @@ export default function NotesIngestPage() {
       const result = await structureNotes({ apiKey, model, image: prepared });
       setStructured(result);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(null);
     }

--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
 import { useLocale, useT } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -25,8 +26,8 @@ function newId(): string {
 export default function IngestPage() {
   const t = useT();
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
+  const settings = useSettings();
+  const apiKey = settings?.anthropic_api_key;
   const apiKeyConfigured = !!apiKey;
 
   const [items, setItems] = useState<BulkItem[]>([]);

--- a/src/components/assessment/coach-drawer.tsx
+++ b/src/components/assessment/coach-drawer.tsx
@@ -1,19 +1,19 @@
 "use client";
 
 import { useState } from "react";
-import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils/cn";
 import { useLocale } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { askCoach, type CoachContext, type CoachMessage } from "~/lib/ai/coach";
+import { getErrorMessage } from "~/lib/utils/error";
 import { Sparkles, X, Send, Loader2 } from "lucide-react";
 
 export function CoachDrawer({ context }: { context: CoachContext }) {
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
-  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+  const settings = useSettings();
+  const apiKey = settings?.anthropic_api_key;
+  const model = settings?.default_ai_model ?? "claude-opus-4-7";
 
   const [open, setOpen] = useState(false);
   const [history, setHistory] = useState<CoachMessage[]>([]);
@@ -42,7 +42,7 @@ export function CoachDrawer({ context }: { context: CoachContext }) {
       });
       setHistory((h) => [...h, { role: "assistant", content: reply }]);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(false);
     }

--- a/src/components/assessment/wizard.tsx
+++ b/src/components/assessment/wizard.tsx
@@ -12,6 +12,8 @@ import {
   type TestId,
 } from "~/lib/assessment/catalog";
 import { todayISO } from "~/lib/utils/date";
+import { getErrorMessage } from "~/lib/utils/error";
+import { useSettings } from "~/hooks/use-settings";
 import type { ComprehensiveAssessment } from "~/types/clinical";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
@@ -79,8 +81,7 @@ export function AssessmentWizard({ assessmentId }: WizardProps) {
     () => db.comprehensive_assessments.get(assessmentId),
     [assessmentId],
   );
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const baseline = settings?.[0] ?? null;
+  const baseline = useSettings() ?? null;
 
   const [draft, setDraft] = useState<AssessmentDraft>({});
   const [tests, setTests] = useState<TestId[]>([]);
@@ -441,7 +442,7 @@ function ReviewView({
         updated_at: now(),
       });
     } catch (e) {
-      setAiError(e instanceof Error ? e.message : String(e));
+      setAiError(getErrorMessage(e));
     } finally {
       setAiBusy(false);
     }

--- a/src/components/daily/morning-checkin.tsx
+++ b/src/components/daily/morning-checkin.tsx
@@ -6,6 +6,7 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { dailyEntrySchema } from "~/lib/validators/schemas";
 import { todayISO } from "~/lib/utils/date";
+import { formatZodIssues } from "~/lib/utils/validation";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { runEngineAndPersist } from "~/lib/rules/engine";
@@ -157,7 +158,7 @@ export function MorningCheckin({
         reflection_lang: locale,
       });
       if (!parsed.success) {
-        setError(parsed.error.issues.map((i) => i.message).join(", "));
+        setError(formatZodIssues(parsed.error));
         return;
       }
       const payload = {

--- a/src/components/dashboard/emergency-card.tsx
+++ b/src/components/dashboard/emergency-card.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import { useLiveQuery } from "dexie-react-hooks";
 import { useState } from "react";
-import { db } from "~/lib/db/dexie";
 import { useZoneStatus } from "~/hooks/use-zone-status";
 import { useLocale } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { Phone, AlertOctagon, MapPin, ChevronDown, ChevronUp } from "lucide-react";
 
 export function EmergencyCard() {
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const s = settings?.[0];
+  const s = useSettings();
   const { zone } = useZoneStatus();
 
   const hasAnyContact =

--- a/src/components/dashboard/pillar-tiles.tsx
+++ b/src/components/dashboard/pillar-tiles.tsx
@@ -3,16 +3,15 @@
 import Link from "next/link";
 import { useLiveQuery } from "dexie-react-hooks";
 import { useMemo } from "react";
-import {
-  differenceInCalendarDays,
-  format,
-  parseISO,
-} from "date-fns";
+import { format, parseISO } from "date-fns";
 import { db } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
 import { useWeather } from "~/hooks/use-weather";
+import { useSettings } from "~/hooks/use-settings";
 import { Sparkline } from "~/components/ui/sparkline";
 import { PROTOCOL_BY_ID } from "~/config/protocols";
+import { cycleDayFor } from "~/lib/treatment/engine";
+import { todayISO as todayISOString } from "~/lib/utils/date";
 import { cn } from "~/lib/utils/cn";
 import {
   ArrowDown,
@@ -60,14 +59,14 @@ export function PillarTiles() {
   const cycles = useLiveQuery(() =>
     db.treatment_cycles.orderBy("start_date").reverse().limit(1).toArray(),
   );
-  const settings = useLiveQuery(() => db.settings.toArray());
+  const settings = useSettings();
 
   const ordered = (dailies ?? []).slice().reverse();
-  const todayISO = format(new Date(), "yyyy-MM-dd");
+  const todayISO = todayISOString();
   const todayEntry = ordered.find((d) => d.date === todayISO);
   const recentCycle = (cycles ?? [])[0];
   const latestLab = (labs ?? [])[0];
-  const baselineWeight = settings?.[0]?.baseline_weight_kg;
+  const baselineWeight = settings?.baseline_weight_kg;
 
   // -- Symptoms 7d -------------------------------------------------------
   const symptomSeries = useMemo(
@@ -89,8 +88,7 @@ export function PillarTiles() {
     if (!recentCycle || recentCycle.status !== "active") return null;
     const protocol = PROTOCOL_BY_ID[recentCycle.protocol_id];
     if (!protocol) return null;
-    const cycleDay =
-      differenceInCalendarDays(new Date(), parseISO(recentCycle.start_date)) + 1;
+    const cycleDay = cycleDayFor(recentCycle.start_date);
     const doseDays = protocol.dose_days;
     const next = doseDays.find((d) => d >= cycleDay);
     if (next === undefined) return null;

--- a/src/components/dashboard/sarcopenia-card.tsx
+++ b/src/components/dashboard/sarcopenia-card.tsx
@@ -4,6 +4,7 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { useLocale } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import {
   assessSarcopenia,
   sarcopeniaLevelLabel,
@@ -31,11 +32,11 @@ export function SarcopeniaCard() {
       .limit(1)
       .toArray(),
   );
-  const settings = useLiveQuery(() => db.settings.toArray());
+  const settings = useSettings();
 
   const assessment = assessSarcopenia(
     latest?.[0] ?? null,
-    settings?.[0] ?? null,
+    settings ?? null,
   );
 
   const noData =

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -2,11 +2,10 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
 import { useTodayFeed } from "~/hooks/use-today-feed";
 import { useWeather } from "~/hooks/use-weather";
 import { useLocale } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { generateNarrative } from "~/lib/nudges/ai-narrative";
 import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -84,9 +83,9 @@ export function TodayFeed({
     excludeIds.length === 0
       ? rawFeed
       : rawFeed.filter((f) => !excludeIds.includes(f.id));
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
-  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+  const settings = useSettings();
+  const apiKey = settings?.anthropic_api_key;
+  const model = settings?.default_ai_model ?? "claude-opus-4-7";
 
   const [expanded, setExpanded] = useState(false);
   const [narrative, setNarrative] = useState<string | null>(null);

--- a/src/components/dashboard/today-plan-card.tsx
+++ b/src/components/dashboard/today-plan-card.tsx
@@ -3,11 +3,12 @@
 import Link from "next/link";
 import { useMemo } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { format, parseISO, differenceInCalendarDays } from "date-fns";
+import { format } from "date-fns";
 import { db } from "~/lib/db/dexie";
 import { Card } from "~/components/ui/card";
 import { useLocale } from "~/hooks/use-translate";
 import { PROTOCOL_BY_ID } from "~/config/protocols";
+import { cycleDayFor } from "~/lib/treatment/engine";
 import type { TreatmentCycle } from "~/types/treatment";
 import type { PatientTask } from "~/types/task";
 import {
@@ -64,8 +65,7 @@ export function TodayPlanCard() {
     if (!active) return base;
     const protocol = PROTOCOL_BY_ID[active.protocol_id];
     if (!protocol) return base;
-    const cycleDay =
-      differenceInCalendarDays(new Date(), parseISO(active.start_date)) + 1;
+    const cycleDay = cycleDayFor(active.start_date);
     const phase = protocol.phase_windows.find(
       (p) => cycleDay >= p.day_start && cycleDay <= p.day_end,
     );

--- a/src/components/fortnightly/fortnightly-form.tsx
+++ b/src/components/fortnightly/fortnightly-form.tsx
@@ -6,9 +6,11 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { useUIStore } from "~/stores/ui-store";
 import { useLocale, useT } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { runEngineAndPersist } from "~/lib/rules/engine";
 import { fortnightlyAssessmentSchema } from "~/lib/validators/schemas";
 import { todayISO } from "~/lib/utils/date";
+import { formatZodIssues } from "~/lib/utils/validation";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { SectionHeader } from "~/components/ui/page-header";
 import { Button } from "~/components/ui/button";
@@ -48,8 +50,7 @@ export function FortnightlyForm({ entryId }: { entryId?: number }) {
   const locale = useLocale();
   const router = useRouter();
   const enteredBy = useUIStore((s) => s.enteredBy);
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const baseline = settings?.[0];
+  const baseline = useSettings();
 
   const existing = useLiveQuery(
     () => (entryId ? db.fortnightly_assessments.get(entryId) : undefined),
@@ -98,7 +99,7 @@ export function FortnightlyForm({ entryId }: { entryId?: number }) {
         sarc_f_total: sarcFilled ? scoreSarcF(form.sarc_f_responses!) : undefined,
       });
       if (!parsed.success) {
-        setError(parsed.error.issues.map((i) => i.message).join(", "));
+        setError(formatZodIssues(parsed.error));
         return;
       }
       const payload = {

--- a/src/components/tasks/preset-picker.tsx
+++ b/src/components/tasks/preset-picker.tsx
@@ -6,17 +6,10 @@ import { useLocale } from "~/hooks/use-translate";
 import { addDays, parseISO } from "date-fns";
 import { TASK_PRESETS } from "~/config/task-presets";
 import type { PatientTask, TaskPreset } from "~/types/task";
-import { todayISO } from "~/lib/utils/date";
+import { toISODate, todayISO } from "~/lib/utils/date";
 import { cn } from "~/lib/utils/cn";
 import { Card, CardContent } from "~/components/ui/card";
 import { Plus, Check } from "lucide-react";
-
-function toISODate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${dd}`;
-}
 
 export function PresetPicker() {
   const locale = useLocale();

--- a/src/components/treatment/cycle-calendar.tsx
+++ b/src/components/treatment/cycle-calendar.tsx
@@ -6,6 +6,7 @@ import { db } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
 import type { Protocol, TreatmentCycle } from "~/types/treatment";
 import { cycleDayFor, currentPhase } from "~/lib/treatment/engine";
+import { MS_PER_DAY } from "~/lib/utils/date";
 import { FlaskConical } from "lucide-react";
 
 type Swatch = {
@@ -100,7 +101,7 @@ export function CycleCalendar({
         Math.min(
           protocol.cycle_length_days,
           Math.floor(
-            (parseISO(l.date).getTime() - start.getTime()) / 86400000,
+            (parseISO(l.date).getTime() - start.getTime()) / MS_PER_DAY,
           ) + 1,
         ),
       ),

--- a/src/components/weekly/weekly-form.tsx
+++ b/src/components/weekly/weekly-form.tsx
@@ -8,6 +8,7 @@ import { useUIStore } from "~/stores/ui-store";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { weekStartISO, weekDates, formatWeekRange } from "~/lib/utils/week";
 import { weeklyAssessmentSchema } from "~/lib/validators/schemas";
+import { formatZodIssues } from "~/lib/utils/validation";
 import { runEngineAndPersist } from "~/lib/rules/engine";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -145,7 +146,7 @@ export function WeeklyForm({ entryId }: { entryId?: number }) {
         week_summary: form.week_summary || undefined,
       });
       if (!parsed.success) {
-        setError(parsed.error.issues.map((i) => i.message).join(", "));
+        setError(formatZodIssues(parsed.error));
         return;
       }
       const payload = {

--- a/src/hooks/use-metrics.ts
+++ b/src/hooks/use-metrics.ts
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
+import { useSettings } from "~/hooks/use-settings";
 import type { DailyEntry, Settings } from "~/types/clinical";
 
 export interface BodyMetrics {
@@ -30,8 +31,7 @@ export function useBodyMetrics(): BodyMetrics {
   const entries = useLiveQuery(() =>
     db.daily_entries.orderBy("date").reverse().limit(28).toArray(),
   );
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const baseline = settings?.[0];
+  const baseline = useSettings();
 
   return useMemo(
     () => computeMetrics(entries ?? [], baseline),

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import type { Settings } from "~/types/clinical";
+
+// Reactively read the single Settings row the app uses (Anchor is
+// single-patient). Returns `undefined` while Dexie is still loading and after
+// load when no Settings row exists yet (pre-onboarding). Consumers should
+// treat `undefined` as "not ready / no settings".
+export function useSettings(): Settings | undefined {
+  const rows = useLiveQuery(() => db.settings.toArray());
+  return rows?.[0];
+}

--- a/src/hooks/use-today-feed.ts
+++ b/src/hooks/use-today-feed.ts
@@ -2,12 +2,13 @@
 
 import { useMemo } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { differenceInCalendarDays, parseISO } from "date-fns";
 import { db } from "~/lib/db/dexie";
 import { composeTodayFeed } from "~/lib/nudges/compose";
 import { PROTOCOL_BY_ID } from "~/config/protocols";
 import { NUDGE_LIBRARY } from "~/config/treatment-nudges";
 import { todayISO } from "~/lib/utils/date";
+import { cycleDayFor } from "~/lib/treatment/engine";
+import { useSettings } from "~/hooks/use-settings";
 import type { FeedItem } from "~/types/feed";
 import type { CycleContext, NudgeTemplate } from "~/types/treatment";
 import type { CurrentWeather } from "~/lib/weather/open-meteo";
@@ -17,7 +18,7 @@ export function useTodayFeed({
 }: {
   weather: CurrentWeather | null;
 }): FeedItem[] {
-  const settings = useLiveQuery(() => db.settings.toArray());
+  const settings = useSettings();
   const dailies = useLiveQuery(() =>
     db.daily_entries.orderBy("date").reverse().limit(28).toArray(),
   );
@@ -31,7 +32,7 @@ export function useTodayFeed({
   );
 
   return useMemo(() => {
-    const s = settings?.[0] ?? null;
+    const s = settings ?? null;
     const orderedDailies = (dailies ?? []).slice().reverse();
     const orderedLabs = (labs ?? []).slice().reverse();
     const openAlerts = (alerts ?? []).filter((a) => !a.resolved);
@@ -41,8 +42,7 @@ export function useTodayFeed({
     if (active) {
       const protocol = PROTOCOL_BY_ID[active.protocol_id];
       if (protocol) {
-        const cycleDay =
-          differenceInCalendarDays(new Date(), parseISO(active.start_date)) + 1;
+        const cycleDay = cycleDayFor(active.start_date);
         const phase = protocol.phase_windows.find(
           (p) => cycleDay >= p.day_start && cycleDay <= p.day_end,
         );

--- a/src/hooks/use-weather.ts
+++ b/src/hooks/use-weather.ts
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
+import { useSettings } from "~/hooks/use-settings";
 import {
   fetchCurrentWeather,
   type CurrentWeather,
@@ -11,8 +10,7 @@ import {
 const CACHE_MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 export function useWeather(): CurrentWeather | null {
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const s = settings?.[0];
+  const s = useSettings();
   const city = s?.home_city;
   const lat = s?.home_lat;
   const lon = s?.home_lon;

--- a/src/lib/ingest/save.ts
+++ b/src/lib/ingest/save.ts
@@ -1,5 +1,6 @@
 import { db, now } from "~/lib/db/dexie";
 import { runEngineAndPersist } from "~/lib/rules/engine";
+import { todayISO } from "~/lib/utils/date";
 import type {
   IngestedDocument,
   IngestedDocumentKind,
@@ -72,7 +73,7 @@ export async function saveExtraction(
 
   if (extraction.labs && Object.keys(extraction.labs).length > 0) {
     const labRow: LabResult = {
-      date: extraction.document_date ?? todayDate(),
+      date: extraction.document_date ?? todayISO(),
       source: "external",
       notes: extraction.summary,
       ...extraction.labs,
@@ -84,7 +85,7 @@ export async function saveExtraction(
 
   if (extraction.imaging && extraction.imaging.modality) {
     const imgId = await db.imaging.add({
-      date: extraction.imaging.date ?? extraction.document_date ?? todayDate(),
+      date: extraction.imaging.date ?? extraction.document_date ?? todayISO(),
       modality: extraction.imaging.modality,
       findings_summary:
         extraction.imaging.findings_summary ?? extraction.summary ?? "",
@@ -97,7 +98,7 @@ export async function saveExtraction(
 
   if (extraction.ctdna) {
     const ctId = await db.ctdna_results.add({
-      date: extraction.ctdna.date ?? extraction.document_date ?? todayDate(),
+      date: extraction.ctdna.date ?? extraction.document_date ?? todayISO(),
       platform: extraction.ctdna.platform ?? "other",
       detected: extraction.ctdna.detected ?? false,
       value: extraction.ctdna.value,
@@ -112,7 +113,7 @@ export async function saveExtraction(
     const pid = await db.pending_results.add({
       test_name: item.test_name,
       category: item.category,
-      ordered_date: todayDate(),
+      ordered_date: todayISO(),
       received: false,
       created_at: ts,
       updated_at: ts,
@@ -143,12 +144,4 @@ export async function saveExtraction(
 
   await runEngineAndPersist();
   return result;
-}
-
-function todayDate(): string {
-  const d = new Date();
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${dd}`;
 }

--- a/src/lib/state/baselines.ts
+++ b/src/lib/state/baselines.ts
@@ -10,17 +10,8 @@
 // - cycle_matched: same cycle day of the previous cycle — the right reference
 //   for "is this cycle worse than the last one".
 // - fixed: a hard clinical constant.
+import { isoFromEpochDay, toEpochDays } from "~/lib/utils/date";
 import type { Baseline, Observation } from "./types";
-
-function toEpochDays(iso: string): number {
-  const t = Date.parse(iso);
-  if (Number.isNaN(t)) return Number.NaN;
-  return Math.floor(t / 86_400_000);
-}
-
-function isoFromEpochDay(day: number): string {
-  return new Date(day * 86_400_000).toISOString().slice(0, 10);
-}
 
 function meanOf(observations: readonly Observation[]): number | null {
   const valid = observations

--- a/src/lib/state/build.ts
+++ b/src/lib/state/build.ts
@@ -11,6 +11,7 @@ import type {
 } from "~/types/clinical";
 import type { TreatmentCycle } from "~/types/treatment";
 import { PROTOCOL_BY_ID } from "~/config/protocols";
+import { MS_PER_DAY, toEpochDays } from "~/lib/utils/date";
 import { METRIC_REGISTRY } from "./metrics";
 import {
   cycleMatchedBaseline,
@@ -82,7 +83,7 @@ function resolveActiveCycle(
       : PROTOCOL_BY_ID[candidate.protocol_id];
   const startMs = Date.parse(candidate.start_date);
   if (Number.isNaN(startMs)) return null;
-  const cycleDay = Math.floor((asOf - startMs) / 86_400_000) + 1;
+  const cycleDay = Math.floor((asOf - startMs) / MS_PER_DAY) + 1;
   return {
     cycle_id: candidate.id,
     cycle_number: candidate.cycle_number,
@@ -181,8 +182,8 @@ function computeTrajectory(
 
   const fresh = (() => {
     if (!latest) return false;
-    const asOfDay = Math.floor(Date.parse(inputs.as_of) / 86_400_000);
-    const latestDay = Math.floor(Date.parse(latest.date) / 86_400_000);
+    const asOfDay = toEpochDays(inputs.as_of);
+    const latestDay = toEpochDays(latest.date);
     if (Number.isNaN(asOfDay) || Number.isNaN(latestDay)) return false;
     return asOfDay - latestDay <= metric.cadence_days * 2;
   })();

--- a/src/lib/state/slope.ts
+++ b/src/lib/state/slope.ts
@@ -1,14 +1,6 @@
 // Slope / acceleration primitives — pure functions, no Dexie, no Date.now.
+import { isoFromEpochDay, toEpochDays } from "~/lib/utils/date";
 import type { Observation } from "./types";
-
-function toEpochDays(iso: string): number {
-  // Always reduce the observation's date to midnight UTC so observations
-  // logged at different times of day don't produce artificial sub-day slope
-  // noise. Accepts both YYYY-MM-DD and full ISO datetimes.
-  const t = Date.parse(iso);
-  if (Number.isNaN(t)) return Number.NaN;
-  return Math.floor(t / 86_400_000);
-}
 
 /**
  * Returns observations whose `date` falls within the closed interval
@@ -87,9 +79,7 @@ export function accelOver(
   if (Number.isNaN(asOfDay)) return null;
   const recent = observationsInWindow(observations, asOfISO, halfWindow);
   const priorEndDay = asOfDay - halfWindow;
-  const priorEndISO = new Date(priorEndDay * 86_400_000)
-    .toISOString()
-    .slice(0, 10);
+  const priorEndISO = isoFromEpochDay(priorEndDay);
   const prior = observationsInWindow(observations, priorEndISO, halfWindow);
   const sRecent = olsSlopePerDay(recent);
   const sPrior = olsSlopePerDay(prior);

--- a/src/lib/tasks/engine.ts
+++ b/src/lib/tasks/engine.ts
@@ -6,13 +6,7 @@ import type {
   TaskInstance,
 } from "~/types/task";
 import type { CycleContext } from "~/types/treatment";
-
-function toISODate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${dd}`;
-}
+import { toISODate } from "~/lib/utils/date";
 
 export function nextRecurringDueDate(task: PatientTask, today: Date): string {
   if (task.schedule_kind !== "recurring") return task.due_date ?? toISODate(today);

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,11 +1,28 @@
 import { format, parseISO } from "date-fns";
 
-export function todayISO(): string {
-  const d = new Date();
+export const MS_PER_DAY = 86_400_000;
+
+export function toISODate(d: Date): string {
   const yyyy = d.getFullYear();
   const mm = String(d.getMonth() + 1).padStart(2, "0");
   const dd = String(d.getDate()).padStart(2, "0");
   return `${yyyy}-${mm}-${dd}`;
+}
+
+export function todayISO(): string {
+  return toISODate(new Date());
+}
+
+// Convert an ISO date or datetime to epoch-day (UTC midnight buckets).
+// Returns NaN for inputs Date.parse can't handle.
+export function toEpochDays(iso: string): number {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return Number.NaN;
+  return Math.floor(t / MS_PER_DAY);
+}
+
+export function isoFromEpochDay(day: number): string {
+  return new Date(day * MS_PER_DAY).toISOString().slice(0, 10);
 }
 
 export function formatDate(iso: string, locale: "en" | "zh" = "en"): string {

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,0 +1,4 @@
+// Narrow an unknown caught value to a displayable message string.
+export function getErrorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -1,0 +1,6 @@
+import type { ZodError } from "zod";
+
+// Flatten a ZodError's issue list into a comma-separated user-facing string.
+export function formatZodIssues(error: ZodError): string {
+  return error.issues.map((i) => i.message).join(", ");
+}


### PR DESCRIPTION
## Summary

Surgical DRY pass over the codebase — no behaviour change. An explore agent
surveyed 169 source files and identified concrete duplication clusters; this PR
fixes the high-ROI, low-risk ones by giving each copy-pasted helper a single
home.

### Utilities added / extended

- **`src/lib/utils/date.ts`** — new `MS_PER_DAY`, `toISODate`, `toEpochDays`,
  `isoFromEpochDay`. Replaces local copies in `state/slope`, `state/baselines`,
  `state/build`, `tasks/engine`, `tasks/preset-picker`,
  `treatment/cycle-calendar`, and the ad-hoc `todayDate()` in `ingest/save`.
- **`src/lib/utils/error.ts`** — new `getErrorMessage(e: unknown)`. Replaces
  the `e instanceof Error ? e.message : String(e)` pattern in 4 files
  (`coach-drawer`, `assessment/wizard`, `ingest/meal`, `ingest/notes`).
- **`src/lib/utils/validation.ts`** — new `formatZodIssues(error)`. Replaces
  the `.issues.map(i => i.message).join(", ")` pattern in 3 form components
  (`morning-checkin`, `weekly-form`, `fortnightly-form`).
- **`src/hooks/use-settings.ts`** — new `useSettings()` returning the single
  Settings row. Replaces `useLiveQuery(() => db.settings.toArray())` +
  `settings?.[0]?.foo` in 10 components/hooks. Four call sites
  (dashboard, onboarding, reports, settings page) still read the raw array
  because they rely on the loaded-vs-loading distinction.

### Cycle-day computation

Three callers (`pillar-tiles`, `today-plan-card`, `use-today-feed`) reimplemented
`differenceInCalendarDays(new Date(), parseISO(start)) + 1`; they now delegate
to the existing `cycleDayFor()` helper in `lib/treatment/engine`.

### Stats

- 27 files changed, 123 insertions, 118 deletions
- 3 new utility files, 0 behaviour changes
- All 166 unit tests pass
- Typecheck clean, `next build` succeeds, lint shows only pre-existing warnings

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 166/166 pass
- [x] `pnpm build` succeeds
- [x] `pnpm lint` — no new warnings introduced
- [ ] Manual smoke: daily check-in save, fortnightly form save, onboarding gate
- [ ] Manual smoke: dashboard renders with and without an active cycle
- [ ] Manual smoke: ingest/meal and ingest/notes save flows

https://claude.ai/code/session_01X8S9jA6DVndoeaeeZ4SdsK