### PR TITLE
Slice D: service worker + push subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "recharts": "^2.12.3",
     "tailwind-merge": "^2.2.2",
     "tesseract.js": "^7.0.0",
+    "web-push": "^3.6.7",
     "zod": "^3.22.4",
     "zustand": "^4.5.2"
   },
@@ -53,6 +54,7 @@
     "@types/node": "^20.11.30",
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.22",
+    "@types/web-push": "^3.6.4",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       tesseract.js:
         specifier: ^7.0.0
         version: 7.0.0
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -111,6 +114,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.22
         version: 18.3.7(@types/react@18.3.28)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.4.0
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
@@ -1031,6 +1037,9 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1319,6 +1328,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
@@ -1376,6 +1388,9 @@ packages:
   bmp-js@0.1.0:
     resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -1396,6 +1411,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -1683,6 +1701,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
@@ -2073,6 +2094,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -2332,6 +2357,12 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2428,6 +2459,9 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -3375,6 +3409,11 @@ packages:
 
   wasm-feature-detect@1.8.0:
     resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -4335,6 +4374,10 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 20.19.39
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.39
@@ -4641,6 +4684,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@1.1.0: {}
 
   ast-types-flow@0.0.8: {}
@@ -4682,6 +4732,8 @@ snapshots:
 
   bmp-js@0.1.0: {}
 
+  bn.js@4.12.3: {}
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -4710,6 +4762,8 @@ snapshots:
       electron-to-chromium: 1.5.340
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   busboy@1.6.0:
     dependencies:
@@ -4999,6 +5053,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.340: {}
 
@@ -5592,6 +5650,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -5859,6 +5919,17 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5942,6 +6013,8 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   min-indent@1.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@3.1.5:
     dependencies:
@@ -6977,6 +7050,16 @@ snapshots:
       xml-name-validator: 5.0.0
 
   wasm-feature-detect@1.8.0: {}
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@3.0.1: {}
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,73 @@
+// Anchor service worker — Slice D push subscriptions.
+//
+// Scope is narrow by design: we only handle `push` events to display
+// notifications, and `notificationclick` to focus / open the right
+// page. We deliberately avoid fetch-caching and background sync in
+// this slice — Dexie + the app's existing pull retry handle offline
+// reads, and fetch interception adds cache-invalidation complexity
+// we'd rather not own yet.
+
+/* eslint-env serviceworker */
+
+self.addEventListener("install", () => {
+  // Activate the new SW immediately instead of waiting for all tabs to
+  // close. Safe here because we don't cache anything that could go
+  // stale.
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  // Claim open clients so the first install gets push coverage without
+  // a reload.
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+  // Payloads are JSON shaped as { title, body, url?, tag? }. We pass
+  // through whatever the server sent verbatim; a missing payload
+  // falls back to a safe generic message.
+  let data = {};
+  try {
+    if (event.data) data = event.data.json();
+  } catch (_err) {
+    data = { title: "Anchor", body: event.data ? event.data.text() : "" };
+  }
+
+  const title = data.title || "Anchor";
+  const options = {
+    body: data.body || "",
+    icon: "/anchor-mark.svg",
+    badge: "/anchor-mark.svg",
+    // `tag` lets a newer push replace an older one of the same kind
+    // so we don't stack "appointment tomorrow" notifications.
+    tag: data.tag || undefined,
+    data: { url: data.url || "/" },
+    renotify: true,
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const target = (event.notification.data && event.notification.data.url) || "/";
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clients) => {
+        // Prefer focusing an existing Anchor tab, then navigating it.
+        for (const client of clients) {
+          if ("focus" in client) {
+            client.focus();
+            if ("navigate" in client) client.navigate(target);
+            return;
+          }
+        }
+        // No open tabs → open a new one.
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(target);
+        }
+      }),
+  );
+});

--- a/src/app/api/push/public-key/route.ts
+++ b/src/app/api/push/public-key/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+// Exposes the VAPID public key to the browser so it can subscribe via
+// PushManager. Public by design — anyone with the key can only *send*
+// to subscriptions they've been given the endpoint + auth for, and
+// those are bound to the user's browser.
+export const runtime = "nodejs";
+
+export async function GET() {
+  const key = process.env.VAPID_PUBLIC_KEY;
+  if (!key) {
+    return NextResponse.json(
+      { error: "VAPID_PUBLIC_KEY not configured." },
+      { status: 503 },
+    );
+  }
+  return NextResponse.json({ public_key: key });
+}

--- a/src/app/api/push/send-test/route.ts
+++ b/src/app/api/push/send-test/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getSupabaseServer } from "~/lib/supabase/server";
+import { getServiceRoleClient, sendPushToUser } from "~/lib/push/server";
+
+// Dev helper: sends a test push to every subscription belonging to the
+// currently signed-in user. Not gated by an "admin" flag because the
+// payload + recipient are constrained to self; still, we refuse to run
+// if NODE_ENV is production AND ALLOW_PUSH_TEST isn't set, so a
+// misplaced bookmark doesn't wake dad up in the middle of the night.
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  if (
+    process.env.NODE_ENV === "production" &&
+    process.env.ALLOW_PUSH_TEST !== "1"
+  ) {
+    return NextResponse.json(
+      { error: "Push test disabled in production." },
+      { status: 403 },
+    );
+  }
+  const sb = getSupabaseServer();
+  if (!sb) {
+    return NextResponse.json(
+      { error: "Supabase is not configured." },
+      { status: 503 },
+    );
+  }
+  const { data: auth } = await sb.auth.getUser();
+  if (!auth.user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+  const service = getServiceRoleClient();
+  if (!service) {
+    return NextResponse.json(
+      { error: "SUPABASE_SERVICE_ROLE_KEY not configured." },
+      { status: 503 },
+    );
+  }
+
+  const result = await sendPushToUser(service, auth.user.id, {
+    title: "Anchor test",
+    body: "Push is wired up.",
+    url: "/",
+    tag: "test",
+  });
+  return NextResponse.json(result);
+}

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { getSupabaseServer } from "~/lib/supabase/server";
+
+// POST: upsert a PushSubscription for the current user + device.
+// The body shape mirrors what PushSubscription.toJSON() produces on
+// the client, plus an optional user_agent so Settings → Notifications
+// can show a per-device list.
+
+export const runtime = "nodejs";
+
+interface RequestBody {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+  user_agent?: string;
+  locale?: "en" | "zh";
+}
+
+export async function POST(req: Request) {
+  const sb = getSupabaseServer();
+  if (!sb) {
+    return NextResponse.json(
+      { error: "Supabase is not configured." },
+      { status: 503 },
+    );
+  }
+  const { data: auth } = await sb.auth.getUser();
+  if (!auth.user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  if (!body?.endpoint || !body.keys?.p256dh || !body.keys?.auth) {
+    return NextResponse.json(
+      { error: "endpoint + keys.p256dh + keys.auth are required" },
+      { status: 400 },
+    );
+  }
+
+  const { error } = await sb
+    .from("push_subscriptions")
+    .upsert(
+      {
+        user_id: auth.user.id,
+        endpoint: body.endpoint,
+        p256dh: body.keys.p256dh,
+        auth: body.keys.auth,
+        user_agent: body.user_agent ?? null,
+        locale: body.locale ?? "en",
+      },
+      { onConflict: "user_id,endpoint" },
+    );
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/push/unsubscribe/route.ts
+++ b/src/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { getSupabaseServer } from "~/lib/supabase/server";
+
+// POST: delete the subscription row matching { user_id, endpoint }.
+// The client calls this after PushSubscription.unsubscribe() so the
+// cron never fires to a dead endpoint.
+
+export const runtime = "nodejs";
+
+interface RequestBody {
+  endpoint: string;
+}
+
+export async function POST(req: Request) {
+  const sb = getSupabaseServer();
+  if (!sb) {
+    return NextResponse.json(
+      { error: "Supabase is not configured." },
+      { status: 503 },
+    );
+  }
+  const { data: auth } = await sb.auth.getUser();
+  if (!auth.user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  if (!body?.endpoint) {
+    return NextResponse.json({ error: "endpoint required" }, { status: 400 });
+  }
+
+  const { error } = await sb
+    .from("push_subscriptions")
+    .delete()
+    .eq("user_id", auth.user.id)
+    .eq("endpoint", body.endpoint);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -10,6 +10,7 @@ import { useLocale, useT } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { AccountButton } from "~/components/shared/account-button";
 import { HouseholdSection } from "~/components/settings/household-section";
+import { NotificationsSection } from "~/components/settings/notifications-section";
 import { CareTeamSection } from "~/components/settings/care-team-section";
 import { TrackedSymptomsSection } from "~/components/settings/tracked-symptoms-section";
 
@@ -104,6 +105,8 @@ export default function SettingsPage() {
       <AccountButton />
 
       <HouseholdSection />
+
+      <NotificationsSection />
 
       <CareTeamSection />
 

--- a/src/components/settings/notifications-section.tsx
+++ b/src/components/settings/notifications-section.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  disablePush,
+  enablePush,
+  getCurrentSubscription,
+  getPushSupport,
+  sendTestPush,
+} from "~/lib/push/client";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Bell, BellOff, Check, AlertCircle } from "lucide-react";
+
+// Settings → Notifications. One toggle per device: when on, this
+// device receives push for appointment reminders, zone transitions,
+// and the morning digest (Slice E lands the cron that fires them).
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "unsupported"; reason: string }
+  | { kind: "denied" }
+  | { kind: "off" }
+  | { kind: "on"; endpoint: string }
+  | { kind: "error"; message: string };
+
+export function NotificationsSection() {
+  const locale = useLocale();
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
+  const [busy, setBusy] = useState<"enable" | "disable" | "test" | null>(null);
+  const [testedOk, setTestedOk] = useState(false);
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const refresh = useCallback(async () => {
+    const support = getPushSupport();
+    if (support.kind !== "supported") {
+      setStatus({ kind: "unsupported", reason: support.reason });
+      return;
+    }
+    if (support.permission === "denied") {
+      setStatus({ kind: "denied" });
+      return;
+    }
+    const sub = await getCurrentSubscription();
+    if (sub) setStatus({ kind: "on", endpoint: sub.endpoint });
+    else setStatus({ kind: "off" });
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  async function onEnable() {
+    setBusy("enable");
+    try {
+      const res = await enablePush({ locale });
+      if (res.ok) {
+        setStatus({ kind: "on", endpoint: res.endpoint });
+      } else if (res.reason === "denied") {
+        setStatus({ kind: "denied" });
+      } else {
+        setStatus({ kind: "error", message: res.reason });
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function onDisable() {
+    setBusy("disable");
+    try {
+      await disablePush();
+      setStatus({ kind: "off" });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function onTest() {
+    setBusy("test");
+    try {
+      const ok = await sendTestPush();
+      setTestedOk(ok);
+      setTimeout(() => setTestedOk(false), 2500);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="eyebrow">
+          <Bell className="mr-1.5 inline h-3.5 w-3.5" />
+          {L("Notifications", "通知")}
+        </h2>
+        <p className="mt-1 text-xs text-ink-500">
+          {L(
+            "Push reminders for tomorrow's appointments, overdue follow-ups, and zone changes. Per-device — toggle on any phone that should buzz.",
+            "推送明日预约、待跟进项目与状态变化。每台设备独立开关。",
+          )}
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-4">
+          {status.kind === "loading" && (
+            <p className="text-[12.5px] text-ink-500">{L("Checking…", "正在检查…")}</p>
+          )}
+
+          {status.kind === "unsupported" && (
+            <UnsupportedNote reason={status.reason} locale={locale} />
+          )}
+
+          {status.kind === "denied" && (
+            <div className="space-y-2">
+              <div className="flex items-start gap-2 text-[13px]">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-[var(--warn)]" />
+                <div>
+                  <div className="font-semibold text-ink-900">
+                    {L("Browser permission blocked", "浏览器已阻止通知权限")}
+                  </div>
+                  <p className="mt-1 text-[12px] text-ink-500">
+                    {L(
+                      "You denied notifications for this site. Enable them in your browser's site settings, then reload.",
+                      "你拒绝了此站点的通知权限。请在浏览器站点设置中启用后重新加载。",
+                    )}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {status.kind === "off" && (
+            <div className="flex items-center justify-between gap-3">
+              <div className="text-[13px] text-ink-700">
+                {L("Off on this device", "此设备未开启")}
+              </div>
+              <Button onClick={onEnable} disabled={busy !== null} size="md">
+                <Bell className="h-4 w-4" />
+                {busy === "enable"
+                  ? L("Enabling…", "开启中…")
+                  : L("Turn on", "开启")}
+              </Button>
+            </div>
+          )}
+
+          {status.kind === "on" && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-1.5 text-[13px] text-[var(--ok)]">
+                  <Check className="h-4 w-4" />
+                  {L("On for this device", "此设备已开启")}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="md"
+                    onClick={onTest}
+                    disabled={busy !== null}
+                  >
+                    {busy === "test"
+                      ? L("Sending…", "发送中…")
+                      : testedOk
+                        ? L("Sent ✓", "已发送 ✓")
+                        : L("Send test", "测试一下")}
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="md"
+                    onClick={onDisable}
+                    disabled={busy !== null}
+                  >
+                    <BellOff className="h-4 w-4" />
+                    {busy === "disable"
+                      ? L("Turning off…", "关闭中…")
+                      : L("Turn off", "关闭")}
+                  </Button>
+                </div>
+              </div>
+              <p className="text-[11px] text-ink-400">
+                {L(
+                  "On iPhone: Web Push only works when Anchor is installed to the home screen.",
+                  "iPhone：需将 Anchor 添加到主屏幕后，通知才能工作。",
+                )}
+              </p>
+            </div>
+          )}
+
+          {status.kind === "error" && (
+            <div className="flex items-start gap-2 text-[12.5px] text-[var(--warn)]">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{status.message}</span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+function UnsupportedNote({
+  reason,
+  locale,
+}: {
+  reason: string;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const label =
+    reason === "no-service-worker"
+      ? L("Your browser doesn't support service workers.", "此浏览器不支持 Service Worker。")
+      : reason === "no-push-manager"
+        ? L(
+            "Push isn't supported in this browser. On iOS Safari, add Anchor to the home screen first.",
+            "此浏览器不支持推送。iOS Safari 需先将 Anchor 添加到主屏幕。",
+          )
+        : reason === "no-notifications"
+          ? L(
+              "Notifications aren't available in this browser.",
+              "此浏览器不支持系统通知。",
+            )
+          : L(
+              "Push isn't available here.",
+              "当前环境不支持推送。",
+            );
+  return <p className="text-[12.5px] text-ink-500">{label}</p>;
+}

--- a/src/components/shared/providers.tsx
+++ b/src/components/shared/providers.tsx
@@ -19,6 +19,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
       // eslint-disable-next-line no-console
       console.warn("[sync] init failed", err);
     });
+    // Slice D: register the push service worker early so subscribing
+    // later (from Settings) is a synchronous-feeling flow. Safe to
+    // call unconditionally — unsupported environments no-op.
+    void import("~/lib/push/client").then(({ registerServiceWorker }) =>
+      registerServiceWorker(),
+    );
   }, []);
 
   useEffect(() => {

--- a/src/lib/push/client.ts
+++ b/src/lib/push/client.ts
@@ -1,0 +1,154 @@
+"use client";
+
+// Client-side push subscribe / unsubscribe / status. Wraps the
+// ServiceWorker + PushManager dance and the server round-trips so the
+// Settings UI stays tiny.
+//
+// Browser capability caveats (worth documenting where someone will read
+// them): Safari on iOS supports Web Push only when the app is installed
+// to the home screen (iOS 16.4+). Desktop Chrome/Firefox/Edge Just
+// Work. On Android, installing the PWA is optional but recommended
+// because the browser keeps the SW alive more aggressively.
+
+export type PushSupport =
+  | { kind: "unsupported"; reason: string }
+  | { kind: "supported"; permission: NotificationPermission };
+
+export function getPushSupport(): PushSupport {
+  if (typeof window === "undefined") {
+    return { kind: "unsupported", reason: "server" };
+  }
+  if (!("serviceWorker" in navigator)) {
+    return { kind: "unsupported", reason: "no-service-worker" };
+  }
+  if (!("PushManager" in window)) {
+    return { kind: "unsupported", reason: "no-push-manager" };
+  }
+  if (!("Notification" in window)) {
+    return { kind: "unsupported", reason: "no-notifications" };
+  }
+  return { kind: "supported", permission: Notification.permission };
+}
+
+export async function getCurrentSubscription(): Promise<PushSubscription | null> {
+  if (typeof window === "undefined") return null;
+  if (!("serviceWorker" in navigator)) return null;
+  try {
+    const reg = await navigator.serviceWorker.getRegistration("/sw.js");
+    if (!reg) return null;
+    return (await reg.pushManager.getSubscription()) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function registerServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (typeof window === "undefined") return null;
+  if (!("serviceWorker" in navigator)) return null;
+  try {
+    return await navigator.serviceWorker.register("/sw.js", { scope: "/" });
+  } catch {
+    return null;
+  }
+}
+
+async function fetchPublicKey(): Promise<string | null> {
+  const res = await fetch("/api/push/public-key");
+  if (!res.ok) return null;
+  const data = (await res.json()) as { public_key?: string };
+  return data.public_key ?? null;
+}
+
+// Web Push needs the VAPID public key as a Uint8Array (not base64url
+// string) when calling subscribe. This helper converts.
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const base64Std = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64Std);
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+export async function enablePush(args: {
+  locale: "en" | "zh";
+}): Promise<
+  | { ok: true; endpoint: string }
+  | { ok: false; reason: string }
+> {
+  const support = getPushSupport();
+  if (support.kind !== "supported") {
+    return { ok: false, reason: support.reason };
+  }
+  const reg = await registerServiceWorker();
+  if (!reg) return { ok: false, reason: "sw-registration-failed" };
+
+  const permission =
+    Notification.permission === "default"
+      ? await Notification.requestPermission()
+      : Notification.permission;
+  if (permission !== "granted") return { ok: false, reason: "denied" };
+
+  const pubKey = await fetchPublicKey();
+  if (!pubKey) return { ok: false, reason: "no-vapid-key" };
+
+  let sub: PushSubscription;
+  try {
+    // PushManager.subscribe accepts BufferSource at runtime; TS's
+    // lib.dom Uint8Array generic is narrower than the spec — cast
+    // through unknown to BufferSource.
+    const appKey = urlBase64ToUint8Array(pubKey) as unknown as BufferSource;
+    sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: appKey,
+    });
+  } catch (err) {
+    return { ok: false, reason: (err as Error).message };
+  }
+
+  const json = sub.toJSON();
+  const body = {
+    endpoint: json.endpoint,
+    keys: json.keys,
+    user_agent: navigator.userAgent,
+    locale: args.locale,
+  };
+  const res = await fetch("/api/push/subscribe", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    // Roll back the browser-side subscription if the server rejected.
+    try {
+      await sub.unsubscribe();
+    } catch {
+      // ignore
+    }
+    return { ok: false, reason: (await res.text()) || "server-rejected" };
+  }
+  return { ok: true, endpoint: json.endpoint ?? "" };
+}
+
+export async function disablePush(): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const sub = await getCurrentSubscription();
+  if (!sub) return { ok: true };
+  const endpoint = sub.endpoint;
+  try {
+    await sub.unsubscribe();
+  } catch {
+    // continue — server cleanup is still worth doing
+  }
+  const res = await fetch("/api/push/unsubscribe", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ endpoint }),
+  });
+  if (!res.ok) return { ok: false, reason: "server-error" };
+  return { ok: true };
+}
+
+export async function sendTestPush(): Promise<boolean> {
+  const res = await fetch("/api/push/send-test", { method: "POST" });
+  return res.ok;
+}

--- a/src/lib/push/server.ts
+++ b/src/lib/push/server.ts
@@ -1,0 +1,125 @@
+import webpush from "web-push";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+// Server-side push helpers. VAPID keys live as Vercel env vars:
+//   VAPID_PUBLIC_KEY  (base64-url, also exposed to the client via
+//                      /api/push/public-key so the SW can subscribe)
+//   VAPID_PRIVATE_KEY (base64-url, never leaves the server)
+//   VAPID_SUBJECT     ("mailto:ops@anchor.example" — identifies the
+//                      push sender to push providers)
+//
+// The morning-digest cron (Slice E) needs a service-role Supabase
+// client to read every household's subscriptions; the subscribe /
+// unsubscribe routes use the request-scoped client so RLS gates them
+// to the caller's own rows.
+
+let configured = false;
+
+function ensureConfigured(): boolean {
+  if (configured) return true;
+  const pub = process.env.VAPID_PUBLIC_KEY;
+  const priv = process.env.VAPID_PRIVATE_KEY;
+  const subj = process.env.VAPID_SUBJECT ?? "mailto:ops@anchor.invalid";
+  if (!pub || !priv) return false;
+  webpush.setVapidDetails(subj, pub, priv);
+  configured = true;
+  return true;
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  url?: string;
+  tag?: string;
+}
+
+export interface PushSubscriptionRow {
+  id: string;
+  user_id: string;
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}
+
+// Returns a service-role Supabase client when the env var is set.
+// Only call this from a server route / cron handler — never from a
+// client bundle. No-op (returns null) if the env var is missing so
+// local dev without the service key doesn't break.
+export function getServiceRoleClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+// Sends one notification to one subscription. Caller is responsible
+// for deleting the row if this returns 410 (Gone) — that's the
+// convention PushManager uses to signal the subscription is dead.
+export async function sendPush(
+  sub: PushSubscriptionRow,
+  payload: PushPayload,
+): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
+  if (!ensureConfigured()) {
+    return {
+      ok: false,
+      status: 503,
+      error: "VAPID keys not configured on the server.",
+    };
+  }
+  try {
+    await webpush.sendNotification(
+      {
+        endpoint: sub.endpoint,
+        keys: { p256dh: sub.p256dh, auth: sub.auth },
+      },
+      JSON.stringify(payload),
+      { TTL: 60 * 60 * 12 },
+    );
+    return { ok: true };
+  } catch (err) {
+    const statusCode =
+      (err as { statusCode?: number })?.statusCode ??
+      (err as { status?: number })?.status ??
+      500;
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, status: statusCode, error: message };
+  }
+}
+
+// Dispatches a push to every active subscription for a user. Rows
+// that come back 410 are deleted so we don't keep retrying dead
+// endpoints. Requires a service-role client.
+export async function sendPushToUser(
+  serviceRole: SupabaseClient,
+  userId: string,
+  payload: PushPayload,
+): Promise<{ sent: number; removed: number; failed: number }> {
+  const { data, error } = await serviceRole
+    .from("push_subscriptions")
+    .select("id, user_id, endpoint, p256dh, auth")
+    .eq("user_id", userId);
+  if (error) throw error;
+  const rows = (data ?? []) as PushSubscriptionRow[];
+  let sent = 0;
+  let removed = 0;
+  let failed = 0;
+  for (const sub of rows) {
+    const res = await sendPush(sub, payload);
+    if (res.ok) {
+      sent += 1;
+      await serviceRole
+        .from("push_subscriptions")
+        .update({ last_pushed_at: new Date().toISOString() })
+        .eq("id", sub.id);
+    } else if (res.status === 404 || res.status === 410) {
+      // Endpoint gone — drop the row so it doesn't linger.
+      await serviceRole.from("push_subscriptions").delete().eq("id", sub.id);
+      removed += 1;
+    } else {
+      failed += 1;
+    }
+  }
+  return { sent, removed, failed };
+}

--- a/supabase/migrations/2026_04_23_slice_d_push.sql
+++ b/supabase/migrations/2026_04_23_slice_d_push.sql
@@ -1,0 +1,52 @@
+-- Anchor Slice D — push subscription storage
+--
+-- One row per (user, device). The morning-digest cron (Slice E) iterates
+-- these rows per household and fans out notifications via web-push.
+-- RLS: users only see + mutate their own subscriptions. Cron uses the
+-- service-role key to read all rows in a household's members.
+
+CREATE TABLE IF NOT EXISTS public.push_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  endpoint text NOT NULL,
+  p256dh text NOT NULL,
+  auth text NOT NULL,
+  user_agent text,
+  locale text DEFAULT 'en',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  last_pushed_at timestamptz,
+  UNIQUE (user_id, endpoint)
+);
+
+CREATE INDEX IF NOT EXISTS push_subscriptions_user_idx
+  ON public.push_subscriptions (user_id);
+
+ALTER TABLE public.push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "push_subscriptions read own" ON public.push_subscriptions;
+CREATE POLICY "push_subscriptions read own"
+  ON public.push_subscriptions FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "push_subscriptions insert own" ON public.push_subscriptions;
+CREATE POLICY "push_subscriptions insert own"
+  ON public.push_subscriptions FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "push_subscriptions delete own" ON public.push_subscriptions;
+CREATE POLICY "push_subscriptions delete own"
+  ON public.push_subscriptions FOR DELETE
+  TO authenticated
+  USING (user_id = auth.uid());
+
+-- Update allowed for own rows so the cron's own-row last_pushed_at
+-- bookkeeping works from the service-role client AND users can update
+-- their own locale preference.
+DROP POLICY IF EXISTS "push_subscriptions update own" ON public.push_subscriptions;
+CREATE POLICY "push_subscriptions update own"
+  ON public.push_subscriptions FOR UPDATE
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary

Slice D of the accounts + sync + push plan. Lays the plumbing for morning-digest + appointment reminder pushes. Each signed-in device can turn notifications on from Settings; the server stores one row per (user, endpoint) and fans out via `web-push` whenever Slice E's cron (next PR) composes a payload.

## Env required in Vercel

Before this can deliver real pushes:

- `VAPID_PUBLIC_KEY` (base64-url, client-exposed via `/api/push/public-key`)
- `VAPID_PRIVATE_KEY` (base64-url, server-only)
- `VAPID_SUBJECT` (e.g. `mailto:ops@anchor.example` — identifies sender to push providers)
- `SUPABASE_SERVICE_ROLE_KEY` (needed for the fan-out path; the subscribe/unsubscribe routes use the user-scoped client)

Generate VAPID keys once with `npx web-push generate-vapid-keys` and paste both into Vercel env.

**⚠️ Supabase migration required.** Run `supabase/migrations/2026_04_23_slice_d_push.sql` — adds the `push_subscriptions` table with per-user RLS.

## Pieces

- **`public/sw.js`** — narrow-scope service worker. `push` → `showNotification`; `notificationclick` → focus/navigate. No fetch-caching (not worth the invalidation cost this slice).
- **`supabase/migrations/2026_04_23_slice_d_push.sql`** — `push_subscriptions (user_id, endpoint, p256dh, auth, user_agent, locale, last_pushed_at)` with `UNIQUE (user_id, endpoint)` and "own rows only" RLS.
- **`src/lib/push/server.ts`** — VAPID config from env, `sendPush(sub, payload)`, `sendPushToUser(serviceRole, userId, payload)` which iterates a user's subscriptions and drops rows that return 404/410 so the cron doesn't keep retrying dead endpoints. `getServiceRoleClient()` helper for cron / test routes.
- **API routes** under `/api/push/`:
  - `GET  /api/push/public-key` — returns the VAPID public key to the SW subscriber.
  - `POST /api/push/subscribe` — upsert `(user_id, endpoint)`.
  - `POST /api/push/unsubscribe` — delete by `endpoint`.
  - `POST /api/push/send-test` — dev helper; refuses in production unless `ALLOW_PUSH_TEST=1`.
- **`src/lib/push/client.ts`** — `getPushSupport`, `registerServiceWorker`, `enablePush` / `disablePush` / `sendTestPush`. Rollback: if the server rejects subscribe we unsubscribe the browser-side PushSubscription so we don't leak zombies.
- **`src/components/settings/notifications-section.tsx`** — single toggle with explicit per-state copy (unsupported / denied / off / on / error), bilingual, test-send button, iOS Safari home-screen caveat. Mounted on `/settings` between Household and Care-team sections.
- **`providers.tsx`** — auto-registers the SW at app mount so subscribing later from Settings is fast.

New deps: `web-push` + `@types/web-push`.

## Not in this PR (Slice E is next)

- The Vercel Cron that actually fires daily digests / appointment reminders.
- Per-user quiet hours or per-event-kind preferences; for v1 every household member gets the same schedule.

## Gate

- `pnpm typecheck` clean
- `pnpm test` — 281/281 (no new tests; push can't be unit-tested meaningfully without a live browser — manual flow below)
- `pnpm build` clean

## Test plan

- [ ] Set `VAPID_PUBLIC_KEY` + `VAPID_PRIVATE_KEY` + `VAPID_SUBJECT` on the preview environment.
- [ ] Run the migration in the Supabase project.
- [ ] Open `/settings` on a real Chrome/Firefox device. "Turn on" → browser permission prompt → success state → "Send test" fires an OS notification.
- [ ] Check `push_subscriptions` table in Supabase — exactly one row per (user, endpoint).
- [ ] "Turn off" → row disappears in Supabase; the SW unsubscribes.
- [ ] On iOS: verify Anchor is installable from Safari's share menu; then test the toggle there.

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8

---
_Generated by [Claude Code](https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8)_