### PR TITLE
Slice B: scope cloud_rows sync by household_id

### DIFF
--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -3,6 +3,7 @@
 import { useLocale } from "~/hooks/use-translate";
 import { PageHeader } from "~/components/ui/page-header";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
+import { HouseholdHeader } from "~/components/family/household-header";
 import { ZoneBanner } from "~/components/family/zone-banner";
 import { NextUp } from "~/components/family/next-up";
 import { QuickNote } from "~/components/family/quick-note";
@@ -20,6 +21,8 @@ export default function FamilyPage() {
         eyebrow={locale === "zh" ? "家人视图" : "FAMILY VIEW"}
         title={locale === "zh" ? "爸爸今天" : "Today with dad"}
       />
+
+      <HouseholdHeader />
 
       <EmergencyCard />
 

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -79,7 +79,7 @@ export default function InvitePage() {
     <div className="mx-auto max-w-md space-y-5 p-6 pt-16">
       <PageHeader
         eyebrow="CARE TEAM"
-        title="Joining the household"
+        title="Joining the family"
       />
 
       {phase.kind === "checking" && <Spinner label="Checking invite…" />}
@@ -94,7 +94,7 @@ export default function InvitePage() {
               </div>
             </div>
             <p className="text-[13px] text-ink-500">
-              Sign in or create your account to join this household. After
+              Sign in or create your account to join this family. After
               signing in you&rsquo;ll land straight on the family view.
             </p>
             <Link

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { getSupabaseBrowser } from "~/lib/supabase/client";
+import {
+  acceptInvite,
+  friendlyInviteError,
+} from "~/lib/supabase/households";
+import { PageHeader } from "~/components/ui/page-header";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent } from "~/components/ui/card";
+import { Loader2, Users, Check, AlertCircle } from "lucide-react";
+
+// Landing page for someone following a household invite link. Handles
+// three states:
+//   (1) User is already signed in → accept immediately, redirect to /family
+//   (2) User is signed out → bounce to /login with ?next= set so we come back here
+//   (3) Accept failed (expired / revoked / already accepted) → show the reason
+//
+// The token in the URL is a uuid v4. It's not secret in the strict sense
+// (leaks into browser history); security is enforced by expiry, single-
+// use semantics, and revoke. Treat it as a bearer capability for joining
+// one specific household.
+
+type Phase =
+  | { kind: "checking" }
+  | { kind: "needs_signin" }
+  | { kind: "accepting" }
+  | { kind: "accepted" }
+  | { kind: "error"; message: string };
+
+export default function InvitePage() {
+  const params = useParams<{ token: string }>();
+  const token = params?.token;
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>({ kind: "checking" });
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+
+    (async () => {
+      const sb = getSupabaseBrowser();
+      if (!sb) {
+        if (!cancelled)
+          setPhase({
+            kind: "error",
+            message: "Supabase is not configured on this build.",
+          });
+        return;
+      }
+      const { data: auth } = await sb.auth.getUser();
+      if (!auth.user) {
+        if (!cancelled) setPhase({ kind: "needs_signin" });
+        return;
+      }
+      if (!cancelled) setPhase({ kind: "accepting" });
+      try {
+        await acceptInvite(token);
+        if (cancelled) return;
+        setPhase({ kind: "accepted" });
+        // Short pause so the "welcome" state is readable, then land on
+        // /family where the newly-joined carer sees dad's data.
+        setTimeout(() => router.replace("/family"), 1200);
+      } catch (err) {
+        if (!cancelled)
+          setPhase({ kind: "error", message: friendlyInviteError(err) });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, router]);
+
+  return (
+    <div className="mx-auto max-w-md space-y-5 p-6 pt-16">
+      <PageHeader
+        eyebrow="CARE TEAM"
+        title="Joining the household"
+      />
+
+      {phase.kind === "checking" && <Spinner label="Checking invite…" />}
+
+      {phase.kind === "needs_signin" && (
+        <Card>
+          <CardContent className="space-y-3 pt-5">
+            <div className="flex items-center gap-2">
+              <Users className="h-4 w-4 text-[var(--tide-2)]" />
+              <div className="text-[14px] font-semibold text-ink-900">
+                You&rsquo;ve been invited
+              </div>
+            </div>
+            <p className="text-[13px] text-ink-500">
+              Sign in or create your account to join this household. After
+              signing in you&rsquo;ll land straight on the family view.
+            </p>
+            <Link
+              href={`/login?next=${encodeURIComponent(`/invite/${token}`)}`}
+            >
+              <Button size="lg" className="w-full">
+                Sign in to accept
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      )}
+
+      {phase.kind === "accepting" && <Spinner label="Accepting invite…" />}
+
+      {phase.kind === "accepted" && (
+        <Card>
+          <CardContent className="flex items-start gap-3 pt-5">
+            <Check className="mt-0.5 h-5 w-5 text-[var(--ok)]" />
+            <div>
+              <div className="text-[14px] font-semibold text-ink-900">
+                Welcome to the team
+              </div>
+              <p className="mt-1 text-[13px] text-ink-500">
+                Taking you to the family view&hellip;
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {phase.kind === "error" && (
+        <Card>
+          <CardContent className="flex items-start gap-3 pt-5">
+            <AlertCircle className="mt-0.5 h-5 w-5 text-[var(--warn)]" />
+            <div className="flex-1">
+              <div className="text-[14px] font-semibold text-ink-900">
+                Can&rsquo;t accept invite
+              </div>
+              <p className="mt-1 text-[13px] text-ink-500">{phase.message}</p>
+              <p className="mt-3 text-[12px] text-ink-500">
+                Ask the primary carer to send you a new invite link.
+              </p>
+              <Link
+                href="/"
+                className="mt-3 inline-block text-[12px] text-ink-500 underline-offset-2 hover:underline"
+              >
+                Go to dashboard
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Spinner({ label }: { label: string }) {
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        {label}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -285,6 +285,43 @@ export default function OnboardingPage() {
           updated_at: ts,
         });
       }
+
+      // Slice A — if the user is signed in and doesn't already belong to
+      // a household, stand one up now with themselves as primary_carer.
+      // Invited family members arrive via /invite/<token> which skips
+      // onboarding entirely, so any user reaching this point is the one
+      // creating the household.
+      try {
+        const { getSupabaseBrowser } = await import("~/lib/supabase/client");
+        const sb = getSupabaseBrowser();
+        if (sb) {
+          const { data: auth } = await sb.auth.getUser();
+          if (auth.user) {
+            const {
+              getCurrentMembership,
+              createHousehold,
+              updateMyProfile,
+            } = await import("~/lib/supabase/households");
+            const existing = await getCurrentMembership();
+            if (!existing) {
+              await createHousehold({
+                name: `${(form.profile_name || "Patient").trim()}'s household`,
+                patient_name: (form.profile_name || "Patient").trim(),
+              });
+            }
+            // Mirror the user-facing name + locale onto their profile
+            // so carers see a sensible display name everywhere.
+            await updateMyProfile({
+              display_name: (form.profile_name || "").trim() || "Patient",
+              locale: form.locale,
+            });
+          }
+        }
+      } catch {
+        // Network or Supabase hiccup shouldn't block onboarding; the
+        // Settings → Household section lets the user finish setup.
+      }
+
       router.replace("/");
     } finally {
       setSaving(false);

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -305,7 +305,7 @@ export default function OnboardingPage() {
             const existing = await getCurrentMembership();
             if (!existing) {
               await createHousehold({
-                name: `${(form.profile_name || "Patient").trim()}'s household`,
+                name: `${(form.profile_name || "Patient").trim()}'s family`,
                 patient_name: (form.profile_name || "Patient").trim(),
               });
             }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import { PracticesCard } from "~/components/dashboard/practices-card";
 import { TodayFeed } from "~/components/dashboard/today-feed";
 import { SyncPromptCard } from "~/components/dashboard/sync-prompt-card";
 import { useLocale, useT } from "~/hooks/use-translate";
+import { useHousehold } from "~/hooks/use-household";
 import { PageHeader, SectionHeader } from "~/components/ui/page-header";
 
 export default function DashboardPage() {
@@ -26,6 +27,7 @@ export default function DashboardPage() {
   const router = useRouter();
   const settings = useLiveQuery(() => db.settings.toArray());
   const profileName = settings?.[0]?.profile_name;
+  const { membership } = useHousehold();
 
   useEffect(() => {
     // First-run gate: no settings row (or no onboarded_at) → onboarding.
@@ -33,6 +35,16 @@ export default function DashboardPage() {
       router.replace("/onboarding");
     }
   }, [router, settings]);
+
+  // Non-primary household members see the family view by default —
+  // the clinician-heavy dashboard would overwhelm a visiting carer.
+  // Primary carers keep the full dashboard.
+  useEffect(() => {
+    if (!membership) return;
+    if (membership.role !== "primary_carer") {
+      router.replace("/family");
+    }
+  }, [membership, router]);
 
   const { greeting, eyebrow } = useMemo(() => {
     const now = new Date();

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import { settingsSchema, type SettingsInput } from "~/lib/validators/schemas";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { AccountButton } from "~/components/shared/account-button";
+import { HouseholdSection } from "~/components/settings/household-section";
 import { CareTeamSection } from "~/components/settings/care-team-section";
 import { TrackedSymptomsSection } from "~/components/settings/tracked-symptoms-section";
 
@@ -101,6 +102,8 @@ export default function SettingsPage() {
       </div>
 
       <AccountButton />
+
+      <HouseholdSection />
 
       <CareTeamSection />
 

--- a/src/components/family/household-header.tsx
+++ b/src/components/family/household-header.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useHousehold } from "~/hooks/use-household";
+import {
+  getHousehold,
+  listHouseholdMembers,
+} from "~/lib/supabase/households";
+import type {
+  Household,
+  HouseholdMemberWithProfile,
+} from "~/types/household";
+import { useLocale } from "~/hooks/use-translate";
+import { Users, Settings as SettingsIcon } from "lucide-react";
+
+// Small avatar stack + household name at the top of /family so any
+// carer landing on the page sees which household they're looking at
+// and who else is on it. Tap goes to Settings → Household.
+
+export function HouseholdHeader() {
+  const locale = useLocale();
+  const { membership, profile } = useHousehold();
+  const [household, setHousehold] = useState<Household | null>(null);
+  const [members, setMembers] = useState<HouseholdMemberWithProfile[]>([]);
+
+  useEffect(() => {
+    if (!membership) {
+      setHousehold(null);
+      setMembers([]);
+      return;
+    }
+    void (async () => {
+      const [h, ms] = await Promise.all([
+        getHousehold(membership.household_id),
+        listHouseholdMembers(membership.household_id),
+      ]);
+      setHousehold(h);
+      setMembers(ms);
+    })();
+  }, [membership]);
+
+  if (!membership || !household) return null;
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  return (
+    <Link
+      href="/settings"
+      className="flex items-center gap-3 rounded-[var(--r-md)] border border-ink-100 bg-paper-2 px-3 py-2.5 hover:border-ink-300"
+    >
+      <Users className="h-4 w-4 shrink-0 text-[var(--tide-2)]" />
+      <div className="min-w-0 flex-1">
+        <div className="text-[13px] font-semibold text-ink-900">
+          {household.patient_display_name}
+        </div>
+        <div className="truncate text-[11.5px] text-ink-500">
+          {members.length === 0
+            ? L("No one else yet", "暂无其他成员")
+            : members
+                .map((m) =>
+                  m.user_id === profile?.id
+                    ? L(`${m.profile.display_name} (you)`, `${m.profile.display_name}（你）`)
+                    : m.profile.display_name || "—",
+                )
+                .join(" · ")}
+        </div>
+      </div>
+      <SettingsIcon className="h-3.5 w-3.5 shrink-0 text-ink-400" />
+    </Link>
+  );
+}

--- a/src/components/settings/household-section.tsx
+++ b/src/components/settings/household-section.tsx
@@ -82,7 +82,7 @@ export function HouseholdSection() {
       <section className="space-y-3">
         <h2 className="eyebrow">
           <Users className="mr-1.5 inline h-3.5 w-3.5" />
-          Household
+          Family
         </h2>
         <p className="text-[12px] text-ink-500">Loading&hellip;</p>
       </section>
@@ -94,11 +94,11 @@ export function HouseholdSection() {
       <section className="space-y-3">
         <h2 className="eyebrow">
           <Users className="mr-1.5 inline h-3.5 w-3.5" />
-          Household
+          Family
         </h2>
         <Card>
           <CardContent className="py-4 text-[12.5px] text-ink-500">
-            You aren&rsquo;t part of a household yet. Sign in and either
+            You aren&rsquo;t part of a family yet. Sign in and either
             create one from the dashboard or accept an invite link.
           </CardContent>
         </Card>
@@ -111,7 +111,7 @@ export function HouseholdSection() {
       <div>
         <h2 className="eyebrow">
           <Users className="mr-1.5 inline h-3.5 w-3.5" />
-          Household
+          Family
         </h2>
         {household && (
           <p className="mt-1 text-xs text-ink-500">
@@ -137,7 +137,7 @@ export function HouseholdSection() {
           if (!householdId) return;
           if (
             !window.confirm(
-              "Remove this person from the household? They'll keep their account.",
+              "Remove this person from the family? They'll keep their account.",
             )
           )
             return;
@@ -163,7 +163,7 @@ export function HouseholdSection() {
           onLeave={async () => {
             if (
               !window.confirm(
-                "Leave this household? You'll stop seeing their data.",
+                "Leave this family? You'll stop seeing their data.",
               )
             )
               return;
@@ -469,7 +469,7 @@ function LeaveButton({ onLeave }: { onLeave: () => Promise<void> }) {
         className="inline-flex items-center gap-1.5 rounded-md border border-ink-200 px-3 py-2 text-[12px] text-ink-600 hover:border-[var(--warn)] hover:text-[var(--warn)]"
       >
         <LogOut className="h-3.5 w-3.5" />
-        Leave household
+        Leave family
       </button>
     </div>
   );

--- a/src/components/settings/household-section.tsx
+++ b/src/components/settings/household-section.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useHousehold } from "~/hooks/use-household";
+import {
+  createInvite,
+  getHousehold,
+  inviteUrl,
+  leaveHousehold,
+  listHouseholdMembers,
+  listInvites,
+  removeMember,
+  revokeInvite,
+  updateMyProfile,
+} from "~/lib/supabase/households";
+import type {
+  Household,
+  HouseholdInvite,
+  HouseholdMemberWithProfile,
+  HouseholdRole,
+} from "~/types/household";
+import { Field, TextInput } from "~/components/ui/field";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent } from "~/components/ui/card";
+import {
+  Users,
+  Star,
+  UserPlus,
+  Copy,
+  CheckCircle2,
+  Trash2,
+  LogOut,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+const ROLE_LABEL: Record<HouseholdRole, string> = {
+  primary_carer: "Primary carer",
+  family: "Family",
+  clinician: "Clinician",
+  observer: "Observer",
+};
+
+const ROLE_TONE: Record<HouseholdRole, string> = {
+  primary_carer: "bg-[var(--tide-soft)] text-[var(--tide-2)]",
+  family: "bg-ink-100 text-ink-700",
+  clinician: "bg-[var(--sand)] text-ink-900",
+  observer: "bg-paper-2 text-ink-500",
+};
+
+export function HouseholdSection() {
+  const { membership, profile, loading, refresh } = useHousehold();
+  const [household, setHousehold] = useState<Household | null>(null);
+  const [members, setMembers] = useState<HouseholdMemberWithProfile[]>([]);
+  const [invites, setInvites] = useState<HouseholdInvite[]>([]);
+
+  const householdId = membership?.household_id ?? null;
+  const isPrimary = membership?.role === "primary_carer";
+
+  const loadAll = useCallback(async () => {
+    if (!householdId) {
+      setHousehold(null);
+      setMembers([]);
+      setInvites([]);
+      return;
+    }
+    const [h, ms, inv] = await Promise.all([
+      getHousehold(householdId),
+      listHouseholdMembers(householdId),
+      listInvites(householdId),
+    ]);
+    setHousehold(h);
+    setMembers(ms);
+    setInvites(inv);
+  }, [householdId]);
+
+  useEffect(() => {
+    void loadAll();
+  }, [loadAll]);
+
+  if (loading) {
+    return (
+      <section className="space-y-3">
+        <h2 className="eyebrow">
+          <Users className="mr-1.5 inline h-3.5 w-3.5" />
+          Household
+        </h2>
+        <p className="text-[12px] text-ink-500">Loading&hellip;</p>
+      </section>
+    );
+  }
+
+  if (!membership) {
+    return (
+      <section className="space-y-3">
+        <h2 className="eyebrow">
+          <Users className="mr-1.5 inline h-3.5 w-3.5" />
+          Household
+        </h2>
+        <Card>
+          <CardContent className="py-4 text-[12.5px] text-ink-500">
+            You aren&rsquo;t part of a household yet. Sign in and either
+            create one from the dashboard or accept an invite link.
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="eyebrow">
+          <Users className="mr-1.5 inline h-3.5 w-3.5" />
+          Household
+        </h2>
+        {household && (
+          <p className="mt-1 text-xs text-ink-500">
+            {household.name} &middot; caring for{" "}
+            <span className="text-ink-700">
+              {household.patient_display_name}
+            </span>
+          </p>
+        )}
+      </div>
+
+      <MyProfileCard
+        profileName={profile?.display_name ?? ""}
+        careLabel={profile?.care_role_label ?? ""}
+        onSaved={refresh}
+      />
+
+      <MembersList
+        members={members}
+        currentUserId={profile?.id ?? null}
+        isPrimary={isPrimary}
+        onRemove={async (uid) => {
+          if (!householdId) return;
+          if (
+            !window.confirm(
+              "Remove this person from the household? They'll keep their account.",
+            )
+          )
+            return;
+          await removeMember({ household_id: householdId, user_id: uid });
+          await loadAll();
+        }}
+      />
+
+      {isPrimary && householdId && (
+        <InvitePanel
+          householdId={householdId}
+          invites={invites}
+          onCreated={loadAll}
+          onRevoke={async (id) => {
+            await revokeInvite(id);
+            await loadAll();
+          }}
+        />
+      )}
+
+      {!isPrimary && householdId && (
+        <LeaveButton
+          onLeave={async () => {
+            if (
+              !window.confirm(
+                "Leave this household? You'll stop seeing their data.",
+              )
+            )
+              return;
+            await leaveHousehold(householdId);
+            await refresh();
+          }}
+        />
+      )}
+    </section>
+  );
+}
+
+function MyProfileCard({
+  profileName,
+  careLabel,
+  onSaved,
+}: {
+  profileName: string;
+  careLabel: string;
+  onSaved: () => Promise<void>;
+}) {
+  const [name, setName] = useState(profileName);
+  const [label, setLabel] = useState(careLabel);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setName(profileName);
+    setLabel(careLabel);
+  }, [profileName, careLabel]);
+
+  const dirty = name !== profileName || label !== careLabel;
+
+  async function save() {
+    setSaving(true);
+    try {
+      await updateMyProfile({
+        display_name: name.trim() || profileName,
+        care_role_label: label.trim() || null,
+      });
+      await onSaved();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 pt-4">
+        <div className="text-[11px] font-medium uppercase tracking-[0.1em] text-ink-400">
+          Your profile
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Field label="Display name">
+            <TextInput value={name} onChange={(e) => setName(e.target.value)} />
+          </Field>
+          <Field label="Role label (optional)">
+            <TextInput
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g. Son, Wife, Palliative RN"
+            />
+          </Field>
+        </div>
+        <div className="flex justify-end">
+          <Button onClick={save} disabled={!dirty || saving} size="md">
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MembersList({
+  members,
+  currentUserId,
+  isPrimary,
+  onRemove,
+}: {
+  members: HouseholdMemberWithProfile[];
+  currentUserId: string | null;
+  isPrimary: boolean;
+  onRemove: (uid: string) => Promise<void>;
+}) {
+  if (members.length === 0) return null;
+  return (
+    <Card>
+      <CardContent className="pt-4">
+        <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.1em] text-ink-400">
+          Members
+        </div>
+        <ul className="divide-y divide-ink-100">
+          {members.map((m) => (
+            <li
+              key={m.user_id}
+              className="flex items-center justify-between py-2.5"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[13.5px] font-medium text-ink-900">
+                    {m.profile.display_name || "—"}
+                  </span>
+                  {m.user_id === currentUserId && (
+                    <span className="mono text-[10px] text-ink-400">
+                      YOU
+                    </span>
+                  )}
+                  {m.role === "primary_carer" && (
+                    <Star
+                      className="h-3 w-3 fill-[var(--tide-2)] text-[var(--tide-2)]"
+                      aria-label="Primary carer"
+                    />
+                  )}
+                </div>
+                <div className="mt-0.5 flex items-center gap-1.5 text-[11.5px] text-ink-500">
+                  {m.profile.care_role_label && (
+                    <span>{m.profile.care_role_label}</span>
+                  )}
+                  {m.profile.care_role_label && " · "}
+                  <span
+                    className={cn(
+                      "rounded-full px-1.5 py-0.5 text-[9.5px] font-medium uppercase tracking-[0.08em]",
+                      ROLE_TONE[m.role],
+                    )}
+                  >
+                    {ROLE_LABEL[m.role]}
+                  </span>
+                </div>
+              </div>
+              {isPrimary && m.user_id !== currentUserId && (
+                <button
+                  type="button"
+                  onClick={() => void onRemove(m.user_id)}
+                  className="rounded-md p-1.5 text-ink-500 hover:bg-ink-100/40 hover:text-red-700"
+                  aria-label="Remove"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+function InvitePanel({
+  householdId,
+  invites,
+  onCreated,
+  onRevoke,
+}: {
+  householdId: string;
+  invites: HouseholdInvite[];
+  onCreated: () => Promise<void>;
+  onRevoke: (id: string) => Promise<void>;
+}) {
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<HouseholdRole>("family");
+  const [creating, setCreating] = useState(false);
+  const [lastUrl, setLastUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function send() {
+    setCreating(true);
+    try {
+      const inv = await createInvite({
+        household_id: householdId,
+        email_hint: email.trim() || undefined,
+        role,
+      });
+      const url = inviteUrl(
+        inv.token,
+        typeof window !== "undefined" ? window.location.origin : "",
+      );
+      setLastUrl(url);
+      setEmail("");
+      await onCreated();
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function copy() {
+    if (!lastUrl) return;
+    try {
+      await navigator.clipboard.writeText(lastUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  }
+
+  const pending = invites.filter(
+    (i) => !i.accepted_at && !i.revoked_at && new Date(i.expires_at) > new Date(),
+  );
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 pt-4">
+        <div className="text-[11px] font-medium uppercase tracking-[0.1em] text-ink-400">
+          Invite a family member or clinician
+        </div>
+        <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+          <Field label="Email (optional hint)">
+            <TextInput
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="catherine@example.com"
+            />
+          </Field>
+          <div>
+            <div className="mb-1 text-sm font-medium text-ink-800">Role</div>
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value as HouseholdRole)}
+              className="h-11 rounded-lg border border-ink-200 bg-paper-2 px-3 text-sm"
+            >
+              <option value="family">Family</option>
+              <option value="primary_carer">Primary carer</option>
+              <option value="clinician">Clinician</option>
+              <option value="observer">Observer</option>
+            </select>
+          </div>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-[11px] text-ink-500">
+            Generates a one-use link. Share it by email, iMessage, or
+            anywhere else. Expires in 14 days.
+          </p>
+          <Button onClick={send} disabled={creating} size="md">
+            <UserPlus className="h-4 w-4" />
+            {creating ? "Creating…" : "Create link"}
+          </Button>
+        </div>
+
+        {lastUrl && (
+          <div className="rounded-md border border-[var(--tide-2)]/40 bg-[var(--tide-soft)]/40 p-3 text-[12.5px]">
+            <div className="mb-1 flex items-center gap-1.5 font-semibold text-ink-900">
+              <CheckCircle2 className="h-3.5 w-3.5 text-[var(--tide-2)]" />
+              Invite ready
+            </div>
+            <div className="flex items-center gap-2">
+              <code className="min-w-0 flex-1 truncate rounded bg-paper-2 px-2 py-1 text-[11px] text-ink-700">
+                {lastUrl}
+              </code>
+              <button
+                type="button"
+                onClick={copy}
+                className="inline-flex items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-[11px] text-ink-700 hover:bg-ink-100/40"
+              >
+                <Copy className="h-3 w-3" />
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {pending.length > 0 && (
+          <div className="space-y-1.5 border-t border-ink-100 pt-3">
+            <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-400">
+              Pending invites ({pending.length})
+            </div>
+            <ul className="space-y-1">
+              {pending.map((inv) => (
+                <li
+                  key={inv.id}
+                  className="flex items-center justify-between gap-2 text-[12px]"
+                >
+                  <div className="min-w-0 flex-1 truncate">
+                    <span className="text-ink-700">
+                      {inv.email_hint ?? "(no email hint)"}
+                    </span>{" "}
+                    &middot;{" "}
+                    <span className="text-ink-500">{ROLE_LABEL[inv.role]}</span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void onRevoke(inv.id)}
+                    className="text-ink-500 hover:text-red-700"
+                  >
+                    Revoke
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function LeaveButton({ onLeave }: { onLeave: () => Promise<void> }) {
+  return (
+    <div className="flex justify-end">
+      <button
+        type="button"
+        onClick={() => void onLeave()}
+        className="inline-flex items-center gap-1.5 rounded-md border border-ink-200 px-3 py-2 text-[12px] text-ink-600 hover:border-[var(--warn)] hover:text-[var(--warn)]"
+      >
+        <LogOut className="h-3.5 w-3.5" />
+        Leave household
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/use-household.ts
+++ b/src/hooks/use-household.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getSupabaseBrowser } from "~/lib/supabase/client";
+import {
+  getCurrentMembership,
+  getCurrentProfile,
+} from "~/lib/supabase/households";
+import type {
+  HouseholdMembership,
+  Profile,
+} from "~/types/household";
+
+// Live-loading current-user membership + profile. Returns undefined
+// while loading so components can fall back; null when the user is
+// signed out or Supabase isn't configured.
+
+export function useHousehold(): {
+  membership: HouseholdMembership | null | undefined;
+  profile: Profile | null | undefined;
+  loading: boolean;
+  refresh: () => Promise<void>;
+} {
+  const [membership, setMembership] =
+    useState<HouseholdMembership | null | undefined>(undefined);
+  const [profile, setProfile] = useState<Profile | null | undefined>(undefined);
+
+  const load = async () => {
+    const [m, p] = await Promise.all([
+      getCurrentMembership().catch(() => null),
+      getCurrentProfile().catch(() => null),
+    ]);
+    setMembership(m);
+    setProfile(p);
+  };
+
+  useEffect(() => {
+    void load();
+    const sb = getSupabaseBrowser();
+    if (!sb) return;
+    const { data: sub } = sb.auth.onAuthStateChange(() => {
+      void load();
+    });
+    return () => sub?.subscription.unsubscribe();
+  }, []);
+
+  return {
+    membership,
+    profile,
+    loading: membership === undefined || profile === undefined,
+    refresh: load,
+  };
+}

--- a/src/lib/supabase/households.ts
+++ b/src/lib/supabase/households.ts
@@ -1,0 +1,212 @@
+import { getSupabaseBrowser } from "./client";
+import type {
+  Household,
+  HouseholdInvite,
+  HouseholdMembership,
+  HouseholdMemberWithProfile,
+  HouseholdRole,
+  Profile,
+} from "~/types/household";
+
+// Thin wrappers over Supabase RPC + table queries for the Slice A
+// household + profile + invite surface. Every function is a no-op
+// returning null/empty when Supabase isn't configured, so local-only
+// sessions keep working.
+
+export async function getCurrentMembership(): Promise<HouseholdMembership | null> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return null;
+  const { data: user } = await sb.auth.getUser();
+  const uid = user.user?.id;
+  if (!uid) return null;
+  const { data, error } = await sb
+    .from("household_memberships")
+    .select("*")
+    .eq("user_id", uid)
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data as HouseholdMembership | null;
+}
+
+export async function getCurrentProfile(): Promise<Profile | null> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return null;
+  const { data: user } = await sb.auth.getUser();
+  const uid = user.user?.id;
+  if (!uid) return null;
+  const { data, error } = await sb
+    .from("profiles")
+    .select("*")
+    .eq("id", uid)
+    .maybeSingle();
+  if (error) throw error;
+  return data as Profile | null;
+}
+
+export async function updateMyProfile(
+  patch: Partial<Pick<Profile, "display_name" | "locale" | "care_role_label">>,
+): Promise<void> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return;
+  const { data: user } = await sb.auth.getUser();
+  const uid = user.user?.id;
+  if (!uid) return;
+  const { error } = await sb.from("profiles").update(patch).eq("id", uid);
+  if (error) throw error;
+}
+
+export async function listHouseholdMembers(
+  householdId: string,
+): Promise<HouseholdMemberWithProfile[]> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return [];
+  const { data, error } = await sb
+    .from("household_memberships")
+    .select(
+      "household_id, user_id, role, invited_by, joined_at, profile:profiles!inner(*)",
+    )
+    .eq("household_id", householdId)
+    .order("joined_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as unknown as HouseholdMemberWithProfile[];
+}
+
+export async function getHousehold(
+  householdId: string,
+): Promise<Household | null> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return null;
+  const { data, error } = await sb
+    .from("households")
+    .select("*")
+    .eq("id", householdId)
+    .maybeSingle();
+  if (error) throw error;
+  return data as Household | null;
+}
+
+// RPC: create a household AND enrol the current user as primary_carer.
+// Returns the new household id.
+export async function createHousehold(args: {
+  name: string;
+  patient_name: string;
+}): Promise<string> {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("supabase_not_configured");
+  const { data, error } = await sb.rpc("create_household", {
+    household_name: args.name,
+    patient_name: args.patient_name,
+  });
+  if (error) throw error;
+  if (typeof data !== "string") throw new Error("create_household_failed");
+  return data;
+}
+
+// RPC: accept an invite token, atomically creating a membership and
+// marking the invite accepted. Returns the household id the user
+// joined.
+export async function acceptInvite(token: string): Promise<string> {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("supabase_not_configured");
+  const { data, error } = await sb.rpc("accept_household_invite", {
+    invite_token: token,
+  });
+  if (error) throw error;
+  if (typeof data !== "string") throw new Error("accept_invite_failed");
+  return data;
+}
+
+export async function createInvite(args: {
+  household_id: string;
+  email_hint?: string;
+  role: HouseholdRole;
+}): Promise<HouseholdInvite> {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("supabase_not_configured");
+  const { data: user } = await sb.auth.getUser();
+  const uid = user.user?.id;
+  if (!uid) throw new Error("not_signed_in");
+  const { data, error } = await sb
+    .from("household_invites")
+    .insert({
+      household_id: args.household_id,
+      email_hint: args.email_hint ?? null,
+      role: args.role,
+      invited_by: uid,
+    })
+    .select("*")
+    .single();
+  if (error) throw error;
+  return data as HouseholdInvite;
+}
+
+export async function listInvites(
+  householdId: string,
+): Promise<HouseholdInvite[]> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return [];
+  const { data, error } = await sb
+    .from("household_invites")
+    .select("*")
+    .eq("household_id", householdId)
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as HouseholdInvite[];
+}
+
+export async function revokeInvite(inviteId: string): Promise<void> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return;
+  const { error } = await sb
+    .from("household_invites")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", inviteId);
+  if (error) throw error;
+}
+
+export async function leaveHousehold(householdId: string): Promise<void> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return;
+  const { data: user } = await sb.auth.getUser();
+  const uid = user.user?.id;
+  if (!uid) return;
+  const { error } = await sb
+    .from("household_memberships")
+    .delete()
+    .eq("household_id", householdId)
+    .eq("user_id", uid);
+  if (error) throw error;
+}
+
+export async function removeMember(args: {
+  household_id: string;
+  user_id: string;
+}): Promise<void> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return;
+  const { error } = await sb
+    .from("household_memberships")
+    .delete()
+    .eq("household_id", args.household_id)
+    .eq("user_id", args.user_id);
+  if (error) throw error;
+}
+
+// Builds the /invite/<token> URL from an invite record. The token is a
+// uuid; no further secret required since access is already guarded by
+// the expiry + accepted_at + revoked_at fields.
+export function inviteUrl(token: string, origin: string): string {
+  return `${origin.replace(/\/$/, "")}/invite/${token}`;
+}
+
+export function friendlyInviteError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes("invite_not_found")) return "This invite link is invalid.";
+  if (msg.includes("invite_revoked")) return "This invite has been revoked.";
+  if (msg.includes("invite_already_accepted"))
+    return "This invite has already been accepted.";
+  if (msg.includes("invite_expired")) return "This invite has expired.";
+  if (msg.includes("not_signed_in")) return "Please sign in first.";
+  return msg;
+}

--- a/src/lib/sync/household-context.ts
+++ b/src/lib/sync/household-context.ts
@@ -1,0 +1,91 @@
+import { getSupabaseBrowser } from "~/lib/supabase/client";
+
+// The sync layer needs the current user's household_id to tag writes,
+// filter pulls, and scope realtime subscriptions. This module keeps a
+// cached value + refresh triggers so the rest of the sync code can call
+// `getCachedHouseholdId()` synchronously from the queue processor
+// without hammering Supabase on every upsert.
+//
+// Refresh happens:
+//   - on module import (first load),
+//   - on `supabase.auth.onAuthStateChange` (sign-in / sign-out),
+//   - explicitly via `refreshHouseholdId()` from init.ts after pulls.
+//
+// When the user has no household yet (brand-new signup pre-create,
+// or Supabase is unconfigured) we return null and the sync layer
+// defers writes into its queue — Slice A's onboarding finish step
+// calls `create_household` and a subsequent refresh picks it up.
+
+let cached: string | null = null;
+let loaded = false;
+const listeners = new Set<() => void>();
+
+export function getCachedHouseholdId(): string | null {
+  return cached;
+}
+
+export function isHouseholdLoaded(): boolean {
+  return loaded;
+}
+
+export function onHouseholdChange(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+export async function refreshHouseholdId(): Promise<string | null> {
+  const sb = getSupabaseBrowser();
+  if (!sb) {
+    cached = null;
+    loaded = true;
+    notify();
+    return null;
+  }
+  try {
+    const { data: user } = await sb.auth.getUser();
+    const uid = user.user?.id;
+    if (!uid) {
+      cached = null;
+      loaded = true;
+      notify();
+      return null;
+    }
+    const { data, error } = await sb
+      .from("household_memberships")
+      .select("household_id")
+      .eq("user_id", uid)
+      .limit(1)
+      .maybeSingle();
+    if (error) throw error;
+    const next = (data?.household_id as string | undefined) ?? null;
+    if (next !== cached) {
+      cached = next;
+      notify();
+    }
+    loaded = true;
+    return cached;
+  } catch {
+    // Leave the previous cache in place on transient failure; the next
+    // auth change or scheduled refresh will pick up the right value.
+    loaded = true;
+    return cached;
+  }
+}
+
+// Test-only reset so each test starts from a clean cache.
+export function __resetHouseholdContextForTests(): void {
+  cached = null;
+  loaded = false;
+  listeners.clear();
+}
+
+// Test-only seed so unit tests that exercise queue/pull/realtime don't
+// need to mock Supabase just to preload the household id.
+export function __setHouseholdIdForTests(id: string | null): void {
+  cached = id;
+  loaded = true;
+}

--- a/src/lib/sync/init.ts
+++ b/src/lib/sync/init.ts
@@ -3,6 +3,7 @@ import { attachSyncHooks } from "./hooks";
 import { pullFromCloud, resetPullCursor } from "./pull";
 import { startSyncRetryTimer, stopSyncRetryTimer } from "./queue";
 import { subscribeToCloudChanges, unsubscribeFromCloudChanges } from "./realtime";
+import { refreshHouseholdId } from "./household-context";
 
 let initialized = false;
 
@@ -27,18 +28,25 @@ export async function initSync(): Promise<void> {
 
   const { data } = await supabase.auth.getUser();
   if (data.user) {
+    // Slice B: resolve the household id before the first pull so the
+    // pull can scope by it. Without a household the pull returns 0
+    // rows and we'll try again once onboarding / invite-accept fills
+    // in the membership.
+    await refreshHouseholdId();
     await pullFromCloud();
     subscribeToCloudChanges();
   }
 
   supabase.auth.onAuthStateChange(async (event) => {
     if (event === "SIGNED_IN" || event === "TOKEN_REFRESHED") {
+      await refreshHouseholdId();
       await pullFromCloud();
       subscribeToCloudChanges();
     } else if (event === "SIGNED_OUT") {
       unsubscribeFromCloudChanges();
       // Next sign-in triggers a fresh full pull so we see all cloud data.
       resetPullCursor();
+      await refreshHouseholdId();
     }
   });
 

--- a/src/lib/sync/pull.ts
+++ b/src/lib/sync/pull.ts
@@ -2,6 +2,10 @@ import { db } from "~/lib/db/dexie";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
 import { SYNCED_TABLES, type SyncedTable } from "./tables";
 import { withSyncSuppressed } from "./queue";
+import {
+  getCachedHouseholdId,
+  refreshHouseholdId,
+} from "./household-context";
 
 const LAST_PULLED_KEY = "anchor.lastPulledAt";
 
@@ -21,10 +25,20 @@ export async function pullFromCloud(): Promise<{ pulled: number } | null> {
   const lastPulledAt =
     window.localStorage.getItem(LAST_PULLED_KEY) ?? "1970-01-01T00:00:00Z";
 
+  // Slice B: scope the pull to the current user's household. Without
+  // a household we skip — the user is either signed out or mid-
+  // onboarding before create_household runs.
+  let householdId = getCachedHouseholdId();
+  if (!householdId) {
+    householdId = await refreshHouseholdId();
+  }
+  if (!householdId) return { pulled: 0 };
+
   // Fetch rows newer than our last pull. Limit to 5000 for safety.
   const { data, error } = await supabase
     .from("cloud_rows")
     .select("table_name,local_id,data,deleted,updated_at")
+    .eq("household_id", householdId)
     .gt("updated_at", lastPulledAt)
     .order("updated_at", { ascending: true })
     .limit(5000);

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -1,4 +1,5 @@
 import { getSupabaseBrowser } from "~/lib/supabase/client";
+import { getCachedHouseholdId, refreshHouseholdId } from "./household-context";
 import type { SyncedTable } from "./tables";
 
 export type SyncOp =
@@ -43,6 +44,20 @@ async function processQueue(): Promise<void> {
   const supabase = getSupabaseBrowser();
   if (!supabase) return;
 
+  // Slice B: tag every push with the current user's household_id so
+  // RLS can scope reads to the family. If we don't know the household
+  // yet (fresh sign-in, brand-new signup pre-create_household), try
+  // to resolve it now; if still unknown, leave the queue intact and
+  // retry on the next tick.
+  let householdId = getCachedHouseholdId();
+  if (!householdId) {
+    householdId = await refreshHouseholdId();
+  }
+  if (!householdId) {
+    // No household yet — can't satisfy RLS. Hold the ops.
+    return;
+  }
+
   processing = true;
   try {
     while (pending.length > 0) {
@@ -55,6 +70,7 @@ async function processQueue(): Promise<void> {
               local_id: op.local_id,
               data: op.data,
               deleted: false,
+              household_id: householdId,
               updated_at: new Date().toISOString(),
             },
             { onConflict: "table_name,local_id" },
@@ -68,7 +84,8 @@ async function processQueue(): Promise<void> {
               updated_at: new Date().toISOString(),
             })
             .eq("table_name", op.table)
-            .eq("local_id", op.local_id);
+            .eq("local_id", op.local_id)
+            .eq("household_id", householdId);
           if (error) throw error;
         }
         pending.shift();

--- a/src/lib/sync/realtime.ts
+++ b/src/lib/sync/realtime.ts
@@ -1,22 +1,60 @@
 import type { RealtimeChannel } from "@supabase/supabase-js";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
 import { pullFromCloud } from "./pull";
+import {
+  getCachedHouseholdId,
+  onHouseholdChange,
+  refreshHouseholdId,
+} from "./household-context";
 
 let channel: RealtimeChannel | null = null;
+let subscribedHouseholdId: string | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let householdUnsub: (() => void) | null = null;
 
-// Subscribe to cloud_rows changes. When any row changes we debounce a pull so
-// Tom's device sees dad's updates within ~1s without hammering Supabase.
+// Subscribe to cloud_rows changes scoped to the current user's
+// household. When any row changes we debounce a pull so other
+// household members see updates within ~1s without hammering
+// Supabase. Re-subscribes automatically when the household id
+// changes (sign-in / sign-out / join).
 export function subscribeToCloudChanges(): void {
-  if (channel) return;
+  if (householdUnsub) return;       // already wired
+  void ensureSubscription();
+  householdUnsub = onHouseholdChange(() => {
+    void ensureSubscription();
+  });
+}
+
+async function ensureSubscription(): Promise<void> {
   const supabase = getSupabaseBrowser();
   if (!supabase) return;
 
+  let householdId = getCachedHouseholdId();
+  if (!householdId) {
+    householdId = await refreshHouseholdId();
+  }
+
+  // Subscribe only if the household changed (or we have none yet).
+  if (householdId === subscribedHouseholdId && channel) return;
+
+  // Tear down any existing channel first.
+  if (channel) {
+    void supabase.removeChannel(channel);
+    channel = null;
+    subscribedHouseholdId = null;
+  }
+  if (!householdId) return;
+
   channel = supabase
-    .channel("cloud_rows_changes")
+    .channel(`cloud_rows:${householdId}`)
     .on(
       "postgres_changes",
-      { event: "*", schema: "public", table: "cloud_rows" },
+      {
+        event: "*",
+        schema: "public",
+        table: "cloud_rows",
+        filter: `household_id=eq.${householdId}`,
+      },
       () => {
         if (debounceTimer) clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {
@@ -25,17 +63,22 @@ export function subscribeToCloudChanges(): void {
       },
     )
     .subscribe();
+  subscribedHouseholdId = householdId;
 }
 
 export function unsubscribeFromCloudChanges(): void {
-  if (!channel) return;
   const supabase = getSupabaseBrowser();
-  if (supabase) {
+  if (channel && supabase) {
     void supabase.removeChannel(channel);
   }
   channel = null;
+  subscribedHouseholdId = null;
   if (debounceTimer) {
     clearTimeout(debounceTimer);
     debounceTimer = null;
+  }
+  if (householdUnsub) {
+    householdUnsub();
+    householdUnsub = null;
   }
 }

--- a/src/types/household.ts
+++ b/src/types/household.ts
@@ -1,0 +1,56 @@
+// Per-user identity inside a household. Mirrors the Supabase schema in
+// supabase/migrations/2026_04_23_slice_a_households.sql. These are the
+// types the client sees after the Supabase query round-trips.
+
+export type HouseholdRole =
+  | "primary_carer"
+  | "family"
+  | "clinician"
+  | "observer";
+
+export interface Profile {
+  id: string;                 // uuid = auth.users.id
+  display_name: string;
+  avatar_url?: string | null;
+  locale: "en" | "zh";
+  care_role_label?: string | null;  // free-text ("Son", "Palliative RN")
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Household {
+  id: string;
+  name: string;
+  patient_display_name: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HouseholdMembership {
+  household_id: string;
+  user_id: string;
+  role: HouseholdRole;
+  invited_by?: string | null;
+  joined_at: string;
+}
+
+export interface HouseholdInvite {
+  id: string;
+  household_id: string;
+  token: string;
+  email_hint?: string | null;
+  role: HouseholdRole;
+  invited_by: string;
+  created_at: string;
+  expires_at: string;
+  accepted_by?: string | null;
+  accepted_at?: string | null;
+  revoked_at?: string | null;
+}
+
+// A member row joined with their profile — what the Settings UI and
+// the /family call-list render.
+export interface HouseholdMemberWithProfile extends HouseholdMembership {
+  profile: Profile;
+}

--- a/supabase/migrations/2026_04_23_slice_a_households.sql
+++ b/supabase/migrations/2026_04_23_slice_a_households.sql
@@ -1,0 +1,363 @@
+-- Anchor Slice A — household foundation + profiles
+--
+-- Moves the Supabase schema from shared-single-account to per-user
+-- identity inside a household. Every carer signs in as themselves and
+-- sees dad's data via `household_memberships`. The existing
+-- `cloud_rows` table picks up a nullable `household_id` column (tagged
+-- by the client on push; RLS scoping lands in Slice B).
+--
+-- Run in the Supabase SQL editor. Idempotent: uses IF NOT EXISTS and
+-- DROP POLICY IF EXISTS throughout so reruns are safe.
+
+-- ─── profiles ────────────────────────────────────────────────────────
+-- One row per auth user. Created on signup via trigger (below).
+
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name text NOT NULL DEFAULT '',
+  avatar_url text,
+  locale text NOT NULL DEFAULT 'en',
+  care_role_label text,            -- free-text "Son", "Wife", "Oncology Nurse"
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+DROP TRIGGER IF EXISTS profiles_set_updated_at ON public.profiles;
+CREATE TRIGGER profiles_set_updated_at
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- Auto-create a profile row whenever a new auth.users row appears.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, display_name)
+  VALUES (
+    NEW.id,
+    coalesce(NEW.raw_user_meta_data->>'display_name', split_part(NEW.email, '@', 1))
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- ─── households ──────────────────────────────────────────────────────
+-- One row per patient. The `created_by` user is automatically made a
+-- primary_carer via the `household_memberships` insert below.
+
+CREATE TABLE IF NOT EXISTS public.households (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,                       -- "Hu family" — freetext
+  patient_display_name text NOT NULL,       -- "Hu Lin"
+  created_by uuid NOT NULL REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+DROP TRIGGER IF EXISTS households_set_updated_at ON public.households;
+CREATE TRIGGER households_set_updated_at
+  BEFORE UPDATE ON public.households
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ─── household_memberships ──────────────────────────────────────────
+-- Join table: who belongs to which household, with what role.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'household_role') THEN
+    CREATE TYPE public.household_role AS ENUM (
+      'primary_carer',  -- can invite, remove, change roles
+      'family',         -- full read/write; no admin actions
+      'clinician',      -- read/write scoped to clinical data (reserved; same as family for now)
+      'observer'        -- read-only (reserved; enforcement in Slice B)
+    );
+  END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS public.household_memberships (
+  household_id uuid NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role public.household_role NOT NULL DEFAULT 'family',
+  invited_by uuid REFERENCES auth.users(id),
+  joined_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (household_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS household_memberships_user_idx
+  ON public.household_memberships (user_id);
+
+-- ─── household_invites ───────────────────────────────────────────────
+-- A primary carer generates an invite for a specific role. The
+-- invitee follows the shareable link (/invite/<token>), signs up (or
+-- signs in), and the server-side RPC function below creates a
+-- membership for them.
+
+CREATE TABLE IF NOT EXISTS public.household_invites (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  household_id uuid NOT NULL REFERENCES public.households(id) ON DELETE CASCADE,
+  token uuid NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  email_hint text,
+  role public.household_role NOT NULL DEFAULT 'family',
+  invited_by uuid NOT NULL REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '14 days'),
+  accepted_by uuid REFERENCES auth.users(id),
+  accepted_at timestamptz,
+  revoked_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS household_invites_household_idx
+  ON public.household_invites (household_id);
+CREATE INDEX IF NOT EXISTS household_invites_token_idx
+  ON public.household_invites (token);
+
+-- ─── cloud_rows gets a household_id ─────────────────────────────────
+-- Nullable for now; Slice B scopes RLS to it and makes it NOT NULL.
+
+ALTER TABLE public.cloud_rows
+  ADD COLUMN IF NOT EXISTS household_id uuid REFERENCES public.households(id);
+
+CREATE INDEX IF NOT EXISTS cloud_rows_household_id_idx
+  ON public.cloud_rows (household_id);
+
+-- ─── helper functions ────────────────────────────────────────────────
+
+-- Returns the current user's (only) household id, or NULL if none.
+-- Used by RLS policies so they stay a single USING clause. The
+-- codebase assumes one household per user for now; if that changes,
+-- this function and its callers grow a household-selector cookie.
+CREATE OR REPLACE FUNCTION public.current_household_id()
+  RETURNS uuid
+  LANGUAGE sql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+  SELECT household_id FROM public.household_memberships
+  WHERE user_id = auth.uid()
+  LIMIT 1;
+$$;
+
+-- Accepts an invite token, atomically creates a membership for the
+-- current user, and marks the invite accepted. Errors if the invite
+-- is expired, revoked, already accepted, or doesn't exist.
+CREATE OR REPLACE FUNCTION public.accept_household_invite(invite_token uuid)
+  RETURNS uuid   -- the household_id the user joined
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+DECLARE
+  invite public.household_invites%ROWTYPE;
+  current_user_id uuid;
+BEGIN
+  current_user_id := auth.uid();
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_signed_in';
+  END IF;
+
+  SELECT * INTO invite FROM public.household_invites WHERE token = invite_token;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'invite_not_found';
+  END IF;
+  IF invite.revoked_at IS NOT NULL THEN
+    RAISE EXCEPTION 'invite_revoked';
+  END IF;
+  IF invite.accepted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'invite_already_accepted';
+  END IF;
+  IF invite.expires_at < now() THEN
+    RAISE EXCEPTION 'invite_expired';
+  END IF;
+
+  INSERT INTO public.household_memberships (household_id, user_id, role, invited_by)
+  VALUES (invite.household_id, current_user_id, invite.role, invite.invited_by)
+  ON CONFLICT (household_id, user_id) DO UPDATE SET role = EXCLUDED.role;
+
+  UPDATE public.household_invites
+  SET accepted_by = current_user_id, accepted_at = now()
+  WHERE id = invite.id;
+
+  RETURN invite.household_id;
+END;
+$$;
+
+-- Creates a household and immediately enrols the current user as
+-- primary_carer. Returns the new household id.
+CREATE OR REPLACE FUNCTION public.create_household(
+  household_name text,
+  patient_name text
+)
+  RETURNS uuid
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid;
+  new_household_id uuid;
+BEGIN
+  current_user_id := auth.uid();
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_signed_in';
+  END IF;
+
+  INSERT INTO public.households (name, patient_display_name, created_by)
+  VALUES (household_name, patient_name, current_user_id)
+  RETURNING id INTO new_household_id;
+
+  INSERT INTO public.household_memberships (household_id, user_id, role, invited_by)
+  VALUES (new_household_id, current_user_id, 'primary_carer', current_user_id);
+
+  RETURN new_household_id;
+END;
+$$;
+
+-- ─── row level security ──────────────────────────────────────────────
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.households ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.household_memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.household_invites ENABLE ROW LEVEL SECURITY;
+
+-- Profiles: read any profile you share a household with; update only your own.
+DROP POLICY IF EXISTS "profiles read (same household)" ON public.profiles;
+CREATE POLICY "profiles read (same household)"
+  ON public.profiles FOR SELECT
+  TO authenticated
+  USING (
+    id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.household_memberships m1
+      JOIN public.household_memberships m2 USING (household_id)
+      WHERE m1.user_id = auth.uid() AND m2.user_id = public.profiles.id
+    )
+  );
+
+DROP POLICY IF EXISTS "profiles update own" ON public.profiles;
+CREATE POLICY "profiles update own"
+  ON public.profiles FOR UPDATE
+  TO authenticated
+  USING (id = auth.uid())
+  WITH CHECK (id = auth.uid());
+
+-- Households: members can read; primary_carer can update.
+DROP POLICY IF EXISTS "households read (members)" ON public.households;
+CREATE POLICY "households read (members)"
+  ON public.households FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.household_memberships
+      WHERE household_id = public.households.id AND user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "households update (primary)" ON public.households;
+CREATE POLICY "households update (primary)"
+  ON public.households FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.household_memberships
+      WHERE household_id = public.households.id
+        AND user_id = auth.uid()
+        AND role = 'primary_carer'
+    )
+  );
+
+-- Memberships: members can read the list; primary_carer can insert/delete.
+-- Self-deletion (leaving) is allowed for anyone.
+DROP POLICY IF EXISTS "memberships read (same household)" ON public.household_memberships;
+CREATE POLICY "memberships read (same household)"
+  ON public.household_memberships FOR SELECT
+  TO authenticated
+  USING (
+    household_id IN (
+      SELECT household_id FROM public.household_memberships WHERE user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "memberships insert (primary)" ON public.household_memberships;
+CREATE POLICY "memberships insert (primary)"
+  ON public.household_memberships FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.household_memberships
+      WHERE household_id = public.household_memberships.household_id
+        AND user_id = auth.uid()
+        AND role = 'primary_carer'
+    )
+  );
+
+DROP POLICY IF EXISTS "memberships delete (self or primary)" ON public.household_memberships;
+CREATE POLICY "memberships delete (self or primary)"
+  ON public.household_memberships FOR DELETE
+  TO authenticated
+  USING (
+    user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.household_memberships m
+      WHERE m.household_id = public.household_memberships.household_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'primary_carer'
+    )
+  );
+
+-- Invites: members of the household can read (so they can list pending);
+-- only primary_carer can create or revoke. The accept RPC above is
+-- security-definer and bypasses these for the accept path.
+DROP POLICY IF EXISTS "invites read (household members)" ON public.household_invites;
+CREATE POLICY "invites read (household members)"
+  ON public.household_invites FOR SELECT
+  TO authenticated
+  USING (
+    household_id IN (
+      SELECT household_id FROM public.household_memberships WHERE user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "invites insert (primary)" ON public.household_invites;
+CREATE POLICY "invites insert (primary)"
+  ON public.household_invites FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.household_memberships
+      WHERE household_id = public.household_invites.household_id
+        AND user_id = auth.uid()
+        AND role = 'primary_carer'
+    )
+  );
+
+DROP POLICY IF EXISTS "invites update (primary)" ON public.household_invites;
+CREATE POLICY "invites update (primary)"
+  ON public.household_invites FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.household_memberships
+      WHERE household_id = public.household_invites.household_id
+        AND user_id = auth.uid()
+        AND role = 'primary_carer'
+    )
+  );
+
+-- cloud_rows RLS stays permissive in this slice. Slice B rewires it to
+-- `household_id = current_household_id()`.
+
+-- ─── realtime ────────────────────────────────────────────────────────
+ALTER PUBLICATION supabase_realtime ADD TABLE public.households;
+ALTER PUBLICATION supabase_realtime ADD TABLE public.household_memberships;
+ALTER PUBLICATION supabase_realtime ADD TABLE public.household_invites;
+ALTER PUBLICATION supabase_realtime ADD TABLE public.profiles;

--- a/supabase/migrations/2026_04_23_slice_b_scoping.sql
+++ b/supabase/migrations/2026_04_23_slice_b_scoping.sql
@@ -1,0 +1,109 @@
+-- Anchor Slice B — cloud_rows scoped by household_id
+--
+-- Slice A added a nullable `household_id` column to cloud_rows. This
+-- migration:
+--   (1) Backfills any legacy row (household_id IS NULL) with the one
+--       existing household — safe because prior deployments were
+--       single-account single-household.
+--   (2) Makes household_id NOT NULL.
+--   (3) Replaces the permissive "authenticated sees everything" RLS
+--       policies on cloud_rows with policies scoped to the caller's
+--       membership.
+--
+-- Idempotent: reruns are safe.
+
+-- ─── 1. backfill ────────────────────────────────────────────────────
+-- Any rows without a household get attached to the single existing
+-- household, if one exists. (If there are somehow zero or multiple
+-- households, the NOT NULL constraint below will flag it.)
+
+DO $$
+DECLARE
+  target_household uuid;
+  household_count int;
+BEGIN
+  SELECT count(*) INTO household_count FROM public.households;
+
+  IF household_count = 0 THEN
+    RAISE NOTICE 'Slice B: no households exist yet — skipping backfill. Run again after the first household is created.';
+    RETURN;
+  END IF;
+
+  IF household_count > 1 THEN
+    RAISE EXCEPTION 'Slice B backfill refuses to run: % households exist, can''t auto-pick a target. Backfill manually by mapping cloud_rows to their household.', household_count;
+  END IF;
+
+  SELECT id INTO target_household FROM public.households LIMIT 1;
+
+  UPDATE public.cloud_rows
+    SET household_id = target_household
+    WHERE household_id IS NULL;
+END$$;
+
+-- ─── 2. NOT NULL ────────────────────────────────────────────────────
+-- Only safe once every row has a household. Wrapped so reruns after
+-- the constraint is already applied don't blow up.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'cloud_rows'
+      AND column_name  = 'household_id'
+      AND is_nullable  = 'YES'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM public.cloud_rows WHERE household_id IS NULL
+  ) THEN
+    ALTER TABLE public.cloud_rows ALTER COLUMN household_id SET NOT NULL;
+  END IF;
+END$$;
+
+-- ─── 3. replace permissive RLS with household-scoped RLS ────────────
+
+DROP POLICY IF EXISTS "authenticated read" ON public.cloud_rows;
+DROP POLICY IF EXISTS "authenticated insert" ON public.cloud_rows;
+DROP POLICY IF EXISTS "authenticated update" ON public.cloud_rows;
+DROP POLICY IF EXISTS "authenticated delete" ON public.cloud_rows;
+
+-- A row is visible iff the caller belongs to its household.
+CREATE POLICY "cloud_rows read (household member)"
+  ON public.cloud_rows FOR SELECT
+  TO authenticated
+  USING (
+    household_id IN (
+      SELECT household_id FROM public.household_memberships WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "cloud_rows insert (household member)"
+  ON public.cloud_rows FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    household_id IN (
+      SELECT household_id FROM public.household_memberships WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "cloud_rows update (household member)"
+  ON public.cloud_rows FOR UPDATE
+  TO authenticated
+  USING (
+    household_id IN (
+      SELECT household_id FROM public.household_memberships WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    household_id IN (
+      SELECT household_id FROM public.household_memberships WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "cloud_rows delete (household member)"
+  ON public.cloud_rows FOR DELETE
+  TO authenticated
+  USING (
+    household_id IN (
+      SELECT household_id FROM public.household_memberships WHERE user_id = auth.uid()
+    )
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -72,3 +72,11 @@ CREATE POLICY "authenticated delete"
 
 -- Realtime: enable so the app can subscribe to changes (Tom sees dad's logs).
 ALTER PUBLICATION supabase_realtime ADD TABLE public.cloud_rows;
+
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Slice A — household foundation + profiles.
+-- Source of truth: supabase/migrations/2026_04_23_slice_a_households.sql
+-- For new installs: the migration file is run after this schema.sql
+-- via the Supabase CLI. For the consolidated view, read that file.
+-- ═══════════════════════════════════════════════════════════════════

--- a/tests/unit/households.test.ts
+++ b/tests/unit/households.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  friendlyInviteError,
+  inviteUrl,
+} from "~/lib/supabase/households";
+
+describe("friendlyInviteError", () => {
+  const cases: Array<[string, string]> = [
+    ["invite_not_found", "This invite link is invalid."],
+    ["invite_revoked", "This invite has been revoked."],
+    ["invite_already_accepted", "This invite has already been accepted."],
+    ["invite_expired", "This invite has expired."],
+    ["not_signed_in", "Please sign in first."],
+  ];
+
+  for (const [needle, expected] of cases) {
+    it(`maps ${needle} to "${expected}"`, () => {
+      expect(friendlyInviteError(new Error(needle))).toBe(expected);
+    });
+  }
+
+  it("maps an anywhere-containing message", () => {
+    const err = new Error("something: invite_expired at db");
+    expect(friendlyInviteError(err)).toBe("This invite has expired.");
+  });
+
+  it("falls back to the raw message for unknown errors", () => {
+    expect(friendlyInviteError(new Error("boom"))).toBe("boom");
+    expect(friendlyInviteError("plain string")).toBe("plain string");
+  });
+});
+
+describe("inviteUrl", () => {
+  it("joins origin and token correctly", () => {
+    expect(inviteUrl("abc-123", "https://anchor.example.com")).toBe(
+      "https://anchor.example.com/invite/abc-123",
+    );
+  });
+  it("strips a trailing slash on the origin", () => {
+    expect(inviteUrl("xyz", "https://anchor.example.com/")).toBe(
+      "https://anchor.example.com/invite/xyz",
+    );
+  });
+  it("works with a localhost origin", () => {
+    expect(inviteUrl("t", "http://localhost:3000")).toBe(
+      "http://localhost:3000/invite/t",
+    );
+  });
+});

--- a/tests/unit/sync-queue.test.ts
+++ b/tests/unit/sync-queue.test.ts
@@ -21,9 +21,17 @@ import {
   withSyncSuppressed,
   __resetSyncQueueForTests,
 } from "~/lib/sync/queue";
+import {
+  __resetHouseholdContextForTests,
+  __setHouseholdIdForTests,
+} from "~/lib/sync/household-context";
+
+const TEST_HOUSEHOLD = "00000000-0000-0000-0000-000000000001";
 
 beforeEach(() => {
   __resetSyncQueueForTests();
+  __resetHouseholdContextForTests();
+  __setHouseholdIdForTests(TEST_HOUSEHOLD);
   upsertMock.mockReset();
   updateMock.mockReset();
   eqMock.mockReset();
@@ -72,8 +80,34 @@ describe("sync queue — enqueueSync", () => {
       table_name: "daily_entries",
       local_id: 42,
       deleted: false,
+      household_id: TEST_HOUSEHOLD,
       data: { id: 42, date: "2026-04-22" },
     });
+  });
+
+  it("holds ops in the queue when there's no household yet", async () => {
+    __setHouseholdIdForTests(null);
+    enqueueSync({
+      kind: "upsert",
+      table: "daily_entries",
+      local_id: 7,
+      data: { id: 7 },
+    });
+    await flushMicrotasks();
+    expect(upsertMock).not.toHaveBeenCalled();
+    expect(pendingSyncCount()).toBe(1);
+
+    // Once the household resolves, the retried drain pushes.
+    __setHouseholdIdForTests(TEST_HOUSEHOLD);
+    enqueueSync({
+      kind: "upsert",
+      table: "medications",
+      local_id: 8,
+      data: { id: 8 },
+    });
+    await flushMicrotasks();
+    expect(upsertMock).toHaveBeenCalledTimes(2);
+    expect(pendingSyncCount()).toBe(0);
   });
 
   it("pushes a delete op as a soft delete (deleted=true)", async () => {
@@ -86,9 +120,10 @@ describe("sync queue — enqueueSync", () => {
 
     expect(updateMock).toHaveBeenCalledTimes(1);
     expect(updateMock.mock.calls[0]?.[0]).toMatchObject({ deleted: true });
-    // Two .eq() filters: table_name, local_id
+    // Three .eq() filters now: table_name, local_id, household_id
     expect(eqMock).toHaveBeenNthCalledWith(1, "table_name", "medications");
     expect(eqMock).toHaveBeenNthCalledWith(2, "local_id", 9);
+    expect(eqMock).toHaveBeenNthCalledWith(3, "household_id", TEST_HOUSEHOLD);
   });
 });
 


### PR DESCRIPTION
## Summary

Slice B of the accounts + sync + push plan. Every sync write now carries `household_id`; every read filters by it; Supabase RLS enforces the same boundary server-side. A family member joining household X only ever sees X's rows, even if they share local Dexie ids with another household.

**Stacked on PR #55.** GitHub's base is `claude/slice-a-households`; flip to `main` after #55 merges.

**⚠️ Supabase migration required.** Run `supabase/migrations/2026_04_23_slice_b_scoping.sql` after Slice A's migration. Idempotent; refuses to run the backfill if >1 households exist (forces manual resolution).

## Client

- **`src/lib/sync/household-context.ts`** — cached current-user household id; refresh on auth state change; change listeners so realtime can resubscribe; test-only seed helper.
- **`queue.ts`** — upserts carry `household_id`; soft-deletes add a third `.eq("household_id", …)` filter; when no household is known yet the queue holds ops until refresh resolves one.
- **`pull.ts`** — `.eq("household_id", id)` on the fetch; bails out with `pulled: 0` when no household resolved (signed out or mid-onboarding).
- **`realtime.ts`** — channel per household with a server-side `filter: "household_id=eq.<id>"`, auto-teardown + resubscribe when the household id changes.
- **`init.ts`** — `refreshHouseholdId()` runs on boot and on auth state change so sync has a valid id before the first pull.

## Supabase

`supabase/migrations/2026_04_23_slice_b_scoping.sql`:

1. Backfills every existing `cloud_rows.household_id` from the one existing household (single-household legacy state).
2. Flips `household_id` to `NOT NULL` once backfill is clean.
3. Replaces the four permissive "authenticated = true" RLS policies on `cloud_rows` with "household member" policies requiring `household_id` to be in the caller's `household_memberships` list.
4. Refuses to run the backfill when more than one household exists — forces manual resolution instead of guessing.

## Gate

- `pnpm typecheck` clean
- `pnpm test` — **275/275** (+1 new case: "holds ops until the household resolves")
- `pnpm build` clean

## Test plan

- [ ] Apply the migration on a test Supabase project with exactly one household — verify backfill populates every row and the `NOT NULL` constraint takes hold.
- [ ] Create a second test user + household; verify they can't read the first household's `cloud_rows` (RLS blocks the query).
- [ ] Sign in → watch the network tab: pulls have `household_id=eq.<uuid>` on the URL; upserts include `household_id` in the payload.
- [ ] Sign out → sign back in: the realtime channel name changes to match the new household; stale subscription is torn down.
- [ ] Member of household A pushes an update while logged in as B → write is rejected by RLS.

## Not in this PR (tracked)

- Slice C: `entered_by_user_id` FK on DailyEntry + visible attribution chips.
- A "repush everything local" button for devices that accumulated pre-Slice-B queue items with no household_id tag — in practice the retry timer + refresh loop handles this, but an explicit force-push might be useful later.

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8

---
_Generated by [Claude Code](https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8)_