### PR TITLE
feat: wire Supabase PAT auth into MCP server config

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,3 +9,9 @@ NEXT_PUBLIC_APP_NAME=Anchor
 # From Supabase → Project Settings → API
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Supabase Personal Access Token — used by Claude Code's MCP server so Claude
+# can query the database directly during development. Generate one at:
+# https://supabase.com/dashboard/account/tokens
+# Keep this out of version control (.env.local is gitignored).
+SUPABASE_PAT=

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "supabase": {
       "type": "http",
-      "url": "https://mcp.supabase.com/mcp?project_ref=tzmxmknkccxbvjhfvsdy"
+      "url": "https://mcp.supabase.com/mcp?project_ref=tzmxmknkccxbvjhfvsdy",
+      "headers": {
+        "Authorization": "Bearer ${SUPABASE_PAT}"
+      }
     }
   }
 }

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -35,6 +35,22 @@ NEXT_PUBLIC_SUPABASE_URL=https://tzmxmknkccxbvjhfvsdy.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_7TeUX3uaUaeL3oqCx7oHdA_Ub0P6Buw
 ```
 
+### Claude Code MCP (developer machines only)
+
+`.mcp.json` configures the Supabase MCP server so Claude Code can query the
+database directly during development. It reads a PAT from the environment:
+
+1. Go to https://supabase.com/dashboard/account/tokens → **Generate new token**.
+2. Name it `anchor-dev` and copy the token.
+3. Add it to your local `.env.local`:
+   ```
+   SUPABASE_PAT=sbp_xxxxxxxxxxxxxxxxxxxx
+   ```
+4. Reload Claude Code (or run `claude /mcp` to confirm the server connects).
+
+This variable is only needed on developer machines and is never used in
+production. Do not add `SUPABASE_PAT` to Vercel.
+
 ## 3. Vercel deploy (5 min)
 
 1. Go to https://vercel.com → **Add new → Project** → import


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `.mcp.json` now includes `Authorization: Bearer ${SUPABASE_PAT}` header so Claude Code can authenticate against the Supabase MCP HTTP endpoint
- `.env.local.example` documents the new `SUPABASE_PAT` variable with instructions
- `DEPLOY.md` adds a "Claude Code MCP" section explaining how to generate and store the PAT locally

## Test plan

- [ ] Generate a PAT at https://supabase.com/dashboard/account/tokens
- [ ] Add `SUPABASE_PAT=<token>` to `.env.local`
- [ ] Reload Claude Code and run `/mcp` — confirm `supabase` server shows as connected
- [ ] Verify `SUPABASE_PAT` is NOT added to Vercel environment variables

https://claude.ai/code/session_01GK5M2XVsydms1Pt1UfLkv4
EOF
)