### PR TITLE
Fix daily check-in formatting + cluster of user-reported gaps

### DIFF
--- a/src/agents/run.ts
+++ b/src/agents/run.ts
@@ -77,9 +77,9 @@ export async function runAgent(args: RunAgentArgs): Promise<AgentOutput> {
   if (!apiKey) {
     throw new Error("ANTHROPIC_API_KEY is not configured on the server");
   }
-  const [{ default: Anthropic }, { zodOutputFormat }] = await Promise.all([
+  const [{ default: Anthropic }, { jsonOutputFormat }] = await Promise.all([
     import("@anthropic-ai/sdk"),
-    import("@anthropic-ai/sdk/helpers/zod"),
+    import("~/lib/anthropic/json-output"),
   ]);
   const client = new Anthropic({ apiKey });
 
@@ -115,7 +115,7 @@ export async function runAgent(args: RunAgentArgs): Promise<AgentOutput> {
         cache_control: { type: "ephemeral" },
       },
     ],
-    output_config: { format: zodOutputFormat(AgentOutputSchema) },
+    output_config: { format: jsonOutputFormat(AgentOutputSchema) },
     messages: [{ role: "user", content: [{ type: "text", text: userText }] }],
   });
 

--- a/src/agents/schema.ts
+++ b/src/agents/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 
 // Shared Zod output schema for every specialist agent. The server uses this
 // as the `output_config.format` target so Claude returns validated JSON.
@@ -20,7 +20,7 @@ const dexiePatchSchema = z.object({
     "pending_results",
   ]),
   strategy: z.enum(["upsert_by_date", "add"]),
-  data: z.record(z.unknown()),
+  data: z.record(z.string(), z.unknown()),
 });
 
 const safetyFlagSchema = z.object({

--- a/src/app/api/ai/assessment-summary/route.ts
+++ b/src/app/api/ai/assessment-summary/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
-import { z } from "zod";
-import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { z } from "zod/v4";
+import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import { SUMMARY_SYSTEM } from "~/lib/ai/coach";
 
 export const runtime = "nodejs";
@@ -51,7 +51,7 @@ export async function POST(req: Request) {
           cache_control: { type: "ephemeral" },
         },
       ],
-      output_config: { format: zodOutputFormat(SummarySchema) },
+      output_config: { format: jsonOutputFormat(SummarySchema) },
       messages: [
         {
           role: "user",

--- a/src/app/api/ai/ingest-meal/route.ts
+++ b/src/app/api/ai/ingest-meal/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
-import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import { MealSchema, MEAL_SYSTEM } from "~/lib/ingest/meal-vision";
 import type { PreparedImage } from "~/lib/ingest/image";
 
@@ -38,7 +38,7 @@ export async function POST(req: Request) {
       system: [
         { type: "text", text: MEAL_SYSTEM, cache_control: { type: "ephemeral" } },
       ],
-      output_config: { format: zodOutputFormat(MealSchema) },
+      output_config: { format: jsonOutputFormat(MealSchema) },
       messages: [
         {
           role: "user",

--- a/src/app/api/ai/ingest-notes/route.ts
+++ b/src/app/api/ai/ingest-notes/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
-import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import {
   NotesStructureSchema,
   NOTES_SYSTEM,
@@ -41,7 +41,7 @@ export async function POST(req: Request) {
       system: [
         { type: "text", text: NOTES_SYSTEM, cache_control: { type: "ephemeral" } },
       ],
-      output_config: { format: zodOutputFormat(NotesStructureSchema) },
+      output_config: { format: jsonOutputFormat(NotesStructureSchema) },
       messages: [
         {
           role: "user",

--- a/src/app/api/ai/ingest-report/route.ts
+++ b/src/app/api/ai/ingest-report/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
-import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import {
   ExtractionSchema,
   EXTRACTION_SYSTEM,
@@ -84,7 +84,7 @@ export async function POST(req: Request) {
           cache_control: { type: "ephemeral" },
         },
       ],
-      output_config: { format: zodOutputFormat(ExtractionSchema) },
+      output_config: { format: jsonOutputFormat(ExtractionSchema) },
       messages: [{ role: "user", content }],
     });
     if (!response.parsed_output) {

--- a/src/app/api/ai/ingest-universal/route.ts
+++ b/src/app/api/ai/ingest-universal/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
-import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import {
   INGEST_SYSTEM,
   ingestDraftSchema,
@@ -95,7 +95,7 @@ export async function POST(req: Request) {
           cache_control: { type: "ephemeral" },
         },
       ],
-      output_config: { format: zodOutputFormat(ingestDraftSchema) },
+      output_config: { format: jsonOutputFormat(ingestDraftSchema) },
       messages: [{ role: "user", content }],
     });
     if (!response.parsed_output) {

--- a/src/app/api/parse-appointment/route.ts
+++ b/src/app/api/parse-appointment/route.ts
@@ -73,9 +73,9 @@ export async function POST(req: Request) {
     );
   }
 
-  const [{ default: Anthropic }, { zodOutputFormat }] = await Promise.all([
+  const [{ default: Anthropic }, { jsonOutputFormat }] = await Promise.all([
     import("@anthropic-ai/sdk"),
-    import("@anthropic-ai/sdk/helpers/zod"),
+    import("~/lib/anthropic/json-output"),
   ]);
   const client = new Anthropic({ apiKey });
 
@@ -122,7 +122,7 @@ export async function POST(req: Request) {
           cache_control: { type: "ephemeral" },
         },
       ],
-      output_config: { format: zodOutputFormat(parsedAppointmentSchema) },
+      output_config: { format: jsonOutputFormat(parsedAppointmentSchema) },
       messages: [{ role: "user", content: userContent }],
     });
     if (!response.parsed_output) {

--- a/src/app/daily/[id]/page.tsx
+++ b/src/app/daily/[id]/page.tsx
@@ -28,6 +28,8 @@ export default function EditDailyPage() {
 
   if (date === null) return null;
   return (
-    <DailyWizard entryId={Number.isFinite(id) ? id : undefined} date={date} />
+    <div className="mx-auto max-w-3xl p-4 md:p-8">
+      <DailyWizard entryId={Number.isFinite(id) ? id : undefined} date={date} />
+    </div>
   );
 }

--- a/src/app/daily/new/page.tsx
+++ b/src/app/daily/new/page.tsx
@@ -31,5 +31,9 @@ function Inner() {
   }, [date]);
 
   if (entryId === undefined) return null;
-  return <DailyWizard entryId={entryId ?? undefined} date={date} />;
+  return (
+    <div className="mx-auto max-w-3xl p-4 md:p-8">
+      <DailyWizard entryId={entryId ?? undefined} date={date} />
+    </div>
+  );
 }

--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -164,7 +164,7 @@ export default function IngestPage() {
               type="file"
               className="hidden"
               multiple
-              accept="image/*,application/pdf"
+              accept="image/*,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.docx"
               onChange={(e) => {
                 void enqueueFiles(e.target.files);
                 e.target.value = "";
@@ -298,8 +298,8 @@ function DropZone({
       }
     >
       {locale === "zh"
-        ? "拖放任意数量的文件到这里（PDF / JPG / PNG）"
-        : "Drop any number of files here (PDF · JPG · PNG)"}
+        ? "拖放任意数量的文件到这里（PDF / JPG / PNG / DOCX）"
+        : "Drop any number of files here (PDF · JPG · PNG · DOCX)"}
     </div>
   );
 }

--- a/src/app/labs/page.tsx
+++ b/src/app/labs/page.tsx
@@ -22,7 +22,6 @@ import {
 } from "~/config/lab-reference-ranges";
 import { cn } from "~/lib/utils/cn";
 import {
-  Camera,
   ChevronRight,
   Sparkles,
   Upload,
@@ -115,46 +114,31 @@ export default function LabsPage() {
         }
       />
 
-      {/* Frictionless ingest CTAs */}
-      <div className="grid gap-3 sm:grid-cols-2">
-        <Link
-          href="/ingest"
-          className="group flex items-center gap-3 rounded-[var(--r-md)] border border-ink-900 bg-ink-900 px-4 py-3.5 text-paper transition-transform hover:-translate-y-[1px]"
-        >
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-paper/15">
-            <Upload className="h-4 w-4" />
+      {/* Unified ingest CTA — identical surface to Smart Capture. A lab
+        * report is just one of the document kinds the universal parser
+        * classifies; keeping two entry points out of sync produced the
+        * "why are these different?" confusion. */}
+      <Link
+        href="/ingest"
+        className="group flex items-center gap-3 rounded-[var(--r-md)] border border-ink-900 bg-ink-900 px-4 py-3.5 text-paper transition-transform hover:-translate-y-[1px]"
+      >
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-paper/15">
+          <Upload className="h-4 w-4" />
+        </div>
+        <div className="flex-1">
+          <div className="text-[13.5px] font-semibold">
+            {locale === "zh"
+              ? "导入任何医疗资料"
+              : "Drop in anything medical"}
           </div>
-          <div className="flex-1">
-            <div className="text-[13.5px] font-semibold">
-              {locale === "zh" ? "上传化验报告" : "Upload lab report"}
-            </div>
-            <div className="mono mt-0.5 text-[10px] uppercase tracking-wider text-ink-300">
-              {locale === "zh" ? "PDF / 图片 · 自动提取" : "PDF / photo · auto-extract"}
-            </div>
+          <div className="mono mt-0.5 text-[10px] uppercase tracking-wider text-ink-300">
+            {locale === "zh"
+              ? "PDF / 图片 / DOCX · 自动识别化验、影像、就诊函"
+              : "PDF · photo · DOCX · labs, imaging, letters auto-detected"}
           </div>
-          <ChevronRight className="h-4 w-4 text-ink-300" />
-        </Link>
-        <Link
-          href="/ingest?camera=1"
-          className="group flex items-center gap-3 rounded-[var(--r-md)] border border-ink-100/70 bg-paper-2 px-4 py-3.5 hover:border-ink-300"
-        >
-          <div
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md"
-            style={{ background: "var(--tide-soft)", color: "var(--tide-2)" }}
-          >
-            <Camera className="h-4 w-4" />
-          </div>
-          <div className="flex-1">
-            <div className="text-[13.5px] font-semibold text-ink-900">
-              {locale === "zh" ? "拍一张照片" : "Snap a photo"}
-            </div>
-            <div className="mono mt-0.5 text-[10px] uppercase tracking-wider text-ink-400">
-              {locale === "zh" ? "手写纸质结果" : "Handwritten or printout"}
-            </div>
-          </div>
-          <ChevronRight className="h-4 w-4 text-ink-400" />
-        </Link>
-      </div>
+        </div>
+        <ChevronRight className="h-4 w-4 text-ink-300" />
+      </Link>
 
       {/* Hero picker */}
       <div className="-mx-4 flex gap-1.5 overflow-x-auto px-4 pb-0.5 md:mx-0 md:px-0">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,10 +36,8 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#f5f1e8" },
-    { media: "(prefers-color-scheme: dark)", color: "#19212f" },
-  ],
+  themeColor: "#f5f1e8",
+  colorScheme: "light",
   width: "device-width",
   initialScale: 1,
   maximumScale: 5,
@@ -48,7 +46,7 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" data-theme="light" style={{ colorScheme: "light" }}>
       <body>
         <Providers>
           <div className="flex min-h-screen bg-paper">

--- a/src/app/medications/log/page.tsx
+++ b/src/app/medications/log/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
@@ -19,7 +20,16 @@ import {
 } from "~/lib/medication/log";
 import type { Medication, MedicationTodayStatus } from "~/types/medication";
 import { DRUGS_BY_ID } from "~/config/drug-registry";
-import { Check, X, AlertCircle, Pill, ChevronRight } from "lucide-react";
+import {
+  Check,
+  X,
+  AlertCircle,
+  Pill,
+  ChevronRight,
+  Pencil,
+  Plus,
+  ClipboardList,
+} from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 
 const COMMON_SIDE_EFFECTS = [
@@ -36,6 +46,7 @@ const COMMON_SIDE_EFFECTS = [
 
 export default function MedicationLogPage() {
   const locale = useLocale();
+  const router = useRouter();
   const ctx = useActiveCycleContext();
   const cycleId = ctx?.cycle.id;
   const cycleDay = ctx?.cycle_day;
@@ -92,18 +103,42 @@ export default function MedicationLogPage() {
       <PageHeader
         title={locale === "zh" ? "今日用药记录" : "Today's medication log"}
         subtitle={cycleLabel}
+        action={
+          <div className="flex flex-wrap gap-2">
+            <Link href="/prescriptions">
+              <Button size="sm" variant="secondary">
+                <ClipboardList className="h-3.5 w-3.5" />
+                {locale === "zh" ? "管理处方" : "Prescriptions"}
+              </Button>
+            </Link>
+            <Link href="/prescriptions">
+              <Button size="sm">
+                <Plus className="h-3.5 w-3.5" />
+                {locale === "zh" ? "添加" : "Add"}
+              </Button>
+            </Link>
+          </div>
+        }
       />
 
-      {!ctx && (
+      {!ctx && statuses.length === 0 && (
         <Card>
-          <CardContent className="p-6 text-sm text-ink-500">
-            {locale === "zh"
-              ? "开始一个治疗周期后，系统将自动填充今日应服用的药物。"
-              : "Start an active treatment cycle and this page will auto-populate today's medications."}
-            <div className="mt-4">
+          <CardContent className="space-y-3 p-6 text-sm text-ink-500">
+            <div>
+              {locale === "zh"
+                ? "当前没有活动处方。开始一个治疗周期会自动填充药物，或你也可以手动添加。"
+                : "No active prescriptions yet. Start a treatment cycle to auto-populate, or add one manually."}
+            </div>
+            <div className="flex flex-wrap gap-2">
               <Link href="/treatment/new">
-                <Button variant="secondary">
+                <Button variant="secondary" size="sm">
                   {locale === "zh" ? "开始新周期" : "Start a cycle"}
+                </Button>
+              </Link>
+              <Link href="/prescriptions">
+                <Button size="sm">
+                  <Plus className="h-3.5 w-3.5" />
+                  {locale === "zh" ? "添加处方" : "Add prescription"}
                 </Button>
               </Link>
             </div>
@@ -169,6 +204,18 @@ export default function MedicationLogPage() {
           onClose={() => setSheetFor(null)}
         />
       )}
+
+      {statuses.length > 0 && (
+        <div className="sticky bottom-24 flex items-center justify-end gap-2 pt-2 md:bottom-6">
+          <Button variant="ghost" onClick={() => router.push("/prescriptions")}>
+            {locale === "zh" ? "修改处方" : "Edit prescriptions"}
+          </Button>
+          <Button onClick={() => router.push("/")}>
+            <Check className="h-4 w-4" />
+            {locale === "zh" ? "完成" : "Save & close"}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
@@ -227,7 +274,7 @@ function MedRow({
             </div>
           </div>
         </div>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Button
             onClick={onTaken}
             size="sm"
@@ -246,6 +293,14 @@ function MedRow({
             <X className="h-3.5 w-3.5" />
             {locale === "zh" ? "漏服" : "Missed"}
           </Button>
+          <Link
+            href="/prescriptions"
+            aria-label={locale === "zh" ? "编辑处方" : "Edit prescription"}
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-ink-200 text-ink-500 hover:border-ink-400 hover:text-ink-900"
+            title={locale === "zh" ? "修改剂量或停用" : "Change dose or stop"}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Link>
           <Button
             onClick={onDetails}
             size="sm"

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -27,6 +27,7 @@ import { cn } from "~/lib/utils/cn";
 // patient isn't gated behind data they don't have on hand.
 const STEPS = [
   "welcome",
+  "user_type",
   "profile",
   "preferences",
   "team",
@@ -44,6 +45,7 @@ type StepKey = (typeof STEPS)[number];
 const STEP_LABELS: Record<Locale, Record<StepKey, string>> = {
   en: {
     welcome: "Welcome",
+    user_type: "Who you are",
     profile: "About you",
     team: "Clinical team",
     baselines: "Baselines",
@@ -53,6 +55,7 @@ const STEP_LABELS: Record<Locale, Record<StepKey, string>> = {
   },
   zh: {
     welcome: "欢迎",
+    user_type: "您的身份",
     profile: "基本信息",
     team: "医疗团队",
     baselines: "基线数据",
@@ -63,6 +66,8 @@ const STEP_LABELS: Record<Locale, Record<StepKey, string>> = {
 };
 
 interface FormState {
+  user_type: "patient" | "caregiver" | "clinician" | "";
+  invite_code: string;
   profile_name: string;
   dob: string;
   diagnosis_date: string;
@@ -90,6 +95,8 @@ interface FormState {
 }
 
 const EMPTY: FormState = {
+  user_type: "",
+  invite_code: "",
   profile_name: "",
   dob: "",
   diagnosis_date: "",
@@ -143,6 +150,7 @@ export default function OnboardingPage() {
       // Prefill from partial existing settings
       setForm((f) => ({
         ...f,
+        user_type: s.user_type ?? f.user_type,
         profile_name: s.profile_name ?? "",
         dob: s.dob ?? "",
         diagnosis_date: s.diagnosis_date ?? "",
@@ -208,9 +216,10 @@ export default function OnboardingPage() {
   }
 
   const canContinue = useMemo(() => {
+    if (step === "user_type") return form.user_type !== "";
     if (step === "profile") return form.profile_name.trim().length > 0;
     return true;
-  }, [step, form.profile_name]);
+  }, [step, form.profile_name, form.user_type]);
 
   async function finish() {
     setSaving(true);
@@ -234,6 +243,7 @@ export default function OnboardingPage() {
         }
       }
       const payload: Settings = {
+        user_type: form.user_type || undefined,
         profile_name: form.profile_name.trim() || "Patient",
         dob: form.dob || undefined,
         diagnosis_date: form.diagnosis_date || undefined,
@@ -272,7 +282,13 @@ export default function OnboardingPage() {
         await db.settings.add(payload);
       }
       setUILocale(form.locale);
-      setEnteredBy("hulin");
+      setEnteredBy(
+        form.user_type === "caregiver"
+          ? "catherine"
+          : form.user_type === "clinician"
+            ? "clinician"
+            : "hulin",
+      );
 
       if (form.start_cycle && form.cycle_start_date) {
         await db.treatment_cycles.add({
@@ -347,6 +363,9 @@ export default function OnboardingPage() {
       </header>
 
       {step === "welcome" && <WelcomeStep locale={locale} />}
+      {step === "user_type" && (
+        <UserTypeStep form={form} update={update} locale={locale} />
+      )}
       {step === "profile" && (
         <ProfileStep form={form} update={update} locale={locale} />
       )}
@@ -432,6 +451,110 @@ function WelcomeStep({ locale }: { locale: Locale }) {
           </li>
         ))}
       </ul>
+    </Card>
+  );
+}
+
+function UserTypeStep({
+  form,
+  update,
+  locale,
+}: {
+  form: FormState;
+  update: <K extends keyof FormState>(k: K, v: FormState[K]) => void;
+  locale: Locale;
+}) {
+  const options: Array<{
+    id: "patient" | "caregiver" | "clinician";
+    title: { en: string; zh: string };
+    body: { en: string; zh: string };
+  }> = [
+    {
+      id: "patient",
+      title: { en: "I'm the patient", zh: "我是患者" },
+      body: {
+        en: "You'll log your own check-ins. Family and clinicians can join later via an invite link.",
+        zh: "您本人记录每日检查。家人和医生可稍后通过邀请链接加入。",
+      },
+    },
+    {
+      id: "caregiver",
+      title: { en: "I'm family or a caregiver", zh: "我是家人或照护者" },
+      body: {
+        en: "You're setting this up to support the patient — or you're already part of their care circle.",
+        zh: "您在为患者设置 Anchor —— 或您已是照护圈的一员。",
+      },
+    },
+    {
+      id: "clinician",
+      title: { en: "I'm a clinician", zh: "我是医护" },
+      body: {
+        en: "You're part of the medical team and will view the patient's record with their consent.",
+        zh: "您是医疗团队的一员，将在患者同意下查看记录。",
+      },
+    },
+  ];
+  return (
+    <Card className="p-6 space-y-4">
+      <div className="serif text-[22px] leading-tight">
+        {locale === "zh" ? "您是谁？" : "Who are you?"}
+      </div>
+      <p className="text-[13px] text-ink-500">
+        {locale === "zh"
+          ? "这决定了你的第一屏：记录、照护，还是查看。随时可在设置里更改。"
+          : "Sets your first screen — logging, supporting, or reviewing. You can change this in Settings anytime."}
+      </p>
+      <div className="space-y-2">
+        {options.map((opt) => {
+          const active = form.user_type === opt.id;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => update("user_type", opt.id)}
+              aria-pressed={active}
+              className={cn(
+                "w-full rounded-xl border p-4 text-left transition-colors",
+                active
+                  ? "border-ink-900 bg-ink-900 text-paper"
+                  : "border-ink-200 bg-paper-2 hover:border-ink-400",
+              )}
+            >
+              <div className="text-[14px] font-semibold">
+                {opt.title[locale]}
+              </div>
+              <div
+                className={cn(
+                  "mt-1 text-[12.5px]",
+                  active ? "text-paper/75" : "text-ink-500",
+                )}
+              >
+                {opt.body[locale]}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      {form.user_type && form.user_type !== "patient" && (
+        <Field
+          label={
+            locale === "zh"
+              ? "患者的邀请代码（如果已有）"
+              : "Patient's invite code (if you have one)"
+          }
+          hint={
+            locale === "zh"
+              ? "之后也可在「设置 → 家庭/医疗团队」里关联。"
+              : "You can also link later from Settings → Family / care team."
+          }
+        >
+          <TextInput
+            value={form.invite_code}
+            onChange={(e) => update("invite_code", e.target.value)}
+            placeholder={locale === "zh" ? "粘贴邀请代码" : "Paste invite code"}
+          />
+        </Field>
+      )}
     </Card>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { RecentTrends } from "~/components/dashboard/recent-trends";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
 import { PendingInvitesCard } from "~/components/dashboard/pending-invites-card";
+import { NextClinicCard } from "~/components/dashboard/next-clinic-card";
 import { ScheduleCard } from "~/components/dashboard/schedule-card";
 import { ChangeSignalsCard } from "~/components/dashboard/change-signals-card";
 import { SignalLoopSummaryCard } from "~/components/dashboard/signal-loop-summary-card";
@@ -96,6 +97,8 @@ export default function DashboardPage() {
       <QuickCheckinCard />
 
       <PendingInvitesCard />
+
+      <NextClinicCard />
 
       <ScheduleCard />
 

--- a/src/app/prescriptions/page.tsx
+++ b/src/app/prescriptions/page.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import { Suspense, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db, now } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import {
+  ensureCycleMedications,
+  getActiveMedications,
+} from "~/lib/medication/active";
+import { DRUGS_BY_ID } from "~/config/drug-registry";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, TextInput } from "~/components/ui/field";
+import type { Medication } from "~/types/medication";
+import {
+  ArrowLeft,
+  Check,
+  Pencil,
+  Pill,
+  Plus,
+  Save,
+  Trash2,
+  X,
+} from "lucide-react";
+
+// Current-prescriptions view. Lists every active medication (protocol-derived
+// + user-added) with inline edit + delete. When the user lands here straight
+// after creating a chemo cycle (via `?cycle=<id>&from=treatment-new`), the
+// page seeds the cycle's protocol meds first and shows a "Review & confirm"
+// banner so the user explicitly approves the generated prescriptions before
+// anything is logged against them.
+
+export default function PrescriptionsPage() {
+  return (
+    <Suspense fallback={null}>
+      <Inner />
+    </Suspense>
+  );
+}
+
+function Inner() {
+  const locale = useLocale();
+  const router = useRouter();
+  const params = useSearchParams();
+  const cycleIdParam = params.get("cycle");
+  const fromTreatment = params.get("from") === "treatment-new";
+  const addingNew = params.get("new") === "1";
+  const cycleId = cycleIdParam ? Number(cycleIdParam) : undefined;
+  const [seeded, setSeeded] = useState(false);
+
+  const cycle = useLiveQuery(
+    () => (cycleId ? db.treatment_cycles.get(cycleId) : undefined),
+    [cycleId],
+  );
+
+  useEffect(() => {
+    if (!cycle) return;
+    void (async () => {
+      await ensureCycleMedications(cycle);
+      setSeeded(true);
+    })();
+  }, [cycle]);
+
+  const meds = useLiveQuery(() => getActiveMedications(cycleId), [
+    cycleId,
+    seeded,
+  ]);
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const grouped = useMemo(() => {
+    const protocolMeds: Medication[] = [];
+    const userMeds: Medication[] = [];
+    for (const m of meds ?? []) {
+      if (m.source === "user_added") userMeds.push(m);
+      else protocolMeds.push(m);
+    }
+    return { protocolMeds, userMeds };
+  }, [meds]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-8">
+      <PageHeader
+        eyebrow={L("Prescriptions", "处方")}
+        title={L("Current prescriptions", "当前处方")}
+        subtitle={L(
+          "Every active medication — protocol-derived and anything you've added. Edit dose, timing, or duration without touching today's log.",
+          "所有活动药物 —— 来自方案和自行添加的。可修改剂量、时间、疗程，不影响今日记录。",
+        )}
+        action={
+          <Link href="/prescriptions?new=1">
+            <Button size="sm">
+              <Plus className="h-3.5 w-3.5" />
+              {L("Add", "新增")}
+            </Button>
+          </Link>
+        }
+      />
+
+      {addingNew && <NewPrescriptionForm locale={locale} />}
+
+      {fromTreatment && cycle && (
+        <Card className="border-[var(--tide-2)]/40 bg-[var(--tide-soft)]">
+          <CardContent className="space-y-2 p-4">
+            <div className="eyebrow text-[var(--tide-2)]">
+              {L("Review & confirm", "复核并确认")}
+            </div>
+            <p className="text-[13px] text-ink-900">
+              {L(
+                "Anchor has generated these prescriptions from the protocol. Edit anything that doesn't match what your oncologist actually ordered, then continue.",
+                "Anchor 已按方案生成这些处方。如与肿瘤科医师实际开具的不符，请先修改后再继续。",
+              )}
+            </p>
+            <div className="flex gap-2 pt-1">
+              <Button
+                size="sm"
+                onClick={() => router.push(`/treatment/${cycle.id}`)}
+              >
+                <Check className="h-3.5 w-3.5" />
+                {L("Looks right — continue", "核对无误 — 继续")}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => router.push("/treatment")}
+              >
+                <ArrowLeft className="h-3.5 w-3.5" />
+                {L("Back to treatments", "返回治疗列表")}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {meds !== undefined && meds.length === 0 && (
+        <Card>
+          <CardContent className="space-y-2 p-5 text-center text-[13px] text-ink-500">
+            <Pill className="mx-auto h-5 w-5 text-ink-300" />
+            <div>
+              {L(
+                "No active prescriptions. Start a treatment cycle to auto-seed protocol meds, or add one manually.",
+                "暂无活动处方。开始一个治疗周期以自动填充方案药物，或手动添加。",
+              )}
+            </div>
+            <div className="flex justify-center gap-2 pt-2">
+              <Link href="/treatment/new">
+                <Button size="sm" variant="secondary">
+                  {L("Start a cycle", "开始周期")}
+                </Button>
+              </Link>
+              <Link href="/prescriptions?new=1">
+                <Button size="sm">
+                  <Plus className="h-3.5 w-3.5" />
+                  {L("Add prescription", "添加处方")}
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {grouped.protocolMeds.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="eyebrow">
+            {L("Protocol-derived", "方案处方")}
+          </h2>
+          <ul className="space-y-2">
+            {grouped.protocolMeds.map((m) => (
+              <PrescriptionRow key={m.id} med={m} locale={locale} />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {grouped.userMeds.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="eyebrow">
+            {L("Added by you", "自行添加")}
+          </h2>
+          <ul className="space-y-2">
+            {grouped.userMeds.map((m) => (
+              <PrescriptionRow key={m.id} med={m} locale={locale} />
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function NewPrescriptionForm({ locale }: { locale: "en" | "zh" }) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [dose, setDose] = useState("");
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  async function save() {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      const slug = name
+        .trim()
+        .toLowerCase()
+        .replace(/[^\w\s-]+/g, "")
+        .replace(/\s+/g, "_")
+        .slice(0, 40);
+      await db.medications.add({
+        drug_id: `custom:${slug || "medication"}`,
+        display_name: name.trim(),
+        category: "other",
+        dose: dose.trim() || "—",
+        route: "PO",
+        schedule: { kind: "prn" },
+        source: "user_added",
+        active: true,
+        notes: notes.trim() || undefined,
+        started_on: new Date().toISOString().slice(0, 10),
+        created_at: now(),
+        updated_at: now(),
+      });
+      router.replace("/prescriptions");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card className="border-[var(--tide-2)]/40">
+      <CardContent className="space-y-3 p-4">
+        <div className="eyebrow">{L("New prescription", "新增处方")}</div>
+        <Field label={L("Name", "药名")}>
+          <TextInput
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={L("e.g. Ondansetron", "例如 昂丹司琼")}
+            autoFocus
+          />
+        </Field>
+        <Field label={L("Dose", "剂量")}>
+          <TextInput
+            value={dose}
+            onChange={(e) => setDose(e.target.value)}
+            placeholder={L("e.g. 8 mg oral, PRN", "例如 8 mg 口服，按需")}
+          />
+        </Field>
+        <Field label={L("Notes", "备注")}>
+          <TextInput
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+        </Field>
+        <div className="flex gap-2">
+          <Button onClick={() => void save()} disabled={saving || !name.trim()}>
+            <Save className="h-3.5 w-3.5" />
+            {saving ? L("Saving…", "保存中…") : L("Save", "保存")}
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => router.replace("/prescriptions")}
+          >
+            {L("Cancel", "取消")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PrescriptionRow({
+  med,
+  locale,
+}: {
+  med: Medication;
+  locale: "en" | "zh";
+}) {
+  const catalogue = DRUGS_BY_ID[med.drug_id];
+  const name =
+    (locale === "zh" ? catalogue?.name.zh : catalogue?.name.en) ??
+    med.display_name ??
+    med.drug_id;
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const [editing, setEditing] = useState(false);
+  const [dose, setDose] = useState(med.dose ?? "");
+  const [notes, setNotes] = useState(med.notes ?? "");
+  const [saving, setSaving] = useState(false);
+
+  async function save() {
+    if (!med.id) return;
+    setSaving(true);
+    try {
+      await db.medications.update(med.id, {
+        dose: dose.trim() || undefined,
+        notes: notes.trim() || undefined,
+        updated_at: now(),
+      });
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function del() {
+    if (!med.id) return;
+    if (
+      !window.confirm(
+        L(
+          `Stop ${name}? Past logs are kept; this only deactivates the prescription.`,
+          `停用 ${name}？历史记录保留，仅将处方置为停用。`,
+        ),
+      )
+    ) {
+      return;
+    }
+    await db.medications.update(med.id, {
+      active: false,
+      stopped_on: now(),
+      updated_at: now(),
+    });
+  }
+
+  return (
+    <li className="rounded-[var(--r-md)] border border-ink-100 bg-paper-2">
+      <div className="flex items-start gap-3 p-3">
+        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
+          <Pill className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <div className="text-[14px] font-semibold text-ink-900">{name}</div>
+            <div className="mono text-[10.5px] uppercase tracking-[0.12em] text-ink-400">
+              {med.category}
+              {med.source === "user_added" ? " · self-added" : ""}
+            </div>
+          </div>
+          {!editing ? (
+            <div className="mt-0.5 text-[12.5px] text-ink-500">
+              {med.dose || L("No dose recorded", "尚未记录剂量")}
+              {med.schedule?.label?.[locale] &&
+                ` · ${med.schedule.label[locale]}`}
+            </div>
+          ) : (
+            <div className="mt-2 space-y-2">
+              <Field label={L("Dose", "剂量")}>
+                <TextInput
+                  value={dose}
+                  onChange={(e) => setDose(e.target.value)}
+                  placeholder={L("e.g. 500 mg BD", "例如 500 mg BD")}
+                />
+              </Field>
+              <Field label={L("Notes", "备注")}>
+                <TextInput
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder={L(
+                    "Reason for dose change, etc.",
+                    "剂量变更原因等",
+                  )}
+                />
+              </Field>
+            </div>
+          )}
+          {med.notes && !editing && (
+            <div className="mt-1 text-[11.5px] text-ink-500">{med.notes}</div>
+          )}
+        </div>
+        <div className="flex shrink-0 gap-1">
+          {!editing ? (
+            <>
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                aria-label={L("Edit", "编辑")}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-ink-200 text-ink-600 hover:border-ink-400"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => void del()}
+                aria-label={L("Stop prescription", "停用处方")}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-ink-200 text-ink-500 hover:border-[var(--warn)] hover:text-[var(--warn)]"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => void save()}
+                disabled={saving}
+                aria-label={L("Save", "保存")}
+                className="flex h-7 w-7 items-center justify-center rounded-md bg-ink-900 text-paper hover:bg-ink-700 disabled:opacity-60"
+              >
+                <Save className="h-3.5 w-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setDose(med.dose ?? "");
+                  setNotes(med.notes ?? "");
+                  setEditing(false);
+                }}
+                aria-label={L("Cancel", "取消")}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-ink-200 text-ink-500 hover:text-ink-900"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/app/treatment/new/page.tsx
+++ b/src/app/treatment/new/page.tsx
@@ -23,7 +23,10 @@ export default function NewTreatmentCyclePage() {
       created_at: now(),
       updated_at: now(),
     });
-    router.push(`/treatment/${id}`);
+    // After creating a new cycle, drop the user into the prescription
+    // review screen so they can confirm / edit the protocol-derived meds
+    // (dose, timing, duration) before anything is logged against them.
+    router.push(`/prescriptions?cycle=${id}&from=treatment-new`);
   }
 
   return (

--- a/src/components/daily/daily-wizard.tsx
+++ b/src/components/daily/daily-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useLiveQuery } from "dexie-react-hooks";
 import Link from "next/link";
@@ -646,40 +646,7 @@ function CategoryFields({
 
   if (catId === "practice") {
     return (
-      <div className="space-y-3">
-        <Toggle
-          label={L("Morning practice completed", "晨间修习完成")}
-          checked={draft.practice_morning_completed ?? false}
-          onChange={(v) =>
-            patch("practice_morning_completed", v ? true : undefined)
-          }
-        />
-        {draft.practice_morning_completed && (
-          <ScaleInput
-            label={L("Morning quality (0–5)", "晨间质量（0–5）")}
-            value={draft.practice_morning_quality ?? 3}
-            onChange={(n) => patch("practice_morning_quality", n)}
-            min={0}
-            max={5}
-          />
-        )}
-        <Toggle
-          label={L("Evening practice completed", "晚间修习完成")}
-          checked={draft.practice_evening_completed ?? false}
-          onChange={(v) =>
-            patch("practice_evening_completed", v ? true : undefined)
-          }
-        />
-        {draft.practice_evening_completed && (
-          <ScaleInput
-            label={L("Evening quality (0–5)", "晚间质量（0–5）")}
-            value={draft.practice_evening_quality ?? 3}
-            onChange={(n) => patch("practice_evening_quality", n)}
-            min={0}
-            max={5}
-          />
-        )}
-      </div>
+      <PracticeFields draft={draft} patch={patch} locale={locale} />
     );
   }
 
@@ -837,6 +804,205 @@ function CategoryFields({
   }
 
   return null;
+}
+
+function PracticeFields({
+  draft,
+  patch,
+  locale,
+}: {
+  draft: Draft;
+  patch: <K extends keyof DailyEntry>(k: K, v: DailyEntry[K] | undefined) => void;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const practices = useLiveQuery(
+    () =>
+      db.medications
+        .where("category")
+        .equals("behavioural")
+        .filter((m) => m.active)
+        .toArray(),
+    [],
+  );
+
+  // Fallback controls on first use, before any practices have been set up.
+  if (practices === undefined) return null;
+  if (practices.length === 0) {
+    return (
+      <div className="space-y-3">
+        <div className="rounded-[var(--r-md)] border border-dashed border-ink-200 bg-paper p-3 text-[12.5px] text-ink-500">
+          {L(
+            "No practices configured yet — add Qigong, breathing, or your own under Practices so they appear here each day.",
+            "还未配置任何修习 —— 在「修习」中加入气功、呼吸法或自定义项目，之后就会每天出现在这里。",
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Link
+            href="/practices/new"
+            className="rounded-md border border-ink-200 px-2.5 py-1.5 text-[12px] text-ink-700 hover:bg-ink-100/40"
+          >
+            {L("Add a practice", "添加修习")}
+          </Link>
+        </div>
+        <Toggle
+          label={L(
+            "Did any practice today (morning)",
+            "今天上午有做修习",
+          )}
+          checked={draft.practice_morning_completed ?? false}
+          onChange={(v) =>
+            patch("practice_morning_completed", v ? true : undefined)
+          }
+        />
+        <Toggle
+          label={L(
+            "Did any practice today (evening)",
+            "今天晚上有做修习",
+          )}
+          checked={draft.practice_evening_completed ?? false}
+          onChange={(v) =>
+            patch("practice_evening_completed", v ? true : undefined)
+          }
+        />
+      </div>
+    );
+  }
+
+  const morning = practices.filter((m) => isMorningScheduled(m.schedule));
+  const evening = practices.filter((m) => isEveningScheduled(m.schedule));
+  const other = practices.filter(
+    (m) => !isMorningScheduled(m.schedule) && !isEveningScheduled(m.schedule),
+  );
+
+  return (
+    <div className="space-y-4">
+      {morning.length > 0 && (
+        <PracticeGroup
+          title={L("Morning", "上午")}
+          practices={morning}
+          locale={locale}
+          groupCompleted={draft.practice_morning_completed ?? false}
+          onGroupCompleted={(v) =>
+            patch("practice_morning_completed", v ? true : undefined)
+          }
+          quality={draft.practice_morning_quality}
+          onQuality={(n) => patch("practice_morning_quality", n)}
+        />
+      )}
+      {evening.length > 0 && (
+        <PracticeGroup
+          title={L("Evening", "晚上")}
+          practices={evening}
+          locale={locale}
+          groupCompleted={draft.practice_evening_completed ?? false}
+          onGroupCompleted={(v) =>
+            patch("practice_evening_completed", v ? true : undefined)
+          }
+          quality={draft.practice_evening_quality}
+          onQuality={(n) => patch("practice_evening_quality", n)}
+        />
+      )}
+      {other.length > 0 && (
+        <PracticeGroup
+          title={L("Other", "其他")}
+          practices={other}
+          locale={locale}
+        />
+      )}
+    </div>
+  );
+}
+
+function PracticeGroup({
+  title,
+  practices,
+  locale,
+  groupCompleted,
+  onGroupCompleted,
+  quality,
+  onQuality,
+}: {
+  title: string;
+  practices: Array<{
+    id?: number;
+    drug_id: string;
+    display_name?: string;
+    dose?: string;
+  }>;
+  locale: "en" | "zh";
+  groupCompleted?: boolean;
+  onGroupCompleted?: (v: boolean) => void;
+  quality?: number;
+  onQuality?: (n: number) => void;
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  return (
+    <div className="space-y-2">
+      <div className="eyebrow text-ink-500">{title}</div>
+      <ul className="space-y-1.5">
+        {practices.map((m) => {
+          const name = m.display_name ?? m.drug_id;
+          return (
+            <li
+              key={m.id ?? m.drug_id}
+              className="flex items-center justify-between rounded-[var(--r-md)] bg-paper-2 px-3 py-2"
+            >
+              <div className="min-w-0">
+                <div className="truncate text-[13px] text-ink-900">{name}</div>
+                {m.dose && (
+                  <div className="text-[11px] text-ink-500">{m.dose}</div>
+                )}
+              </div>
+              <Link
+                href="/practices"
+                className="mono shrink-0 text-[10px] uppercase tracking-[0.12em] text-ink-400 hover:text-ink-700"
+              >
+                {L("Manage", "管理")}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+      {onGroupCompleted && (
+        <Toggle
+          label={L(
+            `Completed this ${title.toLowerCase()} session`,
+            `本时段已完成`,
+          )}
+          checked={groupCompleted ?? false}
+          onChange={onGroupCompleted}
+        />
+      )}
+      {groupCompleted && onQuality && (
+        <ScaleInput
+          label={L("Quality (0–5)", "质量（0–5）")}
+          value={quality ?? 3}
+          onChange={onQuality}
+          min={0}
+          max={5}
+        />
+      )}
+    </div>
+  );
+}
+
+function isMorningScheduled(schedule: unknown): boolean {
+  const s = schedule as { clock_times?: string[] } | null | undefined;
+  if (!s?.clock_times?.length) return false;
+  return s.clock_times.some((t) => {
+    const hour = Number(t.split(":")[0]);
+    return Number.isFinite(hour) && hour < 12;
+  });
+}
+
+function isEveningScheduled(schedule: unknown): boolean {
+  const s = schedule as { clock_times?: string[] } | null | undefined;
+  if (!s?.clock_times?.length) return false;
+  return s.clock_times.some((t) => {
+    const hour = Number(t.split(":")[0]);
+    return Number.isFinite(hour) && hour >= 12;
+  });
 }
 
 function ReviewScreen({

--- a/src/components/dashboard/next-clinic-card.tsx
+++ b/src/components/dashboard/next-clinic-card.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { format, formatDistanceToNowStrict, isToday, isTomorrow } from "date-fns";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { Card } from "~/components/ui/card";
+import { activeFast, hasActivePrep } from "~/lib/appointments/prep";
+import { Stethoscope, ChevronRight, Clock, MapPin, UserRound } from "lucide-react";
+
+// Dedicated "NEXT CLINIC APPOINTMENT" card. Separate from the broader
+// Schedule card because (a) clinic consults drive the bridge-strategy
+// conversation and (b) the patient has asked that this be surfaced as a
+// single glance rather than buried in a day-window list.
+
+export function NextClinicCard() {
+  const locale = useLocale();
+  const appointments = useLiveQuery(
+    () =>
+      db.appointments
+        .where("[kind+starts_at]")
+        .between(["clinic", ""], ["clinic", "￿"])
+        .toArray(),
+    [],
+  );
+
+  const next = useMemo(() => {
+    if (!appointments) return null;
+    const now = Date.now();
+    const upcoming = appointments
+      .filter((a) => a.status !== "cancelled" && a.status !== "missed")
+      .map((a) => ({ a, t: new Date(a.starts_at).getTime() }))
+      .filter(({ t }) => Number.isFinite(t) && t >= now)
+      .sort((x, y) => x.t - y.t);
+    return upcoming[0]?.a ?? null;
+  }, [appointments]);
+
+  if (!next) return null;
+
+  const when = new Date(next.starts_at);
+  const dateLabel = isToday(when)
+    ? locale === "zh"
+      ? "今天"
+      : "Today"
+    : isTomorrow(when)
+      ? locale === "zh"
+        ? "明天"
+        : "Tomorrow"
+      : locale === "zh"
+        ? format(when, "M 月 d 日 EEEE")
+        : format(when, "EEE · d MMM");
+  const timeLabel = next.all_day
+    ? locale === "zh"
+      ? "全天"
+      : "All day"
+    : format(when, locale === "zh" ? "HH:mm" : "h:mm a");
+  const awayLabel = formatDistanceToNowStrict(when, { addSuffix: true });
+
+  const fast = activeFast(next);
+  const prepBadge = hasActivePrep(next);
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
+            <Stethoscope className="h-5 w-5" />
+          </div>
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="eyebrow">
+              {locale === "zh" ? "下一次就诊" : "Next clinic appointment"}
+            </div>
+            <div className="serif truncate text-[17px] text-ink-900">
+              {next.title}
+            </div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[12px] text-ink-500">
+              <span className="inline-flex items-center gap-1">
+                <Clock className="h-3 w-3" />
+                {dateLabel} · {timeLabel}
+                <span className="mono text-[10.5px] text-ink-400">
+                  · {awayLabel}
+                </span>
+              </span>
+              {next.doctor && (
+                <span className="inline-flex items-center gap-1">
+                  <UserRound className="h-3 w-3" />
+                  {next.doctor}
+                </span>
+              )}
+              {next.location && (
+                <span className="inline-flex items-center gap-1 truncate">
+                  <MapPin className="h-3 w-3" />
+                  {next.location}
+                </span>
+              )}
+            </div>
+            {(fast || prepBadge) && (
+              <div className="mt-1 flex flex-wrap gap-1.5">
+                {fast && (
+                  <span className="a-chip warn">
+                    {locale === "zh" ? "需空腹" : "Fasting"}
+                  </span>
+                )}
+                {!fast && prepBadge && (
+                  <span className="a-chip sand">
+                    {locale === "zh" ? "需准备" : "Prep"}
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+        <Link
+          href={next.id ? `/schedule/${next.id}` : "/schedule"}
+          className="inline-flex shrink-0 items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-[11px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+        >
+          {locale === "zh" ? "打开" : "Open"}
+          <ChevronRight className="h-3 w-3" />
+        </Link>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/practices-card.tsx
+++ b/src/components/dashboard/practices-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
@@ -15,9 +15,30 @@ import {
 import { logMedicationEvent } from "~/lib/medication/log";
 import { expectedDosesToday } from "~/lib/medication/log";
 import type { Medication } from "~/types/medication";
-import { Check, ChevronRight, Plus, Sparkles } from "lucide-react";
+import { Check, ChevronRight, Pause, Play, Plus, Sparkles, X } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { todayISO } from "~/lib/utils/date";
+
+// Best-effort duration parse: "20 min", "10 breaths", "5m", "1h". Falls back
+// to 5 minutes when the dose string doesn't mention a time unit.
+function durationSeconds(dose: string | undefined): number {
+  if (!dose) return 5 * 60;
+  const s = dose.toLowerCase();
+  const h = s.match(/(\d+(?:\.\d+)?)\s*h/);
+  if (h) return Math.round(Number(h[1]) * 3600);
+  const m = s.match(/(\d+(?:\.\d+)?)\s*m(?!s)/);
+  if (m) return Math.round(Number(m[1]) * 60);
+  const sec = s.match(/(\d+)\s*s/);
+  if (sec) return Number(sec[1]);
+  return 5 * 60;
+}
+
+function formatClock(sec: number): string {
+  const abs = Math.max(0, Math.round(sec));
+  const mm = Math.floor(abs / 60).toString().padStart(2, "0");
+  const ss = (abs % 60).toString().padStart(2, "0");
+  return `${mm}:${ss}`;
+}
 
 /**
  * Dashboard card for daily behavioural practices — breathing, meditation,
@@ -143,6 +164,28 @@ function PracticeRow({
   const count = `${logged}/${Math.max(due, 1)}`;
   const custom = isCustomPractice(med);
 
+  const total = useMemo(() => durationSeconds(med.dose), [med.dose]);
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const [paused, setPaused] = useState(false);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (remaining === null || paused) return;
+    tickRef.current = setInterval(() => {
+      setRemaining((r) => (r === null ? r : r - 1));
+    }, 1000);
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+    };
+  }, [remaining, paused]);
+
+  useEffect(() => {
+    if (remaining !== null && remaining <= 0) {
+      void finishSession();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [remaining]);
+
   const onLog = async () => {
     if (!med.id) return;
     await logMedicationEvent({
@@ -152,47 +195,125 @@ function PracticeRow({
     });
   };
 
+  const startSession = () => {
+    setPaused(false);
+    setRemaining(total);
+  };
+
+  const cancelSession = () => {
+    if (tickRef.current) clearInterval(tickRef.current);
+    setRemaining(null);
+    setPaused(false);
+  };
+
+  const finishSession = async () => {
+    if (tickRef.current) clearInterval(tickRef.current);
+    setRemaining(null);
+    setPaused(false);
+    await onLog();
+  };
+
+  const running = remaining !== null;
+
   return (
-    <li className="flex items-center gap-3 rounded-[var(--r-md)] bg-paper-2 px-3 py-2">
-      <button
-        type="button"
-        onClick={onLog}
-        disabled={complete}
-        aria-label={complete ? "Done" : "Log practice"}
-        className={cn(
-          "flex h-6 w-6 shrink-0 items-center justify-center rounded-md border transition-colors",
-          complete
-            ? "border-[var(--ok)] bg-[var(--ok)] text-white"
-            : "border-ink-300 bg-paper hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]",
-        )}
-      >
-        {complete ? (
-          <Check className="h-3.5 w-3.5" strokeWidth={3} />
-        ) : (
-          <Sparkles className="h-3.5 w-3.5" />
-        )}
-      </button>
-      <div className="min-w-0 flex-1">
-        <div
+    <li className="rounded-[var(--r-md)] bg-paper-2 px-3 py-2">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onLog}
+          disabled={complete}
+          aria-label={complete ? "Done" : "Mark done without timer"}
           className={cn(
-            "truncate text-[13px] font-medium",
-            complete ? "text-ink-500 line-through" : "text-ink-900",
+            "flex h-6 w-6 shrink-0 items-center justify-center rounded-md border transition-colors",
+            complete
+              ? "border-[var(--ok)] bg-[var(--ok)] text-white"
+              : "border-ink-300 bg-paper hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]",
           )}
         >
-          {name}
-          {custom && (
-            <span className="mono ml-2 text-[9px] uppercase tracking-[0.12em] text-ink-400">
-              custom
-            </span>
+          {complete ? (
+            <Check className="h-3.5 w-3.5" strokeWidth={3} />
+          ) : (
+            <Sparkles className="h-3.5 w-3.5" />
           )}
-        </div>
-        <div className="text-[11px] text-ink-500">
-          {med.dose} · {scheduleSummary(med.schedule, locale)}
-        </div>
+        </button>
+        <button
+          type="button"
+          onClick={running ? undefined : startSession}
+          disabled={complete || running}
+          className="min-w-0 flex-1 text-left disabled:cursor-default"
+        >
+          <div
+            className={cn(
+              "truncate text-[13px] font-medium",
+              complete ? "text-ink-500 line-through" : "text-ink-900",
+            )}
+          >
+            {name}
+            {custom && (
+              <span className="mono ml-2 text-[9px] uppercase tracking-[0.12em] text-ink-400">
+                custom
+              </span>
+            )}
+          </div>
+          <div className="text-[11px] text-ink-500">
+            {med.dose} · {scheduleSummary(med.schedule, locale)}
+          </div>
+        </button>
+        {!running && !complete && (
+          <button
+            type="button"
+            onClick={startSession}
+            className="inline-flex shrink-0 items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-[11px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+            aria-label={locale === "zh" ? "开始" : "Start"}
+          >
+            <Play className="h-3 w-3" />
+            {locale === "zh" ? "开始" : "Start"}
+          </button>
+        )}
+        {!running && (
+          <span className="mono shrink-0 text-[10px] uppercase tracking-[0.12em] text-ink-400">
+            {count}
+          </span>
+        )}
       </div>
-      <span className="mono shrink-0 text-[10px] uppercase tracking-[0.12em] text-ink-400">
-        {count}
-      </span>
+      {running && (
+        <div className="mt-2 flex items-center gap-2 border-t border-ink-100 pt-2">
+          <span className="mono text-[18px] font-medium tabular-nums text-ink-900">
+            {formatClock(remaining ?? 0)}
+          </span>
+          <div className="flex-1" />
+          <button
+            type="button"
+            onClick={() => setPaused((p) => !p)}
+            className="inline-flex items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-[11px] text-ink-700 hover:border-[var(--tide-2)]"
+          >
+            {paused ? <Play className="h-3 w-3" /> : <Pause className="h-3 w-3" />}
+            {paused
+              ? locale === "zh"
+                ? "继续"
+                : "Resume"
+              : locale === "zh"
+                ? "暂停"
+                : "Pause"}
+          </button>
+          <button
+            type="button"
+            onClick={() => void finishSession()}
+            className="inline-flex items-center gap-1 rounded-md bg-ink-900 px-2 py-1 text-[11px] text-paper hover:bg-ink-700"
+          >
+            <Check className="h-3 w-3" />
+            {locale === "zh" ? "完成" : "Done"}
+          </button>
+          <button
+            type="button"
+            onClick={cancelSession}
+            className="inline-flex items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-[11px] text-ink-500 hover:text-ink-900"
+          >
+            <X className="h-3 w-3" />
+            {locale === "zh" ? "取消" : "Cancel"}
+          </button>
+        </div>
+      )}
     </li>
   );
 }

--- a/src/components/ingest/universal-drop.tsx
+++ b/src/components/ingest/universal-drop.tsx
@@ -35,6 +35,22 @@ export function UniversalDrop({
     setError(null);
     setBusy(true);
     try {
+      const lowerName = file.name.toLowerCase();
+      const isDocx =
+        file.type ===
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+        lowerName.endsWith(".docx");
+      if (isDocx) {
+        const { docxToText } = await import("~/lib/ingest/docx");
+        const extracted = await docxToText(file);
+        if (!extracted.trim()) {
+          throw new Error(
+            "The .docx looks empty — couldn't find any readable text inside.",
+          );
+        }
+        await callRoute({ text: extracted, source: "paste" });
+        return;
+      }
       const prepared = await prepareImageForVision(file, { maxEdge: 1800 });
       await callRoute({
         image: prepared,
@@ -114,11 +130,10 @@ export function UniversalDrop({
             }
           >
             <ImagePlus className="h-3.5 w-3.5" />
-            {L("Photo / PDF", "照片 / PDF")}
+            {L("Photo / PDF / DOCX", "照片 / PDF / DOCX")}
             <input
               type="file"
-              accept="image/*,application/pdf"
-              capture="environment"
+              accept="image/*,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.docx"
               className="hidden"
               disabled={busy}
               onChange={(e) => {

--- a/src/components/schedule/appointment-form.tsx
+++ b/src/components/schedule/appointment-form.tsx
@@ -14,6 +14,7 @@ import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
 import { Field, TextInput, Textarea } from "~/components/ui/field";
 import { PrepEditor } from "~/components/schedule/prep-editor";
+import { AttendeeChips } from "~/components/schedule/attendee-chips";
 
 const KINDS: AppointmentKind[] = [
   "clinic",
@@ -263,23 +264,10 @@ export function AppointmentForm({
         label={t("schedule.form.attendees")}
         hint={t("schedule.form.attendeesHint")}
       >
-        <Textarea
-          rows={2}
-          value={(form.attendees ?? []).join("\n")}
-          onChange={(e) =>
-            update(
-              "attendees",
-              e.target.value
-                .split(/\r?\n/)
-                .map((s) => s.trim())
-                .filter(Boolean),
-            )
-          }
-          placeholder={
-            locale === "zh"
-              ? "一行一位，例如：\nThomas\nCatherine\nWendy"
-              : "One per line, e.g.:\nThomas\nCatherine\nWendy"
-          }
+        <AttendeeChips
+          value={form.attendees ?? []}
+          onChange={(next) => update("attendees", next)}
+          locale={locale}
         />
       </Field>
 

--- a/src/components/schedule/attendee-chips.tsx
+++ b/src/components/schedule/attendee-chips.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { X, Plus } from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+// Multi-chip attendee picker backed by the care-team registry. The user taps
+// a chip to add the member, or types a free-text name (Enter / comma / tab)
+// for someone who isn't on the team yet. Selected values are persisted as
+// `attendees: string[]` on the appointment — the same shape the old text
+// area produced, so read-only consumers don't need to change.
+
+export function AttendeeChips({
+  value,
+  onChange,
+  locale,
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+  locale: "en" | "zh";
+}) {
+  const team = useLiveQuery(() => db.care_team.toArray(), []);
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const suggestions = useMemo(() => {
+    const names = new Set(value.map((v) => v.trim().toLowerCase()));
+    const q = query.trim().toLowerCase();
+    return (team ?? [])
+      .filter((m) => !!m.name && !names.has(m.name.trim().toLowerCase()))
+      .filter((m) => !q || m.name.toLowerCase().includes(q))
+      .slice(0, 8);
+  }, [team, value, query]);
+
+  function add(name: string) {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    if (value.some((v) => v.trim().toLowerCase() === trimmed.toLowerCase()))
+      return;
+    onChange([...value, trimmed]);
+    setQuery("");
+    inputRef.current?.focus();
+  }
+
+  function remove(index: number) {
+    const next = value.slice();
+    next.splice(index, 1);
+    onChange(next);
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-ink-200 bg-paper-2 p-2">
+        {value.map((v, i) => (
+          <span
+            key={`${v}-${i}`}
+            className="inline-flex items-center gap-1 rounded-full bg-[var(--tide-soft)] px-2 py-1 text-[12px] text-[var(--tide-2)]"
+          >
+            {v}
+            <button
+              type="button"
+              onClick={() => remove(i)}
+              aria-label={`Remove ${v}`}
+              className="text-[var(--tide-2)]/70 hover:text-[var(--tide-2)]"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
+              if (query.trim()) {
+                e.preventDefault();
+                add(query);
+              }
+            } else if (
+              e.key === "Backspace" &&
+              query === "" &&
+              value.length > 0
+            ) {
+              e.preventDefault();
+              remove(value.length - 1);
+            }
+          }}
+          placeholder={
+            value.length === 0
+              ? L("Add from care team or type a name…", "从护理团队选择或输入姓名…")
+              : L("Add another…", "再加一位…")
+          }
+          className="min-w-[10ch] flex-1 bg-transparent text-[13px] outline-none placeholder:text-ink-400"
+        />
+      </div>
+      {suggestions.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {suggestions.map((m) => (
+            <button
+              key={m.id ?? m.name}
+              type="button"
+              onClick={() => add(m.name)}
+              className="inline-flex items-center gap-1 rounded-full border border-ink-200 bg-paper px-2 py-1 text-[11.5px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+            >
+              <Plus className="h-3 w-3" />
+              {m.name}
+              {m.role && (
+                <span className="mono text-[9px] uppercase tracking-[0.1em] text-ink-400">
+                  · {m.role}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/care-team-section.tsx
+++ b/src/components/settings/care-team-section.tsx
@@ -182,8 +182,8 @@ export function CareTeamSection() {
           </h2>
           <p className="mt-1 text-xs text-ink-500">
             {L(
-              "One source of truth for everyone involved in care. Attendee chips on appointments read from here.",
-              "团队名单的唯一来源。预约上的陪同人名从这里读取。",
+              "One source of truth for everyone involved in care. Attendee chips on appointments read from here. To give a family member or clinician their own login, send them a household invite from Settings → Household.",
+              "团队名单的唯一来源。预约上的陪同人名从这里读取。如需邀请家人或医生使用自己的账号登录，请在「设置 → 家庭」处生成邀请链接。",
             )}
           </p>
         </div>

--- a/src/lib/anthropic/json-output.ts
+++ b/src/lib/anthropic/json-output.ts
@@ -1,0 +1,10 @@
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import type { z as zv4 } from "zod/v4";
+
+// Thin wrapper around the SDK's `zodOutputFormat`. The SDK's type signature
+// expects a zod v3 `ZodType`, but its runtime calls `z.toJSONSchema()` (v4
+// only). We pass v4 schemas — this shim keeps the type checker happy without
+// the ` as any` sprinkled at every call site.
+export function jsonOutputFormat<T extends zv4.ZodTypeAny>(schema: T) {
+  return zodOutputFormat(schema as unknown as Parameters<typeof zodOutputFormat>[0]);
+}

--- a/src/lib/appointments/parse-schema.ts
+++ b/src/lib/appointments/parse-schema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod/v4";
+
+// Schema the vision/email parser is asked to emit. Lives in its own file (and
+// on zod/v4) because the Anthropic SDK's `zodOutputFormat` helper imports
+// `zod/v4` internally — passing a v3 schema throws "Cannot read properties of
+// undefined (reading 'def')". The forms schema stays on zod v3 in
+// `./schema.ts` so form-validation behaviour is unchanged.
+
+const appointmentKindSchema = z.enum([
+  "clinic",
+  "chemo",
+  "scan",
+  "blood_test",
+  "procedure",
+  "other",
+]);
+
+export const parsedAppointmentSchema = z.object({
+  kind: appointmentKindSchema,
+  title: z.string().min(1),
+  starts_at: z.string(), // ISO; parser does its best, we validate on save
+  ends_at: z.string().optional(),
+  all_day: z.boolean().optional(),
+  location: z.string().optional(),
+  doctor: z.string().optional(),
+  phone: z.string().optional(),
+  notes: z.string().optional(),
+  confidence: z.enum(["high", "medium", "low"]),
+  ambiguities: z.array(z.string()).optional(),
+});
+
+export type ParsedAppointment = z.infer<typeof parsedAppointmentSchema>;

--- a/src/lib/appointments/schema.ts
+++ b/src/lib/appointments/schema.ts
@@ -104,20 +104,11 @@ export const appointmentInputSchema = z.object({
 
 export type AppointmentInput = z.infer<typeof appointmentInputSchema>;
 
-// Schema the vision/email parser is asked to emit. Kept lean so the LLM
-// doesn't hallucinate URLs or status transitions it has no evidence for.
-export const parsedAppointmentSchema = z.object({
-  kind: appointmentKindSchema,
-  title: z.string().min(1),
-  starts_at: z.string(), // ISO; parser does its best, we validate on save
-  ends_at: z.string().optional(),
-  all_day: z.boolean().optional(),
-  location: z.string().optional(),
-  doctor: z.string().optional(),
-  phone: z.string().optional(),
-  notes: z.string().optional(),
-  confidence: z.enum(["high", "medium", "low"]),
-  ambiguities: z.array(z.string()).optional(),
-});
-
-export type ParsedAppointment = z.infer<typeof parsedAppointmentSchema>;
+// The parsed-output schema lives in `./parse-schema.ts` — it must be a zod/v4
+// schema so it can be fed to the Anthropic SDK's `zodOutputFormat` helper,
+// which internally calls `z.toJSONSchema` (v4-only). Re-exported here for
+// backwards compatibility with existing imports.
+export {
+  parsedAppointmentSchema,
+  type ParsedAppointment,
+} from "./parse-schema";

--- a/src/lib/ingest/bulk.ts
+++ b/src/lib/ingest/bulk.ts
@@ -43,6 +43,15 @@ function isDirectImage(file: File): boolean {
   return file.type.startsWith("image/");
 }
 
+function isDocx(file: File): boolean {
+  const lower = file.name.toLowerCase();
+  return (
+    file.type ===
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+    lower.endsWith(".docx")
+  );
+}
+
 export type BulkMutator = (
   id: string,
   patch: Partial<BulkItem>,
@@ -225,7 +234,60 @@ export async function processBulkItem(
   if (isDirectImage(item.file)) {
     return processBulkItemVision(item, mutate);
   }
+  if (isDocx(item.file)) {
+    return processBulkItemDocx(item, mutate);
+  }
   return processBulkItemOcr(item, mutate);
+}
+
+/**
+ * Client-side extract of a .docx — treat the result like OCR text so the rest
+ * of the parsing pipeline (heuristic → Claude) works unchanged.
+ */
+export async function processBulkItemDocx(
+  item: BulkItem,
+  mutate: BulkMutator,
+): Promise<void> {
+  const docRow: IngestedDocument = {
+    filename: item.file.name,
+    mime_type:
+      item.file.type ||
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    size_bytes: item.file.size,
+    kind: "other",
+    uploaded_at: now(),
+    status: "ocr_pending",
+    created_at: now(),
+    updated_at: now(),
+  };
+  const docId = (await db.ingested_documents.add(docRow)) as number;
+  mutate(item.id, { status: "ocr", documentId: docId, progress: "reading docx" });
+
+  try {
+    const { docxToText } = await import("./docx");
+    const text = await docxToText(item.file);
+    if (!text.trim()) throw new Error("No readable text in this .docx");
+    await db.ingested_documents.update(docId, {
+      ocr_text: text,
+      ocr_confidence: 1,
+      status: "ocr_complete",
+      updated_at: now(),
+    });
+    mutate(item.id, {
+      ocrText: text,
+      ocrConfidence: 1,
+      status: "parsing",
+      progress: undefined,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await db.ingested_documents.update(docId, {
+      status: "error",
+      error_message: msg,
+      updated_at: now(),
+    });
+    mutate(item.id, { status: "ocr_failed", error: msg });
+  }
 }
 
 export async function saveBulkItem(

--- a/src/lib/ingest/claude-parser.ts
+++ b/src/lib/ingest/claude-parser.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import type { PreparedImage } from "~/lib/ingest/image";
 
 const LabsSchema = z.object({

--- a/src/lib/ingest/docx.ts
+++ b/src/lib/ingest/docx.ts
@@ -1,0 +1,103 @@
+"use client";
+
+// Minimal client-side .docx → plain-text extractor. A .docx is a ZIP
+// containing `word/document.xml`; we walk local-file-headers, inflate the
+// single entry we need via the browser's native DecompressionStream, strip
+// the XML tags, and return the visible text. No dependencies — keeps the
+// client bundle small on routes that don't need it (this file is lazy-loaded
+// only when the user picks a .docx in the smart-capture file picker).
+
+export const DOCX_MIME =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+export async function docxToText(file: File): Promise<string> {
+  const buf = new Uint8Array(await file.arrayBuffer());
+  const entry = findZipEntry(buf, "word/document.xml");
+  if (!entry) {
+    throw new Error(
+      "Couldn't find word/document.xml inside this .docx — file may be corrupt or password-protected.",
+    );
+  }
+  let xmlBytes: Uint8Array;
+  if (entry.method === 0) {
+    xmlBytes = buf.slice(entry.dataStart, entry.dataStart + entry.compressedSize);
+  } else if (entry.method === 8) {
+    xmlBytes = await inflateRaw(
+      buf.slice(entry.dataStart, entry.dataStart + entry.compressedSize),
+    );
+  } else {
+    throw new Error(`Unsupported compression method ${entry.method}`);
+  }
+  const xml = new TextDecoder("utf-8").decode(xmlBytes);
+  return stripDocxXml(xml);
+}
+
+interface ZipEntry {
+  method: number;
+  compressedSize: number;
+  dataStart: number;
+}
+
+// Scan the concatenated stream of local file headers (PK\x03\x04). We do not
+// rely on the end-of-central-directory, which keeps this robust even on
+// truncated / streaming .docx files.
+function findZipEntry(buf: Uint8Array, target: string): ZipEntry | null {
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  let i = 0;
+  while (i + 30 <= buf.length) {
+    const sig = view.getUint32(i, true);
+    if (sig !== 0x04034b50) break;
+    const method = view.getUint16(i + 8, true);
+    const compressedSize = view.getUint32(i + 18, true);
+    const nameLen = view.getUint16(i + 26, true);
+    const extraLen = view.getUint16(i + 28, true);
+    const name = new TextDecoder("utf-8").decode(
+      buf.subarray(i + 30, i + 30 + nameLen),
+    );
+    const dataStart = i + 30 + nameLen + extraLen;
+    if (name === target) {
+      return { method, compressedSize, dataStart };
+    }
+    i = dataStart + compressedSize;
+  }
+  return null;
+}
+
+async function inflateRaw(data: Uint8Array): Promise<Uint8Array> {
+  if (typeof DecompressionStream === "undefined") {
+    throw new Error(
+      "Your browser doesn't support DecompressionStream — can't unpack .docx.",
+    );
+  }
+  const stream = new Blob([data as BlobPart]).stream().pipeThrough(
+    new DecompressionStream("deflate-raw"),
+  );
+  const out = await new Response(stream).arrayBuffer();
+  return new Uint8Array(out);
+}
+
+// OOXML word/document.xml stores runs of text inside <w:t> elements. Paragraph
+// boundaries are <w:p>. Strip everything else and normalise whitespace so the
+// output is suitable for pasting into the universal ingest LLM.
+function stripDocxXml(xml: string): string {
+  const paragraphs = xml
+    .split(/<w:p[^>]*>/i)
+    .map((p) => {
+      const texts = Array.from(p.matchAll(/<w:t[^>]*>([^<]*)<\/w:t>/gi)).map(
+        (m) => decodeEntities(m[1] ?? ""),
+      );
+      return texts.join("");
+    })
+    .filter((p) => p.trim().length > 0);
+  return paragraphs.join("\n\n").trim();
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)));
+}

--- a/src/lib/ingest/draft-schema.ts
+++ b/src/lib/ingest/draft-schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 
 // Zod schema mirroring `IngestDraft` from src/types/ingest.ts. Used by
 // the /api/ai/ingest-universal route to parse Claude's structured
@@ -8,7 +8,7 @@ import { z } from "zod";
 export const ingestOpSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("add_appointment"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
@@ -18,12 +18,12 @@ export const ingestOpSchema = z.discriminatedUnion("kind", [
       title_contains: z.string().optional(),
       on_date: z.string().optional(),
     }),
-    changes: z.record(z.unknown()),
+    changes: z.record(z.string(), z.unknown()),
     reason: z.string(),
   }),
   z.object({
     kind: z.literal("add_lab_result"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
@@ -32,22 +32,22 @@ export const ingestOpSchema = z.discriminatedUnion("kind", [
       id: z.number().int().optional(),
       on_date: z.string(),
     }),
-    changes: z.record(z.unknown()),
+    changes: z.record(z.string(), z.unknown()),
     reason: z.string(),
   }),
   z.object({
     kind: z.literal("add_imaging"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
     kind: z.literal("add_ctdna_result"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
     kind: z.literal("add_medication"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
@@ -57,37 +57,37 @@ export const ingestOpSchema = z.discriminatedUnion("kind", [
       drug_id: z.string().optional(),
       name_contains: z.string().optional(),
     }),
-    changes: z.record(z.unknown()),
+    changes: z.record(z.string(), z.unknown()),
     reason: z.string(),
   }),
   z.object({
     kind: z.literal("add_care_team_member"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
     kind: z.literal("add_task"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
     kind: z.literal("add_life_event"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
     kind: z.literal("add_treatment_cycle"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
     kind: z.literal("add_decision"),
-    data: z.record(z.unknown()),
+    data: z.record(z.string(), z.unknown()),
     reason: z.string().optional(),
   }),
   z.object({
     kind: z.literal("update_settings"),
-    changes: z.record(z.unknown()),
+    changes: z.record(z.string(), z.unknown()),
     reason: z.string(),
   }),
 ]);

--- a/src/lib/ingest/meal-vision.ts
+++ b/src/lib/ingest/meal-vision.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import type { PreparedImage } from "./image";
 
 export const MealSchema = z.object({

--- a/src/lib/ingest/notes-vision.ts
+++ b/src/lib/ingest/notes-vision.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 import type { PreparedImage } from "./image";
 
 export const NotesStructureSchema = z.object({

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -37,24 +37,28 @@
   --r-md: 14px;
   --r-lg: 22px;
   --r-xl: 28px;
+
+  color-scheme: light;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --paper:   oklch(18% 0.012 250);
-    --paper-2: oklch(22% 0.012 250);
-    --ink-100: oklch(28% 0.010 250);
-    --ink-200: oklch(34% 0.010 250);
-    --ink-300: oklch(44% 0.010 250);
-    --ink-400: oklch(60% 0.010 250);
-    --ink-500: oklch(72% 0.010 250);
-    --ink-700: oklch(88% 0.008 250);
-    --ink-900: oklch(96% 0.006 250);
-    --tide-soft: oklch(32% 0.05 210);
-    --warn-soft: oklch(28% 0.06 50);
-    --ok-soft:   oklch(28% 0.04 160);
-    --sand:      oklch(30% 0.025 75);
-  }
+/* Dark-mode palette — opt-in only (legibility on the dark theme wasn't
+ * usable yet, so we lock to light by default). Add `data-theme="dark"`
+ * to <html> to re-enable when the tokens are tuned. */
+html[data-theme="dark"] :root,
+:root[data-theme="dark"] {
+  --paper:   oklch(18% 0.012 250);
+  --paper-2: oklch(22% 0.012 250);
+  --ink-100: oklch(28% 0.010 250);
+  --ink-200: oklch(34% 0.010 250);
+  --ink-300: oklch(44% 0.010 250);
+  --ink-400: oklch(60% 0.010 250);
+  --ink-500: oklch(72% 0.010 250);
+  --ink-700: oklch(88% 0.008 250);
+  --ink-900: oklch(96% 0.006 250);
+  --tide-soft: oklch(32% 0.05 210);
+  --warn-soft: oklch(28% 0.06 50);
+  --ok-soft:   oklch(28% 0.04 160);
+  --sand:      oklch(30% 0.025 75);
 }
 
 html,

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -378,6 +378,10 @@ export interface Settings {
   last_exported_at?: string;
   anthropic_api_key?: string;
   default_ai_model?: string;
+  // Who is using this install: the patient themselves, a family member /
+  // caregiver, or a clinician on the team. Set during onboarding; gates the
+  // care-team invite flow and the default attribution for manual entries.
+  user_type?: "patient" | "caregiver" | "clinician";
   // Which symptom ids (from SYMPTOM_CATALOG) the daily-check-in surfaces.
   // Undefined falls back to defaultTrackedSymptomIds() — the top-10
   // GnP/PDAC list.


### PR DESCRIPTION
## Summary

Addresses the seven (now ten) user-reported issues in a single pass. The biggest single unlock is a **root-cause fix for `"Cannot read properties of undefined (reading 'def')"`** that was breaking smart capture (text/photo), phone-call capture, the `/schedule/new` "smartfill" button, and several other Claude-parse endpoints.

### Root-cause: zod v3 vs v4 in the Anthropic SDK helper

The SDK's `zodOutputFormat` helper imports `zod/v4` internally and calls `z.toJSONSchema(schema)`, which accesses `.def` on the schema. Our schemas were built with the v3 import surface. Fix:

- Migrate only the schemas fed into `zodOutputFormat` to `zod/v4` (`ingestDraftSchema`, `AgentOutputSchema`, `MealSchema`, `NotesStructureSchema`, `ExtractionSchema`, inline `SummarySchema`, new `parsedAppointmentSchema`).
- Added `src/lib/anthropic/json-output.ts` — a thin `jsonOutputFormat<T>()` wrapper so the SDK's v3-typed signature still type-checks with v4 schemas.
- Split `src/lib/appointments/schema.ts`: form-validation stays on v3 (unchanged runtime behaviour); new `parse-schema.ts` holds the v4 output schema for the parser.

### User-visible fixes

- **Daily check-in** — `/daily/new` and `/daily/[id]` now have the same `max-w-3xl p-4 md:p-8` container as the rest of the app. The Practice step pulls from configured behavioural medications (morning / evening / other groups) with a "No practices configured yet" fallback + link to add one. `PracticesCard` supports tap-to-start with an inline timer (Pause / Resume / Done / Cancel) that auto-logs on completion.
- **Smart capture** — accepts `.docx`. Added a dependency-free client-side extractor (`src/lib/ingest/docx.ts`) that walks ZIP local-file-headers, inflates `word/document.xml` via the browser's `DecompressionStream('deflate-raw')`, and strips the XML. Wired into `universal-drop`, bulk queue, and the drop-zone messaging.
- **Labs ingest** — collapsed two CTAs into one. Labs page now points to the same `/ingest` surface with the same "Drop in anything medical" copy.
- **Appointments** — "Who's attending" is now a multi-chip picker (`AttendeeChips`) backed by the care-team registry, with suggested chips and free-text fallback. Stored shape (`attendees: string[]`) unchanged for existing readers.
- **Dashboard** — new `NextClinicCard` that surfaces the very next non-cancelled clinic-kind appointment with doctor/location/fasting/prep cues.
- **Onboarding** — new "Who you are" step (patient / caregiver / clinician). Persisted on `Settings.user_type` and mirrored into the `enteredBy` UI store so attribution defaults correctly.
- **Care team** — copy points to the existing Household invite flow for actual account linking.
- **Medications** — `/medications/log` starts blank when no prescriptions exist, grows an "Edit prescription" icon per row + a sticky "Save & close" footer. New `/prescriptions` view lists every active medication with inline dose/notes edit + stop. Creating a new chemo cycle now redirects into `/prescriptions?cycle=…&from=treatment-new` with a "Review & confirm" banner before anything logs against the protocol-derived meds.
- **Theme** — default to light mode (dark palette was not legible). `<html data-theme="light" style="color-scheme: light">`; dark rules kept as opt-in under `[data-theme="dark"]`.

### Known deferred items

Flagged for a follow-up PR because the scope exceeds this one:

- Calendar import time/timezone bug — not touched yet; needs a targeted reproduction.
- Full chemo / central-calendar integration — architectural refactor.
- `/schedule` redesign to match the design spec.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 352 / 352 passing.
- [x] `pnpm lint` — only pre-existing `<img>` warnings in `ingest/meal` and `ingest/notes`.
- [ ] Manual QA: drop a `.docx` into Smart Capture and confirm text extraction + ingest preview.
- [ ] Manual QA: tap "Smartfill" on `/schedule/new`; the `def` error should no longer appear.
- [ ] Manual QA: start a practice from the dashboard card; timer counts down and auto-logs.
- [ ] Manual QA: `/daily/new` renders with Anchor padding + Practice step lists configured practices.
- [ ] Manual QA: create a new chemo cycle; land on `/prescriptions` with the "Review & confirm" banner.
- [ ] Manual QA: "Who's attending" on a new appointment shows suggested chips from care team and accepts free-text.

https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY)_