### PR TITLE
Care-team registry: Dexie table + Settings UI

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import { settingsSchema, type SettingsInput } from "~/lib/validators/schemas";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { AccountButton } from "~/components/shared/account-button";
+import { CareTeamSection } from "~/components/settings/care-team-section";
 
 export default function SettingsPage() {
   const t = useT();
@@ -99,6 +100,8 @@ export default function SettingsPage() {
       </div>
 
       <AccountButton />
+
+      <CareTeamSection />
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <section className="space-y-3">

--- a/src/components/settings/care-team-section.tsx
+++ b/src/components/settings/care-team-section.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import {
+  addCareTeamMember,
+  removeCareTeamMember,
+  updateCareTeamMember,
+  hydrateFromLegacySettings,
+} from "~/lib/care-team/registry";
+import type { CareTeamMember, CareTeamRole } from "~/types/care-team";
+import { useLocale } from "~/hooks/use-translate";
+import { Field, TextInput } from "~/components/ui/field";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent } from "~/components/ui/card";
+import {
+  Users,
+  Star,
+  Pencil,
+  Trash2,
+  Plus,
+  Check,
+  X,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+const ROLES: CareTeamRole[] = [
+  "family",
+  "oncologist",
+  "surgeon",
+  "gp",
+  "nurse",
+  "allied_health",
+  "other",
+];
+
+const ROLE_LABELS: Record<CareTeamRole, { en: string; zh: string }> = {
+  family: { en: "Family", zh: "家人" },
+  oncologist: { en: "Oncologist", zh: "肿瘤科" },
+  surgeon: { en: "Surgeon", zh: "外科" },
+  gp: { en: "GP", zh: "全科医师" },
+  nurse: { en: "Nurse", zh: "护理" },
+  allied_health: { en: "Allied health", zh: "康复/营养" },
+  other: { en: "Other", zh: "其他" },
+};
+
+interface DraftMember {
+  name: string;
+  role: CareTeamRole;
+  specialty: string;
+  organisation: string;
+  phone: string;
+  email: string;
+  notes: string;
+  is_lead: boolean;
+}
+
+const EMPTY_DRAFT: DraftMember = {
+  name: "",
+  role: "family",
+  specialty: "",
+  organisation: "",
+  phone: "",
+  email: "",
+  notes: "",
+  is_lead: false,
+};
+
+export function CareTeamSection() {
+  const locale = useLocale();
+  const members = useLiveQuery(() => db.care_team.toArray(), []);
+  const settings = useLiveQuery(() => db.settings.toArray(), []);
+
+  const [editing, setEditing] = useState<number | "new" | null>(null);
+  const [draft, setDraft] = useState<DraftMember>(EMPTY_DRAFT);
+  const [saving, setSaving] = useState(false);
+
+  // One-time hydrate from legacy managing_oncologist / hospital_name
+  // once settings are loaded and registry is empty.
+  useEffect(() => {
+    const s = settings?.[0];
+    if (!s || members === undefined) return;
+    if (members.length > 0) return;
+    void hydrateFromLegacySettings({
+      managing_oncologist: s.managing_oncologist,
+      managing_oncologist_phone: s.managing_oncologist_phone,
+      hospital_name: s.hospital_name,
+    });
+  }, [settings, members]);
+
+  const grouped = useMemo(() => {
+    const byRole = new Map<CareTeamRole, CareTeamMember[]>();
+    for (const m of members ?? []) {
+      const list = byRole.get(m.role) ?? [];
+      list.push(m);
+      byRole.set(m.role, list);
+    }
+    for (const list of byRole.values()) {
+      list.sort((a, b) => {
+        if (Boolean(a.is_lead) !== Boolean(b.is_lead)) {
+          return a.is_lead ? -1 : 1;
+        }
+        return a.name.localeCompare(b.name);
+      });
+    }
+    return byRole;
+  }, [members]);
+
+  function startAdd() {
+    setDraft(EMPTY_DRAFT);
+    setEditing("new");
+  }
+
+  function startEdit(m: CareTeamMember) {
+    setDraft({
+      name: m.name,
+      role: m.role,
+      specialty: m.specialty ?? "",
+      organisation: m.organisation ?? "",
+      phone: m.phone ?? "",
+      email: m.email ?? "",
+      notes: m.notes ?? "",
+      is_lead: Boolean(m.is_lead),
+    });
+    setEditing(m.id ?? null);
+  }
+
+  function cancel() {
+    setEditing(null);
+    setDraft(EMPTY_DRAFT);
+  }
+
+  async function save() {
+    if (!draft.name.trim()) return;
+    setSaving(true);
+    try {
+      const payload = {
+        name: draft.name.trim(),
+        role: draft.role,
+        specialty: draft.specialty.trim() || undefined,
+        organisation: draft.organisation.trim() || undefined,
+        phone: draft.phone.trim() || undefined,
+        email: draft.email.trim() || undefined,
+        notes: draft.notes.trim() || undefined,
+        is_lead: draft.is_lead,
+      };
+      if (editing === "new") {
+        await addCareTeamMember(payload);
+      } else if (typeof editing === "number") {
+        await updateCareTeamMember(editing, payload);
+      }
+      cancel();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function remove(id: number) {
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(
+        locale === "zh"
+          ? "从团队列表中移除此成员？"
+          : "Remove this person from the care team?",
+      )
+    ) {
+      return;
+    }
+    await removeCareTeamMember(id);
+  }
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="eyebrow">
+            <Users className="mr-1.5 inline h-3.5 w-3.5" />
+            {L("Care team", "护理团队")}
+          </h2>
+          <p className="mt-1 text-xs text-ink-500">
+            {L(
+              "One source of truth for everyone involved in care. Attendee chips on appointments read from here.",
+              "团队名单的唯一来源。预约上的陪同人名从这里读取。",
+            )}
+          </p>
+        </div>
+        {editing === null && (
+          <Button onClick={startAdd} size="md">
+            <Plus className="h-4 w-4" />
+            {L("Add", "新增")}
+          </Button>
+        )}
+      </div>
+
+      {editing !== null && (
+        <DraftEditor
+          draft={draft}
+          onChange={setDraft}
+          onSave={save}
+          onCancel={cancel}
+          saving={saving}
+          locale={locale}
+        />
+      )}
+
+      {members !== undefined && members.length === 0 && editing === null && (
+        <Card>
+          <CardContent className="py-4 text-center text-[12.5px] text-ink-500">
+            {L(
+              "No one listed yet. Add yourself, the oncologist, and any family chaperones.",
+              "还没有成员。先把自己、肿瘤科医师、家人陪同加进来。",
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="space-y-3">
+        {ROLES.map((role) => {
+          const list = grouped.get(role) ?? [];
+          if (list.length === 0) return null;
+          return (
+            <div key={role} className="space-y-1.5">
+              <div className="text-[10.5px] font-medium uppercase tracking-[0.12em] text-ink-400">
+                {ROLE_LABELS[role][locale]}
+              </div>
+              <ul className="divide-y divide-ink-100 rounded-md border border-ink-100 bg-paper">
+                {list.map((m) => (
+                  <li
+                    key={m.id}
+                    className="flex items-start gap-3 px-3 py-2.5 text-[13px]"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5">
+                        <span className="font-medium text-ink-900">
+                          {m.name}
+                        </span>
+                        {m.is_lead && (
+                          <Star
+                            className="h-3 w-3 fill-[var(--tide-2)] text-[var(--tide-2)]"
+                            aria-label={L("Lead", "主要联系人")}
+                          />
+                        )}
+                      </div>
+                      {(m.specialty || m.organisation) && (
+                        <div className="mt-0.5 text-[11.5px] text-ink-500">
+                          {[m.specialty, m.organisation].filter(Boolean).join(" · ")}
+                        </div>
+                      )}
+                      {(m.phone || m.email) && (
+                        <div className="mt-0.5 text-[11.5px] text-ink-500">
+                          {m.phone && (
+                            <a href={`tel:${m.phone}`} className="underline">
+                              {m.phone}
+                            </a>
+                          )}
+                          {m.phone && m.email && " · "}
+                          {m.email && (
+                            <a href={`mailto:${m.email}`} className="underline">
+                              {m.email}
+                            </a>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex shrink-0 gap-1">
+                      <button
+                        type="button"
+                        onClick={() => startEdit(m)}
+                        className="rounded-md p-1.5 text-ink-500 hover:bg-ink-100/40 hover:text-ink-900"
+                        aria-label={L("Edit", "编辑")}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => m.id && remove(m.id)}
+                        className="rounded-md p-1.5 text-ink-500 hover:bg-ink-100/40 hover:text-red-700"
+                        aria-label={L("Remove", "移除")}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function DraftEditor({
+  draft,
+  onChange,
+  onSave,
+  onCancel,
+  saving,
+  locale,
+}: {
+  draft: DraftMember;
+  onChange: (d: DraftMember) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  return (
+    <Card>
+      <CardContent className="space-y-3 pt-4">
+        <Field label={L("Name", "姓名")}>
+          <TextInput
+            value={draft.name}
+            onChange={(e) => onChange({ ...draft, name: e.target.value })}
+            placeholder={L("Dr Michael Lee", "李医生")}
+            autoFocus
+          />
+        </Field>
+
+        <div>
+          <div className="mb-1 text-[11px] font-medium uppercase tracking-[0.08em] text-ink-400">
+            {L("Role", "角色")}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {ROLES.map((r) => (
+              <button
+                key={r}
+                type="button"
+                onClick={() => onChange({ ...draft, role: r })}
+                className={cn(
+                  "h-8 rounded-full border px-3 text-[12px] font-medium",
+                  draft.role === r
+                    ? "border-ink-900 bg-ink-900 text-paper"
+                    : "border-ink-200 bg-paper-2 text-ink-600 hover:border-ink-400",
+                )}
+              >
+                {ROLE_LABELS[r][locale]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <Field label={L("Specialty", "专业")}>
+            <TextInput
+              value={draft.specialty}
+              onChange={(e) =>
+                onChange({ ...draft, specialty: e.target.value })
+              }
+              placeholder={L("HPB surgeon", "肝胆胰外科")}
+            />
+          </Field>
+          <Field label={L("Organisation", "机构")}>
+            <TextInput
+              value={draft.organisation}
+              onChange={(e) =>
+                onChange({ ...draft, organisation: e.target.value })
+              }
+              placeholder={L("Epworth Richmond", "Epworth Richmond")}
+            />
+          </Field>
+          <Field label={L("Phone", "电话")}>
+            <TextInput
+              value={draft.phone}
+              onChange={(e) => onChange({ ...draft, phone: e.target.value })}
+              inputMode="tel"
+            />
+          </Field>
+          <Field label={L("Email", "邮箱")}>
+            <TextInput
+              type="email"
+              value={draft.email}
+              onChange={(e) => onChange({ ...draft, email: e.target.value })}
+            />
+          </Field>
+        </div>
+
+        <Field label={L("Notes", "备注")}>
+          <TextInput
+            value={draft.notes}
+            onChange={(e) => onChange({ ...draft, notes: e.target.value })}
+            placeholder={L(
+              "After-hours contact, preferred channel…",
+              "下班后联系方式、偏好的沟通渠道……",
+            )}
+          />
+        </Field>
+
+        <label className="flex items-center gap-2 text-[12.5px] text-ink-700">
+          <input
+            type="checkbox"
+            checked={draft.is_lead}
+            onChange={(e) =>
+              onChange({ ...draft, is_lead: e.target.checked })
+            }
+          />
+          {L(
+            "Primary contact for this role",
+            "此角色的主要联系人",
+          )}
+        </label>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <Button variant="ghost" onClick={onCancel} disabled={saving}>
+            <X className="h-4 w-4" />
+            {L("Cancel", "取消")}
+          </Button>
+          <Button onClick={onSave} disabled={saving || !draft.name.trim()} size="md">
+            <Check className="h-4 w-4" />
+            {saving ? L("Saving…", "保存中…") : L("Save", "保存")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/care-team/registry.ts
+++ b/src/lib/care-team/registry.ts
@@ -1,0 +1,107 @@
+import { db, now } from "~/lib/db/dexie";
+import type { CareTeamMember, CareTeamRole } from "~/types/care-team";
+
+// Thin CRUD + query helpers over the `care_team` Dexie table. Kept
+// plain so the Settings UI, the appointment form, and the emergency
+// card all use the same surface.
+
+export async function listCareTeam(): Promise<CareTeamMember[]> {
+  return db.care_team.orderBy("name").toArray();
+}
+
+export async function addCareTeamMember(
+  input: Omit<CareTeamMember, "id" | "created_at" | "updated_at">,
+): Promise<number> {
+  const ts = now();
+  const id = await db.care_team.add({
+    ...input,
+    created_at: ts,
+    updated_at: ts,
+  });
+  if (input.is_lead) {
+    await unmarkOtherLeadsForRole(input.role, id);
+  }
+  return id as number;
+}
+
+export async function updateCareTeamMember(
+  id: number,
+  patch: Partial<CareTeamMember>,
+): Promise<void> {
+  await db.care_team.update(id, { ...patch, updated_at: now() });
+  if (patch.is_lead && patch.role) {
+    await unmarkOtherLeadsForRole(patch.role, id);
+  } else if (patch.is_lead) {
+    const row = await db.care_team.get(id);
+    if (row) await unmarkOtherLeadsForRole(row.role, id);
+  }
+}
+
+export async function removeCareTeamMember(id: number): Promise<void> {
+  await db.care_team.delete(id);
+}
+
+export async function getLeadForRole(
+  role: CareTeamRole,
+): Promise<CareTeamMember | undefined> {
+  const rows = await db.care_team
+    .where("role")
+    .equals(role)
+    .and((r) => Boolean(r.is_lead))
+    .toArray();
+  return rows[0];
+}
+
+// When a member is flagged as lead, any prior lead in the same role
+// gets un-flagged. One-lead-per-role keeps downstream UI
+// (emergency card picks "the" oncologist) unambiguous.
+async function unmarkOtherLeadsForRole(
+  role: CareTeamRole,
+  keepId: number,
+): Promise<void> {
+  const others = await db.care_team
+    .where("role")
+    .equals(role)
+    .and((r) => Boolean(r.is_lead) && r.id !== keepId)
+    .toArray();
+  const ts = now();
+  await Promise.all(
+    others.map((o) =>
+      o.id != null
+        ? db.care_team.update(o.id, { is_lead: false, updated_at: ts })
+        : Promise.resolve(),
+    ),
+  );
+}
+
+// One-time hydrate: if the user has a legacy `managing_oncologist` in
+// settings but no care-team rows exist yet, seed the registry from it so
+// existing data carries forward. Called from the Settings page on mount.
+export async function hydrateFromLegacySettings(args: {
+  managing_oncologist?: string;
+  managing_oncologist_phone?: string;
+  hospital_name?: string;
+}): Promise<void> {
+  const existing = await db.care_team.count();
+  if (existing > 0) return;
+  if (!args.managing_oncologist?.trim()) return;
+  await addCareTeamMember({
+    name: args.managing_oncologist.trim(),
+    role: "oncologist",
+    organisation: args.hospital_name?.trim() || undefined,
+    phone: args.managing_oncologist_phone?.trim() || undefined,
+    is_lead: true,
+  });
+}
+
+// Case-insensitive lookup: given a free-text name from an appointment's
+// `attendees[]`, return the matching registry row if any. Lets the UI
+// show a role badge and phone link without storing a foreign key.
+export function matchMemberByName(
+  name: string,
+  members: readonly CareTeamMember[],
+): CareTeamMember | undefined {
+  const target = name.trim().toLowerCase();
+  if (!target) return undefined;
+  return members.find((m) => m.name.trim().toLowerCase() === target);
+}

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -23,6 +23,7 @@ import type {
 import type { Trial } from "~/types/bridge";
 import type { TreatmentCycle } from "~/types/treatment";
 import type { PatientTask } from "~/types/task";
+import type { CareTeamMember } from "~/types/care-team";
 import type {
   Medication,
   MedicationEvent,
@@ -68,6 +69,7 @@ export class AnchorDB extends Dexie {
   agent_feedback!: Table<AgentFeedbackRow, number>;
   appointments!: Table<Appointment, number>;
   appointment_links!: Table<AppointmentLink, number>;
+  care_team!: Table<CareTeamMember, number>;
 
   constructor() {
     super("anchor_db");
@@ -167,6 +169,15 @@ export class AnchorDB extends Dexie {
         "++id, starts_at, kind, status, cycle_id, [kind+starts_at]",
       appointment_links:
         "++id, from_id, to_id, relation, [to_id+relation]",
+    });
+    // v13: care-team registry. One row per person involved in the
+    // patient's care (family, clinicians, allied health). Consumed by
+    // the appointment attendee chip picker, the emergency card, and
+    // the pre-clinic summary. Indexed on role + is_lead so the
+    // "primary oncologist" / "primary family contact" lookups are
+    // cheap.
+    this.version(13).stores({
+      care_team: "++id, role, is_lead, name",
     });
   }
 }

--- a/src/types/care-team.ts
+++ b/src/types/care-team.ts
@@ -1,0 +1,41 @@
+// Central care-team registry. A single source of truth that every
+// care-team surface (appointment attendees, emergency card, pre-clinic
+// summary, family context) reads from — so "Wendy", "wendy", and
+// "Wendy Hu" never fragment in the database.
+//
+// Each member has a stable numeric id (Dexie autoincrement) plus a
+// human-chosen `name`. Roles are coarse buckets that drive UI
+// treatment (role-coloured chips, grouping in Settings, emergency-card
+// highlighting) rather than fine-grained permissions. Specialty is
+// free-text for the long tail ("HPB surgeon", "Medical Oncology",
+// "Palliative Care RN").
+
+export type CareTeamRole =
+  | "family"         // Thomas, Catherine, Wendy
+  | "oncologist"     // Dr Michael Lee
+  | "surgeon"        // Mark Cullinan
+  | "gp"             // general practitioner
+  | "nurse"          // chemo nurse, care coordinator
+  | "allied_health"  // physio, dietitian, psychologist
+  | "other";
+
+export interface CareTeamMember {
+  id?: number;
+  name: string;
+  role: CareTeamRole;
+  specialty?: string;
+  organisation?: string;  // "Epworth Richmond"
+  phone?: string;
+  email?: string;
+  notes?: string;
+  // When true, this person is the canonical contact for their role — the
+  // managing oncologist, the primary family contact, etc. Used by the
+  // emergency card and pre-clinic summary to pick one per role.
+  is_lead?: boolean;
+  // When true, include this member on newly-created appointments of the
+  // given kinds by default. For now we don't act on this; the flag is
+  // captured so a future pass can default-populate attendees.
+  default_attendee?: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/tests/unit/care-team-registry.test.ts
+++ b/tests/unit/care-team-registry.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { matchMemberByName } from "~/lib/care-team/registry";
+import type { CareTeamMember } from "~/types/care-team";
+
+function member(over: Partial<CareTeamMember> = {}): CareTeamMember {
+  return {
+    id: 1,
+    name: "Dr Michael Lee",
+    role: "oncologist",
+    created_at: "2026-04-22T00:00:00.000Z",
+    updated_at: "2026-04-22T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("matchMemberByName", () => {
+  const roster: CareTeamMember[] = [
+    member({ id: 1, name: "Dr Michael Lee", role: "oncologist" }),
+    member({ id: 2, name: "Wendy", role: "family" }),
+    member({ id: 3, name: "Catherine Hu", role: "family" }),
+  ];
+
+  it("returns the member when names match case-insensitively", () => {
+    expect(matchMemberByName("wendy", roster)?.id).toBe(2);
+    expect(matchMemberByName("WENDY", roster)?.id).toBe(2);
+  });
+
+  it("trims whitespace around the target name", () => {
+    expect(matchMemberByName("  Dr Michael Lee  ", roster)?.id).toBe(1);
+  });
+
+  it("returns undefined when no member matches", () => {
+    expect(matchMemberByName("Dr Strange", roster)).toBeUndefined();
+  });
+
+  it("returns undefined for empty / whitespace-only input", () => {
+    expect(matchMemberByName("", roster)).toBeUndefined();
+    expect(matchMemberByName("   ", roster)).toBeUndefined();
+  });
+
+  it("matches full name exactly, not substring — Wendy shouldn't match Catherine Hu and vice versa", () => {
+    expect(matchMemberByName("Hu", roster)).toBeUndefined();
+    expect(matchMemberByName("Catherine", roster)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a first-class care-team registry so every family member, clinician, and allied-health contact lives in one source of truth, instead of being fragmented across `settings.managing_oncologist` and freetext `Appointment.attendees` strings.

- **Dexie v13** — new `care_team` table, indexed on `role`, `is_lead`, `name`
- **`src/types/care-team.ts`** — `CareTeamMember` with coarse role buckets (`family`, `oncologist`, `surgeon`, `gp`, `nurse`, `allied_health`, `other`) + contact fields + `is_lead` flag for "the" canonical contact per role
- **`src/lib/care-team/registry.ts`** — CRUD helpers; `matchMemberByName` for case-insensitive attendee → registry lookup; one-lead-per-role invariant enforced on write; `hydrateFromLegacySettings` seeds the registry from existing `managing_oncologist` on first load so existing devices carry forward
- **`src/components/settings/care-team-section.tsx`** — Settings UI with role-grouped list, inline editor, lead-star badge, tap-to-call/mail links. Mounted on `/settings` between account and profile.
- **5 new unit tests** for `matchMemberByName` (case-insensitive, trimmed, full-name-not-substring, empty handling).

## Gate

- `pnpm typecheck` clean
- `pnpm test` — **251/251** (+5 for care-team)
- `pnpm build` clean

## Follow-up (planned, separate PRs)

- **Slice 1** — new `/family` route (calm, family-focused view of dad's status + next-up appointments + quick-note + call-the-team directory)
- **Slice 2** — structured attendance on appointments (confirm / tentative / decline)
- **Slice 3** — visible `entered_by` attribution on shared surfaces
- **Slice 4** — `EmergencyCard` reads registry leads with fallback to legacy settings fields

## Test plan

- [ ] Fresh install: add an oncologist with `is_lead`, confirm it appears under Oncologist role with star
- [ ] Add a second oncologist with `is_lead`; confirm the first loses lead automatically
- [ ] Existing device with legacy `settings.managing_oncologist` set: first load of Settings populates a registry entry with role=oncologist, is_lead=true
- [ ] Tap-to-call link on a phone number opens the dialer

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8