### PR TITLE
Calendar: adopt the Anchor design language

### DIFF
--- a/src/components/schedule/calendar.tsx
+++ b/src/components/schedule/calendar.tsx
@@ -11,15 +11,44 @@ import { useRouter } from "next/navigation";
 import { useLocale } from "~/hooks/use-translate";
 import type { Appointment, AppointmentKind } from "~/types/appointment";
 
-// Colour map keyed by appointment kind. Muted, matches the wider
-// paper/ink palette — we're not trying to be cheerful, just legible.
-const KIND_COLORS: Record<AppointmentKind, { bg: string; border: string; text: string }> = {
-  chemo:      { bg: "#1f2937", border: "#0f172a", text: "#f5f1e8" },
-  clinic:     { bg: "#64748b", border: "#334155", text: "#ffffff" },
-  scan:       { bg: "#b45309", border: "#92400e", text: "#ffffff" },
-  blood_test: { bg: "#991b1b", border: "#7f1d1d", text: "#ffffff" },
-  procedure:  { bg: "#4338ca", border: "#312e81", text: "#ffffff" },
-  other:      { bg: "#6b7280", border: "#4b5563", text: "#ffffff" },
+// Event colours map to the Anchor palette (see globals.css tokens).
+// Each kind gets a light soft background + a clear ink/tide/warn
+// accent for the left border + matching readable text. Muted on
+// purpose — we want legibility, not cheer.
+const KIND_STYLES: Record<
+  AppointmentKind,
+  { bg: string; border: string; text: string }
+> = {
+  chemo: {
+    bg: "color-mix(in oklch, var(--tide-soft), transparent 10%)",
+    border: "var(--tide-2)",
+    text: "var(--tide-2)",
+  },
+  clinic: {
+    bg: "var(--paper-2)",
+    border: "var(--ink-400)",
+    text: "var(--ink-700)",
+  },
+  scan: {
+    bg: "var(--sand)",
+    border: "var(--sand-2)",
+    text: "oklch(32% 0.04 70)",
+  },
+  blood_test: {
+    bg: "var(--warn-soft)",
+    border: "var(--warn)",
+    text: "var(--warn)",
+  },
+  procedure: {
+    bg: "color-mix(in oklch, var(--ink-900), transparent 92%)",
+    border: "var(--ink-900)",
+    text: "var(--ink-900)",
+  },
+  other: {
+    bg: "var(--ink-100)",
+    border: "var(--ink-300)",
+    text: "var(--ink-700)",
+  },
 };
 
 export function AppointmentsCalendar({
@@ -33,16 +62,17 @@ export function AppointmentsCalendar({
 
   const events = useMemo<EventInput[]>(() => {
     return appointments.map((a) => {
-      const colors = KIND_COLORS[a.kind] ?? KIND_COLORS.other;
+      const s = KIND_STYLES[a.kind] ?? KIND_STYLES.other;
       return {
         id: String(a.id ?? `new-${a.starts_at}`),
-        title: prefix(a.kind) + a.title,
+        title: a.title,
         start: a.starts_at,
         end: a.ends_at,
         allDay: a.all_day ?? false,
-        backgroundColor: colors.bg,
-        borderColor: colors.border,
-        textColor: colors.text,
+        backgroundColor: s.bg,
+        borderColor: s.border,
+        textColor: s.text,
+        classNames: ["anchor-event", `anchor-event-${a.kind}`],
         extendedProps: {
           kind: a.kind,
           doctor: a.doctor,
@@ -65,7 +95,7 @@ export function AppointmentsCalendar({
   }
 
   return (
-    <div className="overflow-hidden rounded-[var(--r-md)] border border-ink-100/70 bg-paper">
+    <div className="anchor-calendar overflow-hidden rounded-[var(--r-md)] border border-ink-100/70 bg-paper">
       <FullCalendar
         ref={calRef}
         plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
@@ -84,7 +114,13 @@ export function AppointmentsCalendar({
                 day: "日",
                 list: "列表",
               }
-            : undefined
+            : {
+                today: "Today",
+                month: "Month",
+                week: "Week",
+                day: "Day",
+                list: "List",
+              }
         }
         locale={locale === "zh" ? "zh-cn" : "en-au"}
         firstDay={1}
@@ -99,15 +135,4 @@ export function AppointmentsCalendar({
       />
     </div>
   );
-}
-
-function prefix(kind: AppointmentKind): string {
-  switch (kind) {
-    case "chemo":      return "◉ ";
-    case "clinic":     return "☰ ";
-    case "scan":       return "◎ ";
-    case "blood_test": return "∽ ";
-    case "procedure":  return "⊕ ";
-    case "other":      return "· ";
-  }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -155,3 +155,112 @@ body {
   -webkit-backdrop-filter: blur(20px) saturate(140%);
   border: 0.5px solid color-mix(in oklch, var(--ink-900), transparent 92%);
 }
+
+/* -----------------------------------------------------------------
+ * FullCalendar overrides — scoped to .anchor-calendar so FullCalendar's
+ * default Bootstrap-ish look is replaced by the Anchor paper/ink/tide
+ * palette, serif title, mono eyebrows, and pill-style view switcher.
+ * -----------------------------------------------------------------*/
+.anchor-calendar {
+  --fc-border-color: var(--ink-100);
+  --fc-page-bg-color: transparent;
+  --fc-neutral-bg-color: var(--paper-2);
+  --fc-list-event-hover-bg-color: var(--ink-100);
+  --fc-today-bg-color: color-mix(in oklch, var(--tide-soft), transparent 40%);
+  --fc-now-indicator-color: var(--tide-2);
+  --fc-button-text-color: var(--ink-700);
+  --fc-button-bg-color: var(--paper-2);
+  --fc-button-border-color: var(--ink-200);
+  --fc-button-hover-bg-color: var(--ink-100);
+  --fc-button-hover-border-color: var(--ink-300);
+  --fc-button-active-bg-color: var(--ink-900);
+  --fc-button-active-border-color: var(--ink-900);
+  font-family: var(--sans);
+}
+
+.anchor-calendar .fc-toolbar-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.125rem;
+  letter-spacing: -0.01em;
+  color: var(--ink-900);
+}
+
+.anchor-calendar .fc-button {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: var(--r-sm);
+  padding: 0.4rem 0.7rem;
+  box-shadow: none;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.anchor-calendar .fc-button:focus {
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--ink-900), transparent 90%);
+}
+
+.anchor-calendar .fc-button-primary:not(:disabled).fc-button-active,
+.anchor-calendar .fc-button-primary:not(:disabled):active {
+  color: var(--paper);
+}
+
+.anchor-calendar .fc-col-header-cell-cushion {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-400);
+  padding: 0.6rem 0.25rem;
+}
+
+.anchor-calendar .fc-daygrid-day-number,
+.anchor-calendar .fc-list-day-cushion a,
+.anchor-calendar .fc-list-event-time {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--ink-500);
+}
+
+.anchor-calendar .fc-day-today .fc-daygrid-day-number {
+  color: var(--tide-2);
+  font-weight: 600;
+}
+
+.anchor-calendar .fc-event {
+  border-radius: 5px;
+  border-width: 0;
+  padding: 1.5px 5px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.3;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+
+.anchor-calendar .fc-event:hover {
+  filter: brightness(1.06);
+}
+
+/* List view — soft, readable rather than striped */
+.anchor-calendar .fc-list,
+.anchor-calendar .fc-list-day-cushion {
+  background: transparent;
+}
+.anchor-calendar .fc-list-day-cushion {
+  background: var(--paper-2);
+  padding: 0.5rem 0.75rem;
+}
+.anchor-calendar .fc-list-event td {
+  padding: 0.6rem 0.75rem;
+}
+
+/* "Day has more" row */
+.anchor-calendar .fc-daygrid-more-link {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-500);
+}


### PR DESCRIPTION
## Summary

FullCalendar on `/schedule` was rendering with Bootstrap-ish defaults — bright blue today-highlight, stark buttons, sans title, high-saturation event colours — which clashed with the paper/ink/tide palette everywhere else. This PR brings it into the Anchor design language.

- **Scoped CSS overrides under `.anchor-calendar`** in `src/styles/globals.css`: serif toolbar title, mono weekday headers and date numbers, pill-style view switcher, tide-tinted today cell, ink-soft grid lines.
- **Event colours now come from the design tokens** (tide / sand / warn / ink) via `color-mix` for soft backgrounds, with a matching readable text colour per kind. No more hand-picked hex values.
- **Dropped the ASCII prefix glyphs** (◉ ☰ ◎ ∽ ⊕) on event titles — the coloured block already signals the kind.
- **Added English `buttonText` labels** (previously only zh had overrides, so English inherited FullCalendar's defaults).

Pure styling. No behaviour change, no new deps, no schema churn.

## Gate

- `pnpm typecheck` clean
- `pnpm build` clean

## Test plan

- [ ] Visit `/schedule` on the preview — confirm the month grid uses the paper palette, tide-tinted today, and mono weekday labels
- [ ] Switch between Month / Week / List — pill buttons match the Anchor button style
- [ ] Create events of each kind and confirm the colours read cleanly (chemo=tide soft, clinic=paper, scan=sand, blood test=warn soft, procedure=ink, other=ink-100)
- [ ] Dark mode — check tokens flip correctly (all colours reference `var(--…)` so should be automatic)

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8