### PR TITLE
Android APK: TWA scaffolding (manifest polish + assetlinks + bubblewrap)

### DIFF
--- a/DEPLOY-ANDROID.md
+++ b/DEPLOY-ANDROID.md
@@ -1,0 +1,147 @@
+# Shipping Anchor as an Android APK (TWA)
+
+Anchor is a PWA. This guide wraps the live Vercel deploy in a **Trusted
+Web Activity** so dad can install it from an APK on his Android phone
+and it behaves like a native app — full-screen, own icon, own task in
+the recents list. No rewrite: the Next.js code stays exactly as it is.
+
+Two one-time steps on your machine, then the APK is yours to sideload
+or publish.
+
+## Prereqs
+
+- **Node 18+** (already required for this repo)
+- **JDK 17** — `brew install openjdk@17` on macOS, or install from
+  https://adoptium.net/ — Bubblewrap needs `keytool` + `jarsigner`
+- **Android SDK cmdline-tools** — Bubblewrap installs what it needs on
+  first run, but have `$ANDROID_HOME` set to a writable dir (e.g.
+  `~/Library/Android/sdk`). If you already use Android Studio it's
+  wired up.
+- **Bubblewrap CLI** — `npm install -g @bubblewrap/cli`
+
+## One-time config
+
+1. **Publish the production deploy.** Merge to `main`; wait for Vercel
+   to mark the production deploy Ready. Note the domain (e.g.
+   `anchor.yourdomain.com` or `<project>.vercel.app`). Everything below
+   refers to it as `PROD_HOST`.
+
+2. **Edit `twa-manifest.json`** in this repo: replace every occurrence
+   of `REPLACE_WITH_VERCEL_PROD_HOST` with `PROD_HOST` (no protocol).
+   Don't commit the populated file to a public branch if `PROD_HOST` is
+   a private sub-domain — the committed version uses placeholders on
+   purpose.
+
+3. **Run bubblewrap init** in the repo root. It reads
+   `twa-manifest.json` and scaffolds an Android Gradle project at
+   `./android/`:
+
+   ```bash
+   bubblewrap init --manifest=twa-manifest.json --directory=./android
+   ```
+
+   When it asks about signing, pick "Create new key". Save the keystore
+   (`android/android.keystore`) + passwords somewhere you won't lose —
+   losing the keystore means you can never ship an update under the
+   same package id.
+
+4. **Extract the SHA-256 fingerprint** of the keystore:
+
+   ```bash
+   keytool -list -v -keystore android/android.keystore -alias android \
+     | grep 'SHA256:'
+   ```
+
+   Copy the colon-separated hex value (e.g.
+   `AA:BB:CC:DD:…`). Upper-case hex is fine.
+
+5. **Wire the fingerprint into Vercel.** Production env vars
+   (Project → Settings → Environment Variables → Production):
+
+   ```
+   TWA_PACKAGE_NAME=app.vercel.anchor
+   TWA_SHA256_FINGERPRINTS=AA:BB:CC:DD:…
+   ```
+
+   Save and **redeploy** main (Vercel → Deployments → ⋯ → Redeploy).
+   The `/.well-known/assetlinks.json` route now emits the right
+   fingerprint; Chrome's verifier on the phone will green-light the
+   TWA.
+
+6. **Sanity-check** the deployed file in a browser:
+
+   ```
+   https://PROD_HOST/.well-known/assetlinks.json
+   ```
+
+   It should return a non-empty JSON array containing your
+   `package_name` and fingerprint. If it's an empty `[]`, the env vars
+   didn't land — re-check Production scope.
+
+## Build the APK
+
+From the repo root:
+
+```bash
+cd android
+bubblewrap build
+```
+
+Bubblewrap produces:
+
+- `app-release-signed.apk` — sideload-ready, what you send to dad
+- `app-release-bundle.aab` — Play Store upload artefact (optional)
+- `assetlinks.json` — **do NOT** commit or upload; the Next.js route
+  already serves it from env vars
+
+## Install on dad's phone
+
+Easiest sideload path:
+
+1. Plug dad's phone in, USB debugging on (Settings → About →
+   7 taps on Build number → Settings → System → Developer options →
+   USB debugging).
+2. `adb install android/app/build/outputs/apk/release/app-release-signed.apk`
+3. First launch: because assetlinks are verified, the TWA opens
+   fullscreen with no browser chrome. If the URL bar is still visible,
+   step 6 above (sanity-check) probably came back empty.
+
+No USB? Email or AirDrop the APK and open it on the phone — Android
+will prompt "Install unknown apps" for the mail client.
+
+## Iteration
+
+For code changes, no APK rebuild is needed — TWA just loads the live
+production URL. Dad's app updates the instant you push to `main`.
+
+The only time you rebuild the APK is when:
+- the icon, colors, package id, or app name change (edit
+  `twa-manifest.json`, bump `appVersion`, run `bubblewrap update`
+  then `bubblewrap build`)
+- the signing key rotates (rare; update `TWA_SHA256_FINGERPRINTS` in
+  Vercel **before** sending the new APK)
+
+## Play Store (optional, next sprint)
+
+The `.aab` Bubblewrap produces is Play-Store-ready. Publish via
+`Play Console → Create app → Production → Upload`. Enable Play App
+Signing; export the Play-signing cert's SHA-256 and **add it** to
+`TWA_SHA256_FINGERPRINTS` (comma-separated with the upload key). Both
+fingerprints must live there or devices installed via Play will fail
+asset-link verification.
+
+## Troubleshooting
+
+- **URL bar shows inside the APK** → `/.well-known/assetlinks.json`
+  empty or mismatched. Redeploy after setting env vars; verify in
+  browser; clear Chrome's cache on the phone (`adb shell pm clear
+  com.android.chrome`) — assetlinks are cached for ~5 min.
+- **`keytool: command not found`** → `openjdk@17` not on `PATH`.
+  `export PATH="/opt/homebrew/opt/openjdk@17/bin:$PATH"`.
+- **Update loop ("unknown package") after rotating the keystore** →
+  you cannot change the signing key on an installed APK. Uninstall
+  first, install new APK.
+- **Supabase sign-in silently fails in the TWA** → Supabase's auth
+  redirect must include your app's custom scheme OR the same HTTPS
+  redirect you use on the web. We use email/password only, so this
+  doesn't bite us today, but keep it in mind if OAuth lands.

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,20 +1,45 @@
 {
   "name": "Anchor",
   "short_name": "Anchor",
-  "description": "Function preservation + bridge-strategy tracker",
+  "description": "Function preservation + bridge-strategy tracker for metastatic pancreatic cancer.",
+  "id": "/",
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
+  "display_override": ["standalone", "minimal-ui"],
   "orientation": "portrait-primary",
   "background_color": "#f5f1e8",
   "theme_color": "#19212f",
+  "lang": "en",
+  "dir": "ltr",
+  "prefer_related_applications": false,
   "icons": [
     {
       "src": "/anchor-mark.svg",
       "sizes": "any",
       "type": "image/svg+xml",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/anchor-mark.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
     }
   ],
-  "categories": ["health", "medical", "lifestyle"]
+  "categories": ["health", "medical", "lifestyle"],
+  "shortcuts": [
+    {
+      "name": "Tell the team",
+      "short_name": "Log",
+      "description": "Free-text log routed to the specialist agents",
+      "url": "/log"
+    },
+    {
+      "name": "Today's check-in",
+      "short_name": "Check-in",
+      "description": "Symptoms, weight, practice",
+      "url": "/daily/new"
+    }
+  ]
 }

--- a/src/app/.well-known/assetlinks.json/route.ts
+++ b/src/app/.well-known/assetlinks.json/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+
+// Digital Asset Links for the Trusted Web Activity Android wrapper.
+// Chrome validates this file before hiding its browser chrome inside the
+// APK. The TWA build will break silently (fall back to a visible URL bar)
+// if the fingerprint or package name is wrong.
+//
+// Config comes from Vercel env so we can rotate the keystore without
+// shipping code. Set these in Vercel → Project → Settings → Environment
+// Variables for Production:
+//
+//   TWA_PACKAGE_NAME          e.g. app.vercel.anchor
+//   TWA_SHA256_FINGERPRINTS   comma-separated SHA-256 fingerprints of the
+//                             APK signing key, in the 64-hex-with-colons
+//                             format (`keytool -list -v` → "SHA256: …")
+//                             Multiple fingerprints support upload + play
+//                             app signing coexistence.
+//
+// Without both env vars present the route returns an empty 200 response —
+// a live production deploy will still serve the PWA; only the TWA-APK
+// path silently regresses to "browser-looking" mode. See DEPLOY-ANDROID.md
+// for the one-time setup walk-through.
+
+export const runtime = "nodejs";
+// Static-at-build so Chrome's short-lived cache doesn't pin a stale value
+// after an env-var change — a redeploy is what pushes the new asset list.
+export const dynamic = "force-static";
+
+export function GET() {
+  const packageName = process.env.TWA_PACKAGE_NAME;
+  const fingerprints = (process.env.TWA_SHA256_FINGERPRINTS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  if (!packageName || fingerprints.length === 0) {
+    return NextResponse.json([], {
+      headers: { "cache-control": "public, max-age=300" },
+    });
+  }
+
+  return NextResponse.json(
+    [
+      {
+        relation: [
+          "delegate_permission/common.handle_all_urls",
+          "delegate_permission/common.get_login_creds",
+        ],
+        target: {
+          namespace: "android_app",
+          package_name: packageName,
+          sha256_cert_fingerprints: fingerprints,
+        },
+      },
+    ],
+    {
+      // Chrome caches assetlinks briefly. Five minutes balances rotation
+      // freshness vs. per-launch fetch cost.
+      headers: { "cache-control": "public, max-age=300" },
+    },
+  );
+}

--- a/twa-manifest.json
+++ b/twa-manifest.json
@@ -1,0 +1,47 @@
+{
+  "packageId": "app.vercel.anchor",
+  "host": "REPLACE_WITH_VERCEL_PROD_HOST",
+  "name": "Anchor",
+  "launcherName": "Anchor",
+  "display": "standalone",
+  "orientation": "portrait",
+  "themeColor": "#19212f",
+  "themeColorDark": "#19212f",
+  "navigationColor": "#19212f",
+  "navigationColorDark": "#19212f",
+  "navigationDividerColor": "#19212f",
+  "navigationDividerColorDark": "#19212f",
+  "backgroundColor": "#f5f1e8",
+  "enableNotifications": true,
+  "startUrl": "/",
+  "iconUrl": "https://REPLACE_WITH_VERCEL_PROD_HOST/anchor-mark.svg",
+  "maskableIconUrl": "https://REPLACE_WITH_VERCEL_PROD_HOST/anchor-mark.svg",
+  "appVersionName": "1.0.0",
+  "appVersion": 1,
+  "shortcuts": [
+    {
+      "name": "Tell the team",
+      "shortName": "Log",
+      "url": "/log",
+      "iconUrl": "https://REPLACE_WITH_VERCEL_PROD_HOST/anchor-mark.svg"
+    },
+    {
+      "name": "Today's check-in",
+      "shortName": "Check-in",
+      "url": "/daily/new",
+      "iconUrl": "https://REPLACE_WITH_VERCEL_PROD_HOST/anchor-mark.svg"
+    }
+  ],
+  "generatorApp": "bubblewrap-cli",
+  "webManifestUrl": "https://REPLACE_WITH_VERCEL_PROD_HOST/manifest.webmanifest",
+  "fallbackType": "customtabs",
+  "features": {
+    "locationDelegation": { "enabled": false },
+    "playBilling": { "enabled": false }
+  },
+  "alphaDependencies": { "enabled": false },
+  "enableSiteSettingsShortcut": true,
+  "isChromeOSOnly": false,
+  "isMetaQuest": false,
+  "fullScopeUrl": "https://REPLACE_WITH_VERCEL_PROD_HOST/"
+}


### PR DESCRIPTION
## Summary

Zero-rewrite path to a real Android APK dad can sideload. The APK is a **Trusted Web Activity** that renders the production URL fullscreen; Dexie, Supabase, the `/log` surface and the agent backend all work unchanged inside the wrapper.

## What landed

- `public/manifest.webmanifest`:
  - Split `any` + `maskable` icon entries (Play Store wants both)
  - `display_override` for minimal-ui fallback
  - `id` / `lang` / `dir` / `prefer_related_applications` for TWA validity
  - Manifest `shortcuts` surfacing `/log` and `/daily/new` on the launcher long-press menu
- `src/app/.well-known/assetlinks.json/route.ts` (new):
  - Dynamic Next.js route emitting the Digital Asset Links JSON
  - Reads `TWA_PACKAGE_NAME` + `TWA_SHA256_FINGERPRINTS` from Vercel env so the keystore can rotate without shipping code
  - Graceful: returns `[]` when env vars absent (PWA keeps working; only TWA verification degrades)
  - `force-static` + 5 min `cache-control` for Chrome's verifier
- `twa-manifest.json` (new): bubblewrap config at repo root with `REPLACE_WITH_VERCEL_PROD_HOST` placeholders the operator fills in locally
- `DEPLOY-ANDROID.md` (new): complete runbook — prereqs, bubblewrap init, keystore SHA-256 extraction, Vercel env wiring, build, `adb install`. Includes update cadence (no APK rebuild for code changes; only for icon/color/package changes) and Play Store notes for later.

## Gate

- `pnpm typecheck` clean
- `pnpm lint` clean (two pre-existing `<img>` warnings)
- 231 / 231 unit tests
- `pnpm build` succeeds; `/.well-known/assetlinks.json` present as a static route

## What you do after merge

1. Set `TWA_PACKAGE_NAME=app.vercel.anchor` + `TWA_SHA256_FINGERPRINTS=<keystore sha>` in Vercel → Production env (after running `bubblewrap init` to generate the keystore)
2. Redeploy `main` so the env bakes in
3. Verify `https://<prod>/.well-known/assetlinks.json` returns a non-empty JSON array
4. `bubblewrap build` locally → `adb install` on dad's phone

Full step-by-step in `DEPLOY-ANDROID.md`.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build`
- [ ] Post-merge, after setting Vercel env: `curl https://<prod>/.well-known/assetlinks.json` returns JSON with the right `package_name` and `sha256_cert_fingerprints`
- [ ] `bubblewrap validate` against the deployed manifest (optional smoke)
- [ ] Install generated APK; confirm no URL bar shows (fullscreen TWA)

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8