### PR TITLE
Slice F: structured appointment attendance

### DIFF
--- a/src/app/schedule/[id]/page.tsx
+++ b/src/app/schedule/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { Field, Textarea } from "~/components/ui/field";
 import { AppointmentForm } from "~/components/schedule/appointment-form";
+import { AttendanceControls } from "~/components/schedule/attendance-controls";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useState } from "react";
 import type { Appointment, AppointmentLink } from "~/types/appointment";
@@ -102,6 +103,8 @@ export default function AppointmentDetailPage() {
           />
 
           <AttendeeChips appt={appt} locale={locale} t={t} />
+
+          <AttendanceControls appt={appt} locale={locale} />
 
           <FollowUpPrompt appt={appt} locale={locale} t={t} />
 

--- a/src/components/dashboard/schedule-card.tsx
+++ b/src/components/dashboard/schedule-card.tsx
@@ -160,7 +160,30 @@ function UpcomingRow({
   locale: "en" | "zh";
 }) {
   const when = formatWhen(appt, locale);
-  const attendeeChip = appt.doctor || (appt.attendees ?? [])[0];
+  // Slice F: prefer a confirmed attendance name, then tentative, then
+  // falling back to the old doctor / first-attendee chip.
+  const confirmed = (appt.attendance ?? []).find(
+    (a) => a.status === "confirmed",
+  );
+  const tentative = (appt.attendance ?? []).find(
+    (a) => a.status === "tentative",
+  );
+  const chip = confirmed
+    ? { label: confirmed.name, status: "confirmed" as const }
+    : tentative
+      ? { label: tentative.name, status: "tentative" as const }
+      : appt.doctor || (appt.attendees ?? [])[0]
+        ? {
+            label: (appt.doctor || (appt.attendees ?? [])[0])!,
+            status: "pending" as const,
+          }
+        : null;
+  const chipTone =
+    chip?.status === "confirmed"
+      ? "bg-[var(--ok-soft)] text-[var(--ok)]"
+      : chip?.status === "tentative"
+        ? "bg-[var(--sand)] text-ink-900"
+        : "bg-paper-2 text-[var(--tide-2)]";
   return (
     <Link
       href={`/schedule/${appt.id}`}
@@ -172,9 +195,16 @@ function UpcomingRow({
           <span className="truncate text-[13px] font-medium text-ink-900">
             {appt.title}
           </span>
-          {attendeeChip && (
-            <span className="inline-flex shrink-0 items-center rounded-full bg-paper-2 px-1.5 py-px text-[10px] font-medium text-[var(--tide-2)]">
-              {attendeeChip}
+          {chip && (
+            <span
+              className={
+                "inline-flex shrink-0 items-center rounded-full px-1.5 py-px text-[10px] font-medium " +
+                chipTone
+              }
+            >
+              {chip.status === "confirmed" && "✓ "}
+              {chip.status === "tentative" && "? "}
+              {chip.label}
             </span>
           )}
         </div>

--- a/src/components/family/next-up.tsx
+++ b/src/components/family/next-up.tsx
@@ -105,9 +105,24 @@ export function NextUp() {
 function Row({ appt, locale }: { appt: Appointment; locale: "en" | "zh" }) {
   const Icon = KIND_ICON[appt.kind];
   const when = formatWhen(appt, locale);
-  const chips = [
+  // Slice F: prefer structured attendance with status colours; fall
+  // back to doctor / freetext attendees as pending chips.
+  const attendanceChips = (appt.attendance ?? []).map((a) => ({
+    label: a.name,
+    status: a.status as "confirmed" | "tentative" | "declined",
+  }));
+  const pendingNames = [
     ...(appt.doctor ? [appt.doctor] : []),
     ...(appt.attendees ?? []),
+  ].filter(
+    (n) =>
+      !attendanceChips.some(
+        (a) => a.label.trim().toLowerCase() === n.trim().toLowerCase(),
+      ),
+  );
+  const chips = [
+    ...attendanceChips,
+    ...pendingNames.map((n) => ({ label: n, status: "pending" as const })),
   ];
   return (
     <Link
@@ -148,14 +163,34 @@ function Row({ appt, locale }: { appt: Appointment; locale: "en" | "zh" }) {
           )}
           {chips.length > 0 && (
             <div className="mt-1.5 flex flex-wrap gap-1">
-              {chips.map((c, i) => (
-                <span
-                  key={`${c}-${i}`}
-                  className="inline-flex items-center rounded-full bg-ink-100 px-2 py-0.5 text-[11px] text-ink-700"
-                >
-                  {c}
-                </span>
-              ))}
+              {chips.map((c, i) => {
+                const tone =
+                  c.status === "confirmed"
+                    ? "bg-[var(--ok-soft)] text-[var(--ok)]"
+                    : c.status === "tentative"
+                      ? "bg-[var(--sand)] text-ink-900"
+                      : c.status === "declined"
+                        ? "bg-ink-100 text-ink-400 line-through"
+                        : "bg-ink-100 text-ink-700";
+                const prefix =
+                  c.status === "confirmed"
+                    ? "✓ "
+                    : c.status === "tentative"
+                      ? "? "
+                      : "";
+                return (
+                  <span
+                    key={`${c.label}-${i}`}
+                    className={
+                      "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] " +
+                      tone
+                    }
+                  >
+                    {prefix}
+                    {c.label}
+                  </span>
+                );
+              })}
             </div>
           )}
         </div>

--- a/src/components/schedule/attendance-controls.tsx
+++ b/src/components/schedule/attendance-controls.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { db, now } from "~/lib/db/dexie";
+import { useHouseholdProfiles } from "~/hooks/use-household-profiles";
+import {
+  nextStatus,
+  setAttendance,
+  statusFor,
+  type PendingOrStatus,
+} from "~/lib/appointments/attendance";
+import { useLocale } from "~/hooks/use-translate";
+import type { Appointment } from "~/types/appointment";
+import { Check, Clock, X, CircleDashed } from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+// Per-member attendance chip row on the appointment detail page.
+// Each household member gets one button that cycles through the
+// attendance states. Non-member attendees (freetext in
+// appointment.attendees) render as passive pending chips — they
+// can't claim themselves from this device.
+
+const STATUS_LABEL: Record<PendingOrStatus, { en: string; zh: string }> = {
+  pending: { en: "Tap to confirm", zh: "点击确认" },
+  confirmed: { en: "Going", zh: "参加" },
+  tentative: { en: "Maybe", zh: "可能" },
+  declined: { en: "Can't make it", zh: "无法参加" },
+};
+
+const STATUS_TONE: Record<PendingOrStatus, string> = {
+  pending: "bg-paper-2 text-ink-500 border-ink-200",
+  confirmed: "bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok)]/30",
+  tentative: "bg-[var(--sand)] text-ink-900 border-[var(--sand-2)]",
+  declined: "bg-ink-100 text-ink-500 border-ink-300 line-through",
+};
+
+const STATUS_ICON: Record<PendingOrStatus, React.ComponentType<{ className?: string }>> = {
+  pending: CircleDashed,
+  confirmed: Check,
+  tentative: Clock,
+  declined: X,
+};
+
+export function AttendanceControls({
+  appt,
+  locale: localeOverride,
+}: {
+  appt: Appointment;
+  locale?: "en" | "zh";
+}) {
+  const localeCtx = useLocale();
+  const locale = localeOverride ?? localeCtx;
+  const { profilesById } = useHouseholdProfiles();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const members = Array.from(profilesById.values());
+
+  // Build the render list: every household member, plus any freetext
+  // attendee whose name isn't already covered by a member.
+  const memberNames = new Set(
+    members.map((m) => m.display_name.trim().toLowerCase()),
+  );
+  const extras = (appt.attendees ?? []).filter(
+    (n) => n.trim() && !memberNames.has(n.trim().toLowerCase()),
+  );
+
+  async function cycle(name: string, user_id?: string) {
+    if (typeof appt.id !== "number") return;
+    const current = statusFor(appt.attendance, name);
+    const next = nextStatus(current);
+    const attendance = setAttendance(appt.attendance, {
+      name,
+      user_id,
+      status: next,
+      now: new Date(),
+    });
+    await db.appointments.update(appt.id, {
+      attendance,
+      updated_at: now(),
+    });
+  }
+
+  if (members.length === 0 && extras.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="mono mr-1 text-[10px] uppercase tracking-[0.12em] text-ink-400">
+        {L("Going?", "到场？")}
+      </span>
+      {members.map((m) => {
+        const status = statusFor(appt.attendance, m.display_name);
+        const Icon = STATUS_ICON[status];
+        return (
+          <button
+            key={m.id}
+            type="button"
+            onClick={() => void cycle(m.display_name, m.id)}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11.5px] transition-colors",
+              STATUS_TONE[status],
+            )}
+            aria-label={`${m.display_name}: ${STATUS_LABEL[status][locale]}`}
+          >
+            <Icon className="h-3 w-3" />
+            {m.display_name}
+          </button>
+        );
+      })}
+      {extras.map((name, i) => {
+        const status = statusFor(appt.attendance, name);
+        const Icon = STATUS_ICON[status];
+        return (
+          <span
+            key={`extra-${i}`}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11.5px]",
+              STATUS_TONE[status],
+            )}
+          >
+            <Icon className="h-3 w-3" />
+            {name}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/appointments/attendance.ts
+++ b/src/lib/appointments/attendance.ts
@@ -1,0 +1,69 @@
+import type {
+  AppointmentAttendance,
+  AttendanceStatus,
+} from "~/types/appointment";
+
+// Pure reducers for the attendance array on an Appointment. Matching
+// is case-insensitive on `name` so renames in the care-team registry
+// don't fragment the record. A user toggling themselves between
+// pending → confirmed → tentative → declined → pending is the full
+// cycle the detail page drives.
+
+export type PendingOrStatus = AttendanceStatus | "pending";
+
+export function findAttendance(
+  rows: readonly AppointmentAttendance[] | undefined,
+  name: string,
+): AppointmentAttendance | undefined {
+  const target = name.trim().toLowerCase();
+  return (rows ?? []).find((r) => r.name.trim().toLowerCase() === target);
+}
+
+export function statusFor(
+  rows: readonly AppointmentAttendance[] | undefined,
+  name: string,
+): PendingOrStatus {
+  return findAttendance(rows, name)?.status ?? "pending";
+}
+
+// Cycle order: pending → confirmed → tentative → declined → pending.
+// Each tap bumps once; the UI lets the user stop where they want.
+export function nextStatus(current: PendingOrStatus): PendingOrStatus {
+  switch (current) {
+    case "pending":
+      return "confirmed";
+    case "confirmed":
+      return "tentative";
+    case "tentative":
+      return "declined";
+    case "declined":
+      return "pending";
+  }
+}
+
+// Write the new status for a named attendee, replacing or removing any
+// existing row. Returns a new array; original is untouched.
+export function setAttendance(
+  rows: readonly AppointmentAttendance[] | undefined,
+  args: {
+    name: string;
+    user_id?: string;
+    status: PendingOrStatus;
+    now?: Date;
+    note?: string;
+  },
+): AppointmentAttendance[] {
+  const now = (args.now ?? new Date()).toISOString();
+  const rest = (rows ?? []).filter(
+    (r) => r.name.trim().toLowerCase() !== args.name.trim().toLowerCase(),
+  );
+  if (args.status === "pending") return rest;
+  const next: AppointmentAttendance = {
+    name: args.name.trim(),
+    user_id: args.user_id,
+    status: args.status,
+    claimed_at: now,
+    note: args.note,
+  };
+  return [...rest, next];
+}

--- a/src/lib/appointments/schema.ts
+++ b/src/lib/appointments/schema.ts
@@ -42,6 +42,17 @@ export const appointmentInputSchema = z.object({
   attachments: z.array(z.string()).optional(),
   derived_from_cycle: z.boolean().optional(),
   cycle_id: z.number().int().positive().optional(),
+  attendance: z
+    .array(
+      z.object({
+        name: z.string().min(1),
+        user_id: z.string().uuid().optional(),
+        status: z.enum(["confirmed", "tentative", "declined"]),
+        claimed_at: z.string(),
+        note: z.string().optional(),
+      }),
+    )
+    .optional(),
   followup_logged_at: z.string().optional(),
 });
 

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -27,6 +27,23 @@ export type AppointmentStatus =
   | "cancelled"
   | "rescheduled";
 
+// Slice F: structured attendance. Sits alongside the freetext
+// `attendees` list. A name in `attendees` with no matching
+// `attendance` entry renders as pending; members flip themselves
+// between confirmed / tentative / declined / (back to pending) with
+// one tap. Keyed by name (case-insensitive) so renames in the
+// care-team registry don't break old rows; `user_id` is the auth uid
+// when the claim came from a signed-in member.
+export type AttendanceStatus = "confirmed" | "tentative" | "declined";
+
+export interface AppointmentAttendance {
+  name: string;
+  user_id?: string;
+  status: AttendanceStatus;
+  claimed_at: string;
+  note?: string;
+}
+
 export interface Appointment {
   id?: number;
   kind: AppointmentKind;
@@ -41,9 +58,11 @@ export interface Appointment {
   phone?: string;
   notes?: string;                // markdown
   status: AppointmentStatus;
-  // Free-text attendee list. When collaboration lands properly this
-  // becomes a separate attendees table keyed by user_id; for now names.
+  // Free-text attendee list — "who was invited".
   attendees?: string[];
+  // Structured "who's actually going" — one row per member that has
+  // claimed a status. Name-keyed, case-insensitive on read.
+  attendance?: AppointmentAttendance[];
   // Photo / document references (keys into ingested_documents, or bare
   // data URLs for small captures).
   attachments?: string[];

--- a/tests/unit/attendance.test.ts
+++ b/tests/unit/attendance.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  findAttendance,
+  nextStatus,
+  setAttendance,
+  statusFor,
+} from "~/lib/appointments/attendance";
+import type { AppointmentAttendance } from "~/types/appointment";
+
+const NOW = new Date("2026-04-23T12:00:00.000Z");
+
+const thomas: AppointmentAttendance = {
+  name: "Thomas",
+  user_id: "uid-thomas",
+  status: "confirmed",
+  claimed_at: NOW.toISOString(),
+};
+
+describe("findAttendance / statusFor", () => {
+  it("matches case-insensitively and trims whitespace", () => {
+    const rows = [thomas];
+    expect(findAttendance(rows, "THOMAS")?.user_id).toBe("uid-thomas");
+    expect(findAttendance(rows, "  thomas  ")?.user_id).toBe("uid-thomas");
+  });
+
+  it("returns undefined when the name isn't in the list", () => {
+    expect(findAttendance([thomas], "Catherine")).toBeUndefined();
+  });
+
+  it("statusFor falls back to 'pending' when no row exists", () => {
+    expect(statusFor([thomas], "Catherine")).toBe("pending");
+    expect(statusFor(undefined, "anyone")).toBe("pending");
+    expect(statusFor([thomas], "thomas")).toBe("confirmed");
+  });
+});
+
+describe("nextStatus cycle", () => {
+  it("cycles pending → confirmed → tentative → declined → pending", () => {
+    expect(nextStatus("pending")).toBe("confirmed");
+    expect(nextStatus("confirmed")).toBe("tentative");
+    expect(nextStatus("tentative")).toBe("declined");
+    expect(nextStatus("declined")).toBe("pending");
+  });
+});
+
+describe("setAttendance", () => {
+  it("adds a row when none exists for the name", () => {
+    const next = setAttendance([], {
+      name: "Catherine",
+      user_id: "uid-c",
+      status: "tentative",
+      now: NOW,
+    });
+    expect(next).toHaveLength(1);
+    expect(next[0]!.status).toBe("tentative");
+    expect(next[0]!.claimed_at).toBe(NOW.toISOString());
+  });
+
+  it("replaces an existing row for the same name (case-insensitive)", () => {
+    const next = setAttendance([thomas], {
+      name: "thomas",
+      user_id: "uid-thomas",
+      status: "declined",
+      now: NOW,
+    });
+    expect(next).toHaveLength(1);
+    expect(next[0]!.status).toBe("declined");
+  });
+
+  it("removes the row when status flips to 'pending'", () => {
+    const next = setAttendance([thomas], {
+      name: "Thomas",
+      status: "pending",
+      now: NOW,
+    });
+    expect(next).toHaveLength(0);
+  });
+
+  it("does not mutate the input array", () => {
+    const input: AppointmentAttendance[] = [thomas];
+    setAttendance(input, {
+      name: "Thomas",
+      status: "pending",
+      now: NOW,
+    });
+    expect(input).toHaveLength(1);
+  });
+
+  it("leaves unrelated entries alone", () => {
+    const rows: AppointmentAttendance[] = [
+      thomas,
+      {
+        name: "Catherine",
+        user_id: "uid-c",
+        status: "tentative",
+        claimed_at: NOW.toISOString(),
+      },
+    ];
+    const next = setAttendance(rows, {
+      name: "Thomas",
+      status: "pending",
+      now: NOW,
+    });
+    expect(next.map((r) => r.name)).toEqual(["Catherine"]);
+  });
+});


### PR DESCRIPTION
## Summary

Slice F turns `Appointment.attendees` from freetext hints into collaborative state. Each household member gets a single chip on `/schedule/[id]` that cycles **pending → confirmed → tentative → declined → pending**. The status propagates to the dashboard `ScheduleCard` and the `/family` next-up strip with colour + ✓/? prefixes — so Thomas opens `/family` and sees at a glance that Catherine has confirmed Friday's chemo and Wendy is tentative.

No migration needed — `attendance` is an optional array on the existing `appointments` row, mirrored through `cloud_rows` JSONB.

## Data shape

```ts
type AttendanceStatus = "confirmed" | "tentative" | "declined";

interface AppointmentAttendance {
  name: string;            // case-insensitive key
  user_id?: string;        // auth uid when claim came from a signed-in member
  status: AttendanceStatus;
  claimed_at: string;
  note?: string;
}

interface Appointment {
  // …
  attendance?: AppointmentAttendance[];
}
```

## Pieces

- **`src/lib/appointments/attendance.ts`** — pure reducers: `findAttendance` (case-insensitive name match, trims whitespace), `statusFor` (falls back to `'pending'`), `nextStatus` (cycle order), `setAttendance` (replace-or-remove, non-mutating).
- **`src/components/schedule/attendance-controls.tsx`** — per-member chip row on the detail page. Reads household profiles via `useHouseholdProfiles`; non-member freetext attendees render as passive pending chips. Clicking any member's chip writes the next status via `setAttendance` + `db.appointments.update`.
- **`/schedule/[id]`** mounts `AttendanceControls` between `AttendeeChips` and `FollowUpPrompt`.
- **`dashboard/schedule-card.tsx`** — upcoming row chip prefers the first confirmed attendee, then first tentative, then doctor/freetext as pending. Status drives tone.
- **`family/next-up.tsx`** — every attendance row renders with status colour; freetext attendees merge in as pending chips so they don't duplicate.

## Gate

- `pnpm typecheck` clean
- `pnpm test` — **305/305** (+9 new attendance reducer cases)
- `pnpm build` clean

## Test plan

- [ ] `/schedule/[id]` → tap Thomas chip four times → cycles confirmed → tentative → declined → pending.
- [ ] Confirm on one device, open same appointment on another device signed into the same household → status reflects within the existing realtime debounce window.
- [ ] Dashboard `ScheduleCard` upcoming row shows a green ✓ chip once anyone confirms; falls back to amber `?` when only tentatives exist.
- [ ] `/family` next-up shows all structured attendees with their tone, plus any freetext non-members as pending.
- [ ] Declined members render struck-through so you can still see they were invited.

## Not in this PR

- Slice G (presence indicators) is still stretch.

https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8

---
_Generated by [Claude Code](https://claude.ai/code/session_0145BksJeHf8F7RqEsi8Ysi8)_