### PR TITLE
Calendar module: appointments + prep-links + photo/email ingest

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
+    "@fullcalendar/core": "^6.1.20",
+    "@fullcalendar/daygrid": "^6.1.20",
+    "@fullcalendar/interaction": "^6.1.20",
+    "@fullcalendar/list": "^6.1.20",
+    "@fullcalendar/react": "^6.1.20",
+    "@fullcalendar/timegrid": "^6.1.20",
     "@hookform/resolvers": "^3.3.4",
     "@react-pdf/renderer": "^3.4.4",
     "@supabase/ssr": "^0.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,24 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.90.0
         version: 0.90.0(zod@3.25.76)
+      '@fullcalendar/core':
+        specifier: ^6.1.20
+        version: 6.1.20
+      '@fullcalendar/daygrid':
+        specifier: ^6.1.20
+        version: 6.1.20(@fullcalendar/core@6.1.20)
+      '@fullcalendar/interaction':
+        specifier: ^6.1.20
+        version: 6.1.20(@fullcalendar/core@6.1.20)
+      '@fullcalendar/list':
+        specifier: ^6.1.20
+        version: 6.1.20(@fullcalendar/core@6.1.20)
+      '@fullcalendar/react':
+        specifier: ^6.1.20
+        version: 6.1.20(@fullcalendar/core@6.1.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fullcalendar/timegrid':
+        specifier: ^6.1.20
+        version: 6.1.20(@fullcalendar/core@6.1.20)
       '@hookform/resolvers':
         specifier: ^3.3.4
         version: 3.10.0(react-hook-form@7.73.1(react@18.3.1))
@@ -433,6 +451,36 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@fullcalendar/core@6.1.20':
+    resolution: {integrity: sha512-1cukXLlePFiJ8YKXn/4tMKsy0etxYLCkXk8nUCFi11nRONF2Ba2CD5b21/ovtOO2tL6afTJfwmc1ed3HG7eB1g==}
+
+  '@fullcalendar/daygrid@6.1.20':
+    resolution: {integrity: sha512-AO9vqhkLP77EesmJzuU+IGXgxNulsA8mgQHynclJ8U70vSwAVnbcLG9qftiTAFSlZjiY/NvhE7sflve6cJelyQ==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.20
+
+  '@fullcalendar/interaction@6.1.20':
+    resolution: {integrity: sha512-p6txmc5txL0bMiPaJxe2ip6o0T384TyoD2KGdsU6UjZ5yoBlaY+dg7kxfnYKpYMzEJLG58n+URrHr2PgNL2fyA==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.20
+
+  '@fullcalendar/list@6.1.20':
+    resolution: {integrity: sha512-7Hzkbb7uuSqrXwTyD0Ld/7SwWNxPD6SlU548vtkIpH55rZ4qquwtwYdMPgorHos5OynHA4OUrZNcH51CjrCf2g==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.20
+
+  '@fullcalendar/react@6.1.20':
+    resolution: {integrity: sha512-1w0pZtceaUdfAnxMSCGHCQalhi+mR1jOe76sXzyAXpcPz/Lf0zHSdcGK/U2XpZlnQgQtBZW+d+QBnnzVQKCxAA==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.20
+      react: ^16.7.0 || ^17 || ^18 || ^19
+      react-dom: ^16.7.0 || ^17 || ^18 || ^19
+
+  '@fullcalendar/timegrid@6.1.20':
+    resolution: {integrity: sha512-4H+/MWbz3ntA50lrPif+7TsvMeX3R1GSYjiLULz0+zEJ7/Yfd9pupZmAwUs/PBpA6aAcFmeRr0laWfcz1a9V1A==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.20
 
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
@@ -2685,6 +2733,9 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  preact@10.12.1:
+    resolution: {integrity: sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3704,6 +3755,33 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@fullcalendar/core@6.1.20':
+    dependencies:
+      preact: 10.12.1
+
+  '@fullcalendar/daygrid@6.1.20(@fullcalendar/core@6.1.20)':
+    dependencies:
+      '@fullcalendar/core': 6.1.20
+
+  '@fullcalendar/interaction@6.1.20(@fullcalendar/core@6.1.20)':
+    dependencies:
+      '@fullcalendar/core': 6.1.20
+
+  '@fullcalendar/list@6.1.20(@fullcalendar/core@6.1.20)':
+    dependencies:
+      '@fullcalendar/core': 6.1.20
+
+  '@fullcalendar/react@6.1.20(@fullcalendar/core@6.1.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@fullcalendar/core': 6.1.20
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@fullcalendar/timegrid@6.1.20(@fullcalendar/core@6.1.20)':
+    dependencies:
+      '@fullcalendar/core': 6.1.20
+      '@fullcalendar/daygrid': 6.1.20(@fullcalendar/core@6.1.20)
 
   '@hookform/resolvers@3.10.0(react-hook-form@7.73.1(react@18.3.1))':
     dependencies:
@@ -6152,6 +6230,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact@10.12.1: {}
 
   prelude-ls@1.2.1: {}
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,6 +5,7 @@
   },
   "nav": {
     "dashboard": "Dashboard",
+    "schedule": "Schedule",
     "assessment": "Assessment",
     "treatment": "Treatment",
     "daily": "Daily",
@@ -116,6 +117,65 @@
     "back": "Back",
     "saveAndContinue": "Save and continue",
     "saving": "Saving…"
+  },
+  "schedule": {
+    "eyebrow": "SCHEDULE",
+    "title": "Calendar",
+    "back": "Back to calendar",
+    "edit": "Edit appointment",
+    "addManual": "New appointment",
+    "addFromPhoto": "From photo",
+    "addFromEmail": "From email",
+    "upcoming": "Upcoming",
+    "noneUpcoming": "No upcoming appointments.",
+    "prepDue": "Prep due soon",
+    "notFound": "Appointment not found.",
+    "confirmDelete": "Delete this appointment and its links?",
+    "links": "Linked appointments",
+    "linkPrepForOutgoing": "Prep for",
+    "linkPrepForIncoming": "Prep: ",
+    "linkFollowUp": "Follow-up of",
+    "new": {
+      "manual": "New appointment",
+      "fromPhoto": "From a photo",
+      "fromEmail": "From an email",
+      "photoCta": "Take or upload photo",
+      "photoHint": "Appointment letter, clinic card, or scan referral",
+      "emailCta": "Paste email body",
+      "emailLabel": "Email text",
+      "emailPlaceholder": "Paste the full text of the appointment email here — including subject line, dates, times, and any prep instructions.",
+      "parseCta": "Parse",
+      "parsing": "Reading…",
+      "parsed": "Parsed — review and save",
+      "parsedHint": "Anything the parser wasn't sure about is noted at the end of the notes field."
+    },
+    "kind": {
+      "clinic": "Clinic",
+      "chemo": "Chemo",
+      "scan": "Scan",
+      "blood_test": "Blood test",
+      "procedure": "Procedure",
+      "other": "Other"
+    },
+    "status": {
+      "scheduled": "Scheduled",
+      "attended": "Attended",
+      "missed": "Missed",
+      "cancelled": "Cancelled",
+      "rescheduled": "Rescheduled"
+    },
+    "form": {
+      "kind": "Kind",
+      "title": "Title",
+      "startsAt": "Starts",
+      "endsAt": "Ends",
+      "allDay": "All day",
+      "location": "Location",
+      "doctor": "Clinician",
+      "phone": "Phone",
+      "notes": "Notes",
+      "status": "Status"
+    }
   },
   "daily": {
     "title": "Daily check-in",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -5,6 +5,7 @@
   },
   "nav": {
     "dashboard": "概览",
+    "schedule": "日程",
     "assessment": "综合评估",
     "treatment": "化疗方案",
     "daily": "每日",
@@ -116,6 +117,65 @@
     "back": "返回",
     "saveAndContinue": "保存并继续",
     "saving": "保存中…"
+  },
+  "schedule": {
+    "eyebrow": "日程",
+    "title": "日历",
+    "back": "返回日历",
+    "edit": "编辑预约",
+    "addManual": "新建预约",
+    "addFromPhoto": "从照片",
+    "addFromEmail": "从邮件",
+    "upcoming": "即将到来",
+    "noneUpcoming": "暂无即将到来的预约。",
+    "prepDue": "准备事项即将到期",
+    "notFound": "未找到该预约。",
+    "confirmDelete": "删除此预约及其关联？",
+    "links": "关联预约",
+    "linkPrepForOutgoing": "为准备：",
+    "linkPrepForIncoming": "准备项：",
+    "linkFollowUp": "复诊源：",
+    "new": {
+      "manual": "新建预约",
+      "fromPhoto": "从照片添加",
+      "fromEmail": "从邮件添加",
+      "photoCta": "拍照或上传",
+      "photoHint": "预约函、门诊卡或检查申请单",
+      "emailCta": "粘贴邮件内容",
+      "emailLabel": "邮件文本",
+      "emailPlaceholder": "把整封邮件粘贴在这里——包括主题、日期、时间、任何准备说明。",
+      "parseCta": "解析",
+      "parsing": "正在识别…",
+      "parsed": "已解析 —— 请核对并保存",
+      "parsedHint": "识别中不确定的地方已记录在备注末尾。"
+    },
+    "kind": {
+      "clinic": "门诊",
+      "chemo": "化疗",
+      "scan": "影像检查",
+      "blood_test": "化验",
+      "procedure": "操作",
+      "other": "其他"
+    },
+    "status": {
+      "scheduled": "已预约",
+      "attended": "已就诊",
+      "missed": "未到",
+      "cancelled": "已取消",
+      "rescheduled": "已改期"
+    },
+    "form": {
+      "kind": "类型",
+      "title": "标题",
+      "startsAt": "开始时间",
+      "endsAt": "结束时间",
+      "allDay": "全天",
+      "location": "地点",
+      "doctor": "医师",
+      "phone": "电话",
+      "notes": "备注",
+      "status": "状态"
+    }
   },
   "daily": {
     "title": "每日记录",

--- a/src/app/api/parse-appointment/route.ts
+++ b/src/app/api/parse-appointment/route.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { parsedAppointmentSchema } from "~/lib/appointments/schema";
+
+// Server-side vision/text parser for appointment letters, cards, and
+// pasted emails. Accepts either an image (data URL or https URL) or a
+// text body; returns a ParsedAppointment that the /schedule/new form
+// uses as `initial`. No Dexie writes happen here — the client decides
+// whether to accept the parse.
+
+export const runtime = "nodejs";
+
+const RequestSchema = z.object({
+  text: z.string().optional(),
+  imageBase64: z.string().optional(),
+  imageMediaType: z
+    .enum(["image/jpeg", "image/png", "image/gif", "image/webp"])
+    .optional(),
+  locale: z.enum(["en", "zh"]).default("en"),
+  // Today's date in the patient's timezone so the parser can resolve
+  // relative references like "next Tuesday 2pm" without hallucinating
+  // a year.
+  today: z.string(),
+});
+
+const SYSTEM_PROMPT = `You are a careful medical-appointment parser for a patient-tracking app. Given a photo of an appointment letter/card or a pasted email body, extract exactly one appointment.
+
+Fields:
+- kind: one of "clinic" (oncology/specialist consult), "chemo" (infusion visit), "scan" (CT/MRI/PET), "blood_test" (pathology/phlebotomy), "procedure" (line/port/biopsy etc.), or "other"
+- title: short human label, e.g. "Cycle 3 consult with Dr Lee"
+- starts_at: ISO 8601 including timezone offset if known; if only a date is shown, set all_day=true and use T00:00:00+10:00 (Melbourne) as a fallback
+- ends_at: optional
+- all_day: true when no specific time is given
+- location: free-text; include site + level/room if present
+- doctor: named clinician if identifiable
+- phone: contact number if shown
+- notes: anything else explicit on the page/email (what to bring, fasting, pre-med etc.). Do NOT invent prep instructions.
+- confidence: "high" if all core fields are explicit; "medium" if you had to reconcile ambiguity; "low" if you're guessing
+- ambiguities: short bulleted list of what you were unsure about
+
+Return nothing for fields you can't see. Never fabricate. If the input clearly isn't an appointment, still return an object but with confidence "low" and title="Unable to parse".`;
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const parsed = RequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", detail: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const { text, imageBase64, imageMediaType, locale, today } = parsed.data;
+  if (!text && !imageBase64) {
+    return NextResponse.json(
+      { error: "Provide text or imageBase64" },
+      { status: 400 },
+    );
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      {
+        error:
+          "ANTHROPIC_API_KEY is not configured on the server. Set it in Vercel env.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const [{ default: Anthropic }, { zodOutputFormat }] = await Promise.all([
+    import("@anthropic-ai/sdk"),
+    import("@anthropic-ai/sdk/helpers/zod"),
+  ]);
+  const client = new Anthropic({ apiKey });
+
+  const userContent: Array<
+    | { type: "text"; text: string }
+    | {
+        type: "image";
+        source: {
+          type: "base64";
+          media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+          data: string;
+        };
+      }
+  > = [];
+  if (imageBase64 && imageMediaType) {
+    userContent.push({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: imageMediaType,
+        data: stripDataUrlPrefix(imageBase64),
+      },
+    });
+  }
+  userContent.push({
+    type: "text",
+    text: [
+      `Patient locale: ${locale}.`,
+      `Today's date: ${today}.`,
+      text?.trim() ? `Pasted text:\n\n---\n${text}\n---` : "",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  });
+
+  try {
+    const response = await client.messages.parse({
+      model: process.env.ANTHROPIC_LOG_MODEL || "claude-opus-4-7",
+      max_tokens: 800,
+      system: [
+        {
+          type: "text",
+          text: SYSTEM_PROMPT,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      output_config: { format: zodOutputFormat(parsedAppointmentSchema) },
+      messages: [{ role: "user", content: userContent }],
+    });
+    if (!response.parsed_output) {
+      return NextResponse.json(
+        { error: "Parser returned no output" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({ appointment: response.parsed_output });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      { error: "Parse failed", message },
+      { status: 502 },
+    );
+  }
+}
+
+function stripDataUrlPrefix(b64: string): string {
+  const marker = "base64,";
+  const idx = b64.indexOf(marker);
+  return idx >= 0 ? b64.slice(idx + marker.length) : b64;
+}

--- a/src/app/schedule/[id]/page.tsx
+++ b/src/app/schedule/[id]/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { AppointmentForm } from "~/components/schedule/appointment-form";
+import { useLocale, useT } from "~/hooks/use-translate";
+import { useState } from "react";
+import type { Appointment, AppointmentLink } from "~/types/appointment";
+import { ArrowLeft, Link2, Trash2, Pencil } from "lucide-react";
+
+export default function AppointmentDetailPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = Number(params?.id);
+  const t = useT();
+  const locale = useLocale();
+
+  const appt = useLiveQuery(
+    () => (Number.isFinite(id) ? db.appointments.get(id) : undefined),
+    [id],
+  );
+  const incoming = useLiveQuery<AppointmentLink[]>(
+    () =>
+      Number.isFinite(id)
+        ? db.appointment_links.where("to_id").equals(id).toArray()
+        : Promise.resolve([] as AppointmentLink[]),
+    [id],
+  );
+  const outgoing = useLiveQuery<AppointmentLink[]>(
+    () =>
+      Number.isFinite(id)
+        ? db.appointment_links.where("from_id").equals(id).toArray()
+        : Promise.resolve([] as AppointmentLink[]),
+    [id],
+  );
+
+  const [editing, setEditing] = useState(false);
+
+  if (!Number.isFinite(id)) {
+    return (
+      <div className="mx-auto max-w-xl p-6 text-sm text-ink-500">
+        {t("schedule.notFound")}
+      </div>
+    );
+  }
+  if (appt === undefined) return null;
+  if (!appt) {
+    return (
+      <div className="mx-auto max-w-xl p-6">
+        <Button variant="ghost" onClick={() => router.push("/schedule")}>
+          <ArrowLeft className="h-4 w-4" />
+          {t("schedule.back")}
+        </Button>
+        <p className="mt-4 text-sm text-ink-500">{t("schedule.notFound")}</p>
+      </div>
+    );
+  }
+
+  async function remove() {
+    const confirmed = typeof window !== "undefined"
+      ? window.confirm(t("schedule.confirmDelete"))
+      : false;
+    if (!confirmed) return;
+    await db.appointments.delete(id);
+    await db.appointment_links.where("from_id").equals(id).delete();
+    await db.appointment_links.where("to_id").equals(id).delete();
+    router.push("/schedule");
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+      <div>
+        <Link
+          href="/schedule"
+          className="inline-flex items-center gap-1 text-[12px] text-ink-500 hover:text-ink-900"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          {t("schedule.back")}
+        </Link>
+      </div>
+
+      {editing ? (
+        <>
+          <PageHeader
+            eyebrow={t("schedule.eyebrow")}
+            title={t("schedule.edit")}
+          />
+          <AppointmentForm existing={appt} />
+        </>
+      ) : (
+        <>
+          <PageHeader
+            eyebrow={t(`schedule.kind.${appt.kind}`)}
+            title={appt.title}
+          />
+          <Card className="space-y-3 p-5 text-[13px]">
+            <Row
+              label={t("schedule.form.startsAt")}
+              value={formatDateTime(appt.starts_at, locale, appt.all_day)}
+            />
+            {appt.ends_at && (
+              <Row
+                label={t("schedule.form.endsAt")}
+                value={formatDateTime(appt.ends_at, locale, appt.all_day)}
+              />
+            )}
+            {appt.location && (
+              <Row label={t("schedule.form.location")} value={appt.location} />
+            )}
+            {appt.doctor && (
+              <Row label={t("schedule.form.doctor")} value={appt.doctor} />
+            )}
+            {appt.phone && (
+              <Row
+                label={t("schedule.form.phone")}
+                value={
+                  <a href={`tel:${appt.phone}`} className="underline">
+                    {appt.phone}
+                  </a>
+                }
+              />
+            )}
+            <Row
+              label={t("schedule.form.status")}
+              value={t(`schedule.status.${appt.status}`)}
+            />
+            {appt.notes && (
+              <div>
+                <div className="mb-1 text-[11px] uppercase tracking-[0.12em] text-ink-400">
+                  {t("schedule.form.notes")}
+                </div>
+                <p className="whitespace-pre-wrap text-[12.5px] leading-relaxed text-ink-700">
+                  {appt.notes}
+                </p>
+              </div>
+            )}
+          </Card>
+
+          {(incoming?.length || outgoing?.length) && (
+            <Card className="space-y-2 p-4">
+              <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-ink-500">
+                <Link2 className="h-3.5 w-3.5" />
+                {t("schedule.links")}
+              </div>
+              {(outgoing ?? []).map((l) => (
+                <LinkRow key={`out-${l.id}`} link={l} as="from" t={t} />
+              ))}
+              {(incoming ?? []).map((l) => (
+                <LinkRow key={`in-${l.id}`} link={l} as="to" t={t} />
+              ))}
+            </Card>
+          )}
+
+          <div className="flex items-center justify-between gap-2 pt-2">
+            <Button variant="danger" onClick={remove} size="md">
+              <Trash2 className="h-4 w-4" />
+              {t("common.delete")}
+            </Button>
+            <Button onClick={() => setEditing(true)} size="lg">
+              <Pencil className="h-4 w-4" />
+              {t("common.edit")}
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-baseline justify-between gap-2">
+      <span className="mono text-[11px] uppercase tracking-[0.12em] text-ink-400">
+        {label}
+      </span>
+      <span className="text-right text-ink-900">{value}</span>
+    </div>
+  );
+}
+
+function LinkRow({
+  link,
+  as,
+  t,
+}: {
+  link: AppointmentLink;
+  as: "from" | "to";
+  t: (k: string) => string;
+}) {
+  const otherId = as === "from" ? link.to_id : link.from_id;
+  const other = useLiveQuery(
+    () => db.appointments.get(otherId),
+    [otherId],
+  ) as Appointment | undefined;
+  if (!other) return null;
+  const relationKey =
+    link.relation === "prep_for"
+      ? as === "from"
+        ? "schedule.linkPrepForOutgoing"
+        : "schedule.linkPrepForIncoming"
+      : "schedule.linkFollowUp";
+  return (
+    <Link
+      href={`/schedule/${otherId}`}
+      className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-[12.5px] hover:bg-paper-2"
+    >
+      <span className="text-ink-500">{t(relationKey)}</span>
+      <span className="truncate font-medium text-ink-900">{other.title}</span>
+    </Link>
+  );
+}
+
+function formatDateTime(
+  iso: string,
+  locale: "en" | "zh",
+  allDay?: boolean,
+): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(locale === "zh" ? "zh-CN" : "en-AU", {
+    dateStyle: "medium",
+    ...(allDay ? {} : { timeStyle: "short" }),
+  });
+}

--- a/src/app/schedule/new/page.tsx
+++ b/src/app/schedule/new/page.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, Textarea } from "~/components/ui/field";
+import { useLocale, useT } from "~/hooks/use-translate";
+import { AppointmentForm } from "~/components/schedule/appointment-form";
+import type { ParsedAppointment } from "~/lib/appointments/schema";
+import type { Appointment } from "~/types/appointment";
+import { Loader2, ImagePlus, Mail, FilePen } from "lucide-react";
+
+function NewAppointmentInner() {
+  const t = useT();
+  const locale = useLocale();
+  const params = useSearchParams();
+  const via = params.get("via") ?? "manual";
+  const prefillDate = params.get("date");
+
+  const [parsed, setParsed] = useState<Partial<Appointment> | null>(null);
+
+  const initial: Partial<Appointment> | undefined = parsed
+    ? parsed
+    : prefillDate
+      ? {
+          starts_at: new Date(`${prefillDate}T09:00:00`).toISOString(),
+          all_day: false,
+        }
+      : undefined;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={t("schedule.eyebrow")}
+        title={
+          via === "photo"
+            ? t("schedule.new.fromPhoto")
+            : via === "email"
+              ? t("schedule.new.fromEmail")
+              : t("schedule.new.manual")
+        }
+      />
+
+      {via === "photo" && !parsed && (
+        <PhotoIngest onParsed={setParsed} locale={locale} t={t} />
+      )}
+      {via === "email" && !parsed && (
+        <EmailIngest onParsed={setParsed} locale={locale} t={t} />
+      )}
+
+      {(via === "manual" || parsed) && (
+        <>
+          {parsed && (
+            <Card className="p-3 text-[12.5px] text-ink-700">
+              <div className="mb-1 flex items-center gap-1.5 font-semibold">
+                <FilePen className="h-3.5 w-3.5" />
+                {t("schedule.new.parsed")}
+              </div>
+              <div className="text-ink-500">{t("schedule.new.parsedHint")}</div>
+            </Card>
+          )}
+          <AppointmentForm initial={initial} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function PhotoIngest({
+  onParsed,
+  locale,
+  t,
+}: {
+  onParsed: (a: Partial<Appointment>) => void;
+  locale: "en" | "zh";
+  t: (k: string) => string;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onFile(file: File) {
+    setError(null);
+    setBusy(true);
+    try {
+      const dataUrl = await fileToDataUrl(file);
+      const mediaType = (file.type || "image/jpeg") as
+        | "image/jpeg"
+        | "image/png"
+        | "image/gif"
+        | "image/webp";
+      const res = await fetch("/api/parse-appointment", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          imageBase64: dataUrl,
+          imageMediaType: mediaType,
+          locale,
+          today: new Date().toISOString().slice(0, 10),
+        }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const data = (await res.json()) as { appointment: ParsedAppointment };
+      onParsed(toAppointmentShape(data.appointment));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card className="space-y-3 p-5">
+      <label className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-md border border-dashed border-ink-300 bg-paper-2 p-8 text-center hover:border-ink-500">
+        <ImagePlus className="h-6 w-6 text-ink-500" />
+        <span className="text-sm font-semibold text-ink-900">
+          {t("schedule.new.photoCta")}
+        </span>
+        <span className="text-[12px] text-ink-500">
+          {t("schedule.new.photoHint")}
+        </span>
+        <input
+          type="file"
+          accept="image/*"
+          capture="environment"
+          className="hidden"
+          disabled={busy}
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) void onFile(f);
+          }}
+        />
+      </label>
+      {busy && (
+        <div
+          role="status"
+          className="flex items-center gap-2 text-[13px] text-ink-700"
+        >
+          <Loader2 className="h-4 w-4 animate-spin" />
+          {t("schedule.new.parsing")}
+        </div>
+      )}
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-2.5 text-[12.5px] text-[var(--warn)]"
+        >
+          {error}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function EmailIngest({
+  onParsed,
+  locale,
+  t,
+}: {
+  onParsed: (a: Partial<Appointment>) => void;
+  locale: "en" | "zh";
+  t: (k: string) => string;
+}) {
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await fetch("/api/parse-appointment", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          text,
+          locale,
+          today: new Date().toISOString().slice(0, 10),
+        }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const data = (await res.json()) as { appointment: ParsedAppointment };
+      onParsed(toAppointmentShape(data.appointment));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card className="space-y-3 p-5">
+      <div className="flex items-center gap-1.5 text-[12.5px] font-semibold text-ink-900">
+        <Mail className="h-3.5 w-3.5" />
+        {t("schedule.new.emailCta")}
+      </div>
+      <Field label={t("schedule.new.emailLabel")}>
+        <Textarea
+          rows={10}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={t("schedule.new.emailPlaceholder")}
+          disabled={busy}
+        />
+      </Field>
+      {busy && (
+        <div className="flex items-center gap-2 text-[13px] text-ink-700">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          {t("schedule.new.parsing")}
+        </div>
+      )}
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-2.5 text-[12.5px] text-[var(--warn)]"
+        >
+          {error}
+        </div>
+      )}
+      <div className="flex justify-end">
+        <Button onClick={submit} disabled={busy || !text.trim()} size="lg">
+          {t("schedule.new.parseCta")}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function toAppointmentShape(p: ParsedAppointment): Partial<Appointment> {
+  return {
+    kind: p.kind,
+    title: p.title,
+    starts_at: p.starts_at,
+    ends_at: p.ends_at,
+    all_day: p.all_day,
+    location: p.location,
+    doctor: p.doctor,
+    phone: p.phone,
+    notes:
+      p.ambiguities && p.ambiguities.length > 0
+        ? [
+            p.notes ?? "",
+            "",
+            "Parser ambiguities:",
+            ...p.ambiguities.map((a) => `- ${a}`),
+          ]
+            .filter(Boolean)
+            .join("\n")
+        : p.notes,
+    status: "scheduled",
+  };
+}
+
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function NewAppointmentPage() {
+  return (
+    <Suspense fallback={null}>
+      <NewAppointmentInner />
+    </Suspense>
+  );
+}

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale, useT } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Button } from "~/components/ui/button";
+import { AppointmentsCalendar } from "~/components/schedule/calendar";
+import { derivePrepTasks } from "~/lib/appointments/prep-tasks";
+import { Plus, Camera, ClipboardList, AlertTriangle } from "lucide-react";
+import type { Appointment } from "~/types/appointment";
+
+export default function SchedulePage() {
+  const locale = useLocale();
+  const t = useT();
+
+  const appointments = useLiveQuery(
+    () => db.appointments.orderBy("starts_at").toArray(),
+    [],
+    [] as Appointment[],
+  );
+  const links = useLiveQuery(() => db.appointment_links.toArray(), [], []);
+
+  const prep = derivePrepTasks({
+    appointments: appointments ?? [],
+    links: links ?? [],
+  });
+
+  const upcoming = (appointments ?? []).filter(
+    (a) => new Date(a.starts_at).getTime() >= Date.now() - 12 * 3600 * 1000,
+  );
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-8">
+      <PageHeader
+        eyebrow={t("schedule.eyebrow")}
+        title={t("schedule.title")}
+      />
+
+      <div className="flex flex-wrap gap-2">
+        <Link href="/schedule/new">
+          <Button size="lg">
+            <Plus className="h-4 w-4" />
+            {t("schedule.addManual")}
+          </Button>
+        </Link>
+        <Link href="/schedule/new?via=photo">
+          <Button size="lg" variant="secondary">
+            <Camera className="h-4 w-4" />
+            {t("schedule.addFromPhoto")}
+          </Button>
+        </Link>
+        <Link href="/schedule/new?via=email">
+          <Button size="lg" variant="secondary">
+            <ClipboardList className="h-4 w-4" />
+            {t("schedule.addFromEmail")}
+          </Button>
+        </Link>
+      </div>
+
+      {prep.length > 0 && (
+        <section className="rounded-[var(--r-md)] border border-[var(--warn)]/40 bg-[var(--warn)]/5 p-4">
+          <div className="mb-2 flex items-center gap-2 text-[12.5px] font-semibold text-ink-900">
+            <AlertTriangle className="h-4 w-4 text-[var(--warn)]" />
+            {t("schedule.prepDue")}
+          </div>
+          <ul className="space-y-1.5 text-[13px]">
+            {prep.slice(0, 5).map((task) => (
+              <li
+                key={`prep-${task.derived_from_link_id}`}
+                className="flex items-center justify-between"
+              >
+                <span>
+                  {locale === "zh" && task.title_zh ? task.title_zh : task.title}
+                </span>
+                <span className="mono text-[11px] text-ink-500">
+                  {task.due_date}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <AppointmentsCalendar appointments={appointments ?? []} />
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-ink-900">
+          {t("schedule.upcoming")}
+        </h2>
+        {upcoming.length === 0 ? (
+          <p className="text-sm text-ink-500">{t("schedule.noneUpcoming")}</p>
+        ) : (
+          <ul className="divide-y divide-ink-100/70 rounded-[var(--r-md)] border border-ink-100/70 bg-paper">
+            {upcoming.slice(0, 12).map((a) => (
+              <li key={a.id}>
+                <Link
+                  href={`/schedule/${a.id}`}
+                  className="flex items-start justify-between gap-3 px-4 py-3 hover:bg-paper-2"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-[13px] font-semibold text-ink-900">
+                      {a.title}
+                    </div>
+                    <div className="mt-0.5 text-[11.5px] text-ink-500">
+                      {formatRange(a, locale)}
+                      {a.location ? ` · ${a.location}` : ""}
+                      {a.doctor ? ` · ${a.doctor}` : ""}
+                    </div>
+                  </div>
+                  <span className="mono shrink-0 text-[10px] uppercase tracking-[0.12em] text-ink-400">
+                    {t(`schedule.kind.${a.kind}`)}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function formatRange(a: Appointment, locale: "en" | "zh"): string {
+  const start = new Date(a.starts_at);
+  if (Number.isNaN(start.getTime())) return a.starts_at;
+  const datePart = start.toLocaleString(locale === "zh" ? "zh-CN" : "en-AU", {
+    dateStyle: "medium",
+  });
+  if (a.all_day) return datePart;
+  const timePart = start.toLocaleString(locale === "zh" ? "zh-CN" : "en-AU", {
+    timeStyle: "short",
+  });
+  return `${datePart} · ${timePart}`;
+}

--- a/src/components/schedule/appointment-form.tsx
+++ b/src/components/schedule/appointment-form.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { db, now } from "~/lib/db/dexie";
+import { appointmentInputSchema } from "~/lib/appointments/schema";
+import type {
+  Appointment,
+  AppointmentKind,
+  AppointmentStatus,
+} from "~/types/appointment";
+import { useLocale, useT } from "~/hooks/use-translate";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Field, TextInput, Textarea } from "~/components/ui/field";
+
+const KINDS: AppointmentKind[] = [
+  "clinic",
+  "chemo",
+  "scan",
+  "blood_test",
+  "procedure",
+  "other",
+];
+
+interface PrefillLink {
+  to_id: number;
+  relation: "prep_for";
+  offset_days: number;
+}
+
+export function AppointmentForm({
+  existing,
+  initial,
+  linkOnSave,
+}: {
+  existing?: Appointment;
+  // Partial shape handed in from the photo/email parser to prefill the form
+  initial?: Partial<Appointment>;
+  // When present, a prep-link is written from the newly-created
+  // appointment to the given to_id after save.
+  linkOnSave?: PrefillLink;
+}) {
+  const t = useT();
+  const locale = useLocale();
+  const router = useRouter();
+
+  const [form, setForm] = useState<Partial<Appointment>>(() => ({
+    kind: existing?.kind ?? initial?.kind ?? "clinic",
+    title: existing?.title ?? initial?.title ?? "",
+    starts_at: existing?.starts_at ?? initial?.starts_at ?? "",
+    ends_at: existing?.ends_at ?? initial?.ends_at ?? "",
+    all_day: existing?.all_day ?? initial?.all_day ?? false,
+    location: existing?.location ?? initial?.location ?? "",
+    doctor: existing?.doctor ?? initial?.doctor ?? "",
+    phone: existing?.phone ?? initial?.phone ?? "",
+    notes: existing?.notes ?? initial?.notes ?? "",
+    status: existing?.status ?? "scheduled",
+  }));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Live-update when an ingest parse flows in after mount
+    if (initial && !existing) {
+      setForm((f) => ({ ...f, ...initial }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initial?.starts_at, initial?.title, initial?.kind, initial?.location]);
+
+  const startLocal = useMemo(() => toLocalInput(form.starts_at), [form.starts_at]);
+  const endLocal = useMemo(() => toLocalInput(form.ends_at), [form.ends_at]);
+
+  function update<K extends keyof Appointment>(
+    k: K,
+    v: Appointment[K] | undefined,
+  ) {
+    setForm((f) => ({ ...f, [k]: v }));
+  }
+
+  async function save() {
+    setError(null);
+    const parsed = appointmentInputSchema.safeParse({
+      ...form,
+      starts_at:
+        form.starts_at && !form.starts_at.includes("T")
+          ? new Date(form.starts_at).toISOString()
+          : form.starts_at,
+      ends_at: form.ends_at || undefined,
+      location_url: undefined,
+      attendees: form.attendees,
+      attachments: form.attachments,
+    });
+    if (!parsed.success) {
+      setError(
+        parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", "),
+      );
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const ts = now();
+      const record: Appointment = {
+        ...parsed.data,
+        status: parsed.data.status ?? "scheduled",
+        created_at: existing?.created_at ?? ts,
+        updated_at: ts,
+      };
+
+      let id: number;
+      if (existing?.id) {
+        // Dexie's UpdateSpec is stricter than the row shape; cast once at
+        // the boundary where we know the shape matches.
+        await db.appointments.update(
+          existing.id,
+          record as unknown as Partial<Appointment>,
+        );
+        id = existing.id;
+      } else {
+        id = (await db.appointments.add(record)) as number;
+      }
+
+      if (linkOnSave && !existing?.id) {
+        await db.appointment_links.add({
+          from_id: id,
+          to_id: linkOnSave.to_id,
+          relation: linkOnSave.relation,
+          offset_days: linkOnSave.offset_days,
+          created_at: ts,
+        });
+      }
+
+      router.push(`/schedule/${id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card className="space-y-4 p-5">
+      <Field label={t("schedule.form.kind")}>
+        <div className="flex flex-wrap gap-2">
+          {KINDS.map((k) => (
+            <button
+              key={k}
+              type="button"
+              onClick={() => update("kind", k)}
+              className={
+                "h-9 rounded-full border px-3 text-xs font-medium " +
+                (form.kind === k
+                  ? "border-ink-900 bg-ink-900 text-paper"
+                  : "border-ink-200 bg-paper-2 text-ink-500 hover:border-ink-400")
+              }
+            >
+              {t(`schedule.kind.${k}`)}
+            </button>
+          ))}
+        </div>
+      </Field>
+
+      <Field label={t("schedule.form.title")}>
+        <TextInput
+          value={form.title ?? ""}
+          onChange={(e) => update("title", e.target.value)}
+          placeholder={
+            locale === "zh" ? "例：李医生复诊" : "e.g. Cycle 3 consult with Dr Lee"
+          }
+          required
+        />
+      </Field>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <Field label={t("schedule.form.startsAt")}>
+          <TextInput
+            type="datetime-local"
+            value={startLocal}
+            onChange={(e) =>
+              update(
+                "starts_at",
+                e.target.value
+                  ? new Date(e.target.value).toISOString()
+                  : undefined,
+              )
+            }
+            required
+          />
+        </Field>
+        <Field label={t("schedule.form.endsAt")}>
+          <TextInput
+            type="datetime-local"
+            value={endLocal}
+            onChange={(e) =>
+              update(
+                "ends_at",
+                e.target.value
+                  ? new Date(e.target.value).toISOString()
+                  : undefined,
+              )
+            }
+          />
+        </Field>
+      </div>
+
+      <label className="flex items-center gap-2 text-[12.5px] text-ink-700">
+        <input
+          type="checkbox"
+          checked={!!form.all_day}
+          onChange={(e) => update("all_day", e.target.checked)}
+        />
+        {t("schedule.form.allDay")}
+      </label>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <Field label={t("schedule.form.location")}>
+          <TextInput
+            value={form.location ?? ""}
+            onChange={(e) => update("location", e.target.value)}
+            placeholder={
+              locale === "zh" ? "例：Epworth Richmond 四楼" : "Epworth Richmond L4"
+            }
+          />
+        </Field>
+        <Field label={t("schedule.form.doctor")}>
+          <TextInput
+            value={form.doctor ?? ""}
+            onChange={(e) => update("doctor", e.target.value)}
+            placeholder={locale === "zh" ? "例：李医生" : "Dr Michael Lee"}
+          />
+        </Field>
+      </div>
+
+      <Field label={t("schedule.form.phone")}>
+        <TextInput
+          value={form.phone ?? ""}
+          onChange={(e) => update("phone", e.target.value)}
+        />
+      </Field>
+
+      <Field label={t("schedule.form.notes")}>
+        <Textarea
+          value={form.notes ?? ""}
+          onChange={(e) => update("notes", e.target.value)}
+          rows={4}
+          placeholder={
+            locale === "zh"
+              ? "带什么、准备什么、家人陪同……"
+              : "What to bring, prep, who's coming..."
+          }
+        />
+      </Field>
+
+      <Field label={t("schedule.form.status")}>
+        <div className="flex gap-2">
+          {(["scheduled", "attended", "missed", "cancelled"] as AppointmentStatus[]).map(
+            (s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => update("status", s)}
+                className={
+                  "h-8 rounded-md border px-3 text-[11.5px] " +
+                  (form.status === s
+                    ? "border-ink-900 bg-ink-900 text-paper"
+                    : "border-ink-200 bg-paper-2 text-ink-500")
+                }
+              >
+                {t(`schedule.status.${s}`)}
+              </button>
+            ),
+          )}
+        </div>
+      </Field>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-2.5 text-[12.5px] text-[var(--warn)]"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center justify-end gap-2 pt-2">
+        <Button
+          variant="ghost"
+          onClick={() => router.back()}
+          disabled={saving}
+        >
+          {t("common.cancel")}
+        </Button>
+        <Button onClick={save} disabled={saving} size="lg">
+          {saving ? t("common.saving") : t("common.save")}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function toLocalInput(iso: string | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/src/components/schedule/calendar.tsx
+++ b/src/components/schedule/calendar.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import timeGridPlugin from "@fullcalendar/timegrid";
+import listPlugin from "@fullcalendar/list";
+import interactionPlugin from "@fullcalendar/interaction";
+import type { EventClickArg, EventInput } from "@fullcalendar/core";
+import { useRouter } from "next/navigation";
+import { useLocale } from "~/hooks/use-translate";
+import type { Appointment, AppointmentKind } from "~/types/appointment";
+
+// Colour map keyed by appointment kind. Muted, matches the wider
+// paper/ink palette — we're not trying to be cheerful, just legible.
+const KIND_COLORS: Record<AppointmentKind, { bg: string; border: string; text: string }> = {
+  chemo:      { bg: "#1f2937", border: "#0f172a", text: "#f5f1e8" },
+  clinic:     { bg: "#64748b", border: "#334155", text: "#ffffff" },
+  scan:       { bg: "#b45309", border: "#92400e", text: "#ffffff" },
+  blood_test: { bg: "#991b1b", border: "#7f1d1d", text: "#ffffff" },
+  procedure:  { bg: "#4338ca", border: "#312e81", text: "#ffffff" },
+  other:      { bg: "#6b7280", border: "#4b5563", text: "#ffffff" },
+};
+
+export function AppointmentsCalendar({
+  appointments,
+}: {
+  appointments: Appointment[];
+}) {
+  const locale = useLocale();
+  const router = useRouter();
+  const calRef = useRef<FullCalendar>(null);
+
+  const events = useMemo<EventInput[]>(() => {
+    return appointments.map((a) => {
+      const colors = KIND_COLORS[a.kind] ?? KIND_COLORS.other;
+      return {
+        id: String(a.id ?? `new-${a.starts_at}`),
+        title: prefix(a.kind) + a.title,
+        start: a.starts_at,
+        end: a.ends_at,
+        allDay: a.all_day ?? false,
+        backgroundColor: colors.bg,
+        borderColor: colors.border,
+        textColor: colors.text,
+        extendedProps: {
+          kind: a.kind,
+          doctor: a.doctor,
+          location: a.location,
+          status: a.status,
+        },
+      };
+    });
+  }, [appointments]);
+
+  function handleClick(arg: EventClickArg) {
+    const id = arg.event.id;
+    if (!id || id.startsWith("new-")) return;
+    router.push(`/schedule/${id}`);
+  }
+
+  function handleDateClick(arg: { dateStr: string; allDay: boolean }) {
+    const date = arg.dateStr.slice(0, 10);
+    router.push(`/schedule/new?date=${date}`);
+  }
+
+  return (
+    <div className="overflow-hidden rounded-[var(--r-md)] border border-ink-100/70 bg-paper">
+      <FullCalendar
+        ref={calRef}
+        plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
+        initialView="dayGridMonth"
+        headerToolbar={{
+          left: "prev,next today",
+          center: "title",
+          right: "dayGridMonth,timeGridWeek,listWeek",
+        }}
+        buttonText={
+          locale === "zh"
+            ? {
+                today: "今天",
+                month: "月",
+                week: "周",
+                day: "日",
+                list: "列表",
+              }
+            : undefined
+        }
+        locale={locale === "zh" ? "zh-cn" : "en-au"}
+        firstDay={1}
+        events={events}
+        eventClick={handleClick}
+        dateClick={handleDateClick}
+        height="auto"
+        nowIndicator
+        eventDisplay="block"
+        dayMaxEventRows={3}
+        weekends
+      />
+    </div>
+  );
+}
+
+function prefix(kind: AppointmentKind): string {
+  switch (kind) {
+    case "chemo":      return "◉ ";
+    case "clinic":     return "☰ ";
+    case "scan":       return "◎ ";
+    case "blood_test": return "∽ ";
+    case "procedure":  return "⊕ ";
+    case "other":      return "· ";
+  }
+}

--- a/src/components/shared/add-fab.tsx
+++ b/src/components/shared/add-fab.tsx
@@ -10,6 +10,7 @@ import {
   X,
   CalendarDays,
   CalendarRange,
+  CalendarClock,
   Stethoscope,
   Utensils,
   NotebookPen,
@@ -38,6 +39,16 @@ const ITEMS: FabItem[] = [
     },
     icon: MessageSquarePlus,
     tone: "sand",
+  },
+  {
+    href: "/schedule/new",
+    label: { en: "New appointment", zh: "新建预约" },
+    hint: {
+      en: "Clinic / chemo / scan / blood test",
+      zh: "门诊 / 化疗 / 检查 / 化验",
+    },
+    icon: CalendarClock,
+    tone: "tide",
   },
   {
     href: "/daily/new",

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -14,6 +14,7 @@ import {
   Syringe,
   ListTodo,
   Sparkles,
+  CalendarDays,
   Menu,
   X,
 } from "lucide-react";
@@ -25,6 +26,7 @@ import { useT, useLocale } from "~/hooks/use-translate";
 // logging FAB) rather than via top-level nav — it's a cross-cutting concept.
 const ITEMS = [
   { href: "/", key: "nav.dashboard", icon: LayoutDashboard },
+  { href: "/schedule", key: "nav.schedule", icon: CalendarDays },
   { href: "/assessment", key: "nav.assessment", icon: Compass },
   { href: "/treatment", key: "nav.treatment", icon: Syringe },
   { href: "/labs", key: "nav.labs", icon: FlaskConical },

--- a/src/lib/appointments/prep-tasks.ts
+++ b/src/lib/appointments/prep-tasks.ts
@@ -1,0 +1,97 @@
+import type { Appointment, AppointmentLink } from "~/types/appointment";
+import type { PatientTask } from "~/types/task";
+
+// Pure helper: given a set of appointments and their directed prep-links,
+// emit the patient_tasks we'd like to see in the reminder engine.
+//
+// Two patterns:
+//  1) "blood test" appointment already scheduled → its row becomes the
+//     task, and the task's `due_date` is the appointment's own starts_at.
+//  2) No `from_id` row exists yet ("I know I need to book a blood test
+//     the day before chemo but haven't booked it") — the link carries
+//     an `offset_days` value and the task's due_date becomes
+//     `to.starts_at - offset_days`. The task's title is a generated
+//     "Book <kind>" instead.
+//
+// We return full PatientTask shapes with synthetic negative ids so the
+// feed composer can dedupe if it already has one. The caller
+// (useLiveQuery-driven) flattens these into the task list.
+
+export interface DerivePrepTasksArgs {
+  appointments: readonly Appointment[];
+  links: readonly AppointmentLink[];
+}
+
+export interface DerivedPrepTask extends PatientTask {
+  derived_from_appointment_id?: number;
+  derived_from_link_id?: number;
+}
+
+export function derivePrepTasks(args: DerivePrepTasksArgs): DerivedPrepTask[] {
+  const byId = new Map<number, Appointment>();
+  for (const a of args.appointments) {
+    if (typeof a.id === "number") byId.set(a.id, a);
+  }
+  const out: DerivedPrepTask[] = [];
+
+  for (const link of args.links) {
+    if (link.relation !== "prep_for") continue;
+    const to = byId.get(link.to_id);
+    if (!to) continue;
+    const from = byId.get(link.from_id);
+
+    const dueDate = deriveDueDate(from, to, link.offset_days);
+    if (!dueDate) continue;
+
+    const title = from
+      ? `Prep: ${from.title}`
+      : `Book prep for ${to.title}`;
+    const titleZh = from
+      ? `准备：${from.title}`
+      : `为"${to.title}"预约准备项`;
+
+    out.push({
+      // Negative id so there's no chance of colliding with real Dexie rows
+      // if the derived tasks ever leak into write paths. Use link.id when
+      // we have it so the id is stable across re-derives.
+      id: link.id ? -1 - link.id : undefined,
+      title,
+      title_zh: titleZh,
+      category: from?.kind === "blood_test" ? "clinical" : "admin",
+      priority: "high",
+      schedule_kind: "once",
+      due_date: dueDate,
+      lead_time_days: Math.max(1, link.offset_days ?? 1),
+      active: true,
+      surface_dashboard: true,
+      surface_daily: false,
+      notes: link.notes,
+      created_at: link.created_at,
+      updated_at: link.created_at,
+      derived_from_appointment_id: from?.id,
+      derived_from_link_id: link.id,
+    });
+  }
+
+  out.sort((a, b) => {
+    const ad = a.due_date ?? "";
+    const bd = b.due_date ?? "";
+    return ad < bd ? -1 : ad > bd ? 1 : 0;
+  });
+  return out;
+}
+
+function deriveDueDate(
+  from: Appointment | undefined,
+  to: Appointment,
+  offsetDays: number | undefined,
+): string | null {
+  if (from?.starts_at) {
+    return from.starts_at.slice(0, 10);
+  }
+  const offset = Number.isFinite(offsetDays) ? Number(offsetDays) : 1;
+  const toDate = new Date(to.starts_at);
+  if (Number.isNaN(toDate.getTime())) return null;
+  toDate.setUTCDate(toDate.getUTCDate() - offset);
+  return toDate.toISOString().slice(0, 10);
+}

--- a/src/lib/appointments/schema.ts
+++ b/src/lib/appointments/schema.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+export const appointmentKindSchema = z.enum([
+  "clinic",
+  "chemo",
+  "scan",
+  "blood_test",
+  "procedure",
+  "other",
+]);
+
+export const appointmentStatusSchema = z.enum([
+  "scheduled",
+  "attended",
+  "missed",
+  "cancelled",
+  "rescheduled",
+]);
+
+// Input schema for create / edit forms. `id`, `created_at`, `updated_at`
+// are assigned by the persistence layer, not by the form.
+export const appointmentInputSchema = z.object({
+  kind: appointmentKindSchema,
+  title: z.string().trim().min(1, "Title required").max(200),
+  starts_at: z
+    .string()
+    .refine((s) => !Number.isNaN(Date.parse(s)), "Invalid start date"),
+  ends_at: z
+    .string()
+    .refine((s) => !s || !Number.isNaN(Date.parse(s)), "Invalid end date")
+    .optional()
+    .or(z.literal("")),
+  all_day: z.boolean().optional(),
+  timezone: z.string().optional(),
+  location: z.string().max(200).optional(),
+  location_url: z.string().url().optional().or(z.literal("")),
+  doctor: z.string().max(100).optional(),
+  phone: z.string().max(60).optional(),
+  notes: z.string().max(5000).optional(),
+  status: appointmentStatusSchema.default("scheduled"),
+  attendees: z.array(z.string().trim().min(1)).optional(),
+  attachments: z.array(z.string()).optional(),
+  derived_from_cycle: z.boolean().optional(),
+  cycle_id: z.number().int().positive().optional(),
+});
+
+export type AppointmentInput = z.infer<typeof appointmentInputSchema>;
+
+// Schema the vision/email parser is asked to emit. Kept lean so the LLM
+// doesn't hallucinate URLs or status transitions it has no evidence for.
+export const parsedAppointmentSchema = z.object({
+  kind: appointmentKindSchema,
+  title: z.string().min(1),
+  starts_at: z.string(), // ISO; parser does its best, we validate on save
+  ends_at: z.string().optional(),
+  all_day: z.boolean().optional(),
+  location: z.string().optional(),
+  doctor: z.string().optional(),
+  phone: z.string().optional(),
+  notes: z.string().optional(),
+  confidence: z.enum(["high", "medium", "low"]),
+  ambiguities: z.array(z.string()).optional(),
+});
+
+export type ParsedAppointment = z.infer<typeof parsedAppointmentSchema>;

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -34,6 +34,7 @@ import type {
   AgentStateRow,
   LogEventRow,
 } from "~/types/agent";
+import type { Appointment, AppointmentLink } from "~/types/appointment";
 
 export class AnchorDB extends Dexie {
   daily_entries!: Table<DailyEntry, number>;
@@ -65,6 +66,8 @@ export class AnchorDB extends Dexie {
   log_events!: Table<LogEventRow, number>;
   agent_runs!: Table<AgentRunRow, number>;
   agent_feedback!: Table<AgentFeedbackRow, number>;
+  appointments!: Table<Appointment, number>;
+  appointment_links!: Table<AppointmentLink, number>;
 
   constructor() {
     super("anchor_db");
@@ -152,6 +155,18 @@ export class AnchorDB extends Dexie {
     this.version(11).stores({
       agent_feedback:
         "++id, agent_id, run_id, by, kind, at, [agent_id+at]",
+    });
+    // v12: scheduling module. `appointments` is first-class for any
+    // anticipated medical event; `appointment_links` is a directed
+    // edge table so a blood test can be flagged as "prep_for" a chemo
+    // consult. Indexes on starts_at / kind make range queries (month
+    // grid, next-week) + kind-filter cheap. Compound
+    // [kind+starts_at] lets "next scan" pull fast.
+    this.version(12).stores({
+      appointments:
+        "++id, starts_at, kind, status, cycle_id, [kind+starts_at]",
+      appointment_links:
+        "++id, from_id, to_id, relation, [to_id+relation]",
     });
   }
 }

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -1,0 +1,76 @@
+// Scheduling + appointments module.
+//
+// An Appointment is any anticipated medical event the patient needs to
+// prepare for, attend, and (usually) have follow-up captures from. We
+// model it one step richer than `life_events` so we can:
+//  - render it as a first-class tile in /schedule
+//  - chain prep dependencies (blood test must happen N days before chemo)
+//  - auto-derive patient_tasks from the dependency graph
+//  - attach photos / notes / result captures per event over its lifecycle
+//
+// Past appointments stay in this table — attended + completed — rather
+// than migrating to life_events. The tabular record is the source of
+// truth; life_events is for narrative entries the patient made directly.
+
+export type AppointmentKind =
+  | "clinic"        // oncology / specialist consult
+  | "chemo"         // infusion visit
+  | "scan"          // CT / MRI / PET
+  | "blood_test"    // pathology / phlebotomy
+  | "procedure"     // line/port/biopsy/etc.
+  | "other";        // allied health, GP, trial visit, etc.
+
+export type AppointmentStatus =
+  | "scheduled"
+  | "attended"
+  | "missed"
+  | "cancelled"
+  | "rescheduled";
+
+export interface Appointment {
+  id?: number;
+  kind: AppointmentKind;
+  title: string;                 // "Cycle 3 consult with Dr Lee"
+  starts_at: string;             // ISO 8601 timestamp
+  ends_at?: string;              // optional; for whole-day leave blank
+  all_day?: boolean;
+  timezone?: string;             // IANA; defaults to device
+  location?: string;             // "Epworth Richmond, level 4"
+  location_url?: string;         // Google Maps link etc.
+  doctor?: string;               // "Dr Michael Lee"
+  phone?: string;
+  notes?: string;                // markdown
+  status: AppointmentStatus;
+  // Free-text attendee list. When collaboration lands properly this
+  // becomes a separate attendees table keyed by user_id; for now names.
+  attendees?: string[];
+  // Photo / document references (keys into ingested_documents, or bare
+  // data URLs for small captures).
+  attachments?: string[];
+  // When true, this row was auto-generated from a treatment_cycle
+  // (e.g. "Cycle 3 Day 1 infusion") and may be overwritten on cycle
+  // edit. Manual edits set this to false so we stop clobbering them.
+  derived_from_cycle?: boolean;
+  cycle_id?: number;
+  created_at: string;
+  updated_at: string;
+}
+
+// Directed edge. Today the only relation that matters clinically is
+// "prep_for" ("this blood test is prep for that chemo consult"), but
+// leaving the relation typed means we can later add "follow_up_of",
+// "rescheduled_from", "blocks", etc. without schema churn.
+export type AppointmentLinkRelation = "prep_for" | "follow_up_of";
+
+export interface AppointmentLink {
+  id?: number;
+  from_id: number;   // the blood test
+  to_id: number;     // the chemo consult the blood test is prep for
+  relation: AppointmentLinkRelation;
+  // Optional offset hint — "blood test due 1 day before chemo". Used
+  // by the task engine to back-fill a patient_task with a sensible
+  // due_date if `from_id` has no starts_at of its own yet.
+  offset_days?: number;
+  notes?: string;
+  created_at: string;
+}

--- a/tests/unit/appointments-prep.test.ts
+++ b/tests/unit/appointments-prep.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { derivePrepTasks } from "~/lib/appointments/prep-tasks";
+import type { Appointment, AppointmentLink } from "~/types/appointment";
+
+const base: Pick<Appointment, "status" | "created_at" | "updated_at"> = {
+  status: "scheduled",
+  created_at: "2026-04-22T00:00:00.000Z",
+  updated_at: "2026-04-22T00:00:00.000Z",
+};
+
+function ap(id: number, overrides: Partial<Appointment>): Appointment {
+  return {
+    id,
+    kind: "clinic",
+    title: `Appt ${id}`,
+    starts_at: "2026-05-01T09:00:00.000Z",
+    ...base,
+    ...overrides,
+  };
+}
+
+function link(
+  id: number,
+  from: number,
+  to: number,
+  offset?: number,
+): AppointmentLink {
+  return {
+    id,
+    from_id: from,
+    to_id: to,
+    relation: "prep_for",
+    offset_days: offset,
+    created_at: base.created_at,
+  };
+}
+
+describe("derivePrepTasks", () => {
+  it("uses the prep appointment's own date when both exist", () => {
+    const tasks = derivePrepTasks({
+      appointments: [
+        ap(1, {
+          kind: "blood_test",
+          title: "FBC + UEC",
+          starts_at: "2026-04-29T08:00:00.000Z",
+        }),
+        ap(2, {
+          kind: "chemo",
+          title: "Cycle 3 infusion",
+          starts_at: "2026-04-30T10:00:00.000Z",
+        }),
+      ],
+      links: [link(10, 1, 2)],
+    });
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.due_date).toBe("2026-04-29");
+    expect(tasks[0]?.title).toBe("Prep: FBC + UEC");
+    expect(tasks[0]?.category).toBe("clinical");
+  });
+
+  it("falls back to to.starts_at − offset_days when prep row is missing", () => {
+    const tasks = derivePrepTasks({
+      appointments: [
+        ap(2, {
+          kind: "clinic",
+          title: "Dr Lee consult",
+          starts_at: "2026-04-30T10:00:00.000Z",
+        }),
+      ],
+      // Only the consult row exists; prep appointment hasn't been booked yet.
+      links: [link(10, 9999, 2, 2)],
+    });
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.due_date).toBe("2026-04-28");
+    expect(tasks[0]?.title).toBe("Book prep for Dr Lee consult");
+    // default offset is 1; we passed 2, so lead_time_days should reflect it
+    expect(tasks[0]?.lead_time_days).toBe(2);
+  });
+
+  it("defaults offset_days to 1 when absent", () => {
+    const tasks = derivePrepTasks({
+      appointments: [
+        ap(2, {
+          kind: "chemo",
+          title: "Cycle 3 infusion",
+          starts_at: "2026-04-30T10:00:00.000Z",
+        }),
+      ],
+      links: [link(10, 9999, 2)],
+    });
+    expect(tasks[0]?.due_date).toBe("2026-04-29");
+  });
+
+  it("ignores non-prep relations", () => {
+    const tasks = derivePrepTasks({
+      appointments: [ap(1, {}), ap(2, {})],
+      links: [
+        { ...link(10, 1, 2), relation: "follow_up_of" } as AppointmentLink,
+      ],
+    });
+    expect(tasks).toEqual([]);
+  });
+
+  it("sorts output by due_date ascending", () => {
+    const tasks = derivePrepTasks({
+      appointments: [
+        ap(1, { starts_at: "2026-05-10T00:00:00.000Z" }),
+        ap(2, { starts_at: "2026-05-20T00:00:00.000Z" }),
+        ap(3, { kind: "blood_test", starts_at: "2026-05-05T00:00:00.000Z" }),
+        ap(4, { kind: "blood_test", starts_at: "2026-05-15T00:00:00.000Z" }),
+      ],
+      links: [link(10, 3, 1), link(11, 4, 2)],
+    });
+    expect(tasks.map((t) => t.due_date)).toEqual(["2026-05-05", "2026-05-15"]);
+  });
+
+  it("skips links whose to-appointment doesn't exist", () => {
+    const tasks = derivePrepTasks({
+      appointments: [ap(1, {})],
+      links: [link(10, 1, 999)],
+    });
+    expect(tasks).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

First-class scheduling module. Every clinic visit, chemo infusion, scan, blood test, or procedure becomes a typed `Appointment`; a directed `appointment_links` edge lets "blood test" be marked as `prep_for` "chemo consult", from which the task engine auto-derives a `patient_task` with the right due date.

## Data model (Dexie v12)

- **`appointments`** — typed event (`kind`/`title`/`starts_at`/`ends_at`/`location`/`doctor`/`phone`/`notes`/`status`/`attendees`/`attachments`/`cycle_id`). Indexed on `starts_at`, `kind`, `status`, `[kind+starts_at]` so month-grid and "next scan" queries are cheap.
- **`appointment_links`** — directed edge `{from_id, to_id, relation, offset_days, notes}`. Today `"prep_for"` + `"follow_up_of"`; shape leaves room for `"rescheduled_from"` / `"blocks"` etc.

## Prep-task derivation

`src/lib/appointments/prep-tasks.ts` — pure helper: `(appointments, links) → DerivedPrepTask[]`.

- **If** a prep appointment is already scheduled, its own `starts_at` becomes the task's `due_date`; title = `"Prep: <that>"`
- **If** only the link exists (you know prep is needed but haven't booked yet), `due_date = to.starts_at − offset_days` (default 1); title = `"Book prep for <that>"`
- Sorted soonest-first so the caller slices cheaply
- 6 unit tests cover both patterns, offset defaults, non-prep relations, and dangling `to_id`

## Patient-facing UI

- **`/schedule`** — FullCalendar month/week/list grid, colour-coded by kind. "Prep due soon" banner shows next 5 derived prep tasks. Upcoming list (next 12) with kind tags + location/doctor strip. Three entry buttons: manual / from photo / from email.
- **`/schedule/new?via=manual|photo|email`** — one page, three paths. Photo accepts a camera capture; email accepts a pasted body. Both POST to `/api/parse-appointment` and prefill the form.
- **`/schedule/[id]`** — read-only detail + linked-appointments section + delete + edit toggle.
- AddFab gets a **"New appointment"** entry; desktop/mobile nav gains a **"Schedule"** route between Dashboard and Assessment.

## Vision / email ingest

`/api/parse-appointment` — server-side `POST` that takes `{ text? imageBase64? imageMediaType? locale today }`, runs `messages.parse()` with a `ParsedAppointmentSchema` Zod shape (enforces kind / title / starts_at + `confidence` + `ambiguities[]`). System prompt is scoped to "one appointment, don't fabricate", ephemeral-cached. Returns 503 when `ANTHROPIC_API_KEY` unset, 502 on Claude error, 400 on invalid body.

## i18n

en + zh for every surface: `nav.schedule`, `schedule.*` (17 keys), `schedule.kind.*` (6), `schedule.status.*` (5), `schedule.form.*` (10), `schedule.new.*` (11).

## Deps added

`@fullcalendar/core @fullcalendar/react @fullcalendar/daygrid @fullcalendar/timegrid @fullcalendar/list @fullcalendar/interaction` (~55 KB gzip total)

## Gate

- `pnpm typecheck` clean
- `pnpm lint` clean (two pre-existing `<img>` warnings)
- **237 / 237** unit tests (was 231; +6 new for prep-tasks)
- `pnpm build` ships `/schedule` (91 KB), `/schedule/[id]` (2.6 KB), `/schedule/new` (2.3 KB), `/api/parse-appointment`

## Next sprint backlog (scoped out)

- Proper attendee invites (user_id FK + Supabase RLS)
- ICS export per event ("Add to Apple/Google Calendar")
- TWA push notifications on the lead-time day
- Auto-generate cycle-derived appointments from `treatment_cycles`
- Per-event capture pipeline that hands photos/notes straight to the log → agent pipeline

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build`
- [ ] Post-merge smoke: create a chemo appointment, create a blood test, link as `prep_for`, confirm "Prep due soon" surfaces the right date on `/schedule`
- [ ] Photo ingest on the Vercel preview: take a picture of any appointment card; confirm parser fills kind + title + date
- [ ] Pasted-email ingest with a real appointment email body

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8