### PR TITLE
Cloud deploy v1: Supabase auth + Dexie sync layer

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,11 @@
-# Anchor is local-first. No required server-side env vars for MVP.
-# Copy to .env.local if you need to set optional overrides.
+# Anchor keeps a local-first Dexie/IndexedDB store and optionally syncs it to
+# a shared Supabase project so dad + Tom see the same data.
+#
+# If both Supabase vars are blank, the app runs fully offline with no cloud
+# sync and no login gate — useful for development and contributors.
+
 NEXT_PUBLIC_APP_NAME=Anchor
+
+# From Supabase → Project Settings → API
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=tzmxmknkccxbvjhfvsdy"
+    }
+  }
+}

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,86 @@
+# Shipping Anchor
+
+End-to-end instructions to get Anchor live on a URL, with cloud persistence
+and login, so dad can use it on his phone and Tom can see the same data.
+
+## 1. Supabase project (10 min)
+
+1. Go to https://supabase.com → **New project**.
+2. Name it `anchor`, pick any region (Sydney if available), set a strong
+   database password (you won't need it day-to-day).
+3. Once the project finishes provisioning, open **SQL Editor** → **New query**.
+4. Paste the contents of `supabase/schema.sql` from this repo and **Run**.
+   You should see the `cloud_rows` table in **Table Editor**.
+5. **Authentication → Providers**: make sure **Email** is enabled. For the
+   fastest flow turn **OFF** "Confirm email" (Authentication → Settings →
+   Email Auth → Confirm email). We can turn it back on later.
+6. **Authentication → URL Configuration**:
+   - Site URL: `https://<your-vercel-domain>` (paste this after step 3 below)
+   - Redirect URLs: add `https://<your-vercel-domain>/auth/callback`
+7. **Authentication → Users → Add user**:
+   - `hulin.melb@hotmail.com` with a simple password dad will remember
+   - `thomas.findoasis@gmail.com` with your password
+
+Copy from **Project Settings → API**:
+- Project URL (`https://xxx.supabase.co`)
+- `anon` / `publishable` key
+
+## 2. Environment variables
+
+Local dev already has a `.env.local` pointing at the Supabase project. For
+production, set the same two keys in Vercel (step 3).
+
+```
+NEXT_PUBLIC_SUPABASE_URL=https://tzmxmknkccxbvjhfvsdy.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_7TeUX3uaUaeL3oqCx7oHdA_Ub0P6Buw
+```
+
+## 3. Vercel deploy (5 min)
+
+1. Go to https://vercel.com → **Add new → Project** → import
+   `flytonewyork/medicai`.
+2. Framework preset: **Next.js** (auto-detected).
+3. Under **Environment Variables**, add the two `NEXT_PUBLIC_SUPABASE_*`
+   entries above. Scope: *Production, Preview, Development*.
+4. Click **Deploy**. First build takes ~2 min.
+5. Once deployed, copy the production URL (e.g.
+   `https://medicai-xxxxx.vercel.app`) and paste it back into Supabase →
+   Authentication → URL Configuration (see step 1.6).
+
+## 4. First-run smoke test
+
+1. Visit the production URL → you land on `/login`.
+2. Sign in with `hulin.melb@hotmail.com` + dad's password.
+3. Complete onboarding (name, diagnosis date, baselines).
+4. Do a daily check-in.
+5. Sign out, sign back in as `thomas.findoasis@gmail.com`.
+6. You should see the same onboarding data + check-in dad just entered.
+   If not, open the browser console — the sync layer logs warnings.
+
+## 5. How the sync works (for future debugging)
+
+- Local reads go through Dexie/IndexedDB as before (fast, offline-safe).
+- Every Dexie write fires a hook that pushes a row into Supabase
+  `cloud_rows` keyed by `(table_name, local_id)`.
+- The app subscribes to `cloud_rows` Realtime changes and pulls any new
+  rows into Dexie. That's how Tom sees dad's updates within ~1 second.
+- If the network drops, writes queue in memory and retry every 15 s.
+- Pull cursor (`anchor.lastPulledAt`) lives in `localStorage`; clearing
+  browser storage forces a full re-pull on next sign-in.
+
+## 6. Known limitations (intentional, ship-first)
+
+- Two users writing the same Dexie table at the same moment can collide
+  on `local_id`. Dad is the primary writer; Tom is mostly a reader. If we
+  see collisions we'll switch to UUID primary keys per row.
+- No server-side validation — all constraints live in the Zod schemas
+  client-side. Acceptable because only dad and Tom have credentials.
+- No end-to-end encryption. Data sits in plaintext in Supabase. Per the
+  user's instruction, the collected data is not considered sensitive.
+
+## 7. Future hardening (not blocking launch)
+
+- Turn on email confirmation in Supabase.
+- Add per-user audit trail (`user_id` column on `cloud_rows`).
+- Migrate to UUID primary keys if multi-writer conflicts appear.
+- Enable Supabase backups on a schedule.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@anthropic-ai/sdk": "^0.90.0",
     "@hookform/resolvers": "^3.3.4",
     "@react-pdf/renderer": "^3.4.4",
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.104.0",
     "@tanstack/react-query": "^5.28.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@react-pdf/renderer':
         specifier: ^3.4.4
         version: 3.4.5(react@18.3.1)
+      '@supabase/ssr':
+        specifier: ^0.10.2
+        version: 0.10.2(@supabase/supabase-js@2.104.0)
+      '@supabase/supabase-js':
+        specifier: ^2.104.0
+        version: 2.104.0
       '@tanstack/react-query':
         specifier: ^5.28.0
         version: 5.99.2(react@18.3.1)
@@ -848,6 +854,38 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@supabase/auth-js@2.104.0':
+    resolution: {integrity: sha512-Vs0ndL+s5an7rOmXtS/nbYnGXL8m+KXlCSrPIcw9bR96ma6qyLYILnE6syuM+rpDnf+Tg4PVNxNB2+oDwoy6mA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.104.0':
+    resolution: {integrity: sha512-O8EyEz/RT1kfWhyJNpVc/VbLeBsohHGBVif/CI83zoMB+Iul/t/NIekH1/7RsH6kuO+b2D4wJhfiaW8Qr47sRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.104.0':
+    resolution: {integrity: sha512-ynylEq6wduQEycj6pL3P+/yIfDQ+CTnBC5I6p+PzcAO2ybj9coAITVtMfboi+g/dacgMslN5MH73rXsRMB29+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.104.0':
+    resolution: {integrity: sha512-9fUVDoTVAhn7a79+AmEx+asUlRtf2yBrji7TQckcKn/WK4hvAA9Lia9er+lnhuz3WNiF1x6kkA4x7bRCJrU+KA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.10.2':
+    resolution: {integrity: sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.102.1
+
+  '@supabase/storage-js@2.104.0':
+    resolution: {integrity: sha512-s2NHtuAWb9nldJ/fS62WnJE6edvCWn31rrO+FJKlAohs99qdVgtLegUReTU2H9WnZiQlVqaBtu386wt6/6lrRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.104.0':
+    resolution: {integrity: sha512-hILwhIjCB53G31jlHUe73NDEmrXudcjcYlVRuvNfEhzf0gyFQaFf7j6rd1UGmYZkFMOg//DFE8Iy9ZbNEgosVw==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -944,6 +982,9 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -1402,6 +1443,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -1990,6 +2035,10 @@ packages:
 
   hyphen@1.14.1:
     resolution: {integrity: sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -4044,6 +4093,51 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@supabase/auth-js@2.104.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.104.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.104.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.104.0':
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/ssr@0.10.2(@supabase/supabase-js@2.104.0)':
+    dependencies:
+      '@supabase/supabase-js': 2.104.0
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.104.0':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.104.0':
+    dependencies:
+      '@supabase/auth-js': 2.104.0
+      '@supabase/functions-js': 2.104.0
+      '@supabase/postgrest-js': 2.104.0
+      '@supabase/realtime-js': 2.104.0
+      '@supabase/storage-js': 2.104.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.21':
@@ -4162,6 +4256,10 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.39
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -4633,6 +4731,8 @@ snapshots:
   confbox@0.1.8: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   cross-fetch@3.2.0:
     dependencies:
@@ -5424,6 +5524,8 @@ snapshots:
   human-signals@5.0.0: {}
 
   hyphen@1.14.1: {}
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.6.3:
     dependencies:

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+
+// OAuth callback handler. Not used for the default email/password flow,
+// but kept in place for future social providers (Google, Apple, GitHub).
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = request.nextUrl;
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") || "/";
+
+  const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!code || !SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    return NextResponse.redirect(`${origin}/login`);
+  }
+
+  const response = NextResponse.redirect(`${origin}${next}`);
+  const supabase = createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options);
+        }
+      },
+    },
+  });
+
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+  if (error) {
+    return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent(error.message)}`);
+  }
+  return response;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
+import { Button } from "~/components/ui/button";
+import { Field, TextInput } from "~/components/ui/field";
+import { PageHeader } from "~/components/ui/page-header";
+
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = searchParams.get("next") || "/";
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [mode, setMode] = useState<"signin" | "signup">("signin");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isSupabaseConfigured()) {
+      setError(
+        "Supabase is not configured. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.",
+      );
+    }
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const supabase = getSupabaseBrowser();
+    if (!supabase) return;
+    setLoading(true);
+    setError(null);
+    setInfo(null);
+    try {
+      if (mode === "signin") {
+        const { error } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
+        if (error) throw error;
+        router.replace(next);
+        router.refresh();
+      } else {
+        const { error } = await supabase.auth.signUp({ email, password });
+        if (error) throw error;
+        setInfo(
+          "Account created. If email confirmation is on, check your inbox; otherwise sign in now.",
+        );
+        setMode("signin");
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-sm space-y-6 p-6 pt-10 md:pt-20">
+      <PageHeader
+        eyebrow="ANCHOR"
+        title={mode === "signin" ? "Sign in" : "Create account"}
+      />
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Field label="Email">
+          <TextInput
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            placeholder="you@example.com"
+          />
+        </Field>
+        <Field label="Password">
+          <TextInput
+            type="password"
+            autoComplete={mode === "signin" ? "current-password" : "new-password"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={6}
+            placeholder="••••••••"
+          />
+        </Field>
+
+        {error && (
+          <div className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-3 text-sm text-[var(--warn)]">
+            {error}
+          </div>
+        )}
+        {info && (
+          <div className="rounded-md border border-ink-200 bg-paper-2 p-3 text-sm text-ink-700">
+            {info}
+          </div>
+        )}
+
+        <Button type="submit" size="lg" className="w-full" disabled={loading}>
+          {loading
+            ? "Please wait…"
+            : mode === "signin"
+              ? "Sign in"
+              : "Create account"}
+        </Button>
+
+        <button
+          type="button"
+          className="w-full text-sm text-ink-500 hover:text-ink-700"
+          onClick={() => {
+            setMode(mode === "signin" ? "signup" : "signin");
+            setError(null);
+            setInfo(null);
+          }}
+        >
+          {mode === "signin"
+            ? "Don't have an account? Create one"
+            : "Already have an account? Sign in"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,6 +8,7 @@ import { db, now } from "~/lib/db/dexie";
 import { settingsSchema, type SettingsInput } from "~/lib/validators/schemas";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
+import { AccountButton } from "~/components/shared/account-button";
 
 export default function SettingsPage() {
   const t = useT();
@@ -96,6 +97,8 @@ export default function SettingsPage() {
           {t("settings.title")}
         </h1>
       </div>
+
+      <AccountButton />
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <section className="space-y-3">

--- a/src/components/shared/account-button.tsx
+++ b/src/components/shared/account-button.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { LogOut, User } from "lucide-react";
+import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
+
+// Minimal "who am I / sign out" control. Rendered in settings.
+export function AccountButton() {
+  const router = useRouter();
+  const [email, setEmail] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isSupabaseConfigured()) return;
+    const supabase = getSupabaseBrowser();
+    if (!supabase) return;
+    supabase.auth.getUser().then(({ data }) => {
+      setEmail(data.user?.email ?? null);
+    });
+  }, []);
+
+  async function handleSignOut() {
+    const supabase = getSupabaseBrowser();
+    if (!supabase) return;
+    setLoading(true);
+    await supabase.auth.signOut();
+    router.replace("/login");
+    router.refresh();
+  }
+
+  if (!isSupabaseConfigured()) return null;
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md border border-ink-100/70 bg-paper-2/60 px-3 py-2.5">
+      <div className="flex min-w-0 items-center gap-2">
+        <User className="h-4 w-4 shrink-0 text-ink-400" aria-hidden />
+        <span className="truncate text-[13px] text-ink-700">
+          {email ?? "—"}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={handleSignOut}
+        disabled={loading}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-ink-200 px-2.5 py-1.5 text-xs text-ink-700 hover:border-ink-300 hover:bg-paper-2 disabled:opacity-50"
+      >
+        <LogOut className="h-3.5 w-3.5" aria-hidden />
+        Sign out
+      </button>
+    </div>
+  );
+}

--- a/src/components/shared/add-fab.tsx
+++ b/src/components/shared/add-fab.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useLocale } from "~/hooks/use-translate";
 import { cn } from "~/lib/utils/cn";
 import {
@@ -100,6 +101,7 @@ const ITEMS: FabItem[] = [
 
 export function AddFab() {
   const locale = useLocale();
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -120,6 +122,8 @@ export function AddFab() {
       window.removeEventListener("mousedown", onClick);
     };
   }, [open]);
+
+  if (pathname === "/login" || pathname?.startsWith("/auth/")) return null;
 
   return (
     <div

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -36,9 +36,15 @@ const ITEMS = [
   { href: "/settings", key: "nav.settings", icon: SettingsIcon },
 ] as const;
 
+function isAuthRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return pathname === "/login" || pathname.startsWith("/auth/");
+}
+
 export function DesktopSidebar() {
   const t = useT();
   const pathname = usePathname();
+  if (isAuthRoute(pathname)) return null;
   return (
     <aside className="hidden md:flex md:w-60 flex-col border-r border-ink-100/60 bg-paper-2/60">
       <div className="px-5 py-6">
@@ -79,6 +85,7 @@ export function DesktopSidebar() {
 export function MobileBottomNav() {
   const t = useT();
   const pathname = usePathname();
+  if (isAuthRoute(pathname)) return null;
   const mobileItems = ITEMS.filter((i) =>
     ["/", "/treatment", "/labs", "/tasks", "/assessment"].includes(i.href),
   );
@@ -121,6 +128,8 @@ export function MobileMoreMenu() {
   useEffect(() => {
     setOpen(false);
   }, [pathname]);
+
+  if (isAuthRoute(pathname)) return null;
 
   return (
     <>

--- a/src/components/shared/providers.tsx
+++ b/src/components/shared/providers.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ensureSeeded } from "~/lib/db/seed";
+import { initSync } from "~/lib/sync/init";
 import { useUIStore } from "~/stores/ui-store";
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -12,6 +13,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     ensureSeeded().catch(() => {
       // seeding failures are non-fatal
+    });
+    initSync().catch((err) => {
+      // eslint-disable-next-line no-console
+      console.warn("[sync] init failed", err);
     });
   }, []);
 

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,21 @@
+import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Public env vars — safe to expose to the browser.
+// The anon key is intentionally public; Row Level Security on the server is
+// what actually protects the data.
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export function isSupabaseConfigured(): boolean {
+  return Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+}
+
+let _client: SupabaseClient | null = null;
+
+export function getSupabaseBrowser(): SupabaseClient | null {
+  if (!isSupabaseConfigured()) return null;
+  if (_client) return _client;
+  _client = createBrowserClient(SUPABASE_URL!, SUPABASE_ANON_KEY!);
+  return _client;
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,31 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+// Server-side client used in middleware, route handlers, and server
+// components. Session state is read/written via the request cookies so that
+// Next.js can SSR an authenticated page.
+export function getSupabaseServer(): SupabaseClient | null {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return null;
+  const cookieStore = cookies();
+  return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // setAll can be called from a Server Component where cookies are
+          // read-only; ignore — middleware will refresh the session next.
+        }
+      },
+    },
+  });
+}

--- a/src/lib/sync/hooks.ts
+++ b/src/lib/sync/hooks.ts
@@ -1,0 +1,105 @@
+import { db } from "~/lib/db/dexie";
+import { enqueueSync } from "./queue";
+import { SYNCED_TABLES, type SyncedTable } from "./tables";
+
+let attached = false;
+
+// Attach Dexie `creating` / `updating` / `deleting` hooks to every synced
+// table. The hooks fire inside the Dexie transaction; we defer the actual
+// enqueue to `transaction.on('complete')` so a rolled-back transaction never
+// leaks a ghost sync op.
+export function attachSyncHooks(): void {
+  if (attached) return;
+  attached = true;
+
+  for (const name of SYNCED_TABLES) {
+    const table = (db as unknown as Record<string, DexieTableLike>)[name];
+    if (!table || typeof table.hook !== "function") {
+      // eslint-disable-next-line no-console
+      console.warn(`[sync] table ${name} missing from Dexie schema`);
+      continue;
+    }
+
+    // `creating` — primKey is undefined until Dexie assigns it. `this.onsuccess`
+    // receives the assigned id after the insert resolves.
+    table.hook("creating", function (
+      this: DexieHookContext,
+      _primKey,
+      obj,
+      trans,
+    ) {
+      this.onsuccess = (assignedKey: number) => {
+        trans.on("complete", () => {
+          enqueueSync({
+            kind: "upsert",
+            table: name as SyncedTable,
+            local_id: assignedKey,
+            data: { ...(obj as object), id: assignedKey },
+          });
+        });
+      };
+    });
+
+    // `updating` — `mods` is the delta. We merge onto `obj` so the cloud row
+    // reflects the full new state, not just the delta.
+    table.hook("updating", function (
+      this: DexieHookContext,
+      mods,
+      primKey,
+      obj,
+      trans,
+    ) {
+      this.onsuccess = () => {
+        trans.on("complete", () => {
+          const merged = { ...(obj as object), ...(mods as object), id: primKey };
+          enqueueSync({
+            kind: "upsert",
+            table: name as SyncedTable,
+            local_id: primKey as number,
+            data: merged,
+          });
+        });
+      };
+    });
+
+    table.hook("deleting", function (primKey, _obj, trans) {
+      trans.on("complete", () => {
+        enqueueSync({
+          kind: "delete",
+          table: name as SyncedTable,
+          local_id: primKey as number,
+        });
+      });
+    });
+  }
+}
+
+// Minimal structural typing for the bits of Dexie we touch. Avoids a large
+// type import from Dexie internals; the runtime shape is what matters.
+type DexieHookContext = { onsuccess?: (assignedKey: number) => void };
+type DexieTransaction = { on(event: "complete", cb: () => void): void };
+type DexieTableLike = {
+  hook(
+    event: "creating",
+    cb: (
+      this: DexieHookContext,
+      primKey: unknown,
+      obj: unknown,
+      trans: DexieTransaction,
+    ) => void,
+  ): void;
+  hook(
+    event: "updating",
+    cb: (
+      this: DexieHookContext,
+      mods: unknown,
+      primKey: unknown,
+      obj: unknown,
+      trans: DexieTransaction,
+    ) => void,
+  ): void;
+  hook(
+    event: "deleting",
+    cb: (primKey: unknown, obj: unknown, trans: DexieTransaction) => void,
+  ): void;
+};

--- a/src/lib/sync/init.ts
+++ b/src/lib/sync/init.ts
@@ -1,0 +1,56 @@
+import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
+import { attachSyncHooks } from "./hooks";
+import { pullFromCloud, resetPullCursor } from "./pull";
+import { startSyncRetryTimer, stopSyncRetryTimer } from "./queue";
+import { subscribeToCloudChanges, unsubscribeFromCloudChanges } from "./realtime";
+
+let initialized = false;
+
+// Call once on app mount (client-side). Safe to call multiple times.
+// - Installs Dexie write hooks so future local writes push to Supabase
+// - If the user is authenticated, pulls cloud rows into Dexie
+// - Subscribes to realtime changes so Tom sees dad's updates live
+// - Reacts to auth state changes (sign in → pull + subscribe;
+//   sign out → stop subscription and reset pull cursor)
+export async function initSync(): Promise<void> {
+  if (initialized) return;
+  if (typeof window === "undefined") return;
+  if (!isSupabaseConfigured()) return;
+
+  initialized = true;
+
+  attachSyncHooks();
+  startSyncRetryTimer();
+
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return;
+
+  const { data } = await supabase.auth.getUser();
+  if (data.user) {
+    await pullFromCloud();
+    subscribeToCloudChanges();
+  }
+
+  supabase.auth.onAuthStateChange(async (event) => {
+    if (event === "SIGNED_IN" || event === "TOKEN_REFRESHED") {
+      await pullFromCloud();
+      subscribeToCloudChanges();
+    } else if (event === "SIGNED_OUT") {
+      unsubscribeFromCloudChanges();
+      // Next sign-in triggers a fresh full pull so we see all cloud data.
+      resetPullCursor();
+    }
+  });
+
+  // Drain queue on reconnect — the retry timer already handles periodic
+  // retries, but this catches the immediate case where the user comes back
+  // online mid-session.
+  window.addEventListener("online", () => {
+    void pullFromCloud();
+  });
+}
+
+export function shutdownSync(): void {
+  stopSyncRetryTimer();
+  unsubscribeFromCloudChanges();
+}

--- a/src/lib/sync/pull.ts
+++ b/src/lib/sync/pull.ts
@@ -1,0 +1,86 @@
+import { db } from "~/lib/db/dexie";
+import { getSupabaseBrowser } from "~/lib/supabase/client";
+import { SYNCED_TABLES, type SyncedTable } from "./tables";
+import { withSyncSuppressed } from "./queue";
+
+const LAST_PULLED_KEY = "anchor.lastPulledAt";
+
+interface CloudRow {
+  table_name: string;
+  local_id: number;
+  data: Record<string, unknown> | null;
+  deleted: boolean;
+  updated_at: string;
+}
+
+export async function pullFromCloud(): Promise<{ pulled: number } | null> {
+  if (typeof window === "undefined") return null;
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return null;
+
+  const lastPulledAt =
+    window.localStorage.getItem(LAST_PULLED_KEY) ?? "1970-01-01T00:00:00Z";
+
+  // Fetch rows newer than our last pull. Limit to 5000 for safety.
+  const { data, error } = await supabase
+    .from("cloud_rows")
+    .select("table_name,local_id,data,deleted,updated_at")
+    .gt("updated_at", lastPulledAt)
+    .order("updated_at", { ascending: true })
+    .limit(5000);
+
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.warn("[sync] pull failed:", error);
+    return null;
+  }
+
+  const rows = (data ?? []) as CloudRow[];
+  if (rows.length === 0) return { pulled: 0 };
+
+  const validTables = new Set<string>(SYNCED_TABLES);
+
+  await withSyncSuppressed(async () => {
+    for (const row of rows) {
+      if (!validTables.has(row.table_name)) continue;
+      const table = (db as unknown as Record<string, DexieTableLike | undefined>)[
+        row.table_name
+      ];
+      if (!table) continue;
+
+      try {
+        if (row.deleted) {
+          await table.delete(row.local_id);
+        } else if (row.data && typeof row.data === "object") {
+          await table.put({ ...row.data, id: row.local_id });
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[sync] apply failed for ${row.table_name}#${row.local_id}`,
+          err,
+        );
+      }
+    }
+  });
+
+  const latest = rows[rows.length - 1].updated_at;
+  window.localStorage.setItem(LAST_PULLED_KEY, latest);
+  return { pulled: rows.length };
+}
+
+// Structural type for the Dexie operations we call during pull.
+type DexieTableLike = {
+  put(row: Record<string, unknown>): Promise<number>;
+  delete(primKey: number): Promise<void>;
+};
+
+export function resetPullCursor(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(LAST_PULLED_KEY);
+}
+
+// Typeguard to ensure the string matches a table name we know about.
+export function isSyncedTable(name: string): name is SyncedTable {
+  return (SYNCED_TABLES as readonly string[]).includes(name);
+}

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -1,0 +1,103 @@
+import { getSupabaseBrowser } from "~/lib/supabase/client";
+import type { SyncedTable } from "./tables";
+
+export type SyncOp =
+  | { kind: "upsert"; table: SyncedTable; local_id: number; data: unknown }
+  | { kind: "delete"; table: SyncedTable; local_id: number };
+
+// In-memory FIFO queue. Cleared by processQueue on success; survives in-memory
+// across hook calls within a tab. If Supabase writes fail (offline), the ops
+// stay in the queue and retry happens on the next push.
+const pending: SyncOp[] = [];
+let processing = false;
+
+// When pulling from the cloud we suppress the push hooks so we don't echo
+// incoming rows straight back to the server.
+let suppressed = 0;
+
+export function isSyncSuppressed(): boolean {
+  return suppressed > 0;
+}
+
+export async function withSyncSuppressed<T>(fn: () => Promise<T>): Promise<T> {
+  suppressed += 1;
+  try {
+    return await fn();
+  } finally {
+    suppressed -= 1;
+  }
+}
+
+export function enqueueSync(op: SyncOp): void {
+  if (suppressed > 0) return;
+  pending.push(op);
+  void processQueue();
+}
+
+export function pendingSyncCount(): number {
+  return pending.length;
+}
+
+async function processQueue(): Promise<void> {
+  if (processing) return;
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return;
+
+  processing = true;
+  try {
+    while (pending.length > 0) {
+      const op = pending[0];
+      try {
+        if (op.kind === "upsert") {
+          const { error } = await supabase.from("cloud_rows").upsert(
+            {
+              table_name: op.table,
+              local_id: op.local_id,
+              data: op.data,
+              deleted: false,
+              updated_at: new Date().toISOString(),
+            },
+            { onConflict: "table_name,local_id" },
+          );
+          if (error) throw error;
+        } else {
+          const { error } = await supabase
+            .from("cloud_rows")
+            .update({
+              deleted: true,
+              updated_at: new Date().toISOString(),
+            })
+            .eq("table_name", op.table)
+            .eq("local_id", op.local_id);
+          if (error) throw error;
+        }
+        pending.shift();
+      } catch (err) {
+        // Write failed (offline, RLS denied, network). Stop draining and
+        // leave the op at the head of the queue so the next tick retries it.
+        // eslint-disable-next-line no-console
+        console.warn("[sync] push failed, will retry:", err);
+        break;
+      }
+    }
+  } finally {
+    processing = false;
+  }
+}
+
+// Periodic retry so queued ops eventually push when the network recovers.
+let retryTimer: ReturnType<typeof setInterval> | null = null;
+
+export function startSyncRetryTimer(intervalMs = 15000): void {
+  if (retryTimer) return;
+  retryTimer = setInterval(() => {
+    if (pending.length > 0) void processQueue();
+  }, intervalMs);
+}
+
+export function stopSyncRetryTimer(): void {
+  if (retryTimer) {
+    clearInterval(retryTimer);
+    retryTimer = null;
+  }
+}

--- a/src/lib/sync/realtime.ts
+++ b/src/lib/sync/realtime.ts
@@ -1,0 +1,41 @@
+import type { RealtimeChannel } from "@supabase/supabase-js";
+import { getSupabaseBrowser } from "~/lib/supabase/client";
+import { pullFromCloud } from "./pull";
+
+let channel: RealtimeChannel | null = null;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Subscribe to cloud_rows changes. When any row changes we debounce a pull so
+// Tom's device sees dad's updates within ~1s without hammering Supabase.
+export function subscribeToCloudChanges(): void {
+  if (channel) return;
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return;
+
+  channel = supabase
+    .channel("cloud_rows_changes")
+    .on(
+      "postgres_changes",
+      { event: "*", schema: "public", table: "cloud_rows" },
+      () => {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          void pullFromCloud();
+        }, 500);
+      },
+    )
+    .subscribe();
+}
+
+export function unsubscribeFromCloudChanges(): void {
+  if (!channel) return;
+  const supabase = getSupabaseBrowser();
+  if (supabase) {
+    void supabase.removeChannel(channel);
+  }
+  channel = null;
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+}

--- a/src/lib/sync/tables.ts
+++ b/src/lib/sync/tables.ts
@@ -1,0 +1,32 @@
+// List of Dexie tables that mirror to Supabase `cloud_rows`.
+// Add new tables here as they're introduced in dexie.ts.
+// Ephemeral / derived tables (none today) can be excluded.
+export const SYNCED_TABLES = [
+  "daily_entries",
+  "weekly_assessments",
+  "fortnightly_assessments",
+  "quarterly_reviews",
+  "labs",
+  "imaging",
+  "ctdna_results",
+  "molecular_profile",
+  "trials",
+  "treatments",
+  "medications",
+  "medication_events",
+  "medication_prompt_events",
+  "change_signals",
+  "signal_events",
+  "life_events",
+  "decisions",
+  "zone_alerts",
+  "family_notes",
+  "settings",
+  "pending_results",
+  "ingested_documents",
+  "comprehensive_assessments",
+  "treatment_cycles",
+  "patient_tasks",
+] as const;
+
+export type SyncedTable = (typeof SYNCED_TABLES)[number];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,67 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+// Any path not in this list requires an authenticated session.
+const PUBLIC_PATHS = new Set([
+  "/login",
+  "/auth/callback",
+]);
+
+function isPublic(pathname: string): boolean {
+  if (PUBLIC_PATHS.has(pathname)) return true;
+  if (pathname.startsWith("/_next")) return true;
+  if (pathname.startsWith("/api/health")) return true;
+  if (pathname === "/favicon.svg" || pathname === "/manifest.webmanifest") return true;
+  return false;
+}
+
+export async function middleware(request: NextRequest) {
+  // If Supabase isn't configured, let everything through so local dev still
+  // works without cloud credentials.
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    return NextResponse.next();
+  }
+
+  const response = NextResponse.next({ request });
+  const supabase = createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options);
+        }
+      },
+    },
+  });
+
+  const { data } = await supabase.auth.getUser();
+  const { pathname } = request.nextUrl;
+
+  if (!data.user && !isPublic(pathname)) {
+    const redirect = request.nextUrl.clone();
+    redirect.pathname = "/login";
+    redirect.searchParams.set("next", pathname);
+    return NextResponse.redirect(redirect);
+  }
+
+  if (data.user && pathname === "/login") {
+    const redirect = request.nextUrl.clone();
+    redirect.pathname = "/";
+    redirect.searchParams.delete("next");
+    return NextResponse.redirect(redirect);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    // Run on all paths except static assets and images.
+    "/((?!_next/static|_next/image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
+};

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,74 @@
+-- Anchor cloud schema
+-- Run this in the Supabase SQL editor after creating a new project.
+-- See DEPLOY.md for step-by-step.
+--
+-- Strategy: a generic `cloud_rows` table mirrors every Dexie table.
+-- Each row is keyed by (table_name, local_id) where local_id is the Dexie
+-- auto-increment id. The full row is stored as jsonb in `data`.
+-- This avoids per-table column mapping for 24 Dexie tables and lets the
+-- schema evolve without migrations.
+
+CREATE TABLE IF NOT EXISTS public.cloud_rows (
+  table_name text NOT NULL,
+  local_id bigint NOT NULL,
+  data jsonb NOT NULL,
+  deleted boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (table_name, local_id)
+);
+
+CREATE INDEX IF NOT EXISTS cloud_rows_updated_at_idx
+  ON public.cloud_rows (updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS cloud_rows_table_name_idx
+  ON public.cloud_rows (table_name);
+
+-- Auto-bump updated_at on any UPDATE so incremental pulls stay correct.
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+  RETURNS trigger
+  LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS cloud_rows_set_updated_at ON public.cloud_rows;
+CREATE TRIGGER cloud_rows_set_updated_at
+  BEFORE UPDATE ON public.cloud_rows
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- Row level security: any authenticated user sees everything.
+-- This matches the family-shared model (dad + Tom both authenticated, both
+-- see the same data pool). Anonymous users have zero access.
+ALTER TABLE public.cloud_rows ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "authenticated read" ON public.cloud_rows;
+CREATE POLICY "authenticated read"
+  ON public.cloud_rows FOR SELECT
+  TO authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS "authenticated insert" ON public.cloud_rows;
+CREATE POLICY "authenticated insert"
+  ON public.cloud_rows FOR INSERT
+  TO authenticated
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "authenticated update" ON public.cloud_rows;
+CREATE POLICY "authenticated update"
+  ON public.cloud_rows FOR UPDATE
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "authenticated delete" ON public.cloud_rows;
+CREATE POLICY "authenticated delete"
+  ON public.cloud_rows FOR DELETE
+  TO authenticated
+  USING (true);
+
+-- Realtime: enable so the app can subscribe to changes (Tom sees dad's logs).
+ALTER PUBLICATION supabase_realtime ADD TABLE public.cloud_rows;


### PR DESCRIPTION
Shipping Anchor to dad requires a cloud-hosted URL with login so Tom can
see the same data dad enters. Keep the existing Dexie/IndexedDB store as
the local read layer and add a thin sync wrapper that mirrors every write
to a shared Supabase project.

Architecture:
- supabase/schema.sql: single `cloud_rows` table keyed by (table_name,
  local_id) stores each Dexie row as jsonb. Avoids per-table column
  mapping for 24 Dexie tables; evolves without migrations. RLS allows
  any authenticated user to read/write (family-shared model).
- src/lib/supabase/: browser + server clients using @supabase/ssr.
  No-op when env vars are unset so local dev still works offline.
- src/middleware.ts: redirects unauthenticated requests to /login
  (bypassed entirely if Supabase isn't configured).
- src/app/login/page.tsx + /auth/callback: email/password sign-in and
  OAuth callback handler.
- src/lib/sync/hooks.ts: attaches Dexie creating/updating/deleting hooks
  to every synced table. Deferred to transaction.on('complete') so
  rollbacks never leak a ghost sync op.
- src/lib/sync/queue.ts: in-memory FIFO that upserts into cloud_rows,
  with 15s retry timer for offline → online recovery. `withSyncSuppressed`
  wraps pull-side writes so incoming rows don't echo back to the server.
- src/lib/sync/pull.ts: fetches rows updated since last pull cursor
  (localStorage) and applies them via bypass-hook Dexie writes.
- src/lib/sync/realtime.ts: subscribes to cloud_rows changes so Tom's
  tab refreshes within ~1s of dad logging a check-in.
- src/lib/sync/init.ts: wires it all together, called from Providers.

DEPLOY.md walks through Supabase project setup, Vercel deploy, and the
smoke test (sign in as dad, enter data, sign in as Tom, verify it syncs).