### PR TITLE
Route all Claude API calls through server-side ANTHROPIC_API_KEY

### DIFF
--- a/src/app/api/ai/assessment-summary/route.ts
+++ b/src/app/api/ai/assessment-summary/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { SUMMARY_SYSTEM } from "~/lib/ai/coach";
+
+export const runtime = "nodejs";
+
+const SummarySchema = z.object({
+  patient: z.string(),
+  clinician: z.string(),
+});
+
+interface RequestBody {
+  model?: string;
+  assessment: Record<string, unknown>;
+  prior_assessment?: Record<string, unknown> | null;
+}
+
+export async function POST(req: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not configured on the server." },
+      { status: 503 },
+    );
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!body?.assessment) {
+    return NextResponse.json(
+      { error: "assessment required" },
+      { status: 400 },
+    );
+  }
+
+  const client = new Anthropic({ apiKey });
+  try {
+    const response = await client.messages.parse({
+      model: body.model ?? "claude-opus-4-7",
+      max_tokens: 800,
+      system: [
+        {
+          type: "text",
+          text: SUMMARY_SYSTEM,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      output_config: { format: zodOutputFormat(SummarySchema) },
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                assessment: body.assessment,
+                prior_assessment: body.prior_assessment ?? null,
+              }),
+            },
+          ],
+        },
+      ],
+    });
+    if (!response.parsed_output) {
+      return NextResponse.json(
+        { error: "No summary returned" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({ result: response.parsed_output });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  COACH_SYSTEM,
+  type CoachContext,
+  type CoachMessage,
+} from "~/lib/ai/coach";
+import type { Locale } from "~/types/clinical";
+
+export const runtime = "nodejs";
+
+interface RequestBody {
+  model?: string;
+  context: CoachContext;
+  history: CoachMessage[];
+  locale?: Locale;
+}
+
+export async function POST(req: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not configured on the server." },
+      { status: 503 },
+    );
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!body?.context || !Array.isArray(body?.history)) {
+    return NextResponse.json(
+      { error: "context and history[] required" },
+      { status: 400 },
+    );
+  }
+
+  const { model = "claude-opus-4-7", context, history, locale = "en" } = body;
+  const contextBlock = `Current step: ${context.stepTitle}\nKey: ${context.stepKey}\nInstructions shown to the user:\n${context.stepInstructions}\n\nRespond in ${locale === "zh" ? "Simplified Chinese (简体中文)" : "English"}.`;
+
+  const client = new Anthropic({ apiKey });
+  try {
+    const response = await client.messages.create({
+      model,
+      max_tokens: 600,
+      system: [
+        {
+          type: "text",
+          text: COACH_SYSTEM,
+          cache_control: { type: "ephemeral" },
+        },
+        { type: "text", text: contextBlock },
+      ],
+      messages: history.map((m) => ({
+        role: m.role,
+        content: [{ type: "text", text: m.content }],
+      })),
+    });
+    const block = response.content.find((b) => b.type === "text");
+    if (!block || block.type !== "text") {
+      return NextResponse.json(
+        { error: "Empty response from coach" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({ reply: block.text });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/ai/feed-narrative/route.ts
+++ b/src/app/api/ai/feed-narrative/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { NARRATIVE_SYSTEM } from "~/lib/nudges/ai-narrative";
+import type { FeedItem } from "~/types/feed";
+import type { Locale } from "~/types/clinical";
+
+export const runtime = "nodejs";
+
+interface RequestBody {
+  locale: Locale;
+  items: FeedItem[];
+  model?: string;
+}
+
+export async function POST(req: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not configured on the server." },
+      { status: 503 },
+    );
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!Array.isArray(body?.items)) {
+    return NextResponse.json({ error: "items[] required" }, { status: 400 });
+  }
+
+  const { locale = "en", items, model = "claude-opus-4-7" } = body;
+  const signals = items
+    .slice(0, 8)
+    .map((item, i) => {
+      const title = item.title[locale] ?? item.title.en;
+      const bodyText = item.body[locale] ?? item.body.en;
+      return `${i + 1}. [${item.category}/${item.tone}] ${title} — ${bodyText}`;
+    })
+    .join("\n");
+
+  const client = new Anthropic({ apiKey });
+  try {
+    const response = await client.messages.create({
+      model,
+      max_tokens: 300,
+      system: [
+        {
+          type: "text",
+          text: NARRATIVE_SYSTEM,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: `Signals for today (language = ${locale === "zh" ? "Simplified Chinese" : "English"}):\n\n${signals}\n\nWrite the opener.`,
+            },
+          ],
+        },
+      ],
+    });
+    const block = response.content.find((b) => b.type === "text");
+    if (!block || block.type !== "text") {
+      return NextResponse.json(
+        { error: "No narrative returned" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({ narrative: block.text.trim() });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/ai/ingest-meal/route.ts
+++ b/src/app/api/ai/ingest-meal/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { MealSchema, MEAL_SYSTEM } from "~/lib/ingest/meal-vision";
+import type { PreparedImage } from "~/lib/ingest/image";
+
+export const runtime = "nodejs";
+
+interface RequestBody {
+  image: PreparedImage;
+  model?: string;
+}
+
+export async function POST(req: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not configured on the server." },
+      { status: 503 },
+    );
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!body?.image?.base64 || !body.image.mediaType) {
+    return NextResponse.json({ error: "image required" }, { status: 400 });
+  }
+
+  const client = new Anthropic({ apiKey });
+  try {
+    const response = await client.messages.parse({
+      model: body.model ?? "claude-opus-4-7",
+      max_tokens: 1024,
+      system: [
+        { type: "text", text: MEAL_SYSTEM, cache_control: { type: "ephemeral" } },
+      ],
+      output_config: { format: zodOutputFormat(MealSchema) },
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: body.image.mediaType,
+                data: body.image.base64,
+              },
+            },
+            {
+              type: "text",
+              text: "Estimate the macros for this meal and, if relevant, the PERT dose.",
+            },
+          ],
+        },
+      ],
+    });
+    if (!response.parsed_output) {
+      return NextResponse.json(
+        { error: "No meal estimate returned" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({ result: response.parsed_output });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/ai/ingest-notes/route.ts
+++ b/src/app/api/ai/ingest-notes/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import {
+  NotesStructureSchema,
+  NOTES_SYSTEM,
+} from "~/lib/ingest/notes-vision";
+import type { PreparedImage } from "~/lib/ingest/image";
+
+export const runtime = "nodejs";
+
+interface RequestBody {
+  image: PreparedImage;
+  model?: string;
+}
+
+export async function POST(req: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not configured on the server." },
+      { status: 503 },
+    );
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!body?.image?.base64 || !body.image.mediaType) {
+    return NextResponse.json({ error: "image required" }, { status: 400 });
+  }
+
+  const client = new Anthropic({ apiKey });
+  try {
+    const response = await client.messages.parse({
+      model: body.model ?? "claude-opus-4-7",
+      max_tokens: 1500,
+      system: [
+        { type: "text", text: NOTES_SYSTEM, cache_control: { type: "ephemeral" } },
+      ],
+      output_config: { format: zodOutputFormat(NotesStructureSchema) },
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: body.image.mediaType,
+                data: body.image.base64,
+              },
+            },
+            {
+              type: "text",
+              text: "Transcribe this note and structure it into Anchor's daily log fields.",
+            },
+          ],
+        },
+      ],
+    });
+    if (!response.parsed_output) {
+      return NextResponse.json(
+        { error: "No notes structure returned" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({ result: response.parsed_output });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/ai/ingest-report/route.ts
+++ b/src/app/api/ai/ingest-report/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import {
+  ExtractionSchema,
+  EXTRACTION_SYSTEM,
+} from "~/lib/ingest/claude-parser";
+import type { PreparedImage } from "~/lib/ingest/image";
+
+export const runtime = "nodejs";
+
+interface RequestBody {
+  text?: string;
+  image?: PreparedImage;
+  model?: string;
+}
+
+export async function POST(req: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not configured on the server." },
+      { status: 503 },
+    );
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!body?.text && !body?.image) {
+    return NextResponse.json(
+      { error: "text or image required" },
+      { status: 400 },
+    );
+  }
+
+  const client = new Anthropic({ apiKey });
+  const content: Array<
+    | { type: "text"; text: string }
+    | {
+        type: "image";
+        source: {
+          type: "base64";
+          media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+          data: string;
+        };
+      }
+  > = [];
+  if (body.image) {
+    content.push({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: body.image.mediaType,
+        data: body.image.base64,
+      },
+    });
+  }
+  if (body.text && body.text.trim().length > 0) {
+    content.push({
+      type: "text",
+      text: body.image
+        ? `The OCR layer also produced the following text. Use it to cross-check the image when values are unclear:\n\n---\n${body.text}\n---`
+        : `Extract structured fields from the following OCR text:\n\n---\n${body.text}\n---`,
+    });
+  } else if (body.image) {
+    content.push({
+      type: "text",
+      text: "Read this medical document and extract the structured fields.",
+    });
+  }
+
+  try {
+    const response = await client.messages.parse({
+      model: body.model ?? "claude-opus-4-7",
+      max_tokens: 2048,
+      system: [
+        {
+          type: "text",
+          text: EXTRACTION_SYSTEM,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      output_config: { format: zodOutputFormat(ExtractionSchema) },
+      messages: [{ role: "user", content }],
+    });
+    if (!response.parsed_output) {
+      return NextResponse.json(
+        { error: "Claude returned no parsed output" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({ result: response.parsed_output });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { useLiveQuery } from "dexie-react-hooks";
 import { format } from "date-fns";
 import { db, now } from "~/lib/db/dexie";
@@ -19,12 +18,11 @@ import {
   type MealEstimate,
 } from "~/lib/ingest/meal-vision";
 import { todayISO } from "~/lib/utils/date";
-import { Sparkles, Check, Loader2, AlertCircle } from "lucide-react";
+import { Sparkles, Check, Loader2 } from "lucide-react";
 
 export default function MealIngestPage() {
   const locale = useLocale();
   const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
   const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
 
   const [prepared, setPrepared] = useState<PreparedImage | null>(null);
@@ -51,11 +49,11 @@ export default function MealIngestPage() {
   }
 
   async function runEstimate() {
-    if (!prepared || !apiKey) return;
+    if (!prepared) return;
     setBusy("estimate");
     setError(null);
     try {
-      const result = await estimateMeal({ apiKey, model, image: prepared });
+      const result = await estimateMeal({ model, image: prepared });
       setEstimate(result);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -139,35 +137,6 @@ export default function MealIngestPage() {
         }
       />
 
-      {!apiKey && (
-        <Card>
-          <CardContent className="flex items-start gap-3 pt-5 text-sm">
-            <AlertCircle
-              className="mt-0.5 h-4 w-4 shrink-0"
-              style={{ color: "var(--warn)" }}
-            />
-            <div>
-              <div className="font-semibold text-ink-900">
-                {locale === "zh"
-                  ? "需要 Anthropic API Key"
-                  : "Claude API key required"}
-              </div>
-              <div className="mt-0.5 text-ink-500">
-                {locale === "zh"
-                  ? "餐食视觉分析使用 Claude Vision。在设置中添加你的密钥。"
-                  : "This flow uses Claude Vision. Add your key in Settings."}
-              </div>
-              <Link
-                href="/settings"
-                className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-[var(--tide-2)]"
-              >
-                {locale === "zh" ? "打开设置" : "Open Settings"} →
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
       <Card>
         <CardContent className="space-y-4 pt-5">
           {!prepared && (
@@ -202,7 +171,7 @@ export default function MealIngestPage() {
           )}
 
           {prepared && !estimate && busy !== "estimate" && (
-            <Button onClick={runEstimate} disabled={!apiKey}>
+            <Button onClick={runEstimate}>
               <Sparkles className="h-4 w-4" />
               {locale === "zh" ? "让 Claude 估算" : "Estimate with Claude"}
             </Button>

--- a/src/app/ingest/notes/page.tsx
+++ b/src/app/ingest/notes/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
@@ -18,14 +17,13 @@ import {
   type NotesStructure,
 } from "~/lib/ingest/notes-vision";
 import { todayISO } from "~/lib/utils/date";
-import { Sparkles, Check, Loader2, AlertCircle } from "lucide-react";
+import { Sparkles, Check, Loader2 } from "lucide-react";
 
 type DailyPatch = NonNullable<NotesStructure["daily_patch"]>;
 
 export default function NotesIngestPage() {
   const locale = useLocale();
   const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
   const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
 
   const [prepared, setPrepared] = useState<PreparedImage | null>(null);
@@ -52,11 +50,11 @@ export default function NotesIngestPage() {
   }
 
   async function runStructure() {
-    if (!prepared || !apiKey) return;
+    if (!prepared) return;
     setBusy("structure");
     setError(null);
     try {
-      const result = await structureNotes({ apiKey, model, image: prepared });
+      const result = await structureNotes({ model, image: prepared });
       setStructured(result);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -140,35 +138,6 @@ export default function NotesIngestPage() {
         }
       />
 
-      {!apiKey && (
-        <Card>
-          <CardContent className="flex items-start gap-3 pt-5 text-sm">
-            <AlertCircle
-              className="mt-0.5 h-4 w-4 shrink-0"
-              style={{ color: "var(--warn)" }}
-            />
-            <div>
-              <div className="font-semibold text-ink-900">
-                {locale === "zh"
-                  ? "需要 Anthropic API Key"
-                  : "Claude API key required"}
-              </div>
-              <div className="mt-0.5 text-ink-500">
-                {locale === "zh"
-                  ? "手写识别使用 Claude Vision。在设置中添加你的密钥。"
-                  : "This flow uses Claude Vision. Add your key in Settings."}
-              </div>
-              <Link
-                href="/settings"
-                className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-[var(--tide-2)]"
-              >
-                {locale === "zh" ? "打开设置" : "Open Settings"} →
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
       <Card>
         <CardContent className="space-y-4 pt-5">
           {!prepared && (
@@ -203,7 +172,7 @@ export default function NotesIngestPage() {
           )}
 
           {prepared && !structured && busy !== "structure" && (
-            <Button onClick={runStructure} disabled={!apiKey}>
+            <Button onClick={runStructure}>
               <Sparkles className="h-4 w-4" />
               {locale === "zh" ? "让 Claude 识别" : "Read with Claude"}
             </Button>

--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -24,9 +24,6 @@ function newId(): string {
 
 export default function IngestPage() {
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
-  const apiKeyConfigured = !!apiKey;
 
   const [items, setItems] = useState<BulkItem[]>([]);
   const itemsRef = useRef<BulkItem[]>([]);
@@ -55,17 +52,15 @@ export default function IngestPage() {
     setItems((prev) => [...prev, ...newItems]);
     itemsRef.current = [...itemsRef.current, ...newItems];
 
-    // Process one at a time to avoid memory pressure. When the file is an
-    // image and a Claude key is configured, processBulkItem skips OCR
-    // entirely and extracts via vision directly; PDFs still go through OCR.
+    // Process one at a time to avoid memory pressure. Images go directly
+    // through Claude Vision (server-side key); PDFs still go through OCR
+    // and then the heuristic parser auto-runs for a first-pass result.
     for (const item of newItems) {
-      await processBulkItem(item, apiKey, mutate);
+      await processBulkItem(item, mutate);
       const latest =
         itemsRef.current.find((i) => i.id === item.id) ?? item;
-      // OCR path finishes at status "parsing" with ocrText populated — auto-run
-      // the heuristic parser so the user sees a first-pass result immediately.
       if (latest.status === "parsing" && latest.ocrText) {
-        await parseBulkItem(latest, "heuristic", apiKey, mutate);
+        await parseBulkItem(latest, "heuristic", true, mutate);
       }
     }
   }
@@ -73,7 +68,7 @@ export default function IngestPage() {
   async function reparseItem(id: string, method: "heuristic" | "claude" | "vision") {
     const item = itemsRef.current.find((i) => i.id === id);
     if (!item) return;
-    await parseBulkItem(item, method, apiKey, mutate);
+    await parseBulkItem(item, method, true, mutate);
   }
 
   async function saveItem(id: string) {
@@ -149,13 +144,6 @@ export default function IngestPage() {
                 e.target.value = "";
               }}
             />
-            {!apiKeyConfigured && (
-              <span className="mono text-[10px] uppercase tracking-wider text-ink-400">
-                {locale === "zh"
-                  ? "· 未配置 Claude 密钥，使用本地规则解析"
-                  : "· No Claude key — local rules only"}
-              </span>
-            )}
           </div>
 
           <DropZone onFiles={(fs) => void enqueueFiles(fs)} locale={locale} />
@@ -171,7 +159,7 @@ export default function IngestPage() {
           {items.length > 0 && (
             <BulkQueue
               items={items}
-              apiKeyConfigured={apiKeyConfigured}
+              apiKeyConfigured={true}
               onParseHeuristic={(id) => void reparseItem(id, "heuristic")}
               onParseClaude={(id) => void reparseItem(id, "claude")}
               onSave={(id) => void saveItem(id)}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -87,7 +87,6 @@ interface FormState {
   cycle_start_date: string;
   locale: Locale;
   home_city: string;
-  anthropic_api_key: string;
 }
 
 const EMPTY: FormState = {
@@ -115,7 +114,6 @@ const EMPTY: FormState = {
   cycle_start_date: todayISO(),
   locale: "en",
   home_city: "",
-  anthropic_api_key: "",
 };
 
 function toNum(s: string): number | undefined {
@@ -178,7 +176,6 @@ export default function OnboardingPage() {
         baseline_calf_cm: s.baseline_calf_cm ? String(s.baseline_calf_cm) : "",
         locale: s.locale,
         home_city: s.home_city ?? "",
-        anthropic_api_key: s.anthropic_api_key ?? "",
       }));
     }
   }, [existingSettings, router]);
@@ -264,7 +261,6 @@ export default function OnboardingPage() {
         home_lat,
         home_lon,
         home_timezone,
-        anthropic_api_key: form.anthropic_api_key.trim() || undefined,
         onboarded_at: ts,
         created_at: existingSettings?.[0]?.created_at ?? ts,
         updated_at: ts,
@@ -808,26 +804,6 @@ function PreferencesStep({
         />
       </Field>
 
-      <Field
-        label={
-          locale === "zh"
-            ? "Anthropic API Key（可选 — 用于 AI 教练和报告解析）"
-            : "Anthropic API key (optional — unlocks the AI coach and report parsing)"
-        }
-        hint={
-          locale === "zh"
-            ? "留空也没关系，本地功能全部可用。之后可以在设置里加。"
-            : "Leave blank and everything local still works. You can add it later in Settings."
-        }
-      >
-        <TextInput
-          type="password"
-          value={form.anthropic_api_key}
-          onChange={(e) => update("anthropic_api_key", e.target.value)}
-          placeholder="sk-ant-..."
-          autoComplete="off"
-        />
-      </Field>
     </Card>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -250,21 +250,12 @@ export default function SettingsPage() {
         </section>
 
         <section className="space-y-3">
-          <h2 className="eyebrow">AI ingestion (optional)</h2>
+          <h2 className="eyebrow">AI model</h2>
           <p className="text-xs text-ink-500">
-            Paste your own Anthropic API key to let Claude structure uploaded
-            reports. The key is stored only in this browser and sent only to
-            api.anthropic.com. Leave blank to rely on the local heuristic parser.
+            Claude calls run through Anchor&rsquo;s server (the shared
+            ANTHROPIC_API_KEY configured in Vercel) — no per-device key
+            needed. This field lets you override the default model.
           </p>
-          <Field label="Anthropic API key">
-            <input
-              type="password"
-              autoComplete="off"
-              className={inputCls}
-              placeholder="sk-ant-…"
-              {...register("anthropic_api_key")}
-            />
-          </Field>
           <Field label="Model (default claude-opus-4-7)">
             <input
               className={inputCls}

--- a/src/components/assessment/coach-drawer.tsx
+++ b/src/components/assessment/coach-drawer.tsx
@@ -12,7 +12,6 @@ import { Sparkles, X, Send, Loader2 } from "lucide-react";
 export function CoachDrawer({ context }: { context: CoachContext }) {
   const locale = useLocale();
   const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
   const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
 
   const [open, setOpen] = useState(false);
@@ -20,10 +19,6 @@ export function CoachDrawer({ context }: { context: CoachContext }) {
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  if (!apiKey) {
-    return null;
-  }
 
   async function send() {
     if (!input.trim() || busy) return;
@@ -34,7 +29,6 @@ export function CoachDrawer({ context }: { context: CoachContext }) {
     setError(null);
     try {
       const reply = await askCoach({
-        apiKey: apiKey!,
         model,
         context,
         history: [...history, userMsg],

--- a/src/components/assessment/wizard.tsx
+++ b/src/components/assessment/wizard.tsx
@@ -413,8 +413,6 @@ function ReviewView({
 
   async function generateAiSummary() {
     const settings = await db.settings.toArray();
-    const apiKey = settings[0]?.anthropic_api_key;
-    if (!apiKey) return;
     setAiBusy(true);
     setAiError(null);
     try {
@@ -430,7 +428,6 @@ function ReviewView({
       const model =
         settings[0]?.default_ai_model ?? "claude-opus-4-7";
       const summary = await summariseAssessment({
-        apiKey,
         model,
         assessment: filled,
       });

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -88,7 +88,6 @@ export function TodayFeed({
       ? rawFeed
       : rawFeed.filter((f) => !excludeIds.includes(f.id));
   const settings = useLiveQuery(() => db.settings.toArray());
-  const apiKey = settings?.[0]?.anthropic_api_key;
   const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
 
   const [expanded, setExpanded] = useState(false);
@@ -97,9 +96,10 @@ export function TodayFeed({
 
   const visible = expanded ? feed : feed.slice(0, 6);
 
-  // Narrative fetch — cached daily per locale
+  // Narrative fetch — cached daily per locale. Uses the server-side
+  // ANTHROPIC_API_KEY via /api/ai/feed-narrative; no per-user key needed.
   useEffect(() => {
-    if (!apiKey || feed.length === 0) return;
+    if (feed.length === 0) return;
     const today = new Date().toISOString().slice(0, 10);
     const cacheTag = `${today}_${locale}`;
     try {
@@ -118,7 +118,6 @@ export function TodayFeed({
     void (async () => {
       try {
         const text = await generateNarrative({
-          apiKey,
           model,
           locale,
           items: feed,
@@ -138,7 +137,7 @@ export function TodayFeed({
         setNarrativeLoading(false);
       }
     })();
-  }, [apiKey, model, locale, feed]);
+  }, [model, locale, feed]);
 
   if (feed.length === 0) {
     return (

--- a/src/lib/ai/coach.ts
+++ b/src/lib/ai/coach.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import type { ComprehensiveAssessment } from "~/types/clinical";
 
 export interface CoachContext {
@@ -13,7 +11,7 @@ export interface CoachMessage {
   content: string;
 }
 
-const COACH_SYSTEM = `You are a warm, measured clinical assistant embedded in Anchor, a function-preservation platform for Hu Lin — a patient with metastatic pancreatic adenocarcinoma on gemcitabine + nab-paclitaxel, bridging to daraxonrasib (RMC-6236).
+export const COACH_SYSTEM = `You are a warm, measured clinical assistant embedded in Anchor, a function-preservation platform for Hu Lin — a patient with metastatic pancreatic adenocarcinoma on gemcitabine + nab-paclitaxel, bridging to daraxonrasib (RMC-6236).
 
 Your job in the comprehensive assessment wizard is to guide Hu Lin or his caregiver through each step. You:
 1. Answer practical "how do I do this?" questions about the current test.
@@ -27,50 +25,29 @@ You can see the current wizard step, its title, and the printed instructions. Us
 
 Never invent clinical advice beyond what's safe for patient self-direction. Defer specific medical decisions to Dr Lee.`;
 
-const SUMMARY_SYSTEM = `You summarise a single comprehensive baseline assessment for Hu Lin's metastatic PDAC platform in two voices — one for Hu Lin himself, one for the clinical team. Both are under 120 words each. The patient summary is warm, plain-language, honest, and highlights one or two things to pay attention to. The clinician summary is clinical, focused on deltas from baseline where applicable, flags any red/orange pillar, and lists up to 3 discussion points for the next Dr Lee visit.
+export const SUMMARY_SYSTEM = `You summarise a single comprehensive baseline assessment for Hu Lin's metastatic PDAC platform in two voices — one for Hu Lin himself, one for the clinical team. Both are under 120 words each. The patient summary is warm, plain-language, honest, and highlights one or two things to pay attention to. The clinician summary is clinical, focused on deltas from baseline where applicable, flags any red/orange pillar, and lists up to 3 discussion points for the next Dr Lee visit.
 
 Respond ONLY with JSON: {"patient": "...", "clinician": "..."}`;
 
 export async function askCoach({
-  apiKey,
   model = "claude-opus-4-7",
   context,
   history,
   locale = "en",
 }: {
-  apiKey: string;
   model?: string;
   context: CoachContext;
   history: CoachMessage[];
   locale?: "en" | "zh";
 }): Promise<string> {
-  const { default: Anthropic } = await import("@anthropic-ai/sdk");
-  const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
-
-  const contextBlock = `Current step: ${context.stepTitle}\nKey: ${context.stepKey}\nInstructions shown to the user:\n${context.stepInstructions}\n\nRespond in ${locale === "zh" ? "Simplified Chinese (简体中文)" : "English"}.`;
-
-  const response = await client.messages.create({
-    model,
-    max_tokens: 600,
-    system: [
-      {
-        type: "text",
-        text: COACH_SYSTEM,
-        cache_control: { type: "ephemeral" },
-      },
-      { type: "text", text: contextBlock },
-    ],
-    messages: history.map((m) => ({
-      role: m.role,
-      content: [{ type: "text", text: m.content }],
-    })),
+  const res = await fetch("/api/ai/coach", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model, context, history, locale }),
   });
-
-  const block = response.content.find((b) => b.type === "text");
-  if (!block || block.type !== "text") {
-    throw new Error("Empty response from coach");
-  }
-  return block.text;
+  if (!res.ok) throw new Error(await res.text());
+  const data = (await res.json()) as { reply: string };
+  return data.reply;
 }
 
 export interface AssessmentSummary {
@@ -79,63 +56,28 @@ export interface AssessmentSummary {
 }
 
 export async function summariseAssessment({
-  apiKey,
   model = "claude-opus-4-7",
   assessment,
   priorAssessment,
 }: {
-  apiKey: string;
   model?: string;
   assessment: ComprehensiveAssessment;
   priorAssessment?: ComprehensiveAssessment | null;
 }): Promise<AssessmentSummary> {
-  const [{ default: Anthropic }, { z }, { zodOutputFormat }] =
-    await Promise.all([
-      import("@anthropic-ai/sdk"),
-      import("zod"),
-      import("@anthropic-ai/sdk/helpers/zod"),
-    ]);
-
-  const SummarySchema = z.object({
-    patient: z.string(),
-    clinician: z.string(),
+  const res = await fetch("/api/ai/assessment-summary", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model,
+      assessment: compactPayload(assessment),
+      prior_assessment: priorAssessment ? compactPayload(priorAssessment) : null,
+    }),
   });
-
-  const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
-  const payload = {
-    assessment: compactPayload(assessment),
-    prior_assessment: priorAssessment ? compactPayload(priorAssessment) : null,
-  };
-
-  const response = await client.messages.parse({
-    model,
-    max_tokens: 800,
-    system: [
-      {
-        type: "text",
-        text: SUMMARY_SYSTEM,
-        cache_control: { type: "ephemeral" },
-      },
-    ],
-    output_config: { format: zodOutputFormat(SummarySchema) },
-    messages: [
-      {
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(payload),
-          },
-        ],
-      },
-    ],
-  });
-
-  if (!response.parsed_output) throw new Error("No summary returned");
-  return response.parsed_output;
+  if (!res.ok) throw new Error(await res.text());
+  const data = (await res.json()) as { result: AssessmentSummary };
+  return data.result;
 }
 
-// Strip undefined fields before sending to minimise tokens and PHI footprint.
 function compactPayload(
   a: ComprehensiveAssessment,
 ): Record<string, unknown> {

--- a/src/lib/ingest/bulk.ts
+++ b/src/lib/ingest/bulk.ts
@@ -98,28 +98,26 @@ export async function processBulkItemOcr(
 export async function parseBulkItem(
   item: BulkItem,
   method: "heuristic" | "claude" | "vision",
-  apiKey: string | undefined,
+  useClaude: boolean,
   mutate: BulkMutator,
 ): Promise<void> {
   if (!item.documentId) return;
-  const canVision = method === "vision" && apiKey && item.visionImage;
-  const canClaudeText = method === "claude" && apiKey && item.ocrText;
+  const canVision = method === "vision" && useClaude && item.visionImage;
+  const canClaudeText = method === "claude" && useClaude && item.ocrText;
   if (!canVision && !canClaudeText && !item.ocrText) return;
 
   mutate(item.id, { status: "parsing", method });
   try {
     let extraction: UnifiedExtraction;
-    if (canVision && item.visionImage && apiKey) {
+    if (canVision && item.visionImage) {
       const claudeOut = await extractWithClaude({
-        apiKey,
         image: item.visionImage,
         // Pass OCR text as an extra signal when we happen to have it
         text: item.ocrText,
       });
       extraction = fromClaude(claudeOut);
-    } else if (canClaudeText && apiKey && item.ocrText) {
+    } else if (canClaudeText && item.ocrText) {
       const claudeOut = await extractWithClaude({
-        apiKey,
         text: item.ocrText,
       });
       extraction = fromClaude(claudeOut);
@@ -151,7 +149,6 @@ export async function parseBulkItem(
  */
 export async function processBulkItemVision(
   item: BulkItem,
-  apiKey: string,
   mutate: BulkMutator,
 ): Promise<void> {
   if (!item.file) return;
@@ -190,7 +187,6 @@ export async function processBulkItemVision(
 
   try {
     const claudeOut = await extractWithClaude({
-      apiKey,
       image: prepared,
     });
     const extraction = fromClaude(claudeOut);
@@ -219,16 +215,15 @@ export async function processBulkItemVision(
 
 /**
  * Entry point that picks the optimal pipeline for a single file.
- * - Image + apiKey → Claude Vision direct (fastest, best quality)
- * - PDF or no apiKey → OCR first, parser runs after
+ * - Image → Claude Vision direct (fastest, best quality; server key)
+ * - PDF → OCR first, parser runs after
  */
 export async function processBulkItem(
   item: BulkItem,
-  apiKey: string | undefined,
   mutate: BulkMutator,
 ): Promise<void> {
-  if (apiKey && isDirectImage(item.file)) {
-    return processBulkItemVision(item, apiKey, mutate);
+  if (isDirectImage(item.file)) {
+    return processBulkItemVision(item, mutate);
   }
   return processBulkItemOcr(item, mutate);
 }

--- a/src/lib/ingest/claude-parser.ts
+++ b/src/lib/ingest/claude-parser.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { z } from "zod";
 import type { PreparedImage } from "~/lib/ingest/image";
 
@@ -96,7 +94,7 @@ export const ExtractionSchema = z.object({
 
 export type ClaudeExtraction = z.infer<typeof ExtractionSchema>;
 
-const SYSTEM_PROMPT = `You are a clinical document parser. You receive a patient's medical document (lab report, radiology report, referral, clinic letter, or ctDNA result) either as OCR-extracted text or directly as an image.
+export const EXTRACTION_SYSTEM = `You are a clinical document parser. You receive a patient's medical document (lab report, radiology report, referral, clinic letter, or ctDNA result) either as OCR-extracted text or directly as an image.
 
 Your job is to extract structured fields into the given schema. Rules:
 1. If a field is not present or unclear, omit it or set it to null. Never invent values.
@@ -112,84 +110,23 @@ Your job is to extract structured fields into the given schema. Rules:
 8. When given an image, read numbers carefully — prefer the most recent / most visible value, and ignore reference-range columns when extracting the patient's result.`;
 
 export async function extractWithClaude({
-  apiKey,
   text,
   image,
   model = "claude-opus-4-7",
 }: {
-  apiKey: string;
-  /** OCR'd text. Supply either this, `image`, or both. */
   text?: string;
-  /** Image to read directly with vision. Supply either this, `text`, or both. */
   image?: PreparedImage;
   model?: string;
 }): Promise<ClaudeExtraction> {
   if (!text && !image) {
     throw new Error("extractWithClaude requires at least text or image input");
   }
-  const [{ default: Anthropic }, { zodOutputFormat }] = await Promise.all([
-    import("@anthropic-ai/sdk"),
-    import("@anthropic-ai/sdk/helpers/zod"),
-  ]);
-  const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
-
-  const content: Array<
-    | { type: "text"; text: string }
-    | {
-        type: "image";
-        source: {
-          type: "base64";
-          media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
-          data: string;
-        };
-      }
-  > = [];
-
-  if (image) {
-    content.push({
-      type: "image",
-      source: {
-        type: "base64",
-        media_type: image.mediaType,
-        data: image.base64,
-      },
-    });
-  }
-  if (text && text.trim().length > 0) {
-    content.push({
-      type: "text",
-      text: image
-        ? `The OCR layer also produced the following text. Use it to cross-check the image when values are unclear:\n\n---\n${text}\n---`
-        : `Extract structured fields from the following OCR text:\n\n---\n${text}\n---`,
-    });
-  } else if (image) {
-    content.push({
-      type: "text",
-      text: "Read this medical document and extract the structured fields.",
-    });
-  }
-
-  const response = await client.messages.parse({
-    model,
-    max_tokens: 2048,
-    system: [
-      {
-        type: "text",
-        text: SYSTEM_PROMPT,
-        cache_control: { type: "ephemeral" },
-      },
-    ],
-    output_config: { format: zodOutputFormat(ExtractionSchema) },
-    messages: [
-      {
-        role: "user",
-        content,
-      },
-    ],
+  const res = await fetch("/api/ai/ingest-report", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text, image, model }),
   });
-
-  if (!response.parsed_output) {
-    throw new Error("Claude returned no parsed output");
-  }
-  return response.parsed_output;
+  if (!res.ok) throw new Error(await res.text());
+  const data = (await res.json()) as { result: ClaudeExtraction };
+  return data.result;
 }

--- a/src/lib/ingest/meal-vision.ts
+++ b/src/lib/ingest/meal-vision.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { z } from "zod";
 import type { PreparedImage } from "./image";
 
@@ -34,7 +32,7 @@ export const MealSchema = z.object({
 
 export type MealEstimate = z.infer<typeof MealSchema>;
 
-const MEAL_SYSTEM = `You estimate the macronutrients of a meal from a single photo for Hu Lin, a patient with metastatic pancreatic adenocarcinoma on first-line gemcitabine + nab-paclitaxel.
+export const MEAL_SYSTEM = `You estimate the macronutrients of a meal from a single photo for Hu Lin, a patient with metastatic pancreatic adenocarcinoma on first-line gemcitabine + nab-paclitaxel.
 
 Rules:
 1. Keep estimates conservative; if unsure, err low on protein and say so in 'notes'.
@@ -43,51 +41,24 @@ Rules:
 4. If the photo is too unclear to judge (blur, distant, empty plate), set confidence=low and note what's missing.
 5. Never invent specific brands or recipes. Describe what's visually present.`;
 
+// Client-side shim. Posts the image to /api/ai/ingest-meal which holds
+// the server-side ANTHROPIC_API_KEY. Kept as a named export with the
+// same signature as before, minus the apiKey parameter.
 export async function estimateMeal({
-  apiKey,
   model = "claude-opus-4-7",
   image,
 }: {
-  apiKey: string;
   model?: string;
   image: PreparedImage;
 }): Promise<MealEstimate> {
-  const [{ default: Anthropic }, { zodOutputFormat }] = await Promise.all([
-    import("@anthropic-ai/sdk"),
-    import("@anthropic-ai/sdk/helpers/zod"),
-  ]);
-  const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
-
-  const response = await client.messages.parse({
-    model,
-    max_tokens: 1024,
-    system: [
-      { type: "text", text: MEAL_SYSTEM, cache_control: { type: "ephemeral" } },
-    ],
-    output_config: { format: zodOutputFormat(MealSchema) },
-    messages: [
-      {
-        role: "user",
-        content: [
-          {
-            type: "image",
-            source: {
-              type: "base64",
-              media_type: image.mediaType,
-              data: image.base64,
-            },
-          },
-          {
-            type: "text",
-            text: "Estimate the macros for this meal and, if relevant, the PERT dose.",
-          },
-        ],
-      },
-    ],
+  const res = await fetch("/api/ai/ingest-meal", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ image, model }),
   });
-
-  if (!response.parsed_output) {
-    throw new Error("No meal estimate returned");
+  if (!res.ok) {
+    throw new Error(await res.text());
   }
-  return response.parsed_output;
+  const data = (await res.json()) as { result: MealEstimate };
+  return data.result;
 }

--- a/src/lib/ingest/notes-vision.ts
+++ b/src/lib/ingest/notes-vision.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { z } from "zod";
 import type { PreparedImage } from "./image";
 
@@ -42,7 +40,7 @@ export const NotesStructureSchema = z.object({
 
 export type NotesStructure = z.infer<typeof NotesStructureSchema>;
 
-const NOTES_SYSTEM = `You're reading a photo of Hu Lin's handwritten daily notes from his cancer-tracking journal and structuring them into Anchor's daily-log fields.
+export const NOTES_SYSTEM = `You're reading a photo of Hu Lin's handwritten daily notes from his cancer-tracking journal and structuring them into Anchor's daily-log fields.
 
 Rules:
 1. First transcribe the note faithfully — no rewording, no added words, no interpretation.
@@ -54,49 +52,18 @@ Rules:
 7. Put any free-text reflection (non-metric sentences) into the 'reflection' field.`;
 
 export async function structureNotes({
-  apiKey,
   model = "claude-opus-4-7",
   image,
 }: {
-  apiKey: string;
   model?: string;
   image: PreparedImage;
 }): Promise<NotesStructure> {
-  const [{ default: Anthropic }, { zodOutputFormat }] = await Promise.all([
-    import("@anthropic-ai/sdk"),
-    import("@anthropic-ai/sdk/helpers/zod"),
-  ]);
-  const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
-
-  const response = await client.messages.parse({
-    model,
-    max_tokens: 1500,
-    system: [
-      { type: "text", text: NOTES_SYSTEM, cache_control: { type: "ephemeral" } },
-    ],
-    output_config: { format: zodOutputFormat(NotesStructureSchema) },
-    messages: [
-      {
-        role: "user",
-        content: [
-          {
-            type: "image",
-            source: {
-              type: "base64",
-              media_type: image.mediaType,
-              data: image.base64,
-            },
-          },
-          {
-            type: "text",
-            text: "Transcribe this note and structure it into Anchor's daily log fields.",
-          },
-        ],
-      },
-    ],
+  const res = await fetch("/api/ai/ingest-notes", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ image, model }),
   });
-  if (!response.parsed_output) {
-    throw new Error("No notes structure returned");
-  }
-  return response.parsed_output;
+  if (!res.ok) throw new Error(await res.text());
+  const data = (await res.json()) as { result: NotesStructure };
+  return data.result;
 }

--- a/src/lib/nudges/ai-narrative.ts
+++ b/src/lib/nudges/ai-narrative.ts
@@ -1,9 +1,7 @@
-"use client";
-
 import type { FeedItem } from "~/types/feed";
 import type { Locale } from "~/types/clinical";
 
-const SYSTEM = `You write a single 2–3 sentence opening line for Hu Lin's dashboard on a pancreatic cancer tracking app.
+export const NARRATIVE_SYSTEM = `You write a single 2–3 sentence opening line for Hu Lin's dashboard on a pancreatic cancer tracking app.
 
 Rules:
 1. You see the top 8 contextual signals for today as a ranked list. Read them, pick the one or two that actually matter right now, and say it.
@@ -14,56 +12,22 @@ Rules:
 6. Under 60 words.`;
 
 export interface NarrativeInput {
-  apiKey: string;
   model?: string;
   locale: Locale;
   items: FeedItem[];
 }
 
 export async function generateNarrative({
-  apiKey,
   model = "claude-opus-4-7",
   locale,
   items,
 }: NarrativeInput): Promise<string> {
-  const { default: Anthropic } = await import("@anthropic-ai/sdk");
-  const client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
-
-  const signals = items
-    .slice(0, 8)
-    .map((item, i) => {
-      const title = item.title[locale] ?? item.title.en;
-      const body = item.body[locale] ?? item.body.en;
-      return `${i + 1}. [${item.category}/${item.tone}] ${title} — ${body}`;
-    })
-    .join("\n");
-
-  const response = await client.messages.create({
-    model,
-    max_tokens: 300,
-    system: [
-      {
-        type: "text",
-        text: SYSTEM,
-        cache_control: { type: "ephemeral" },
-      },
-    ],
-    messages: [
-      {
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: `Signals for today (language = ${locale === "zh" ? "Simplified Chinese" : "English"}):\n\n${signals}\n\nWrite the opener.`,
-          },
-        ],
-      },
-    ],
+  const res = await fetch("/api/ai/feed-narrative", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model, locale, items }),
   });
-
-  const block = response.content.find((b) => b.type === "text");
-  if (!block || block.type !== "text") {
-    throw new Error("No narrative returned");
-  }
-  return block.text.trim();
+  if (!res.ok) throw new Error(await res.text());
+  const data = (await res.json()) as { narrative: string };
+  return data.narrative;
 }


### PR DESCRIPTION
## Summary

Every Claude call now runs through the shared server-side `ANTHROPIC_API_KEY` on Vercel. No family member needs their own API key pasted into Settings for the AI coach, meal photo analysis, handwritten notes parsing, document ingest, or the dashboard AI narrative to work.

## What moved server-side

New routes under `/api/ai/`:

| Route | Replaces client-side Anthropic call in |
| --- | --- |
| `/api/ai/coach` | `components/assessment/coach-drawer.tsx` |
| `/api/ai/assessment-summary` | `components/assessment/wizard.tsx` → `summariseAssessment` |
| `/api/ai/ingest-meal` | `app/ingest/meal/page.tsx` → `estimateMeal` |
| `/api/ai/ingest-notes` | `app/ingest/notes/page.tsx` → `structureNotes` |
| `/api/ai/ingest-report` | `app/ingest/page.tsx` → `extractWithClaude` (via `bulk.ts`) |
| `/api/ai/feed-narrative` | `components/dashboard/today-feed.tsx` → `generateNarrative` |

Pre-existing server routes already used the env key and are unchanged: `/api/parse-appointment`, `/api/agent/[id]/run`.

## Shape

Each lib file kept its exported Zod schema + system prompt (the route imports them) but its implementation collapsed to a thin fetch wrapper. `apiKey` parameter dropped from every caller. `bulk.ts` replaced its `apiKey: string | undefined` parameter (which was doing double-duty as a "use Claude?" gate) with a direct boolean.

## UI

- **Settings** — "Anthropic API key" password input is gone; the section is now one short paragraph + the model-override field, with copy explaining the key lives on the server.
- **Onboarding** — the API-key step on the preferences page is removed. Nothing blocks carers from finishing onboarding now.
- **Ingest meal / notes pages** — the "Claude API key required" warning card is gone; the action buttons no longer disable when no key is configured.

## Compatibility

`settings.anthropic_api_key` stays in the Dexie schema for backwards compat (existing devices with a key stored won't throw on read), but nothing reads it anymore. The Zod `settingsSchema` still accepts it as an optional field so existing data round-trips.

## Gate

- `pnpm typecheck` clean
- `pnpm test` — **251/251**
- `pnpm build` clean

## Test plan

- [ ] With `ANTHROPIC_API_KEY` set in Vercel: visit any of the ingest pages, take a photo, confirm parsing works without any per-user key
- [ ] Dashboard today-feed renders the AI narrative (or gracefully skips when the server has no key)
- [ ] Assessment coach drawer opens and answers
- [ ] Assessment wizard → Generate AI summary → reads; patient + clinician text written back to the comprehensive_assessments row
- [ ] Temporarily unset `ANTHROPIC_API_KEY` on preview → every AI call returns 503 with a clear error message and the UI handles the failure gracefully

## Not in this PR

- **Deleting `anthropic_api_key` from settings schema** — deferred so existing devices with the key stored aren't forced through a migration
- **Rate-limiting / quota controls** on the shared key — orthogonal; the super-brain daily batch already caches aggressively

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8

---
_Generated by [Claude Code](https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8)_