### PR TITLE
Align /daily/new with Anchor design system

### DIFF
--- a/src/components/daily/scale-input.tsx
+++ b/src/components/daily/scale-input.tsx
@@ -10,19 +10,30 @@ interface ScaleInputProps {
   max?: number;
 }
 
-export function ScaleInput({ label, value, onChange, min = 0, max = 10 }: ScaleInputProps) {
+export function ScaleInput({
+  label,
+  value,
+  onChange,
+  min = 0,
+  max = 10,
+}: ScaleInputProps) {
+  const count = max - min + 1;
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-slate-800 dark:text-slate-200">
-          {label}
-        </span>
-        <span className="text-sm tabular-nums text-slate-600 dark:text-slate-400">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-[13px] font-medium text-ink-900">{label}</span>
+        <span className="serif num text-lg leading-none text-ink-900">
           {value}
+          <span className="ml-0.5 mono text-[10px] font-normal text-ink-400">
+            /{max}
+          </span>
         </span>
       </div>
-      <div className="flex flex-wrap gap-1.5">
-        {Array.from({ length: max - min + 1 }, (_, i) => {
+      <div
+        className="grid gap-1.5"
+        style={{ gridTemplateColumns: `repeat(${count}, minmax(0, 1fr))` }}
+      >
+        {Array.from({ length: count }, (_, i) => {
           const n = i + min;
           const active = value === n;
           return (
@@ -30,11 +41,12 @@ export function ScaleInput({ label, value, onChange, min = 0, max = 10 }: ScaleI
               key={n}
               type="button"
               onClick={() => onChange(n)}
+              aria-label={`${label} ${n}`}
               className={cn(
-                "h-10 min-w-[2.25rem] rounded-md border text-sm font-medium",
+                "h-10 rounded-md border text-[12px] font-semibold tabular-nums transition-colors",
                 active
-                  ? "bg-slate-900 text-white border-slate-900 dark:bg-slate-100 dark:text-slate-900 dark:border-slate-100"
-                  : "border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800",
+                  ? "border-ink-900 bg-ink-900 text-paper"
+                  : "border-ink-200 bg-paper-2 text-ink-500 hover:border-ink-400",
               )}
             >
               {n}

--- a/src/components/daily/toggle.tsx
+++ b/src/components/daily/toggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Check } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 
 export function Toggle({
@@ -15,16 +16,26 @@ export function Toggle({
     <button
       type="button"
       onClick={() => onChange(!checked)}
-      className={cn(
-        "flex items-center justify-between w-full rounded-md border px-3 py-3 text-sm text-left",
-        checked
-          ? "bg-slate-900 text-white border-slate-900 dark:bg-slate-100 dark:text-slate-900 dark:border-slate-100"
-          : "border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800",
-      )}
       aria-pressed={checked}
+      className={cn(
+        "flex w-full items-center justify-between gap-3 rounded-md border px-3 py-3 text-left text-[13.5px] transition-colors",
+        checked
+          ? "border-ink-900 bg-ink-900 text-paper"
+          : "border-ink-200 bg-paper-2 text-ink-700 hover:border-ink-400",
+      )}
     >
-      <span>{label}</span>
-      <span className="text-xs">{checked ? "✓" : ""}</span>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span
+        className={cn(
+          "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border",
+          checked
+            ? "border-paper/40 bg-paper text-ink-900"
+            : "border-ink-200 bg-paper",
+        )}
+        aria-hidden
+      >
+        {checked ? <Check className="h-3 w-3" strokeWidth={3} /> : null}
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary

The daily check-in page (`/daily/new`) was still rendering with raw Tailwind `slate-*` + `dark:` variants while every other page uses the Anchor `ink` / `paper` / `tide` tokens. The result:
- Cards, inputs, buttons, and the step-progress bar clashed visually with each other and with the rest of the app.
- On dark mode the slate classes flipped independently of the token theme, so borders and fills stopped matching.

This PR re-skins the whole flow without changing behaviour.

### Changes

- **MorningCheckin**
  - Progress bar → `--tide-2` fill over `ink-100` track.
  - Step label → `.eyebrow`; title → `.serif`.
  - Textarea + `NumberField` inputs now use `ink-200` borders on `paper` with an `ink-900` focus ring, matching the Settings form.
  - Error banner uses `--warn` / `--warn-soft`.

- **ScaleInput**
  - Grid adapts to `min`/`max` (previously the column count was fixed).
  - Active pill uses `ink-900` / `paper` like the `QuickCheckinCard` selector.
  - Value rendered in `.serif .num` with a `/max` subscript for consistency with the dashboard.

- **Toggle**
  - `ink-900` when on; `ink-200` border when off.
  - Trailing `"✓"` glyph replaced with a proper `Check` icon inside a circular indicator.

- **CycleBanner**
  - `ink-100` border on `paper-2`; mono eyebrow link to the treatment page.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only pre-existing `<img>` warnings in ingest pages)
- [ ] Manual: walk the 6-step form on mobile + desktop, verify cards/inputs/buttons share the same palette as Settings and Dashboard
- [ ] Manual: dark mode — confirm no stray slate surfaces

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSRS9s8vjakowqFfA9deFF)_