### PR TITLE
Slice H: universal ingest with preview-diff (Ananda letter acceptance)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.0",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^24.0.0",
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       eslint-config-next:
         specifier: ^14.2.0
         version: 14.2.35(eslint@8.57.1)(typescript@5.9.3)
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3
@@ -1890,6 +1893,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5426,6 +5433,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/src/app/api/ai/ingest-universal/route.ts
+++ b/src/app/api/ai/ingest-universal/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import {
+  INGEST_SYSTEM,
+  ingestDraftSchema,
+} from "~/lib/ingest/draft-schema";
+import type { PreparedImage } from "~/lib/ingest/image";
+import type { IngestDraft, IngestSourceKind } from "~/types/ingest";
+
+export const runtime = "nodejs";
+
+interface RequestBody {
+  text?: string;
+  image?: PreparedImage;
+  source: IngestSourceKind;
+  today?: string;
+  locale?: "en" | "zh";
+  model?: string;
+}
+
+export async function POST(req: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not configured on the server." },
+      { status: 503 },
+    );
+  }
+
+  let body: RequestBody;
+  try {
+    body = (await req.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!body?.text && !body?.image) {
+    return NextResponse.json(
+      { error: "text or image required" },
+      { status: 400 },
+    );
+  }
+  if (!body.source) {
+    return NextResponse.json({ error: "source required" }, { status: 400 });
+  }
+
+  const today = body.today ?? new Date().toISOString().slice(0, 10);
+  const locale = body.locale ?? "en";
+
+  const content: Array<
+    | { type: "text"; text: string }
+    | {
+        type: "image";
+        source: {
+          type: "base64";
+          media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+          data: string;
+        };
+      }
+  > = [];
+  if (body.image) {
+    content.push({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: body.image.mediaType,
+        data: body.image.base64,
+      },
+    });
+  }
+  const prefix = `Today is ${today}. Respond with the structured plan. The patient's locale is ${locale}.`;
+  if (body.text && body.text.trim().length > 0) {
+    content.push({
+      type: "text",
+      text: body.image
+        ? `${prefix}\n\nThe OCR layer also produced the following text — use it to cross-check the image:\n\n---\n${body.text}\n---`
+        : `${prefix}\n\nDocument text:\n\n---\n${body.text}\n---`,
+    });
+  } else if (body.image) {
+    content.push({
+      type: "text",
+      text: `${prefix}\n\nRead this medical document and emit the operations.`,
+    });
+  }
+
+  const client = new Anthropic({ apiKey });
+  try {
+    const response = await client.messages.parse({
+      model: body.model ?? "claude-opus-4-7",
+      max_tokens: 4096,
+      system: [
+        {
+          type: "text",
+          text: INGEST_SYSTEM,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      output_config: { format: zodOutputFormat(ingestDraftSchema) },
+      messages: [{ role: "user", content }],
+    });
+    if (!response.parsed_output) {
+      return NextResponse.json(
+        { error: "No draft returned" },
+        { status: 502 },
+      );
+    }
+    const draft: IngestDraft = {
+      source: body.source,
+      ...response.parsed_output,
+    };
+    return NextResponse.json({ draft });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -10,6 +10,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { CameraCapture } from "~/components/ingest/camera-capture";
 import { BulkQueue } from "~/components/ingest/bulk-queue";
+import { UniversalDrop } from "~/components/ingest/universal-drop";
+import { PreviewDiff } from "~/components/ingest/preview-diff";
+import type { IngestApplyResult, IngestDraft } from "~/types/ingest";
 import {
   parseBulkItem,
   processBulkItem,
@@ -24,6 +27,9 @@ function newId(): string {
 
 export default function IngestPage() {
   const locale = useLocale();
+
+  const [draft, setDraft] = useState<IngestDraft | null>(null);
+  const [appliedResults, setAppliedResults] = useState<IngestApplyResult[] | null>(null);
 
   const [items, setItems] = useState<BulkItem[]>([]);
   const itemsRef = useRef<BulkItem[]>([]);
@@ -116,6 +122,23 @@ export default function IngestPage() {
           </Link>
         }
       />
+
+      {!draft && !appliedResults && (
+        <UniversalDrop onDraft={setDraft} />
+      )}
+
+      {draft && (
+        <PreviewDiff
+          draft={draft}
+          onApplied={(rs) => {
+            setAppliedResults(rs);
+          }}
+          onDiscard={() => {
+            setDraft(null);
+            setAppliedResults(null);
+          }}
+        />
+      )}
 
       <Card>
         <CardContent className="space-y-4 pt-5">

--- a/src/components/ingest/preview-diff.tsx
+++ b/src/components/ingest/preview-diff.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { applyIngestOps } from "~/lib/ingest/operations";
+import type {
+  IngestApplyResult,
+  IngestDraft,
+  IngestOp,
+  IngestOpKind,
+} from "~/types/ingest";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import {
+  CalendarPlus,
+  CalendarClock,
+  TestTube2,
+  Pill,
+  Users,
+  ListChecks,
+  BookOpenText,
+  Check,
+  X,
+  Sparkles,
+  AlertTriangle,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+const OP_ICON: Record<IngestOpKind, React.ComponentType<{ className?: string }>> = {
+  add_appointment: CalendarPlus,
+  update_appointment: CalendarClock,
+  add_lab_result: TestTube2,
+  add_medication: Pill,
+  add_care_team_member: Users,
+  add_task: ListChecks,
+  add_life_event: BookOpenText,
+};
+
+const OP_LABEL: Record<IngestOpKind, { en: string; zh: string }> = {
+  add_appointment: { en: "New appointment", zh: "新增预约" },
+  update_appointment: { en: "Update appointment", zh: "更新预约" },
+  add_lab_result: { en: "New lab result", zh: "新增化验结果" },
+  add_medication: { en: "New medication", zh: "新增用药" },
+  add_care_team_member: { en: "New care-team contact", zh: "新增团队联系人" },
+  add_task: { en: "New task", zh: "新增任务" },
+  add_life_event: { en: "Note this event", zh: "记录事件" },
+};
+
+interface Props {
+  draft: IngestDraft;
+  onApplied: (results: IngestApplyResult[]) => void;
+  onDiscard: () => void;
+}
+
+export function PreviewDiff({ draft, onApplied, onDiscard }: Props) {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  // Per-op include toggle. Defaults: every op selected, except low-
+  // confidence drafts where we let the user opt in deliberately.
+  const initialSelected = useMemo(() => {
+    const set = new Set<number>();
+    if (draft.confidence !== "low") {
+      draft.ops.forEach((_, i) => set.add(i));
+    }
+    return set;
+  }, [draft]);
+  const [selected, setSelected] = useState<Set<number>>(initialSelected);
+  const [applying, setApplying] = useState(false);
+  const [results, setResults] = useState<IngestApplyResult[] | null>(null);
+
+  function toggle(i: number) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  }
+
+  async function applySelected() {
+    const ops = draft.ops.filter((_, i) => selected.has(i));
+    if (ops.length === 0) return;
+    setApplying(true);
+    try {
+      const r = await applyIngestOps(ops);
+      setResults(r);
+      onApplied(r);
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  const okCount = results?.filter((r) => r.ok).length ?? 0;
+  const failCount = (results?.length ?? 0) - okCount;
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 pt-5">
+        <div className="flex items-start gap-2">
+          <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-[var(--tide-2)]" />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[13.5px] font-semibold text-ink-900">
+                {L(
+                  "Proposed changes",
+                  "建议的变更",
+                )}
+              </span>
+              <span
+                className={cn(
+                  "rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em]",
+                  draft.confidence === "high"
+                    ? "bg-[var(--ok-soft)] text-[var(--ok)]"
+                    : draft.confidence === "medium"
+                      ? "bg-ink-100 text-ink-700"
+                      : "bg-[var(--warn-soft)] text-[var(--warn)]",
+                )}
+              >
+                {draft.confidence}
+              </span>
+            </div>
+            <p className="mt-0.5 text-[12px] text-ink-500">{draft.summary}</p>
+          </div>
+        </div>
+
+        {draft.ambiguities.length > 0 && (
+          <div className="rounded-md border border-[var(--sand-2)]/40 bg-[var(--sand)]/40 p-2.5 text-[11.5px] text-ink-700">
+            <div className="mb-1 flex items-center gap-1.5 font-semibold">
+              <AlertTriangle className="h-3 w-3" />
+              {L("Things I guessed", "我做了这些假设")}
+            </div>
+            <ul className="list-disc space-y-0.5 pl-4">
+              {draft.ambiguities.map((a, i) => (
+                <li key={i}>{a}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <ul className="space-y-2">
+          {draft.ops.map((op, i) => (
+            <li key={i}>
+              <OpCard
+                op={op}
+                index={i}
+                selected={selected.has(i)}
+                result={results?.[results.findIndex((r) => r.op === op)] ?? null}
+                onToggle={() => toggle(i)}
+                locale={locale}
+              />
+            </li>
+          ))}
+        </ul>
+
+        {results ? (
+          <div className="flex items-center justify-between rounded-md border border-ink-200 bg-paper-2 p-3 text-[13px]">
+            <div>
+              <span className="font-semibold text-[var(--ok)]">
+                {okCount} {L("applied", "已应用")}
+              </span>
+              {failCount > 0 && (
+                <span className="ml-2 text-[var(--warn)]">
+                  {failCount} {L("failed", "失败")}
+                </span>
+              )}
+            </div>
+            <Button onClick={onDiscard} variant="ghost">
+              {L("Done", "完成")}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between gap-2">
+            <Button variant="ghost" onClick={onDiscard}>
+              <X className="h-4 w-4" />
+              {L("Discard", "放弃")}
+            </Button>
+            <Button
+              onClick={applySelected}
+              disabled={applying || selected.size === 0}
+              size="lg"
+            >
+              <Check className="h-4 w-4" />
+              {applying
+                ? L("Applying…", "应用中…")
+                : L(
+                    `Apply ${selected.size} change${selected.size === 1 ? "" : "s"}`,
+                    `应用 ${selected.size} 项变更`,
+                  )}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function OpCard({
+  op,
+  index,
+  selected,
+  result,
+  onToggle,
+  locale,
+}: {
+  op: IngestOp;
+  index: number;
+  selected: boolean;
+  result: IngestApplyResult | null;
+  onToggle: () => void;
+  locale: "en" | "zh";
+}) {
+  const Icon = OP_ICON[op.kind];
+  const label = OP_LABEL[op.kind][locale];
+  const lines = describeOp(op, locale);
+  const reason = "reason" in op && op.reason ? op.reason : null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-[var(--r-md)] border p-3",
+        result?.ok
+          ? "border-[var(--ok)]/40 bg-[var(--ok-soft)]/40"
+          : result && !result.ok
+            ? "border-[var(--warn)]/40 bg-[var(--warn-soft)]/40"
+            : selected
+              ? "border-ink-900 bg-ink-900/[0.03]"
+              : "border-ink-100 bg-paper-2",
+      )}
+    >
+      <label className="flex cursor-pointer items-start gap-3">
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={onToggle}
+          disabled={Boolean(result)}
+          className="mt-1 h-4 w-4 shrink-0 accent-ink-900"
+        />
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-paper-2 text-[var(--tide-2)]">
+          <Icon className="h-3.5 w-3.5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="text-[12.5px] font-semibold text-ink-900">
+              {label}
+            </span>
+            <span className="mono text-[10px] text-ink-400">#{index + 1}</span>
+          </div>
+          {reason && (
+            <p className="mt-0.5 text-[11.5px] italic text-ink-500">
+              {reason}
+            </p>
+          )}
+          {lines.length > 0 && (
+            <dl className="mt-1.5 space-y-0.5 text-[12px]">
+              {lines.map(([k, v]) => (
+                <div key={k} className="flex gap-1.5">
+                  <dt className="mono text-[10.5px] uppercase tracking-[0.08em] text-ink-400">
+                    {k}
+                  </dt>
+                  <dd className="text-ink-800">{v}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+          {result && !result.ok && (
+            <p className="mt-1.5 text-[11px] text-[var(--warn)]">
+              {result.error}
+            </p>
+          )}
+          {result?.ok && (
+            <p className="mt-1.5 text-[11px] text-[var(--ok)]">
+              {locale === "zh" ? `已保存 #${result.id}` : `Saved as #${result.id}`}
+            </p>
+          )}
+        </div>
+      </label>
+    </div>
+  );
+}
+
+function describeOp(op: IngestOp, locale: "en" | "zh"): Array<[string, string]> {
+  const data = "data" in op ? op.data : "changes" in op ? op.changes : {};
+  const out: Array<[string, string]> = [];
+  function push(key: string, value: unknown) {
+    if (value === null || value === undefined || value === "") return;
+    if (Array.isArray(value)) value = value.join(", ");
+    out.push([key, String(value)]);
+  }
+
+  // Order is curated for readability per op kind; everything else
+  // gets dumped at the end so the user can audit.
+  const showFirst: Record<string, string[]> = {
+    add_appointment: ["title", "kind", "starts_at", "location", "doctor", "phone", "notes"],
+    update_appointment: ["title", "starts_at", "location", "doctor", "status", "notes"],
+    add_lab_result: ["date", "ca199", "albumin", "hemoglobin", "neutrophils", "platelets", "creatinine"],
+    add_medication: ["drug_id", "category", "dose", "schedule", "started_on", "notes"],
+    add_care_team_member: ["name", "role", "specialty", "organisation", "phone", "email"],
+    add_task: ["title", "due_date", "priority", "category", "notes"],
+    add_life_event: ["title", "event_date", "category", "notes"],
+  };
+  const order = showFirst[op.kind] ?? [];
+  for (const k of order) push(k, (data as Record<string, unknown>)[k]);
+  for (const [k, v] of Object.entries(data)) {
+    if (order.includes(k)) continue;
+    push(k, v);
+  }
+
+  // Match info for updates
+  if (op.kind === "update_appointment" && op.match) {
+    if (typeof op.match.id === "number") push("matches id", op.match.id);
+    if (op.match.title_contains)
+      push(locale === "zh" ? "匹配标题" : "matches title", op.match.title_contains);
+    if (op.match.on_date)
+      push(locale === "zh" ? "于日期" : "on date", op.match.on_date);
+  }
+  return out;
+}

--- a/src/components/ingest/universal-drop.tsx
+++ b/src/components/ingest/universal-drop.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import { prepareImageForVision } from "~/lib/ingest/image";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, Textarea } from "~/components/ui/field";
+import { ImagePlus, Loader2, Sparkles, AlertCircle } from "lucide-react";
+import type { IngestDraft, IngestSourceKind } from "~/types/ingest";
+
+// Universal entry point. Patient pastes an email body, types a quick
+// note, or snaps a photo (or picks a PDF — converted to image first).
+// The route returns an IngestDraft which the parent renders as a
+// preview-diff. Nothing writes to Dexie from here.
+
+export function UniversalDrop({
+  onDraft,
+}: {
+  onDraft: (draft: IngestDraft) => void;
+}) {
+  const locale = useLocale();
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  async function parseText() {
+    if (!text.trim()) return;
+    await callRoute({ text, source: "paste" });
+  }
+
+  async function onPhoto(file: File) {
+    setError(null);
+    setBusy(true);
+    try {
+      const prepared = await prepareImageForVision(file, { maxEdge: 1800 });
+      await callRoute({
+        image: prepared,
+        source: file.type === "application/pdf" ? "pdf" : "photo",
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setBusy(false);
+    }
+  }
+
+  async function callRoute(args: {
+    text?: string;
+    image?: Awaited<ReturnType<typeof prepareImageForVision>>;
+    source: IngestSourceKind;
+  }) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/ai/ingest-universal", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          text: args.text,
+          image: args.image,
+          source: args.source,
+          today: new Date().toISOString().slice(0, 10),
+          locale,
+        }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const data = (await res.json()) as { draft: IngestDraft };
+      onDraft(data.draft);
+      setText("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 pt-5">
+        <div className="flex items-center gap-1.5 text-[12.5px] font-semibold text-ink-900">
+          <Sparkles className="h-3.5 w-3.5 text-[var(--tide-2)]" />
+          {L("Drop in anything medical", "导入任何医疗资料")}
+        </div>
+        <p className="text-[12px] text-ink-500">
+          {L(
+            "Paste an email or text, or take a photo of a clinic letter, lab report, prescription, or pre-appointment instructions. We'll show you exactly what would change before anything saves.",
+            "粘贴邮件或文字，或拍一张就诊函、化验单、处方、注意事项的照片。会先把所有变更摆出来给你看，确认后再保存。",
+          )}
+        </p>
+
+        <Field label={L("Text or pasted email", "文字或粘贴邮件")}>
+          <Textarea
+            rows={6}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={L(
+              "Paste the body of a clinic letter, an email, or just type what's on the page.",
+              "粘贴就诊函、邮件，或直接输入文字。",
+            )}
+            disabled={busy}
+          />
+        </Field>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button onClick={parseText} disabled={busy || !text.trim()}>
+            {busy ? L("Reading…", "正在识别…") : L("Read this", "解析")}
+          </Button>
+          <label
+            className={
+              "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-ink-200 px-3 py-2 text-[13px] text-ink-700 hover:bg-ink-100/40 " +
+              (busy ? "pointer-events-none opacity-50" : "")
+            }
+          >
+            <ImagePlus className="h-3.5 w-3.5" />
+            {L("Photo / PDF", "照片 / PDF")}
+            <input
+              type="file"
+              accept="image/*,application/pdf"
+              capture="environment"
+              className="hidden"
+              disabled={busy}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) void onPhoto(f);
+              }}
+            />
+          </label>
+          {busy && (
+            <span className="inline-flex items-center gap-1.5 text-[12px] text-ink-500">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              {L("Reading…", "正在识别…")}
+            </span>
+          )}
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-2.5 text-[12.5px] text-[var(--warn)]"
+          >
+            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/ingest/draft-schema.ts
+++ b/src/lib/ingest/draft-schema.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+// Zod schema mirroring `IngestDraft` from src/types/ingest.ts. Used by
+// the /api/ai/ingest-universal route to parse Claude's structured
+// output. Kept in its own file so the (server-only) Anthropic SDK
+// imports don't leak into the client bundle when the type is read.
+
+export const ingestOpSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("add_appointment"),
+    data: z.record(z.unknown()),
+    reason: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("update_appointment"),
+    match: z.object({
+      id: z.number().int().optional(),
+      title_contains: z.string().optional(),
+      on_date: z.string().optional(),
+    }),
+    changes: z.record(z.unknown()),
+    reason: z.string(),
+  }),
+  z.object({
+    kind: z.literal("add_lab_result"),
+    data: z.record(z.unknown()),
+    reason: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("add_medication"),
+    data: z.record(z.unknown()),
+    reason: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("add_care_team_member"),
+    data: z.record(z.unknown()),
+    reason: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("add_task"),
+    data: z.record(z.unknown()),
+    reason: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("add_life_event"),
+    data: z.record(z.unknown()),
+    reason: z.string().optional(),
+  }),
+]);
+
+export const ingestDraftSchema = z.object({
+  detected_kind: z.enum([
+    "clinic_letter",
+    "appointment_email",
+    "appointment_letter",
+    "lab_report",
+    "imaging_report",
+    "prescription",
+    "discharge_summary",
+    "pre_appointment_instructions",
+    "handwritten_note",
+    "other",
+  ]),
+  summary: z.string(),
+  ops: z.array(ingestOpSchema),
+  ambiguities: z.array(z.string()).default([]),
+  confidence: z.enum(["low", "medium", "high"]),
+});
+
+export const INGEST_SYSTEM = `You are Anchor's universal medical-document parser. You receive a single document — a clinic letter, appointment email, lab report, prescription, discharge summary, pre-appointment instructions, handwritten note — as either text or an image. Read it once and return a structured plan of operations the patient should review and apply.
+
+Patient context (do not contradict): Hu Lin, metastatic pancreatic adenocarcinoma, on first-line gemcitabine + nab-paclitaxel (GnP), bridging to daraxonrasib via the RASolute trial program.
+
+Output discipline:
+1. **Classify** the document with \`detected_kind\`.
+2. **Summarise** in one plain-language sentence (\`summary\`).
+3. **Emit operations** (\`ops\`) — usually 1–25. Each op is one Dexie row write the document implies. Possible kinds:
+   - \`add_appointment\` — for any specific date+time event mentioned. Populate { kind, title, starts_at (ISO 8601, with the document's local date if no timezone), ends_at?, location?, doctor?, phone?, status='scheduled', notes? }. Use kind ∈ { clinic, chemo, scan, blood_test, procedure, other }. **A single calendar row that references multiple distinct visits (e.g. "Dr Lee 10am, infusion 11am") emits TWO ops — never collapse them.**
+   - \`update_appointment\` — only when the document explicitly says "rescheduled from X to Y" or "your previous appointment is now". Provide \`match\` (title_contains + on_date narrows) and \`reason\`.
+   - \`add_lab_result\` — for lab reports. Populate the field per analyte the document reports.
+   - \`add_medication\` — for prescriptions or "start taking X mg".
+   - \`add_care_team_member\` — for any clinician explicitly named on a clinic letterhead with contact details. Use { name, role ∈ {oncologist, surgeon, gp, nurse, allied_health, other}, specialty?, organisation?, phone?, email? }. Skip generic admin staff.
+   - \`add_task\` — for explicit instructions like "fast 6 hours before", "bring referral", "complete pre-op blood test by …". Phrase the task in imperative form.
+   - \`add_life_event\` — for narrative sentences worth preserving (diagnosis confirmed, decision made), not normal events.
+4. **Ambiguities** — list every value you guessed. Examples: "year not stated, assumed 2026", "DOU = Day Oncology Unit, Epworth — guessed location", "kind 'chemo' inferred because GnP context".
+5. **Confidence** — \`high\` only when every op's mandatory fields came directly off the page; \`low\` when the document was photographed at an angle or partially legible.
+
+Rules of thumb:
+- Australian date convention (DD/MM/YYYY). When a year is missing assume the nearest plausible future year.
+- Times default to local Melbourne (Australia/Melbourne, UTC+10/+11). Emit ISO with offset \`+10:00\` unless the document specifies otherwise.
+- Never invent specifics. If something is unclear, leave the field absent and add an ambiguity entry.
+- Each op's \`reason\` is the short sentence the UI will show alongside the proposed change. Be terse: "Letter dated 23 Apr lists Dr Ananda consult on 29 Apr."
+- Never propose deletions. Anchor's preview UI is approve-only this slice.`;
+
+export type IngestDraftParsed = z.infer<typeof ingestDraftSchema>;

--- a/src/lib/ingest/operations.ts
+++ b/src/lib/ingest/operations.ts
@@ -1,0 +1,145 @@
+import { db, now } from "~/lib/db/dexie";
+import { addCareTeamMember } from "~/lib/care-team/registry";
+import type {
+  IngestApplyResult,
+  IngestOp,
+} from "~/types/ingest";
+import type { Appointment } from "~/types/appointment";
+import type { LabResult, LifeEvent } from "~/types/clinical";
+import type { Medication } from "~/types/medication";
+import type { PatientTask } from "~/types/task";
+
+// Dispatcher that turns a typed IngestOp into the right Dexie write.
+// Kept as a single exhaustive switch so adding a new op kind requires
+// updating exactly one place. Returns the new row id (or null) so the
+// UI can render "Open <new appointment>" links after apply.
+//
+// Updates use a soft-match strategy: prefer an exact local id, fall
+// back to title_contains + on_date narrow. If the match resolves to
+// nothing (or to multiple rows) we no-op and surface that as an
+// `apply` failure rather than silently picking a wrong row.
+
+export async function applyIngestOp(
+  op: IngestOp,
+): Promise<IngestApplyResult> {
+  const ts = now();
+  try {
+    switch (op.kind) {
+      case "add_appointment": {
+        const id = (await db.appointments.add({
+          ...(op.data as Appointment),
+          status: op.data.status ?? "scheduled",
+          created_at: ts,
+          updated_at: ts,
+        })) as number;
+        return { op, ok: true, id };
+      }
+      case "update_appointment": {
+        const target = await resolveAppointment(op.match);
+        if (!target?.id) {
+          return {
+            op,
+            ok: false,
+            error: target === null ? "no_match" : "ambiguous_match",
+          };
+        }
+        await db.appointments.update(target.id, {
+          ...op.changes,
+          updated_at: ts,
+        });
+        return { op, ok: true, id: target.id };
+      }
+      case "add_lab_result": {
+        const id = (await db.labs.add({
+          ...(op.data as LabResult),
+          source: op.data.source ?? "external",
+          created_at: ts,
+          updated_at: ts,
+        })) as number;
+        return { op, ok: true, id };
+      }
+      case "add_medication": {
+        const id = (await db.medications.add({
+          ...(op.data as Medication),
+          created_at: ts,
+          updated_at: ts,
+        })) as number;
+        return { op, ok: true, id };
+      }
+      case "add_care_team_member": {
+        const data = op.data;
+        const id = await addCareTeamMember({
+          name: data.name ?? "",
+          role: data.role ?? "other",
+          specialty: data.specialty,
+          organisation: data.organisation,
+          phone: data.phone,
+          email: data.email,
+          notes: data.notes,
+          is_lead: data.is_lead ?? false,
+        });
+        return { op, ok: true, id };
+      }
+      case "add_task": {
+        const id = (await db.patient_tasks.add({
+          ...(op.data as PatientTask),
+          created_at: ts,
+          updated_at: ts,
+        })) as number;
+        return { op, ok: true, id };
+      }
+      case "add_life_event": {
+        const id = (await db.life_events.add({
+          ...(op.data as LifeEvent),
+          created_at: ts,
+          updated_at: ts,
+        })) as number;
+        return { op, ok: true, id };
+      }
+    }
+  } catch (err) {
+    return {
+      op,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function resolveAppointment(match: {
+  id?: number;
+  title_contains?: string;
+  on_date?: string;
+}): Promise<Appointment | null | undefined> {
+  if (typeof match.id === "number") {
+    return (await db.appointments.get(match.id)) ?? null;
+  }
+  const all = await db.appointments.toArray();
+  const candidates = all.filter((a) => {
+    const titleOk = match.title_contains
+      ? a.title.toLowerCase().includes(match.title_contains.toLowerCase())
+      : true;
+    const dateOk = match.on_date
+      ? a.starts_at.startsWith(match.on_date)
+      : true;
+    return titleOk && dateOk;
+  });
+  if (candidates.length === 0) return null;
+  if (candidates.length > 1) return undefined; // ambiguous
+  return candidates[0];
+}
+
+// Apply a list of ops in order. Stops on the first failure when
+// `stopOnError` is true; otherwise records each result and continues.
+export async function applyIngestOps(
+  ops: readonly IngestOp[],
+  options: { stopOnError?: boolean } = {},
+): Promise<IngestApplyResult[]> {
+  const out: IngestApplyResult[] = [];
+  for (const op of ops) {
+    const r = await applyIngestOp(op);
+    out.push(r);
+    if (options.stopOnError && !r.ok) break;
+  }
+  return out;
+}

--- a/src/types/ingest.ts
+++ b/src/types/ingest.ts
@@ -1,0 +1,71 @@
+import type { Appointment } from "./appointment";
+import type { LabResult, LifeEvent } from "./clinical";
+import type { Medication } from "./medication";
+import type { PatientTask } from "./task";
+import type { CareTeamMember } from "./care-team";
+
+// Universal-ingest payload shape. The /api/ai/ingest-universal route
+// classifies a single input (text / image / pasted email) and returns
+// an `IngestDraft`: a list of typed operations that, if applied,
+// produce the rows the document implies. The client renders each op
+// as a diff card before anything writes to Dexie.
+//
+// Why typed ops? A clinic letter often implies multiple changes (a
+// new appointment + a new clinician contact + a follow-up task). One
+// document → many ops. Each op is independently approvable so the
+// patient can accept "schedule this scan" and reject "raise the
+// chemo dose" if they want.
+
+export type IngestSourceKind = "photo" | "paste" | "pdf" | "email";
+
+export type IngestDocumentKind =
+  | "clinic_letter"
+  | "appointment_email"
+  | "appointment_letter"
+  | "lab_report"
+  | "imaging_report"
+  | "prescription"
+  | "discharge_summary"
+  | "pre_appointment_instructions"
+  | "handwritten_note"
+  | "other";
+
+export type IngestOp =
+  | { kind: "add_appointment"; data: Partial<Appointment>; reason?: string }
+  | {
+      kind: "update_appointment";
+      // Match by either exact local id (when the model is reading our
+      // own data) or by a soft hint the client resolves before apply.
+      match: { id?: number; title_contains?: string; on_date?: string };
+      changes: Partial<Appointment>;
+      reason: string;
+    }
+  | { kind: "add_lab_result"; data: Partial<LabResult>; reason?: string }
+  | { kind: "add_medication"; data: Partial<Medication>; reason?: string }
+  | {
+      kind: "add_care_team_member";
+      data: Partial<CareTeamMember>;
+      reason?: string;
+    }
+  | { kind: "add_task"; data: Partial<PatientTask>; reason?: string }
+  | { kind: "add_life_event"; data: Partial<LifeEvent>; reason?: string };
+
+export type IngestOpKind = IngestOp["kind"];
+
+export interface IngestDraft {
+  source: IngestSourceKind;
+  detected_kind: IngestDocumentKind;
+  summary: string; // one-sentence plain-language summary
+  ops: IngestOp[];
+  ambiguities: string[];
+  confidence: "low" | "medium" | "high";
+}
+
+// Result of applying one op locally — surfaces the resulting Dexie
+// row id so the UI can offer "open this appointment" deep links.
+export interface IngestApplyResult {
+  op: IngestOp;
+  ok: boolean;
+  id?: number | string;
+  error?: string;
+}

--- a/tests/unit/ingest-operations.test.ts
+++ b/tests/unit/ingest-operations.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { db } from "~/lib/db/dexie";
+import { applyIngestOps } from "~/lib/ingest/operations";
+import type { IngestOp } from "~/types/ingest";
+
+beforeEach(async () => {
+  // Reset Dexie between tests so applied rows don't leak.
+  await db.delete();
+  await db.open();
+});
+
+describe("applyIngestOps", () => {
+  it("adds appointments and returns their ids", async () => {
+    const ops: IngestOp[] = [
+      {
+        kind: "add_appointment",
+        data: {
+          kind: "clinic",
+          title: "Dr Ananda consult",
+          starts_at: "2026-04-29T09:20:00+10:00",
+        },
+      },
+      {
+        kind: "add_appointment",
+        data: {
+          kind: "chemo",
+          title: "DOU infusion",
+          starts_at: "2026-04-29T10:00:00+10:00",
+          location: "Epworth, Level 2",
+        },
+      },
+    ];
+    const results = await applyIngestOps(ops);
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.ok)).toBe(true);
+    expect(typeof results[0]!.id).toBe("number");
+
+    const all = await db.appointments.toArray();
+    expect(all).toHaveLength(2);
+    const titles = all.map((a) => a.title).sort();
+    expect(titles).toEqual(["DOU infusion", "Dr Ananda consult"]);
+  });
+
+  it("updates an existing appointment matched by title + date", async () => {
+    await db.appointments.add({
+      kind: "clinic",
+      title: "Dr Ananda consult",
+      starts_at: "2026-04-29T09:20:00+10:00",
+      status: "scheduled",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    const op: IngestOp = {
+      kind: "update_appointment",
+      match: { title_contains: "ananda", on_date: "2026-04-29" },
+      changes: { status: "rescheduled", notes: "Rescheduled to 30 Apr" },
+      reason: "Letter dated later supersedes original time",
+    };
+    const [r] = await applyIngestOps([op]);
+    expect(r!.ok).toBe(true);
+
+    const updated = (await db.appointments.toArray())[0];
+    expect(updated!.status).toBe("rescheduled");
+    expect(updated!.notes).toMatch(/Rescheduled/);
+  });
+
+  it("returns no_match when an update can't find a target", async () => {
+    const [r] = await applyIngestOps([
+      {
+        kind: "update_appointment",
+        match: { title_contains: "nonexistent" },
+        changes: { status: "cancelled" },
+        reason: "test",
+      } as IngestOp,
+    ]);
+    expect(r!.ok).toBe(false);
+    expect(r!.error).toBe("no_match");
+  });
+
+  it("returns ambiguous_match when an update matches multiple rows", async () => {
+    const ts = new Date().toISOString();
+    for (let i = 0; i < 2; i += 1) {
+      await db.appointments.add({
+        kind: "clinic",
+        title: `Dr Ananda consult ${i}`,
+        starts_at: "2026-04-29T09:20:00+10:00",
+        status: "scheduled",
+        created_at: ts,
+        updated_at: ts,
+      });
+    }
+    const [r] = await applyIngestOps([
+      {
+        kind: "update_appointment",
+        match: { title_contains: "ananda", on_date: "2026-04-29" },
+        changes: { status: "cancelled" },
+        reason: "test",
+      } as IngestOp,
+    ]);
+    expect(r!.ok).toBe(false);
+    expect(r!.error).toBe("ambiguous_match");
+  });
+
+  it("adds a care-team member and enforces role default", async () => {
+    const [r] = await applyIngestOps([
+      {
+        kind: "add_care_team_member",
+        data: {
+          name: "A/Prof Sumitra Ananda",
+          role: "oncologist",
+          phone: "03 9417 1344",
+          organisation: "Epworth",
+        },
+      },
+    ]);
+    expect(r!.ok).toBe(true);
+
+    const team = await db.care_team.toArray();
+    expect(team).toHaveLength(1);
+    expect(team[0]!.name).toBe("A/Prof Sumitra Ananda");
+    expect(team[0]!.role).toBe("oncologist");
+  });
+
+  it("stops on first error when stopOnError is set", async () => {
+    const ops: IngestOp[] = [
+      {
+        kind: "update_appointment",
+        match: { title_contains: "ghost" },
+        changes: {},
+        reason: "test",
+      },
+      {
+        kind: "add_appointment",
+        data: {
+          kind: "blood_test",
+          title: "FBE",
+          starts_at: "2026-04-30T08:00:00+10:00",
+        },
+      },
+    ];
+    const results = await applyIngestOps(ops, { stopOnError: true });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.ok).toBe(false);
+    const all = await db.appointments.toArray();
+    expect(all).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Slice H of the accounts + sync + push plan — **the universal ingest workflow**. One drop zone for any medical document; Claude classifies + extracts; the patient gets a diff card per proposed change before anything writes to Dexie. Each op is independently approvable so a clinic letter that implies "new appointment + new clinician contact + new task" can land all three or just the ones the patient agrees with.

**Acceptance test (the case you sent):** A/Prof Sumitra Ananda's 12-row chemo schedule PDF (23 Apr 2026) → roughly 18 `add_appointment` ops (each row = clinic visit + DOU infusion) + one `add_care_team_member` op (Ananda contact details from letterhead).

## Pieces

### Types + ops

- **`src/types/ingest.ts`** — `IngestDraft` and `IngestOp` discriminated union over: `add_appointment`, `update_appointment`, `add_lab_result`, `add_medication`, `add_care_team_member`, `add_task`, `add_life_event`.
- **`src/lib/ingest/operations.ts`** — `applyIngestOp` dispatcher (one exhaustive switch). `update_appointment` uses soft matching (`id` exact OR `title_contains` + `on_date` narrows), returning `no_match` / `ambiguous_match` instead of guessing. `applyIngestOps` is the batch helper with optional `stopOnError`.
- **`src/lib/ingest/draft-schema.ts`** — Zod schema mirroring `IngestDraft` + the `INGEST_SYSTEM` prompt. Includes PDAC/GnP context, Australian DD/MM/YYYY date convention, default Melbourne timezone (`+10:00`), and the explicit instruction that **a single row referencing multiple distinct visits emits multiple ops** — Ananda's "Dr Ananda 9:20am, DOU 10:00am" pattern is the canonical case.

### Server

- **`src/app/api/ai/ingest-universal/route.ts`** — one Claude call with `output_config: zodOutputFormat(ingestDraftSchema)`. Accepts `{ text?, image?, source, today, locale, model? }`. Returns the parsed `IngestDraft` for the client to preview.

### Client

- **`src/components/ingest/universal-drop.tsx`** — paste / type / camera / file (incl. PDF — routed through `prepareImageForVision`). Hands the resulting draft to the parent.
- **`src/components/ingest/preview-diff.tsx`** — per-op diff cards: kind icon + curated key/value lines + Claude's reason + per-op include checkbox. Default-selected for `high` / `medium` confidence drafts; opt-in for `low`. Apply runs the selected ops in order; per-op `saved-as #N` / `failed: reason` state renders inline. Ambiguities surface in a sand-coloured note above the list.
- **`src/app/ingest/page.tsx`** — mounts `UniversalDrop` + `PreviewDiff` above the existing bulk-OCR queue (which stays as the multi-file fallback).

## Tests

`tests/unit/ingest-operations.test.ts` — 6 cases against `fake-indexeddb`:
1. Adds two appointments, returns the new ids.
2. Updates an appointment matched by `title_contains` + `on_date`.
3. Returns `no_match` when the soft match finds nothing.
4. Returns `ambiguous_match` when the soft match hits two rows.
5. Adds a care-team member end-to-end.
6. `stopOnError` halts the batch on the first failure.

New deps: `fake-indexeddb` (dev). All other AI plumbing reuses the server-side `ANTHROPIC_API_KEY` from Slice C.

## Not in this PR (tracked)

- Streaming parse UX. Show a single spinner; return when done.
- Auto-apply for high-confidence ops. Always preview.
- Multi-document bundles in one request. Upload one at a time for now.
- "Audit" view of past `IngestDraft`s — the per-document trail will be useful later but isn't load-bearing for v1.

## Gate

- `pnpm typecheck` clean
- `pnpm test` — **287/287** (+6 new ingest-operations tests). Slice E's 9 digest tests live on the still-open `claude/slice-e-cron` PR; will rebase after that merges.
- `pnpm build` clean

## Test plan

- [ ] Set `ANTHROPIC_API_KEY` on the preview env (already in place from Slice C).
- [ ] Open `/ingest`, paste the Ananda letter text → confirm ~18 appointment ops + 1 care-team op surface, with kind chips, doctor names, locations, and ambiguity notes about the year and DOU expansion.
- [ ] Take a photo of the same PDF → same draft round-trips through the vision path.
- [ ] Toggle a few ops off → click Apply → only the kept ops land in Dexie; the rejected ones don't.
- [ ] Re-upload a similar letter → `update_appointment` ops resolve via soft match; ambiguous matches surface as `ambiguous_match` errors instead of silently picking.

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8

---
_Generated by [Claude Code](https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8)_