### PR TITLE
Slice 1: /family route — calm landing for care-team members

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -6,6 +6,7 @@
   "nav": {
     "dashboard": "Dashboard",
     "schedule": "Schedule",
+    "family": "Family",
     "assessment": "Assessment",
     "treatment": "Treatment",
     "daily": "Daily",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -6,6 +6,7 @@
   "nav": {
     "dashboard": "概览",
     "schedule": "日程",
+    "family": "家人",
     "assessment": "综合评估",
     "treatment": "化疗方案",
     "daily": "每日",

--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { EmergencyCard } from "~/components/dashboard/emergency-card";
+import { ZoneBanner } from "~/components/family/zone-banner";
+import { NextUp } from "~/components/family/next-up";
+import { QuickNote } from "~/components/family/quick-note";
+import { CallList } from "~/components/family/call-list";
+
+// Family-facing landing page. Purpose-built for the carer who isn't
+// Thomas: calm status, what's coming up, a quick way to note what they
+// saw, and one-tap access to the care team. Thomas still lands on /.
+
+export default function FamilyPage() {
+  const locale = useLocale();
+  return (
+    <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={locale === "zh" ? "家人视图" : "FAMILY VIEW"}
+        title={locale === "zh" ? "爸爸今天" : "Today with dad"}
+      />
+
+      <EmergencyCard />
+
+      <ZoneBanner />
+
+      <NextUp />
+
+      <QuickNote />
+
+      <CallList />
+
+      <footer className="pt-4 text-center text-[11px] text-ink-400">
+        {locale === "zh"
+          ? "同一账户的家人都能看到相同的内容。"
+          : "Everyone signed into this account sees the same thing."}
+      </footer>
+    </div>
+  );
+}

--- a/src/components/family/call-list.tsx
+++ b/src/components/family/call-list.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import type { CareTeamMember, CareTeamRole } from "~/types/care-team";
+import { Phone, Mail, Star } from "lucide-react";
+
+// Tap-to-call directory, grouped by role. Reads the care-team
+// registry; no opinions, no fallbacks — if it's empty, we point the
+// user at Settings. Hospital / on-call phone from legacy settings is
+// intentionally not surfaced here; the emergency card owns those.
+
+const ROLE_ORDER: CareTeamRole[] = [
+  "oncologist",
+  "surgeon",
+  "nurse",
+  "gp",
+  "allied_health",
+  "family",
+  "other",
+];
+
+const ROLE_LABEL: Record<CareTeamRole, { en: string; zh: string }> = {
+  oncologist: { en: "Oncology", zh: "肿瘤科" },
+  surgeon: { en: "Surgery", zh: "外科" },
+  nurse: { en: "Nursing", zh: "护理" },
+  gp: { en: "GP", zh: "全科医师" },
+  allied_health: { en: "Allied health", zh: "康复 / 营养" },
+  family: { en: "Family", zh: "家人" },
+  other: { en: "Other", zh: "其他" },
+};
+
+export function CallList() {
+  const locale = useLocale();
+  const members = useLiveQuery(() => db.care_team.toArray(), []);
+
+  const grouped = useMemo(() => {
+    const map = new Map<CareTeamRole, CareTeamMember[]>();
+    for (const m of members ?? []) {
+      const list = map.get(m.role) ?? [];
+      list.push(m);
+      map.set(m.role, list);
+    }
+    for (const list of map.values()) {
+      list.sort((a, b) => {
+        if (Boolean(a.is_lead) !== Boolean(b.is_lead)) return a.is_lead ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+    }
+    return map;
+  }, [members]);
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  if (members === undefined) return null;
+
+  return (
+    <section>
+      <h2 className="eyebrow mb-2">{L("Call the team", "联系团队")}</h2>
+      {members.length === 0 ? (
+        <div className="rounded-[var(--r-md)] border border-dashed border-ink-200 bg-paper-2 p-4 text-[12.5px] text-ink-500">
+          {L(
+            "No one listed yet. Add the oncologist, on-call nurse, and family chaperones in Settings.",
+            "还没有成员。请先在设置中添加肿瘤科医师、值班护士与家人。",
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {ROLE_ORDER.map((role) => {
+            const list = grouped.get(role) ?? [];
+            if (list.length === 0) return null;
+            return (
+              <div key={role} className="space-y-1.5">
+                <div className="text-[10.5px] font-medium uppercase tracking-[0.12em] text-ink-400">
+                  {ROLE_LABEL[role][locale]}
+                </div>
+                <ul className="divide-y divide-ink-100 overflow-hidden rounded-[var(--r-md)] border border-ink-100 bg-paper-2">
+                  {list.map((m) => (
+                    <li
+                      key={m.id}
+                      className="flex items-center gap-3 px-3 py-2.5"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-[13.5px] font-medium text-ink-900">
+                            {m.name}
+                          </span>
+                          {m.is_lead && (
+                            <Star
+                              className="h-3 w-3 fill-[var(--tide-2)] text-[var(--tide-2)]"
+                              aria-label={L("Lead", "主要")}
+                            />
+                          )}
+                        </div>
+                        {(m.specialty || m.organisation) && (
+                          <div className="text-[11.5px] text-ink-500">
+                            {[m.specialty, m.organisation]
+                              .filter(Boolean)
+                              .join(" · ")}
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex shrink-0 gap-1">
+                        {m.phone && (
+                          <a
+                            href={`tel:${m.phone}`}
+                            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[var(--tide-soft)] text-[var(--tide-2)] hover:brightness-95"
+                            aria-label={L("Call", "拨打")}
+                          >
+                            <Phone className="h-3.5 w-3.5" />
+                          </a>
+                        )}
+                        {m.email && (
+                          <a
+                            href={`mailto:${m.email}`}
+                            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-ink-100 text-ink-700 hover:bg-ink-200"
+                            aria-label={L("Email", "邮件")}
+                          >
+                            <Mail className="h-3.5 w-3.5" />
+                          </a>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/family/next-up.tsx
+++ b/src/components/family/next-up.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import type { Appointment, AppointmentKind } from "~/types/appointment";
+import {
+  Stethoscope,
+  Syringe,
+  ScanLine,
+  Droplet,
+  ClipboardList,
+  Sparkles,
+  ChevronRight,
+  MapPin,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+// Calm, two-or-three-item strip of what's coming up in the next seven
+// days. Location is tappable if we have a URL; attendee chips show who
+// is (or is planning to be) there. This is the surface that closes the
+// "when is dad's PET CT?" coordination gap.
+
+const KIND_ICON: Record<
+  AppointmentKind,
+  React.ComponentType<{ className?: string }>
+> = {
+  clinic: Stethoscope,
+  chemo: Syringe,
+  scan: ScanLine,
+  blood_test: Droplet,
+  procedure: ClipboardList,
+  other: Sparkles,
+};
+
+const KIND_TONE: Record<AppointmentKind, string> = {
+  clinic: "bg-paper-2 text-ink-700",
+  chemo: "bg-[var(--tide-soft)] text-[var(--tide-2)]",
+  scan: "bg-[var(--sand)] text-ink-900",
+  blood_test: "bg-[var(--warn-soft)] text-[var(--warn)]",
+  procedure: "bg-ink-100 text-ink-900",
+  other: "bg-ink-100 text-ink-700",
+};
+
+export function NextUp() {
+  const locale = useLocale();
+  const appointments = useLiveQuery(
+    () => db.appointments.orderBy("starts_at").toArray(),
+    [],
+  );
+
+  const upcoming = useMemo(() => {
+    const list = appointments ?? [];
+    const now = Date.now();
+    const sevenDays = now + 7 * 24 * 60 * 60 * 1000;
+    return list
+      .filter((a) => {
+        if (a.status === "cancelled") return false;
+        const t = new Date(a.starts_at).getTime();
+        return Number.isFinite(t) && t >= now && t < sevenDays;
+      })
+      .sort(
+        (a, b) =>
+          new Date(a.starts_at).getTime() - new Date(b.starts_at).getTime(),
+      )
+      .slice(0, 3);
+  }, [appointments]);
+
+  if (!appointments) return null;
+
+  return (
+    <section>
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="eyebrow">{locale === "zh" ? "接下来" : "Next up"}</h2>
+        <Link
+          href="/schedule"
+          className="text-[11.5px] text-ink-500 hover:text-ink-900"
+        >
+          {locale === "zh" ? "全部日程" : "All"}
+          <ChevronRight className="ml-0.5 inline h-3 w-3" />
+        </Link>
+      </div>
+
+      {upcoming.length === 0 ? (
+        <div className="rounded-[var(--r-md)] border border-dashed border-ink-200 bg-paper-2 p-4 text-center text-[12.5px] text-ink-500">
+          {locale === "zh"
+            ? "未来七天暂无预约。"
+            : "Nothing scheduled in the next seven days."}
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {upcoming.map((a) => (
+            <li key={a.id}>
+              <Row appt={a} locale={locale} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function Row({ appt, locale }: { appt: Appointment; locale: "en" | "zh" }) {
+  const Icon = KIND_ICON[appt.kind];
+  const when = formatWhen(appt, locale);
+  const chips = [
+    ...(appt.doctor ? [appt.doctor] : []),
+    ...(appt.attendees ?? []),
+  ];
+  return (
+    <Link
+      href={`/schedule/${appt.id}`}
+      className="block rounded-[var(--r-md)] border border-ink-100 bg-paper-2 p-3 hover:border-ink-300"
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            "flex h-9 w-9 shrink-0 items-center justify-center rounded-md",
+            KIND_TONE[appt.kind],
+          )}
+        >
+          <Icon className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-[14px] font-semibold text-ink-900">
+            {appt.title}
+          </div>
+          <div className="mt-0.5 text-[12px] text-ink-500">{when}</div>
+          {(appt.location || appt.location_url) && (
+            <div className="mt-1 flex items-center gap-1 text-[12px] text-ink-600">
+              <MapPin className="h-3 w-3" />
+              {appt.location_url ? (
+                <a
+                  href={appt.location_url}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  onClick={(e) => e.stopPropagation()}
+                  className="underline hover:text-ink-900"
+                >
+                  {appt.location ?? appt.location_url}
+                </a>
+              ) : (
+                <span>{appt.location}</span>
+              )}
+            </div>
+          )}
+          {chips.length > 0 && (
+            <div className="mt-1.5 flex flex-wrap gap-1">
+              {chips.map((c, i) => (
+                <span
+                  key={`${c}-${i}`}
+                  className="inline-flex items-center rounded-full bg-ink-100 px-2 py-0.5 text-[11px] text-ink-700"
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        <ChevronRight className="h-4 w-4 shrink-0 text-ink-400" />
+      </div>
+    </Link>
+  );
+}
+
+function formatWhen(appt: Appointment, locale: "en" | "zh"): string {
+  const d = new Date(appt.starts_at);
+  if (Number.isNaN(d.getTime())) return "";
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const apptDay = new Date(d);
+  apptDay.setHours(0, 0, 0, 0);
+
+  let dayLabel: string;
+  if (apptDay.getTime() === today.getTime()) {
+    dayLabel = locale === "zh" ? "今天" : "Today";
+  } else if (apptDay.getTime() === tomorrow.getTime()) {
+    dayLabel = locale === "zh" ? "明天" : "Tomorrow";
+  } else {
+    dayLabel = d.toLocaleDateString(locale === "zh" ? "zh-CN" : "en-AU", {
+      weekday: "long",
+      day: "numeric",
+      month: "short",
+    });
+  }
+  if (appt.all_day) return dayLabel;
+  const timeLabel = d.toLocaleTimeString(locale === "zh" ? "zh-CN" : "en-AU", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${dayLabel} · ${timeLabel}`;
+}

--- a/src/components/family/quick-note.tsx
+++ b/src/components/family/quick-note.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { useUIStore } from "~/stores/ui-store";
+import { tagInput } from "~/lib/log/tag";
+import { Button } from "~/components/ui/button";
+import { Field, Textarea } from "~/components/ui/field";
+import { Card, CardContent } from "~/components/ui/card";
+import { Send, Check, Loader2 } from "lucide-react";
+
+// One-textarea contribution surface for family members. Writes a
+// `log_events` row tagged (via the existing tagger, or defaulting to
+// "symptom" if no strong signal). The existing daily agent batch picks
+// it up on its next run — no new back-end.
+
+type State = "idle" | "saving" | "done" | "error";
+
+export function QuickNote() {
+  const locale = useLocale();
+  const enteredBy = useUIStore((s) => s.enteredBy);
+  const [text, setText] = useState("");
+  const [state, setState] = useState<State>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    const body = text.trim();
+    if (!body) return;
+    setState("saving");
+    setError(null);
+    try {
+      const tags = tagInput(body);
+      const at = new Date().toISOString();
+      await db.log_events.add({
+        at,
+        input: {
+          text: `[${enteredBy}] ${body}`,
+          tags: tags.length > 0 ? tags : ["symptom"],
+          locale,
+          at,
+        },
+      });
+      setText("");
+      setState("done");
+      window.setTimeout(() => setState("idle"), 2500);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setState("error");
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 pt-4">
+        <div className="flex items-center justify-between">
+          <h2 className="eyebrow">
+            {locale === "zh" ? "告诉团队" : "Tell the team"}
+          </h2>
+          {state === "done" && (
+            <span className="inline-flex items-center gap-1 text-[11.5px] text-[var(--ok)]">
+              <Check className="h-3 w-3" />
+              {locale === "zh" ? "已发送" : "Sent"}
+            </span>
+          )}
+        </div>
+        <Field label={locale === "zh" ? "想记下的一点" : "What you noticed"}>
+          <Textarea
+            rows={4}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={
+              locale === "zh"
+                ? "例如：今天爸爸午饭吃得不多，下午有些乏力，但傍晚散步 20 分钟精神不错。"
+                : "e.g. Dad didn't eat much at lunch, seemed tired in the afternoon, but did a 20-minute walk at dusk and perked up."
+            }
+            disabled={state === "saving"}
+          />
+        </Field>
+        {error && (
+          <div
+            role="alert"
+            className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-2.5 text-[12.5px] text-[var(--warn)]"
+          >
+            {error}
+          </div>
+        )}
+        <div className="flex items-center justify-between">
+          <p className="text-[11px] text-ink-400">
+            {locale === "zh"
+              ? "保存到共享日志，团队可以看到。"
+              : "Saved to the shared log; team members will see it."}
+          </p>
+          <Button onClick={submit} disabled={state === "saving" || !text.trim()}>
+            {state === "saving" ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {locale === "zh" ? "发送中…" : "Sending…"}
+              </>
+            ) : (
+              <>
+                <Send className="h-4 w-4" />
+                {locale === "zh" ? "发送" : "Send"}
+              </>
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/family/zone-banner.tsx
+++ b/src/components/family/zone-banner.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { highestZone } from "~/lib/rules/engine";
+import { useLocale } from "~/hooks/use-translate";
+import type { Zone } from "~/types/clinical";
+import { cn } from "~/lib/utils/cn";
+
+// A calm, one-line status banner for the family surface. Reads all open
+// zone_alerts, picks the highest, and renders a measured sentence — no
+// stacked alerts, no rule ids, no agent output. Family members just need
+// to know "is dad OK right now".
+
+const LABEL: Record<Zone, { en: string; zh: string }> = {
+  green: { en: "Stable", zh: "稳定" },
+  yellow: { en: "Review needed", zh: "需要复核" },
+  orange: { en: "Urgent review", zh: "紧急复核" },
+  red: { en: "Immediate action", zh: "立即处理" },
+};
+
+const DETAIL: Record<Zone, { en: string; zh: string }> = {
+  green: {
+    en: "Nothing urgent right now.",
+    zh: "目前没有紧急情况。",
+  },
+  yellow: {
+    en: "Something's worth a check — Thomas has the detail.",
+    zh: "有一些需要关注的事项 —— Thomas 已在跟进。",
+  },
+  orange: {
+    en: "Talk with Thomas or the clinical team soon.",
+    zh: "请尽快与 Thomas 或临床团队联系。",
+  },
+  red: {
+    en: "Action needed now — see emergency card.",
+    zh: "需要立刻处理 —— 参考紧急联络卡。",
+  },
+};
+
+const TONE: Record<Zone, string> = {
+  green: "bg-[var(--ok-soft)] text-[var(--ok)]",
+  yellow: "bg-[var(--sand)] text-ink-900",
+  orange: "bg-[var(--warn-soft)] text-[var(--warn)]",
+  red: "bg-[var(--warn-soft)] text-[var(--warn)] ring-1 ring-[var(--warn)]/40",
+};
+
+export function ZoneBanner() {
+  const locale = useLocale();
+  const alerts = useLiveQuery(
+    () => db.zone_alerts.toArray(),
+    [],
+  );
+  if (alerts === undefined) return null;
+  const open = alerts.filter((a) => !a.resolved);
+  const zone = highestZone(open.map((a) => a.zone));
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-[var(--r-md)] px-4 py-3",
+        TONE[zone],
+      )}
+      role="status"
+    >
+      <div className="flex h-2 w-2 shrink-0 rounded-full bg-current" />
+      <div className="min-w-0">
+        <div className="text-[14px] font-semibold">{LABEL[zone][locale]}</div>
+        <div className="mt-0.5 text-[12.5px] opacity-80">
+          {DETAIL[zone][locale]}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -14,6 +14,7 @@ import {
   Syringe,
   Sparkles,
   CalendarDays,
+  Users,
   Menu,
   X,
 } from "lucide-react";
@@ -29,6 +30,7 @@ import { useT, useLocale } from "~/hooks/use-translate";
 const ITEMS = [
   { href: "/", key: "nav.dashboard", icon: LayoutDashboard },
   { href: "/schedule", key: "nav.schedule", icon: CalendarDays },
+  { href: "/family", key: "nav.family", icon: Users },
   { href: "/assessment", key: "nav.assessment", icon: Compass },
   { href: "/treatment", key: "nav.treatment", icon: Syringe },
   { href: "/labs", key: "nav.labs", icon: FlaskConical },


### PR DESCRIPTION
## Summary

First slice of the care-team plan — a purpose-built landing page for family members who aren't Thomas (Catherine, Wendy, visiting relatives). Same data, different lens.

`/family` is composed top-to-bottom:

- **EmergencyCard** (reused, pinned)
- **ZoneBanner** — one-line status derived from open `zone_alerts` via the existing `highestZone()` helper. No alert stack, no rule ids, no agent output.
- **NextUp** — next 3 appointments in the coming 7 days, each with kind chip + time + tappable location (uses `location_url`) + attendee/doctor chips. Every row links to `/schedule/[id]`.
- **QuickNote** — single textarea + Send. Writes a `log_events` row through the existing `tagInput` tagger (defaults to `["symptom"]` if no strong signal). The existing daily-batch agent run picks it up — no new back-end.
- **CallList** — reads the `care_team` registry, groups by role (`oncologist` / `surgeon` / `nurse` / `gp` / `allied_health` / `family` / `other`), renders tap-to-call + mailto rows. Empty state points to Settings.

Nav: `/family` added to the desktop sidebar + mobile more-menu between Schedule and Assessment. The 5-slot mobile bottom bar is unchanged per the plan.

Design principles (from the approved plan in `/root/.claude/plans/groovy-rolling-hare.md`):

1. Same data, different lens — no separate database, no per-user filter, no permissions.
2. Additive — Thomas still lands on `/` and keeps the full dashboard.
3. Calm — one banner, not twelve stacked cards.
4. Coordination ready — attendee chips surface who's going (status chips follow in Slice 2).

## Not in this slice (follow-ups queued in the plan file)

- **Slice 2** — structured attendance (`confirm` / `tentative` / `decline`) on appointments
- **Slice 3** — visible `entered_by` attribution on shared surfaces
- **Slice 4** — `EmergencyCard` reads registry leads with fallback to legacy settings fields

## Gate

- `pnpm typecheck` clean
- `pnpm test` — **251/251**
- `pnpm build` clean; `/family` ships at 9.56 kB

## Test plan

- [ ] On a second device signed into the same Supabase account, navigate to `/family`; emergency card + zone banner + next-up + quick-note + call-list all render
- [ ] Empty state: with no `care_team` rows, call-list shows the "add in Settings" message
- [ ] Quick-note: type "dad's ankle feels sore today" → Send → confirm a `log_events` row exists with tags and `[<enteredBy>]` prefix
- [ ] Zone banner reflects current zone (yellow/orange/red) with the appropriate tone chip
- [ ] Tap a `location_url` chip in next-up and confirm it opens in a new tab

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8

---
_Generated by [Claude Code](https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8)_