### PR TITLE
Slice E: Vercel Cron + morning digest push

### DIFF
--- a/src/app/api/cron/morning-digest/route.ts
+++ b/src/app/api/cron/morning-digest/route.ts
@@ -1,0 +1,186 @@
+import { NextResponse } from "next/server";
+import { getServiceRoleClient, sendPushToUser } from "~/lib/push/server";
+import {
+  buildDigest,
+  type DigestAppointment,
+  type DigestZoneAlert,
+  type DigestFollowUp,
+} from "~/lib/cron/digest";
+import { deriveFollowUpTasks } from "~/lib/appointments/follow-up-tasks";
+import type { Appointment } from "~/types/appointment";
+import type { ZoneAlert } from "~/types/clinical";
+
+export const runtime = "nodejs";
+
+// Vercel Cron entry point. Fires at 21:00 UTC daily (configured in
+// vercel.json), which is 07:00 AEST — Hu Lin's morning in Melbourne.
+// Multi-timezone fan-out isn't handled yet; this is a single fire.
+//
+// Auth: Vercel's cron invocation carries `x-vercel-cron: 1` (only
+// from their edge). We also accept `authorization: Bearer <CRON_SECRET>`
+// so dev / staging can trigger it manually via curl.
+//
+// Work: iterate every unique push-subscribed user, load their
+// household's data from cloud_rows, compose a per-user digest, fan out
+// via sendPushToUser. Users whose digest would be empty are skipped.
+
+interface CloudRow<T> {
+  data: T;
+}
+
+function authorised(req: Request): boolean {
+  if (req.headers.get("x-vercel-cron") === "1") return true;
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const auth = req.headers.get("authorization");
+  return auth === `Bearer ${secret}`;
+}
+
+export async function GET(req: Request) {
+  if (!authorised(req)) {
+    return NextResponse.json({ error: "unauthorised" }, { status: 401 });
+  }
+
+  const service = getServiceRoleClient();
+  if (!service) {
+    return NextResponse.json(
+      { error: "SUPABASE_SERVICE_ROLE_KEY not configured" },
+      { status: 503 },
+    );
+  }
+
+  const { data: subRows, error: subErr } = await service
+    .from("push_subscriptions")
+    .select("user_id");
+  if (subErr) {
+    return NextResponse.json({ error: subErr.message }, { status: 500 });
+  }
+  const userIds = Array.from(
+    new Set((subRows ?? []).map((r) => r.user_id as string)),
+  );
+  if (userIds.length === 0) {
+    return NextResponse.json({ users: 0, sent: 0, skipped: 0 });
+  }
+
+  const now = new Date();
+  let totalSent = 0;
+  let totalSkipped = 0;
+
+  // Cache household lookups across users in the same household so we
+  // don't re-fetch cloud_rows for every member.
+  const householdCache = new Map<
+    string,
+    {
+      patient_name: string;
+      appointments: DigestAppointment[];
+      zone_alerts: DigestZoneAlert[];
+      follow_ups: DigestFollowUp[];
+    }
+  >();
+
+  for (const userId of userIds) {
+    const { data: membership } = await service
+      .from("household_memberships")
+      .select("household_id")
+      .eq("user_id", userId)
+      .limit(1)
+      .maybeSingle();
+    const householdId = membership?.household_id as string | undefined;
+    if (!householdId) {
+      totalSkipped += 1;
+      continue;
+    }
+
+    let ctx = householdCache.get(householdId);
+    if (!ctx) {
+      const { data: householdRow } = await service
+        .from("households")
+        .select("patient_display_name")
+        .eq("id", householdId)
+        .maybeSingle();
+      const patient_name =
+        (householdRow?.patient_display_name as string | undefined) ??
+        "Your family";
+
+      const { data: apptRows } = await service
+        .from("cloud_rows")
+        .select("data")
+        .eq("household_id", householdId)
+        .eq("table_name", "appointments")
+        .eq("deleted", false);
+      const appointmentsRaw = ((apptRows ?? []) as CloudRow<Appointment>[]).map(
+        (r) => r.data,
+      );
+
+      const { data: zoneRows } = await service
+        .from("cloud_rows")
+        .select("data")
+        .eq("household_id", householdId)
+        .eq("table_name", "zone_alerts")
+        .eq("deleted", false);
+      const zoneAlertsRaw = ((zoneRows ?? []) as CloudRow<ZoneAlert>[]).map(
+        (r) => r.data,
+      );
+
+      const followUps = deriveFollowUpTasks({
+        appointments: appointmentsRaw,
+        now,
+      }).map((t) => ({
+        title: t.title,
+        due_date: t.due_date,
+      }));
+
+      ctx = {
+        patient_name,
+        appointments: appointmentsRaw.map((a) => ({
+          kind: a.kind,
+          title: a.title,
+          starts_at: a.starts_at,
+          location: a.location ?? null,
+          status: a.status ?? null,
+        })),
+        zone_alerts: zoneAlertsRaw.map((z) => ({
+          zone: z.zone,
+          resolved: z.resolved,
+        })),
+        follow_ups: followUps,
+      };
+      householdCache.set(householdId, ctx);
+    }
+
+    const { data: profile } = await service
+      .from("profiles")
+      .select("locale")
+      .eq("id", userId)
+      .maybeSingle();
+    const locale = ((profile?.locale as string | undefined) ?? "en") as
+      | "en"
+      | "zh";
+
+    const payload = buildDigest({
+      patient_name: ctx.patient_name,
+      locale,
+      now,
+      appointments: ctx.appointments,
+      zone_alerts: ctx.zone_alerts,
+      follow_ups: ctx.follow_ups,
+    });
+    if (!payload) {
+      totalSkipped += 1;
+      continue;
+    }
+
+    try {
+      const result = await sendPushToUser(service, userId, payload);
+      totalSent += result.sent;
+    } catch {
+      totalSkipped += 1;
+    }
+  }
+
+  return NextResponse.json({
+    users: userIds.length,
+    sent: totalSent,
+    skipped: totalSkipped,
+  });
+}

--- a/src/lib/cron/digest.ts
+++ b/src/lib/cron/digest.ts
@@ -1,0 +1,139 @@
+import type { Zone } from "~/types/clinical";
+import { highestZone } from "~/lib/rules/engine";
+
+// Pure digest builder: given a household's context (appointments,
+// open zone alerts, follow-up tasks) + a user's locale, produces the
+// push-payload the morning cron fans out. Returns null when there's
+// nothing worth pinging about (no events, no follow-ups, zone green)
+// — the cron then skips this user entirely so we don't wake anyone
+// up for "everything's fine."
+//
+// The shape is narrow on purpose so the builder is easy to test
+// server-side without touching Dexie or Supabase.
+
+export interface DigestAppointment {
+  kind: string;
+  title: string;
+  starts_at: string;
+  location?: string | null;
+  status?: string | null;
+}
+
+export interface DigestZoneAlert {
+  zone: Zone;
+  resolved?: boolean;
+}
+
+export interface DigestFollowUp {
+  title: string;
+  due_date?: string;
+}
+
+export interface DigestPayload {
+  title: string;
+  body: string;
+  url: string;
+  tag: string;
+}
+
+export interface BuildDigestArgs {
+  patient_name: string;
+  locale: "en" | "zh";
+  now: Date;
+  appointments: readonly DigestAppointment[];
+  zone_alerts: readonly DigestZoneAlert[];
+  follow_ups?: readonly DigestFollowUp[];
+}
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function zoneLabel(z: Zone, locale: "en" | "zh"): string {
+  const labels: Record<Zone, { en: string; zh: string }> = {
+    green: { en: "Stable", zh: "稳定" },
+    yellow: { en: "Review needed", zh: "需复核" },
+    orange: { en: "Urgent review", zh: "紧急复核" },
+    red: { en: "Immediate action", zh: "立即处理" },
+  };
+  return labels[z][locale];
+}
+
+export function buildDigest(args: BuildDigestArgs): DigestPayload | null {
+  const today = startOfDay(args.now);
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const dayAfter = new Date(today);
+  dayAfter.setDate(dayAfter.getDate() + 2);
+
+  const upcoming = args.appointments
+    .filter((a) => {
+      if (a.status === "cancelled" || a.status === "rescheduled") return false;
+      const t = new Date(a.starts_at).getTime();
+      return (
+        Number.isFinite(t) && t >= today.getTime() && t < dayAfter.getTime()
+      );
+    })
+    .sort(
+      (a, b) =>
+        new Date(a.starts_at).getTime() - new Date(b.starts_at).getTime(),
+    );
+
+  const openAlerts = (args.zone_alerts ?? []).filter((z) => !z.resolved);
+  const zone = highestZone(openAlerts.map((a) => a.zone));
+
+  const followUps = (args.follow_ups ?? []).slice(0, 3);
+
+  // Nothing to say: no events today or tomorrow, zone green, no
+  // overdue follow-ups. Skip the user.
+  if (upcoming.length === 0 && zone === "green" && followUps.length === 0) {
+    return null;
+  }
+
+  const isAttentionZone = zone === "red" || zone === "orange";
+  const title = isAttentionZone
+    ? args.locale === "zh"
+      ? `${args.patient_name} · ${zoneLabel(zone, "zh")}`
+      : `${args.patient_name} · ${zoneLabel(zone, "en")}`
+    : args.locale === "zh"
+      ? `${args.patient_name} · 今日`
+      : `Today · ${args.patient_name}`;
+
+  const lines: string[] = [];
+
+  if (zone !== "green" && !isAttentionZone) {
+    // yellow — note it but don't alarm
+    lines.push(zoneLabel(zone, args.locale));
+  }
+
+  for (const a of upcoming.slice(0, 2)) {
+    const time = new Date(a.starts_at).toLocaleTimeString(
+      args.locale === "zh" ? "zh-CN" : "en-AU",
+      { hour: "numeric", minute: "2-digit" },
+    );
+    const location = a.location ? ` · ${a.location}` : "";
+    lines.push(`${time} — ${a.title}${location}`);
+  }
+
+  if (upcoming.length > 2) {
+    lines.push(
+      args.locale === "zh"
+        ? `…还有 ${upcoming.length - 2} 项`
+        : `…and ${upcoming.length - 2} more`,
+    );
+  }
+
+  for (const f of followUps) {
+    const prefix = args.locale === "zh" ? "待记录：" : "Follow up: ";
+    lines.push(`${prefix}${f.title}`);
+  }
+
+  return {
+    title,
+    body: lines.join("\n"),
+    url: isAttentionZone ? "/" : "/family",
+    tag: `digest-${today.toISOString().slice(0, 10)}`,
+  };
+}

--- a/tests/unit/digest.test.ts
+++ b/tests/unit/digest.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { buildDigest } from "~/lib/cron/digest";
+
+const NOW = new Date("2026-04-23T07:00:00+10:00"); // 07:00 AEST Thu 23 Apr
+
+const baseArgs = {
+  patient_name: "Hu Lin",
+  locale: "en" as const,
+  now: NOW,
+};
+
+describe("buildDigest", () => {
+  it("returns null when there's nothing worth saying", () => {
+    const out = buildDigest({
+      ...baseArgs,
+      appointments: [],
+      zone_alerts: [],
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null when zone is green and no appointments/follow-ups", () => {
+    const out = buildDigest({
+      ...baseArgs,
+      appointments: [],
+      zone_alerts: [{ zone: "green", resolved: false }],
+      follow_ups: [],
+    });
+    expect(out).toBeNull();
+  });
+
+  it("summarises today's appointments", () => {
+    const out = buildDigest({
+      ...baseArgs,
+      appointments: [
+        {
+          kind: "chemo",
+          title: "GnP cycle 3",
+          starts_at: "2026-04-23T00:30:00.000Z", // 10:30 AEST
+          location: "Epworth DOU",
+        },
+      ],
+      zone_alerts: [],
+    });
+    expect(out).not.toBeNull();
+    expect(out!.title).toContain("Hu Lin");
+    expect(out!.body).toMatch(/GnP cycle 3/);
+    expect(out!.body).toMatch(/Epworth DOU/);
+    expect(out!.url).toBe("/family");
+    expect(out!.tag).toMatch(/^digest-\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("caps the shown appointments at 2 and adds '…and N more'", () => {
+    const appointments = Array.from({ length: 4 }, (_, i) => ({
+      kind: "blood_test",
+      title: `Test ${i + 1}`,
+      starts_at: `2026-04-23T0${i + 1}:00:00.000Z`,
+    }));
+    const out = buildDigest({ ...baseArgs, appointments, zone_alerts: [] });
+    expect(out!.body).toMatch(/Test 1/);
+    expect(out!.body).toMatch(/Test 2/);
+    expect(out!.body).toMatch(/…and 2 more/);
+  });
+
+  it("surfaces orange/red zone as the headline and routes to /", () => {
+    const out = buildDigest({
+      ...baseArgs,
+      appointments: [],
+      zone_alerts: [{ zone: "red", resolved: false }],
+    });
+    expect(out).not.toBeNull();
+    expect(out!.title).toMatch(/Immediate action/);
+    expect(out!.url).toBe("/");
+  });
+
+  it("skips cancelled and rescheduled appointments", () => {
+    const out = buildDigest({
+      ...baseArgs,
+      appointments: [
+        {
+          kind: "clinic",
+          title: "Skipped",
+          starts_at: "2026-04-23T02:00:00.000Z",
+          status: "cancelled",
+        },
+        {
+          kind: "clinic",
+          title: "Kept",
+          starts_at: "2026-04-23T03:00:00.000Z",
+        },
+      ],
+      zone_alerts: [],
+    });
+    expect(out!.body).not.toMatch(/Skipped/);
+    expect(out!.body).toMatch(/Kept/);
+  });
+
+  it("includes up to three follow-up tasks in the body", () => {
+    const out = buildDigest({
+      ...baseArgs,
+      appointments: [],
+      zone_alerts: [],
+      follow_ups: [
+        { title: "Check scan results" },
+        { title: "Chase blood results" },
+        { title: "Log clinic notes" },
+        { title: "Should not appear" },
+      ],
+    });
+    expect(out).not.toBeNull();
+    expect(out!.body).toMatch(/Check scan results/);
+    expect(out!.body).toMatch(/Chase blood results/);
+    expect(out!.body).toMatch(/Log clinic notes/);
+    expect(out!.body).not.toMatch(/Should not appear/);
+  });
+
+  it("respects Simplified Chinese locale", () => {
+    const out = buildDigest({
+      ...baseArgs,
+      locale: "zh",
+      appointments: [
+        {
+          kind: "chemo",
+          title: "第三轮化疗",
+          starts_at: "2026-04-23T02:00:00.000Z",
+        },
+      ],
+      zone_alerts: [],
+    });
+    expect(out).not.toBeNull();
+    expect(out!.title).toMatch(/今日/);
+    expect(out!.body).toMatch(/第三轮化疗/);
+  });
+
+  it("only considers events today and tomorrow", () => {
+    const out = buildDigest({
+      ...baseArgs,
+      appointments: [
+        {
+          kind: "scan",
+          title: "Way in the future",
+          starts_at: "2026-05-15T02:00:00.000Z",
+        },
+      ],
+      zone_alerts: [],
+    });
+    expect(out).toBeNull();
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/morning-digest",
+      "schedule": "0 21 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Slice E of the accounts + sync + push plan. Fires a **daily morning digest** at 21:00 UTC (07:00 AEST) to every user with a push subscription. Each user gets a per-household digest: today's and tomorrow's appointments, any overdue follow-ups, and a zone-status headline when something needs attention. **Nothing to say = we skip the user** rather than waking them up.

## Wiring

- **`vercel.json`** — crons entry mapping `/api/cron/morning-digest` to the `0 21 * * *` schedule.
- **`src/lib/cron/digest.ts`** — pure `buildDigest()` builder. Returns `null` when there's no upcoming event, no overdue follow-up, and zone is green. Composes a bilingual title (patient name + zone-state when orange/red) + body (timestamped event lines + follow-up prompts), capped at 2 events + 3 follow-ups. Routes red/orange to `/`, everything else to `/family`.
- **`src/app/api/cron/morning-digest/route.ts`** — Vercel Cron handler. Auths via `x-vercel-cron: 1` header OR `Authorization: Bearer <CRON_SECRET>` (dev/staging). Iterates unique push-subscribed users, resolves each to a household, reads appointments + zone_alerts from `cloud_rows` via the service-role client, calls `deriveFollowUpTasks` for per-kind follow-up prompts, fans out via Slice D's `sendPushToUser`. Dead endpoints (404/410) self-delete; live endpoints get `last_pushed_at` stamped. Returns `{ users, sent, skipped }`.
- **`tests/unit/digest.test.ts`** — 9 unit tests covering the full matrix.

## Env required in Vercel

Before the cron delivers anything meaningful:

- `CRON_SECRET` (optional; enables the `Authorization: Bearer` dev/staging fallback)
- `SUPABASE_SERVICE_ROLE_KEY` (already set by Slice D)
- `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` (Slice D)

No new Supabase migration needed — reads existing `cloud_rows`, `push_subscriptions`, `household_memberships`, `households`, `profiles`.

## Gate

- `pnpm typecheck` clean
- `pnpm test` — **290/290** (+9 new in `digest.test.ts`)
- `pnpm build` clean

## Test plan

- [ ] Set env vars on preview. Run Slice D's migration if not already applied.
- [ ] `curl -H "Authorization: Bearer $CRON_SECRET" https://<preview>/api/cron/morning-digest` — expect `{ users, sent, skipped }`.
- [ ] On a subscribed device, confirm a notification arrives with the correct title, body, and `/family` tap-through.
- [ ] Cancel all upcoming appointments + resolve zone alerts → run curl again → user skipped (`skipped: 1, sent: 0`).
- [ ] Red-zone test: create an unresolved red zone_alerts row → curl → notification title becomes `"<patient> · Immediate action"` and tap goes to `/`.

## Not in this PR (tracked)

- **Per-user quiet hours + per-kind preferences.** For v1 every subscribed user gets the same cron output at 21:00 UTC.
- **Multi-timezone fan-out.** Melbourne fires perfectly at 07:00 AEST; Thomas in NYC gets it as a late-afternoon ping. Worth a per-profile-locale send loop later.
- **Appointment-day-before reminders.** Separate cron; will layer on once the morning digest is stable.

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8

---
_Generated by [Claude Code](https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8)_