### PR TITLE
Family invitee onboarding + ICS TZID fix + chemo→calendar sync

### DIFF
--- a/src/app/api/agent/[id]/run/route.ts
+++ b/src/app/api/agent/[id]/run/route.ts
@@ -12,9 +12,8 @@ import { runAgent } from "~/agents/run";
 
 export const runtime = "nodejs";
 // Specialist agents chew through referrals + state and emit up to 2k tokens
-// of structured output. Give them Vercel's Pro ceiling minus headroom so
-// on-demand /agent runs don't time out mid-call.
-export const maxDuration = 120;
+// of structured output. 60s is the safe ceiling across Vercel paid tiers.
+export const maxDuration = 60;
 
 // We accept the day's referrals + current state.md from the caller (the
 // patient's browser, or a Vercel Cron driver) so the route stays stateless

--- a/src/app/api/agent/[id]/run/route.ts
+++ b/src/app/api/agent/[id]/run/route.ts
@@ -11,6 +11,10 @@ import { AGENT_IDS, LOG_TAGS } from "~/types/agent";
 import { runAgent } from "~/agents/run";
 
 export const runtime = "nodejs";
+// Specialist agents chew through referrals + state and emit up to 2k tokens
+// of structured output. Give them Vercel's Pro ceiling minus headroom so
+// on-demand /agent runs don't time out mid-call.
+export const maxDuration = 120;
 
 // We accept the day's referrals + current state.md from the caller (the
 // patient's browser, or a Vercel Cron driver) so the route stays stateless

--- a/src/app/api/ai/assessment-summary/route.ts
+++ b/src/app/api/ai/assessment-summary/route.ts
@@ -5,6 +5,7 @@ import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import { SUMMARY_SYSTEM } from "~/lib/ai/coach";
 
 export const runtime = "nodejs";
+export const maxDuration = 60;
 
 const SummarySchema = z.object({
   patient: z.string(),

--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -8,6 +8,7 @@ import {
 import type { Locale } from "~/types/clinical";
 
 export const runtime = "nodejs";
+export const maxDuration = 60;
 
 interface RequestBody {
   model?: string;

--- a/src/app/api/ai/feed-narrative/route.ts
+++ b/src/app/api/ai/feed-narrative/route.ts
@@ -5,6 +5,7 @@ import type { FeedItem } from "~/types/feed";
 import type { Locale } from "~/types/clinical";
 
 export const runtime = "nodejs";
+export const maxDuration = 60;
 
 interface RequestBody {
   locale: Locale;

--- a/src/app/api/ai/ingest-meal/route.ts
+++ b/src/app/api/ai/ingest-meal/route.ts
@@ -5,6 +5,7 @@ import { MealSchema, MEAL_SYSTEM } from "~/lib/ingest/meal-vision";
 import type { PreparedImage } from "~/lib/ingest/image";
 
 export const runtime = "nodejs";
+export const maxDuration = 60;
 
 interface RequestBody {
   image: PreparedImage;

--- a/src/app/api/ai/ingest-notes/route.ts
+++ b/src/app/api/ai/ingest-notes/route.ts
@@ -8,6 +8,7 @@ import {
 import type { PreparedImage } from "~/lib/ingest/image";
 
 export const runtime = "nodejs";
+export const maxDuration = 60;
 
 interface RequestBody {
   image: PreparedImage;

--- a/src/app/api/ai/ingest-report/route.ts
+++ b/src/app/api/ai/ingest-report/route.ts
@@ -8,6 +8,8 @@ import {
 import type { PreparedImage } from "~/lib/ingest/image";
 
 export const runtime = "nodejs";
+// Vision + Opus parse of a lab / imaging / clinic letter — routinely 15-30s.
+export const maxDuration = 60;
 
 interface RequestBody {
   text?: string;

--- a/src/app/api/ai/ingest-universal/route.ts
+++ b/src/app/api/ai/ingest-universal/route.ts
@@ -10,11 +10,10 @@ import type { IngestDraft, IngestSourceKind } from "~/types/ingest";
 
 export const runtime = "nodejs";
 // Smart-capture ingest can emit up to 25 ops per document, on Opus-4-7
-// with a 4k-token budget + optional image input. The default 10–15s
-// serverless timeout isn't enough — users were seeing
-// FUNCTION_INVOCATION_TIMEOUT on longer clinic letters. 120s sits well
-// under the Vercel Pro 300s cap and covers real-world docs.
-export const maxDuration = 120;
+// with a 4k-token budget + optional image input. Complex multi-page
+// clinic letters have hit FUNCTION_INVOCATION_TIMEOUT at 120s — bump to
+// Vercel Pro's 300s ceiling to cover those tails.
+export const maxDuration = 300;
 
 interface RequestBody {
   text?: string;

--- a/src/app/api/ai/ingest-universal/route.ts
+++ b/src/app/api/ai/ingest-universal/route.ts
@@ -9,6 +9,12 @@ import type { PreparedImage } from "~/lib/ingest/image";
 import type { IngestDraft, IngestSourceKind } from "~/types/ingest";
 
 export const runtime = "nodejs";
+// Smart-capture ingest can emit up to 25 ops per document, on Opus-4-7
+// with a 4k-token budget + optional image input. The default 10–15s
+// serverless timeout isn't enough — users were seeing
+// FUNCTION_INVOCATION_TIMEOUT on longer clinic letters. 120s sits well
+// under the Vercel Pro 300s cap and covers real-world docs.
+export const maxDuration = 120;
 
 interface RequestBody {
   text?: string;

--- a/src/app/api/ai/ingest-universal/route.ts
+++ b/src/app/api/ai/ingest-universal/route.ts
@@ -9,11 +9,13 @@ import type { PreparedImage } from "~/lib/ingest/image";
 import type { IngestDraft, IngestSourceKind } from "~/types/ingest";
 
 export const runtime = "nodejs";
-// Smart-capture ingest can emit up to 25 ops per document, on Opus-4-7
-// with a 4k-token budget + optional image input. Complex multi-page
-// clinic letters have hit FUNCTION_INVOCATION_TIMEOUT at 120s — bump to
-// Vercel Pro's 300s ceiling to cover those tails.
-export const maxDuration = 300;
+// Smart-capture ingest can emit up to 25 ops per document on Opus-4-7
+// with a 4k-token budget + optional image input. 60s is the safe
+// ceiling across all Vercel paid tiers without needing Fluid Compute;
+// complex multi-page clinic letters that still time out should be
+// split or downgraded to Sonnet per-route rather than pushing the
+// platform cap higher.
+export const maxDuration = 60;
 
 interface RequestBody {
   text?: string;

--- a/src/app/api/cron/morning-digest/route.ts
+++ b/src/app/api/cron/morning-digest/route.ts
@@ -11,6 +11,9 @@ import type { Appointment } from "~/types/appointment";
 import type { ZoneAlert } from "~/types/clinical";
 
 export const runtime = "nodejs";
+// Daily digest fans out push notifications and may iterate households;
+// give it generous headroom so it doesn't cut off mid-send.
+export const maxDuration = 300;
 
 // Vercel Cron entry point. Fires at 21:00 UTC daily (configured in
 // vercel.json), which is 07:00 AEST — Hu Lin's morning in Melbourne.

--- a/src/app/api/cron/morning-digest/route.ts
+++ b/src/app/api/cron/morning-digest/route.ts
@@ -11,9 +11,10 @@ import type { Appointment } from "~/types/appointment";
 import type { ZoneAlert } from "~/types/clinical";
 
 export const runtime = "nodejs";
-// Daily digest fans out push notifications and may iterate households;
-// give it generous headroom so it doesn't cut off mid-send.
-export const maxDuration = 300;
+// Daily digest fans out push notifications and may iterate households.
+// 60s is the safe ceiling across Vercel paid tiers without Fluid Compute;
+// if fan-out grows past this the cron should paginate.
+export const maxDuration = 60;
 
 // Vercel Cron entry point. Fires at 21:00 UTC daily (configured in
 // vercel.json), which is 07:00 AEST — Hu Lin's morning in Melbourne.

--- a/src/app/api/ingest-ics/route.ts
+++ b/src/app/api/ingest-ics/route.ts
@@ -15,6 +15,10 @@ export const runtime = "nodejs";
 interface RequestBody {
   url?: string;
   text?: string;
+  // Patient's home IANA timezone; used as the fallback when a VEVENT
+  // has a floating DTSTART (no TZID, no Z suffix). Defaults to
+  // Australia/Melbourne for this install.
+  fallbackTimezone?: string;
 }
 
 function normaliseUrl(raw: string): string {
@@ -74,7 +78,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const events = parseIcs(raw);
+  const events = parseIcs(raw, body.fallbackTimezone);
   if (events.length === 0) {
     return NextResponse.json(
       { error: "No VEVENT blocks found." },

--- a/src/app/api/ingest-ics/route.ts
+++ b/src/app/api/ingest-ics/route.ts
@@ -3,6 +3,10 @@ import { icsEventsToOps, parseIcs } from "~/lib/ingest/ics";
 import type { IngestDraft } from "~/types/ingest";
 
 export const runtime = "nodejs";
+// ICS import fetches a remote webcal URL server-side (sometimes slow iCloud
+// feeds with many years of events) and runs regex parsing over the result.
+// 60s is generous for network + parse.
+export const maxDuration = 60;
 
 // Server-side ICS fetcher. The browser can't fetch a webcal:// URL
 // cross-origin; we do it server-side, normalise the scheme, parse

--- a/src/app/api/parse-appointment/route.ts
+++ b/src/app/api/parse-appointment/route.ts
@@ -9,6 +9,7 @@ import { parsedAppointmentSchema } from "~/lib/appointments/schema";
 // whether to accept the parse.
 
 export const runtime = "nodejs";
+export const maxDuration = 60;
 
 const RequestSchema = z.object({
   text: z.string().optional(),

--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -4,6 +4,7 @@ import { useLocale } from "~/hooks/use-translate";
 import { PageHeader } from "~/components/ui/page-header";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { HouseholdHeader } from "~/components/family/household-header";
+import { ProfileCompletionBanner } from "~/components/family/profile-completion-banner";
 import { PresenceStack } from "~/components/shared/presence-stack";
 import { ZoneBanner } from "~/components/family/zone-banner";
 import { NextUp } from "~/components/family/next-up";
@@ -24,6 +25,8 @@ export default function FamilyPage() {
       />
 
       <HouseholdHeader />
+
+      <ProfileCompletionBanner />
 
       <PresenceStack surface="/family" />
 

--- a/src/app/ingest/pending/page.tsx
+++ b/src/app/ingest/pending/page.tsx
@@ -179,7 +179,7 @@ export default function PendingResultsPage() {
                     )}
                     {r.site && <span>{r.site}</span>}
                     {overdue && (
-                      <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                      <span className="inline-flex items-center gap-1 rounded-full bg-[var(--warn-soft)] px-2 py-0.5 text-[var(--warn)]">
                         <Clock className="h-3 w-3" />
                         {locale === "zh" ? "超期" : "overdue"}
                       </span>

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -7,6 +7,8 @@ import { getSupabaseBrowser } from "~/lib/supabase/client";
 import {
   acceptInvite,
   friendlyInviteError,
+  getCurrentProfile,
+  isProfileComplete,
 } from "~/lib/supabase/households";
 import { PageHeader } from "~/components/ui/page-header";
 import { Button } from "~/components/ui/button";
@@ -61,9 +63,13 @@ export default function InvitePage() {
         await acceptInvite(token);
         if (cancelled) return;
         setPhase({ kind: "accepted" });
-        // Short pause so the "welcome" state is readable, then land on
-        // /family where the newly-joined carer sees dad's data.
-        setTimeout(() => router.replace("/family"), 1200);
+        // If the invitee's profile has no relationship / name yet, run
+        // the welcome wizard so the care-team list renders something
+        // useful. If they're returning (re-invite) and everything's set,
+        // drop them straight on /family.
+        const profile = await getCurrentProfile().catch(() => null);
+        const next = isProfileComplete(profile) ? "/family" : "/invite/welcome";
+        setTimeout(() => router.replace(next), 1200);
       } catch (err) {
         if (!cancelled)
           setPhase({ kind: "error", message: friendlyInviteError(err) });

--- a/src/app/invite/welcome/page.tsx
+++ b/src/app/invite/welcome/page.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useLiveQuery } from "dexie-react-hooks";
+import {
+  getCurrentProfile,
+  getHousehold,
+  isProfileComplete,
+  updateMyProfile,
+} from "~/lib/supabase/households";
+import { useHousehold } from "~/hooks/use-household";
+import { useUIStore } from "~/stores/ui-store";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, TextInput } from "~/components/ui/field";
+import type { Household, Profile } from "~/types/household";
+import type { Locale } from "~/types/clinical";
+import {
+  ChevronRight,
+  ChevronLeft,
+  Check,
+  Heart,
+  Loader2,
+  Users,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+// Post-acceptance onboarding for an invited family / care-team member. The
+// /invite/[token] flow hands off here after `acceptInvite` succeeds so the
+// new member can fill in a display name, relationship, locale, and timezone
+// before they're dropped into /family. Skippable by design — anything left
+// blank falls back to sensible defaults and can be edited later from
+// Settings → Household → Your profile.
+
+type Step = "welcome" | "about" | "preferences" | "done";
+const STEPS: Step[] = ["welcome", "about", "preferences", "done"];
+
+const RELATIONSHIP_SUGGESTIONS: Array<{ id: string; en: string; zh: string }> = [
+  { id: "son", en: "Son", zh: "儿子" },
+  { id: "daughter", en: "Daughter", zh: "女儿" },
+  { id: "spouse", en: "Spouse / partner", zh: "配偶 / 伴侣" },
+  { id: "sibling", en: "Sibling", zh: "兄弟姐妹" },
+  { id: "parent", en: "Parent", zh: "父母" },
+  { id: "friend", en: "Close friend", zh: "好友" },
+  { id: "nurse", en: "Nurse", zh: "护士" },
+  { id: "doctor", en: "Doctor", zh: "医师" },
+  { id: "allied_health", en: "Allied health", zh: "康复 / 营养" },
+];
+
+export default function InviteWelcomePage() {
+  const router = useRouter();
+  const { membership, loading } = useHousehold();
+  const setUILocale = useUIStore((s) => s.setLocale);
+
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [household, setHousehold] = useState<Household | null>(null);
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [step, setStep] = useState<Step>("welcome");
+  const [saving, setSaving] = useState(false);
+
+  // Form state; prefilled from existing profile if something's already there.
+  const [displayName, setDisplayName] = useState("");
+  const [relationship, setRelationship] = useState("");
+  const [customRelationship, setCustomRelationship] = useState("");
+  const [locale, setLocale] = useState<Locale>("en");
+  const [timezone, setTimezone] = useState<string>("");
+
+  // Resolve the browser's IANA timezone as a sensible default. Falls back
+  // to Australia/Melbourne (the patient's locale) when the browser can't
+  // tell us.
+  const browserTimezone = useMemo(() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch {
+      return "Australia/Melbourne";
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const p = await getCurrentProfile();
+        if (cancelled) return;
+        setProfile(p);
+        if (p) {
+          setDisplayName(p.display_name ?? "");
+          setRelationship(p.relationship ?? "");
+          setLocale(p.locale ?? "en");
+          setTimezone(p.timezone ?? browserTimezone);
+        }
+      } finally {
+        if (!cancelled) setLoadingProfile(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [browserTimezone]);
+
+  useEffect(() => {
+    if (!membership?.household_id) return;
+    let cancelled = false;
+    void (async () => {
+      const h = await getHousehold(membership.household_id);
+      if (!cancelled) setHousehold(h);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [membership?.household_id]);
+
+  // Route-guard: if the user hits this URL without an active membership,
+  // send them home. And if their profile is already complete, skip the
+  // welcome and drop them straight on /family.
+  useEffect(() => {
+    if (loading || loadingProfile) return;
+    if (!membership) {
+      router.replace("/");
+      return;
+    }
+    if (isProfileComplete(profile) && step === "welcome") {
+      router.replace("/family");
+    }
+  }, [loading, loadingProfile, membership, profile, router, step]);
+
+  const stepIdx = STEPS.indexOf(step);
+  const progress = ((stepIdx + 1) / STEPS.length) * 100;
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  function pickRelationship(id: string, label: string) {
+    setRelationship(label);
+    setCustomRelationship("");
+  }
+
+  async function finish() {
+    setSaving(true);
+    try {
+      const finalRelationship =
+        customRelationship.trim() || relationship.trim() || null;
+      await updateMyProfile({
+        display_name: displayName.trim() || "Care team member",
+        relationship: finalRelationship,
+        care_role_label: finalRelationship,
+        locale,
+        timezone: timezone || browserTimezone,
+      });
+      setUILocale(locale);
+      router.replace("/family");
+    } catch {
+      // Fail-open: even if the profile write errors we still drop them on
+      // /family rather than trapping them here. Settings → Household lets
+      // them retry.
+      router.replace("/family");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading || loadingProfile) {
+    return (
+      <div className="mx-auto max-w-md space-y-5 p-6 pt-16">
+        <Card>
+          <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading…
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!membership) return null;
+
+  const canContinue =
+    step !== "about" ||
+    displayName.trim().length > 0;
+
+  return (
+    <div className="mx-auto max-w-md space-y-5 p-6 pt-12">
+      <PageHeader
+        eyebrow={L("CARE TEAM", "护理团队")}
+        title={L("Welcome to the team", "欢迎加入团队")}
+      />
+      <div className="h-1 w-full overflow-hidden rounded-full bg-ink-100">
+        <div
+          className="h-full bg-[var(--tide-2)] transition-all duration-300"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      {step === "welcome" && (
+        <Card>
+          <CardContent className="space-y-3 pt-5">
+            <div className="flex items-center gap-2">
+              <Heart className="h-4 w-4 text-[var(--tide-2)]" />
+              <div className="text-[14px] font-semibold text-ink-900">
+                {household
+                  ? L(
+                      `You've joined ${household.patient_display_name}'s care team.`,
+                      `您已加入 ${household.patient_display_name} 的护理团队。`,
+                    )
+                  : L("You've joined the care team.", "您已加入护理团队。")}
+              </div>
+            </div>
+            <p className="text-[13px] text-ink-500">
+              {L(
+                "Two quick questions so everyone knows how you're involved, and you'll see times in your own timezone.",
+                "两个简短问题，让大家知道您的身份，并让时间显示为您所在时区。",
+              )}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === "about" && (
+        <Card>
+          <CardContent className="space-y-4 pt-5">
+            <div className="eyebrow">
+              {L("About you", "您的信息")}
+            </div>
+            <Field label={L("Your name", "您的姓名")}>
+              <TextInput
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder={L("e.g. Thomas Hu", "例如：胡先生")}
+                autoFocus
+              />
+            </Field>
+            <Field
+              label={L("Your relationship to the patient", "您与患者的关系")}
+              hint={L(
+                "Shown on the care-team list — tap a chip or type your own.",
+                "会显示在护理团队名单上 —— 点选或自定义。",
+              )}
+            >
+              <div className="flex flex-wrap gap-1.5">
+                {RELATIONSHIP_SUGGESTIONS.map((r) => {
+                  const label = locale === "zh" ? r.zh : r.en;
+                  const active =
+                    relationship === label && !customRelationship.trim();
+                  return (
+                    <button
+                      key={r.id}
+                      type="button"
+                      onClick={() => pickRelationship(r.id, label)}
+                      className={cn(
+                        "rounded-full border px-2.5 py-1 text-[11.5px] transition-colors",
+                        active
+                          ? "border-ink-900 bg-ink-900 text-paper"
+                          : "border-ink-200 bg-paper-2 text-ink-700 hover:border-ink-400",
+                      )}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+              <TextInput
+                value={customRelationship}
+                onChange={(e) => setCustomRelationship(e.target.value)}
+                placeholder={L("Or type something else", "或自行输入")}
+                className="mt-2"
+              />
+            </Field>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === "preferences" && (
+        <Card>
+          <CardContent className="space-y-4 pt-5">
+            <div className="eyebrow">
+              {L("Preferences", "偏好设置")}
+            </div>
+            <Field label={L("Language", "语言")}>
+              <div className="flex gap-1.5">
+                {(["en", "zh"] as const).map((l) => (
+                  <button
+                    key={l}
+                    type="button"
+                    onClick={() => setLocale(l)}
+                    className={cn(
+                      "flex-1 rounded-md border px-3 py-2 text-[12.5px] transition-colors",
+                      locale === l
+                        ? "border-ink-900 bg-ink-900 text-paper"
+                        : "border-ink-200 bg-paper-2 text-ink-700",
+                    )}
+                  >
+                    {l === "en" ? "English" : "中文"}
+                  </button>
+                ))}
+              </div>
+            </Field>
+            <Field
+              label={L("Your timezone", "您所在时区")}
+              hint={L(
+                "Appointment times on /family are shown in this zone. Auto-detected — edit if you're travelling.",
+                "家庭视图中的预约时间会按此时区显示。已自动识别 —— 外出时可修改。",
+              )}
+            >
+              <TextInput
+                value={timezone}
+                onChange={(e) => setTimezone(e.target.value)}
+                placeholder="Australia/Melbourne"
+              />
+              <button
+                type="button"
+                onClick={() => setTimezone(browserTimezone)}
+                className="mt-1 text-[11.5px] text-ink-500 underline-offset-2 hover:text-ink-900 hover:underline"
+              >
+                {L(
+                  `Use detected (${browserTimezone})`,
+                  `使用识别到的（${browserTimezone}）`,
+                )}
+              </button>
+            </Field>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === "done" && (
+        <Card>
+          <CardContent className="flex items-start gap-3 pt-5">
+            <Users className="mt-0.5 h-5 w-5 text-[var(--tide-2)]" />
+            <div>
+              <div className="text-[14px] font-semibold text-ink-900">
+                {L("All set — opening the family view", "设置完成 —— 正在进入家庭视图")}
+              </div>
+              <p className="mt-1 text-[13px] text-ink-500">
+                {L(
+                  "You can change any of this later from Settings → Household.",
+                  "可随时在「设置 → 家庭」中修改。",
+                )}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="flex items-center justify-between gap-2">
+        {step !== "welcome" && step !== "done" ? (
+          <Button
+            variant="ghost"
+            onClick={() => {
+              const prev = STEPS[Math.max(0, stepIdx - 1)];
+              if (prev) setStep(prev);
+            }}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            {L("Back", "上一步")}
+          </Button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => router.replace("/family")}
+            className="text-[12px] text-ink-500 underline-offset-2 hover:text-ink-900 hover:underline"
+          >
+            {L("Skip and finish later", "跳过，稍后再填")}
+          </button>
+        )}
+        {step === "preferences" ? (
+          <Button onClick={() => void finish()} disabled={saving} size="lg">
+            {saving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Check className="h-4 w-4" />
+            )}
+            {L("Finish", "完成")}
+          </Button>
+        ) : step === "done" ? null : (
+          <Button
+            onClick={() => {
+              const next = STEPS[Math.min(STEPS.length - 1, stepIdx + 1)];
+              if (next) setStep(next);
+            }}
+            disabled={!canContinue}
+            size="lg"
+          >
+            {L("Continue", "继续")}
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/medications/log/page.tsx
+++ b/src/app/medications/log/page.tsx
@@ -14,6 +14,7 @@ import {
   ensureCycleMedications,
   getActiveMedications,
 } from "~/lib/medication/active";
+import { syncCycleToCalendar } from "~/lib/treatment/calendar-sync";
 import {
   compileTodayStatuses,
   logMedicationEvent,
@@ -53,10 +54,11 @@ export default function MedicationLogPage() {
   const [statuses, setStatuses] = useState<MedicationTodayStatus[]>([]);
   const [sheetFor, setSheetFor] = useState<Medication | null>(null);
 
-  // Auto-seed protocol-derived meds when a cycle is active
+  // Auto-seed protocol-derived meds + calendar events when a cycle is active.
   useEffect(() => {
     if (ctx?.cycle) {
       void ensureCycleMedications(ctx.cycle);
+      void syncCycleToCalendar(ctx.cycle);
     }
   }, [ctx?.cycle]);
 

--- a/src/app/prescriptions/page.tsx
+++ b/src/app/prescriptions/page.tsx
@@ -10,6 +10,7 @@ import {
   ensureCycleMedications,
   getActiveMedications,
 } from "~/lib/medication/active";
+import { syncCycleToCalendar } from "~/lib/treatment/calendar-sync";
 import { DRUGS_BY_ID } from "~/config/drug-registry";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent } from "~/components/ui/card";
@@ -61,6 +62,12 @@ function Inner() {
     if (!cycle) return;
     void (async () => {
       await ensureCycleMedications(cycle);
+      // Dose days appear on the schedule as chemo appointments so the
+      // calendar is the single source of truth for "what's coming up."
+      await syncCycleToCalendar(cycle).catch(() => {
+        // Non-fatal — the prescription review screen still works if the
+        // sync errors (e.g. Dexie migration still in flight on first load).
+      });
       setSeeded(true);
     })();
   }, [cycle]);

--- a/src/components/daily/daily-wizard.tsx
+++ b/src/components/daily/daily-wizard.tsx
@@ -146,6 +146,24 @@ function catTouched(id: CatId, draft: Draft): boolean {
   });
 }
 
+// Scale fields default to a visible value (e.g. energy shows "5" by default)
+// but don't commit that value to the draft until the user taps. If the user
+// reads the page and moves on, the "review" screen previously marked the
+// category as empty and refused to save. Stamping these defaults on
+// advance matches the mental model that "what's on screen is what's
+// recorded." Only scale defaults — toggles, weights, and free-text fields
+// stay unrecorded unless actively set.
+const SCALE_DEFAULTS: Partial<Record<string, number>> = {
+  energy: 5,
+  pain_current: 0,
+  pain_worst: 0,
+  mood_clarity: 5,
+  appetite: 5,
+  sleep_quality: 5,
+  practice_morning_quality: 3,
+  practice_evening_quality: 3,
+};
+
 interface Props {
   entryId?: number;
   date: string;
@@ -237,7 +255,26 @@ export function DailyWizard({ entryId, date }: Props) {
     setPhase("stepping");
   }
 
+  function stampDefaultsFor(catId: CatId) {
+    const def = catDef(catId);
+    setDraft((d) => {
+      const next = { ...d };
+      for (const f of def.fields) {
+        const key = f as keyof DailyEntry;
+        const current = (next as Record<string, unknown>)[f];
+        if (current !== undefined && current !== "") continue;
+        const fallback = SCALE_DEFAULTS[f];
+        if (typeof fallback === "number") {
+          (next as Record<string, unknown>)[f] = fallback;
+        }
+      }
+      return next;
+    });
+  }
+
   function advance() {
+    const current = picked[cursor];
+    if (current) stampDefaultsFor(current);
     if (cursor + 1 >= picked.length) {
       setPhase("review");
     } else {

--- a/src/components/family/profile-completion-banner.tsx
+++ b/src/components/family/profile-completion-banner.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  getCurrentProfile,
+  isProfileComplete,
+} from "~/lib/supabase/households";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import { UserCircle2, ChevronRight } from "lucide-react";
+
+// Nag banner shown to carers who landed on /family but never completed the
+// welcome wizard (either because they skipped it or joined before the flow
+// existed). Self-hides as soon as the profile has a name + relationship.
+export function ProfileCompletionBanner() {
+  const locale = useLocale();
+  const [incomplete, setIncomplete] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const p = await getCurrentProfile().catch(() => null);
+      if (!cancelled) setIncomplete(p !== null && !isProfileComplete(p));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!incomplete) return null;
+
+  return (
+    <Link href="/invite/welcome" className="block">
+      <Card className="border-[var(--tide-2)]/40 bg-[var(--tide-soft)] transition-colors hover:border-[var(--tide-2)]">
+        <CardContent className="flex items-center gap-3 p-4">
+          <UserCircle2 className="h-5 w-5 shrink-0 text-[var(--tide-2)]" />
+          <div className="min-w-0 flex-1">
+            <div className="text-[13.5px] font-semibold text-ink-900">
+              {locale === "zh"
+                ? "完善您的个人资料"
+                : "Finish setting up your profile"}
+            </div>
+            <p className="mt-0.5 text-[12px] text-ink-700">
+              {locale === "zh"
+                ? "让团队知道您的身份，时间以您的时区显示。两分钟搞定。"
+                : "Tell the team who you are so times show in your own zone. Takes a minute."}
+            </p>
+          </div>
+          <ChevronRight className="h-4 w-4 shrink-0 text-ink-400" />
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/ingest/calendar-subscribe.tsx
+++ b/src/components/ingest/calendar-subscribe.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -25,6 +27,11 @@ export function CalendarSubscribe({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Pull the patient's home timezone so floating ICS times (no TZID) are
+  // resolved to the right wall clock. Falls back to the browser zone.
+  const settings = useLiveQuery(() => db.settings.toArray(), []);
+  const homeTz = settings?.[0]?.home_timezone;
+
   async function fetchAndParse() {
     const canUrl = url.trim().length > 0;
     const canText = text.trim().length > 0;
@@ -32,12 +39,22 @@ export function CalendarSubscribe({
     setBusy(true);
     setError(null);
     try {
+      const fallbackTimezone =
+        homeTz ??
+        (() => {
+          try {
+            return Intl.DateTimeFormat().resolvedOptions().timeZone;
+          } catch {
+            return "Australia/Melbourne";
+          }
+        })();
+      const payload = canUrl
+        ? { url: url.trim(), fallbackTimezone }
+        : { text, fallbackTimezone };
       const res = await fetch("/api/ingest-ics", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(
-          canUrl ? { url: url.trim() } : { text },
-        ),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error(await res.text());
       const data = (await res.json()) as { draft: IngestDraft };

--- a/src/components/ingest/phone-note.tsx
+++ b/src/components/ingest/phone-note.tsx
@@ -169,7 +169,7 @@ export function PhoneCallNote({
           <Button onClick={submit} disabled={busy || !text.trim()}>
             {busy
               ? L("Reading…", "正在识别…")
-              : L("Structure this", "结构化")}
+              : L("Save", "保存")}
           </Button>
           {canSpeech && (
             <Button

--- a/src/components/ingest/preview-diff.tsx
+++ b/src/components/ingest/preview-diff.tsx
@@ -11,6 +11,7 @@ import type {
 import { useLocale } from "~/hooks/use-translate";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
+import { TextInput, Textarea } from "~/components/ui/field";
 import {
   CalendarPlus,
   CalendarClock,
@@ -88,6 +89,11 @@ export function PreviewDiff({ draft, onApplied, onDiscard }: Props) {
   const [selected, setSelected] = useState<Set<number>>(initialSelected);
   const [applying, setApplying] = useState(false);
   const [results, setResults] = useState<IngestApplyResult[] | null>(null);
+  // Per-op field overrides. Keyed by index. We keep the full (possibly
+  // edited) op here so multi-field edits roll up into one object the
+  // save path can use directly.
+  const [edits, setEdits] = useState<Record<number, IngestOp>>({});
+  const [editingIdx, setEditingIdx] = useState<number | null>(null);
 
   function toggle(i: number) {
     setSelected((prev) => {
@@ -98,8 +104,18 @@ export function PreviewDiff({ draft, onApplied, onDiscard }: Props) {
     });
   }
 
+  function patch(i: number, next: IngestOp) {
+    setEdits((prev) => ({ ...prev, [i]: next }));
+  }
+
+  function effectiveOp(i: number): IngestOp {
+    return edits[i] ?? draft.ops[i]!;
+  }
+
   async function applySelected() {
-    const ops = draft.ops.filter((_, i) => selected.has(i));
+    const ops = draft.ops
+      .map((_, i) => (selected.has(i) ? effectiveOp(i) : null))
+      .filter((o): o is IngestOp => o !== null);
     if (ops.length === 0) return;
     setApplying(true);
     try {
@@ -162,11 +178,16 @@ export function PreviewDiff({ draft, onApplied, onDiscard }: Props) {
           {draft.ops.map((op, i) => (
             <li key={i}>
               <OpCard
-                op={op}
+                op={effectiveOp(i)}
                 index={i}
                 selected={selected.has(i)}
+                editing={editingIdx === i}
                 result={results?.[results.findIndex((r) => r.op === op)] ?? null}
                 onToggle={() => toggle(i)}
+                onEdit={() =>
+                  setEditingIdx((prev) => (prev === i ? null : i))
+                }
+                onChange={(next) => patch(i, next)}
                 locale={locale}
               />
             </li>
@@ -202,10 +223,10 @@ export function PreviewDiff({ draft, onApplied, onDiscard }: Props) {
             >
               <Check className="h-4 w-4" />
               {applying
-                ? L("Applying…", "应用中…")
+                ? L("Saving…", "保存中…")
                 : L(
-                    `Apply ${selected.size} change${selected.size === 1 ? "" : "s"}`,
-                    `应用 ${selected.size} 项变更`,
+                    `Save ${selected.size} item${selected.size === 1 ? "" : "s"}`,
+                    `保存 ${selected.size} 项`,
                   )}
             </Button>
           </div>
@@ -215,25 +236,38 @@ export function PreviewDiff({ draft, onApplied, onDiscard }: Props) {
   );
 }
 
+const EDITABLE_KINDS: IngestOpKind[] = [
+  "add_appointment",
+  "add_task",
+  "add_medication",
+];
+
 function OpCard({
   op,
   index,
   selected,
+  editing,
   result,
   onToggle,
+  onEdit,
+  onChange,
   locale,
 }: {
   op: IngestOp;
   index: number;
   selected: boolean;
+  editing: boolean;
   result: IngestApplyResult | null;
   onToggle: () => void;
+  onEdit: () => void;
+  onChange: (next: IngestOp) => void;
   locale: "en" | "zh";
 }) {
   const Icon = OP_ICON[op.kind];
   const label = OP_LABEL[op.kind][locale];
   const lines = describeOp(op, locale);
   const reason = "reason" in op && op.reason ? op.reason : null;
+  const canEdit = EDITABLE_KINDS.includes(op.kind) && !result;
 
   return (
     <div
@@ -248,40 +282,66 @@ function OpCard({
               : "border-ink-100 bg-paper-2",
       )}
     >
-      <label className="flex cursor-pointer items-start gap-3">
-        <input
-          type="checkbox"
-          checked={selected}
-          onChange={onToggle}
-          disabled={Boolean(result)}
-          className="mt-1 h-4 w-4 shrink-0 accent-ink-900"
-        />
+      <div className="flex items-start gap-3">
+        <label className="mt-1 flex shrink-0 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={onToggle}
+            disabled={Boolean(result)}
+            className="h-4 w-4 accent-ink-900"
+          />
+        </label>
         <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-paper-2 text-[var(--tide-2)]">
           <Icon className="h-3.5 w-3.5" />
         </div>
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5">
-            <span className="text-[12.5px] font-semibold text-ink-900">
-              {label}
-            </span>
-            <span className="mono text-[10px] text-ink-400">#{index + 1}</span>
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span className="text-[12.5px] font-semibold text-ink-900">
+                {label}
+              </span>
+              <span className="mono text-[10px] text-ink-400">
+                #{index + 1}
+              </span>
+            </div>
+            {canEdit && (
+              <button
+                type="button"
+                onClick={onEdit}
+                className="inline-flex items-center gap-1 rounded-md border border-ink-200 px-2 py-0.5 text-[11px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+              >
+                <PencilLine className="h-3 w-3" />
+                {editing
+                  ? locale === "zh"
+                    ? "收起"
+                    : "Done"
+                  : locale === "zh"
+                    ? "编辑"
+                    : "Edit"}
+              </button>
+            )}
           </div>
           {reason && (
             <p className="mt-0.5 text-[11.5px] italic text-ink-500">
               {reason}
             </p>
           )}
-          {lines.length > 0 && (
-            <dl className="mt-1.5 space-y-0.5 text-[12px]">
-              {lines.map(([k, v]) => (
-                <div key={k} className="flex gap-1.5">
-                  <dt className="mono text-[10.5px] uppercase tracking-[0.08em] text-ink-400">
-                    {k}
-                  </dt>
-                  <dd className="text-ink-800">{v}</dd>
-                </div>
-              ))}
-            </dl>
+          {editing && canEdit ? (
+            <OpEditor op={op} onChange={onChange} locale={locale} />
+          ) : (
+            lines.length > 0 && (
+              <dl className="mt-1.5 space-y-0.5 text-[12px]">
+                {lines.map(([k, v]) => (
+                  <div key={k} className="flex gap-1.5">
+                    <dt className="mono text-[10.5px] uppercase tracking-[0.08em] text-ink-400">
+                      {k}
+                    </dt>
+                    <dd className="text-ink-800">{v}</dd>
+                  </div>
+                ))}
+              </dl>
+            )
           )}
           {result && !result.ok && (
             <p className="mt-1.5 text-[11px] text-[var(--warn)]">
@@ -294,9 +354,200 @@ function OpCard({
             </p>
           )}
         </div>
-      </label>
+      </div>
     </div>
   );
+}
+
+// Compact editor shown in the preview card. Only the most commonly
+// incorrect fields are surfaced — title, date/time, location, doctor
+// for appointments; title + due_date for tasks; name + dose + schedule
+// for medications. The full detail form still lives on the detail page
+// post-save; this is just to stop the user having to delete+recreate a
+// row for a single typo.
+function OpEditor({
+  op,
+  onChange,
+  locale,
+}: {
+  op: IngestOp;
+  onChange: (next: IngestOp) => void;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  if (op.kind === "add_appointment") {
+    const data = op.data as Record<string, unknown>;
+    const set = (k: string, v: unknown) =>
+      onChange({ ...op, data: { ...data, [k]: v } });
+    return (
+      <div className="mt-2 grid gap-2 sm:grid-cols-2">
+        <FieldRow label={L("Title", "标题")} full>
+          <TextInput
+            value={(data.title as string) ?? ""}
+            onChange={(e) => set("title", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Starts", "开始时间")}>
+          <TextInput
+            type="datetime-local"
+            value={toDatetimeLocal(data.starts_at as string | undefined)}
+            onChange={(e) =>
+              set("starts_at", fromDatetimeLocal(e.target.value))
+            }
+          />
+        </FieldRow>
+        <FieldRow label={L("Ends", "结束时间")}>
+          <TextInput
+            type="datetime-local"
+            value={toDatetimeLocal(data.ends_at as string | undefined)}
+            onChange={(e) =>
+              set("ends_at", fromDatetimeLocal(e.target.value))
+            }
+          />
+        </FieldRow>
+        <FieldRow label={L("Location", "地点")} full>
+          <TextInput
+            value={(data.location as string) ?? ""}
+            onChange={(e) => set("location", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Doctor", "医师")}>
+          <TextInput
+            value={(data.doctor as string) ?? ""}
+            onChange={(e) => set("doctor", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Phone", "电话")}>
+          <TextInput
+            value={(data.phone as string) ?? ""}
+            onChange={(e) => set("phone", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Notes", "备注")} full>
+          <Textarea
+            rows={2}
+            value={(data.notes as string) ?? ""}
+            onChange={(e) => set("notes", e.target.value)}
+          />
+        </FieldRow>
+      </div>
+    );
+  }
+
+  if (op.kind === "add_task") {
+    const data = op.data as Record<string, unknown>;
+    const set = (k: string, v: unknown) =>
+      onChange({ ...op, data: { ...data, [k]: v } });
+    return (
+      <div className="mt-2 grid gap-2 sm:grid-cols-2">
+        <FieldRow label={L("Title", "标题")} full>
+          <TextInput
+            value={(data.title as string) ?? ""}
+            onChange={(e) => set("title", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Due date", "到期日")}>
+          <TextInput
+            type="date"
+            value={(data.due_date as string) ?? ""}
+            onChange={(e) => set("due_date", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Category", "分类")}>
+          <TextInput
+            value={(data.category as string) ?? ""}
+            onChange={(e) => set("category", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Notes", "备注")} full>
+          <Textarea
+            rows={2}
+            value={(data.notes as string) ?? ""}
+            onChange={(e) => set("notes", e.target.value)}
+          />
+        </FieldRow>
+      </div>
+    );
+  }
+
+  if (op.kind === "add_medication") {
+    const data = op.data as Record<string, unknown>;
+    const set = (k: string, v: unknown) =>
+      onChange({ ...op, data: { ...data, [k]: v } });
+    return (
+      <div className="mt-2 grid gap-2 sm:grid-cols-2">
+        <FieldRow label={L("Drug", "药物")} full>
+          <TextInput
+            value={
+              ((data.display_name as string) ??
+                (data.drug_id as string) ??
+                "") as string
+            }
+            onChange={(e) => set("display_name", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Dose", "剂量")}>
+          <TextInput
+            value={(data.dose as string) ?? ""}
+            onChange={(e) => set("dose", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Started on", "开始日期")}>
+          <TextInput
+            type="date"
+            value={(data.started_on as string) ?? ""}
+            onChange={(e) => set("started_on", e.target.value)}
+          />
+        </FieldRow>
+        <FieldRow label={L("Notes", "备注")} full>
+          <Textarea
+            rows={2}
+            value={(data.notes as string) ?? ""}
+            onChange={(e) => set("notes", e.target.value)}
+          />
+        </FieldRow>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function FieldRow({
+  label,
+  full,
+  children,
+}: {
+  label: string;
+  full?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className={cn("block space-y-1", full && "sm:col-span-2")}>
+      <span className="mono text-[10px] uppercase tracking-[0.1em] text-ink-400">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function toDatetimeLocal(iso?: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+}
+
+function fromDatetimeLocal(v: string): string | undefined {
+  if (!v) return undefined;
+  const d = new Date(v);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toISOString();
 }
 
 function describeOp(op: IngestOp, locale: "en" | "zh"): Array<[string, string]> {

--- a/src/components/ingest/universal-drop.tsx
+++ b/src/components/ingest/universal-drop.tsx
@@ -121,7 +121,7 @@ export function UniversalDrop({
 
         <div className="flex flex-wrap items-center gap-2">
           <Button onClick={parseText} disabled={busy || !text.trim()}>
-            {busy ? L("Reading…", "正在识别…") : L("Read this", "解析")}
+            {busy ? L("Reading…", "正在识别…") : L("Save", "保存")}
           </Button>
           <label
             className={

--- a/src/components/ingest/upload-zone.tsx
+++ b/src/components/ingest/upload-zone.tsx
@@ -32,10 +32,10 @@ export function UploadZone({
         handle(e.dataTransfer.files);
       }}
       className={cn(
-        "rounded-xl border-2 border-dashed p-8 text-center transition-colors",
+        "rounded-[var(--r-md)] border-2 border-dashed p-8 text-center transition-colors",
         dragging
-          ? "border-slate-900 bg-slate-50 dark:border-slate-100 dark:bg-slate-900"
-          : "border-slate-300 bg-white dark:border-slate-700 dark:bg-slate-900/60",
+          ? "border-ink-900 bg-ink-100/40"
+          : "border-ink-200 bg-paper-2",
       )}
     >
       <input
@@ -45,13 +45,13 @@ export function UploadZone({
         className="hidden"
         onChange={(e) => handle(e.target.files)}
       />
-      <Upload className="mx-auto mb-3 h-8 w-8 text-slate-400" />
-      <div className="text-sm font-medium">
+      <Upload className="mx-auto mb-3 h-8 w-8 text-ink-400" />
+      <div className="text-sm font-medium text-ink-900">
         {locale === "zh"
           ? "拖入或选择检查报告 / 影像 / 转诊信"
           : "Drop or choose a lab report, scan, or referral letter"}
       </div>
-      <div className="mt-1 text-xs text-slate-500">
+      <div className="mt-1 text-xs text-ink-500">
         {locale === "zh"
           ? "支持 PDF 和图片。处理全部在本机完成。"
           : "PDF or image. Processing stays on this device."}
@@ -60,13 +60,13 @@ export function UploadZone({
         <button
           type="button"
           onClick={() => inputRef.current?.click()}
-          className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900"
+          className="inline-flex items-center gap-2 rounded-md bg-ink-900 px-4 py-2 text-sm font-medium text-paper hover:bg-ink-700"
         >
           <FileText className="h-4 w-4" />
           {locale === "zh" ? "选择文件" : "Choose file"}
         </button>
       </div>
-      <div className="mt-3 inline-flex items-center gap-1 text-xs text-slate-400">
+      <div className="mt-3 inline-flex items-center gap-1 text-xs text-ink-400">
         <ImageIcon className="h-3 w-3" /> PDF · JPG · PNG
       </div>
     </div>

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -7,6 +7,10 @@ import type {
 } from "react";
 import { forwardRef } from "react";
 
+// Anchor-tokenised form primitives. All styling reads from the ink/paper/tide
+// CSS variables so inputs stay readable even when the OS reports dark mode —
+// Tailwind's `dark:` variant was flipping backgrounds independently of our
+// token theme, leaving dark text on dark fills in Smart Ingest.
 export function Field({
   label,
   hint,
@@ -20,14 +24,10 @@ export function Field({
 }) {
   return (
     <label className={cn("block space-y-1.5", className)}>
-      <span className="text-sm font-medium text-slate-800 dark:text-slate-200">
-        {label}
-      </span>
+      <span className="text-[13px] font-medium text-ink-700">{label}</span>
       {children}
       {hint && (
-        <span className="block text-xs text-slate-500 dark:text-slate-400">
-          {hint}
-        </span>
+        <span className="block text-[11px] text-ink-500">{hint}</span>
       )}
     </label>
   );
@@ -39,24 +39,20 @@ export function FieldLabel({
 }: LabelHTMLAttributes<HTMLLabelElement>) {
   return (
     <label
-      className={cn("text-sm font-medium text-slate-800 dark:text-slate-200", className)}
+      className={cn("text-[13px] font-medium text-ink-700", className)}
       {...props}
     />
   );
 }
 
+const INPUT_CLASSES =
+  "h-11 w-full rounded-md border border-ink-200 bg-paper px-3 text-sm text-ink-900 placeholder:text-ink-400 focus:border-ink-900 focus:outline-none focus:ring-2 focus:ring-ink-900/10";
+
 export const TextInput = forwardRef<
   HTMLInputElement,
   InputHTMLAttributes<HTMLInputElement>
 >(({ className, ...props }, ref) => (
-  <input
-    ref={ref}
-    className={cn(
-      "h-11 w-full rounded-lg border border-slate-300 bg-white px-3 text-sm text-slate-900 placeholder:text-slate-400 focus:border-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-900/10 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-slate-100 dark:focus:ring-slate-100/10",
-      className,
-    )}
-    {...props}
-  />
+  <input ref={ref} className={cn(INPUT_CLASSES, className)} {...props} />
 ));
 TextInput.displayName = "TextInput";
 
@@ -67,7 +63,7 @@ export function Textarea({
   return (
     <textarea
       className={cn(
-        "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm focus:border-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-900/10 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-slate-100 dark:focus:ring-slate-100/10",
+        "w-full rounded-md border border-ink-200 bg-paper px-3 py-2 text-sm text-ink-900 placeholder:text-ink-400 focus:border-ink-900 focus:outline-none focus:ring-2 focus:ring-ink-900/10",
         className,
       )}
       {...props}

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -190,6 +190,13 @@ export class AnchorDB extends Dexie {
       care_team_contacts:
         "++id, date, kind, follow_up_needed, follow_up_by",
     });
+    // v15: index `appointments.ics_uid` so cycle-→-calendar sync can
+    // dedupe in O(k) instead of scanning the whole table each cycle.
+    // Same rows, new index — Dexie migrates in place.
+    this.version(15).stores({
+      appointments:
+        "++id, starts_at, kind, status, cycle_id, ics_uid, [kind+starts_at]",
+    });
   }
 }
 

--- a/src/lib/ingest/ics.ts
+++ b/src/lib/ingest/ics.ts
@@ -24,12 +24,60 @@ function unfold(text: string): string {
   return text.replace(/\r?\n[ \t]/g, "");
 }
 
-// Converts "20260429T092000" (floating), "20260429T092000Z" (UTC),
-// or "TZID=Australia/Melbourne:20260429T092000" into ISO 8601.
-// Floating times without a TZID are interpreted as UTC — we'd
-// rather the user see a clearly-offset value than a silently-wrong
-// local one.
-function parseIcsDate(raw: string): { iso: string; all_day: boolean } | null {
+// Convert a local wall-clock time in the given IANA timezone into a UTC
+// Date. The naive trick: build a UTC date from the components, ask Intl
+// what wall time that shows as in the target zone, and subtract the offset.
+// Handles DST because Intl resolves zone rules per date.
+export function zonedTimeToUtc(
+  y: number,
+  mo: number,
+  d: number,
+  h: number,
+  mi: number,
+  s: number,
+  timezone: string,
+): Date {
+  const asUtc = Date.UTC(y, mo - 1, d, h, mi, s);
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const parts: Record<string, string> = {};
+  for (const p of fmt.formatToParts(new Date(asUtc))) parts[p.type] = p.value;
+  const tzUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    // Intl sometimes returns "24" for midnight in hour12:false mode.
+    parts.hour === "24" ? 0 : Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+  );
+  return new Date(asUtc - (tzUtc - asUtc));
+}
+
+// Converts an ICS DTSTART / DTEND property value into ISO 8601. Handles:
+//   - "20260429T092000Z"                         → UTC
+//   - "TZID=Australia/Melbourne:20260429T092000" → local time in that zone,
+//                                                   resolved to real UTC
+//   - "20260429T092000"                          → floating, resolved using
+//                                                   `fallbackTimezone` so
+//                                                   imports from calendars
+//                                                   without TZID still land
+//                                                   on the patient's clock
+//   - "VALUE=DATE:20260429"                      → all-day
+// `fallbackTimezone` defaults to Australia/Melbourne (patient's home) when
+// the caller doesn't pass one.
+function parseIcsDate(
+  raw: string,
+  fallbackTimezone = "Australia/Melbourne",
+): { iso: string; all_day: boolean } | null {
   // Property form:  DTSTART;TZID=...;VALUE=DATE:...
   const parts = raw.split(":");
   if (parts.length < 2) return null;
@@ -51,18 +99,49 @@ function parseIcsDate(raw: string): { iso: string; all_day: boolean } | null {
       all_day: false,
     };
   }
-  // Floating — append +00:00 but leave a breadcrumb in the
-  // description ambiguity. Caller gets to note this.
-  return {
-    iso: `${y}-${mo}-${d}T${h}:${mi}:${s}+00:00`,
-    all_day: false,
-  };
+  const tzidMatch = params.match(/TZID=([^;:]+)/i);
+  const zone = tzidMatch ? tzidMatch[1] : fallbackTimezone;
+  try {
+    const utc = zonedTimeToUtc(
+      Number(y),
+      Number(mo),
+      Number(d),
+      Number(h),
+      Number(mi),
+      Number(s),
+      zone!,
+    );
+    return { iso: utc.toISOString(), all_day: false };
+  } catch {
+    // Unknown TZID (or Intl refusing the zone name) — fall back to the
+    // patient's home zone rather than silently emitting UTC.
+    try {
+      const utc = zonedTimeToUtc(
+        Number(y),
+        Number(mo),
+        Number(d),
+        Number(h),
+        Number(mi),
+        Number(s),
+        fallbackTimezone,
+      );
+      return { iso: utc.toISOString(), all_day: false };
+    } catch {
+      return null;
+    }
+  }
 }
 
 // Parses an ICS payload into a flat list of VEVENTs. Minimal —
 // ignores alarms, recurrence expansion, attachments. Good enough
 // for an import flow where every event is reviewed in the preview.
-export function parseIcs(raw: string): ParsedVEvent[] {
+// `fallbackTimezone` is used when a VEVENT's DTSTART is a floating
+// time (no TZID, no Z). Pass the patient's home timezone so imports
+// from calendars that drop TZID don't land on the wrong day.
+export function parseIcs(
+  raw: string,
+  fallbackTimezone = "Australia/Melbourne",
+): ParsedVEvent[] {
   const text = unfold(raw);
   const lines = text.split(/\r?\n/);
   const events: ParsedVEvent[] = [];
@@ -86,13 +165,13 @@ export function parseIcs(raw: string): ParsedVEvent[] {
     else if (line.startsWith("DESCRIPTION:"))
       current.description = unescapeIcsText(line.slice(12));
     else if (line.startsWith("DTSTART")) {
-      const parsed = parseIcsDate(line.slice(7));
+      const parsed = parseIcsDate(line.slice(7), fallbackTimezone);
       if (parsed) {
         current.starts_at = parsed.iso;
         current.all_day = parsed.all_day;
       }
     } else if (line.startsWith("DTEND")) {
-      const parsed = parseIcsDate(line.slice(5));
+      const parsed = parseIcsDate(line.slice(5), fallbackTimezone);
       if (parsed) current.ends_at = parsed.iso;
     }
   }

--- a/src/lib/supabase/households.ts
+++ b/src/lib/supabase/households.ts
@@ -45,7 +45,17 @@ export async function getCurrentProfile(): Promise<Profile | null> {
 }
 
 export async function updateMyProfile(
-  patch: Partial<Pick<Profile, "display_name" | "locale" | "care_role_label">>,
+  patch: Partial<
+    Pick<
+      Profile,
+      | "display_name"
+      | "locale"
+      | "care_role_label"
+      | "relationship"
+      | "timezone"
+      | "notification_preference"
+    >
+  >,
 ): Promise<void> {
   const sb = getSupabaseBrowser();
   if (!sb) return;
@@ -54,6 +64,18 @@ export async function updateMyProfile(
   if (!uid) return;
   const { error } = await sb.from("profiles").update(patch).eq("id", uid);
   if (error) throw error;
+}
+
+// True if the carer / family member has at least filled the minimum fields
+// the /family view needs to render a useful call-list (a display name + how
+// they're related). Drives the post-invite welcome flow — if false, we
+// route the user to /invite/welcome instead of straight to /family.
+export function isProfileComplete(p: Profile | null): boolean {
+  if (!p) return false;
+  const hasName = !!p.display_name?.trim();
+  const hasRelationship =
+    !!p.relationship?.trim() || !!p.care_role_label?.trim();
+  return hasName && hasRelationship;
 }
 
 export async function listHouseholdMembers(

--- a/src/lib/treatment/calendar-sync.ts
+++ b/src/lib/treatment/calendar-sync.ts
@@ -1,0 +1,168 @@
+// Treatment cycle → calendar appointment sync.
+//
+// Chemo cycles have dose days defined in their protocol (e.g. GnP is
+// D1/D8/D15 of a 28-day cycle). Historically those days lived only on the
+// cycle record; the schedule / dashboard had no idea a chemo day was
+// coming up unless the user manually created an appointment for it. This
+// module fills that gap.
+//
+// `deriveCycleAppointments` is pure — it takes a TreatmentCycle + Protocol
+// and returns the Appointment rows that should exist on the calendar.
+// `syncCycleToCalendar` does the Dexie writes idempotently: each dose day
+// gets a deterministic `ics_uid` (`cycle-<id>-day-<d>`) and only missing
+// rows are inserted. Existing rows (created manually or previously synced)
+// are left alone so user edits aren't clobbered.
+
+import { db, now } from "~/lib/db/dexie";
+import { PROTOCOL_BY_ID } from "~/config/protocols";
+import type { Appointment } from "~/types/appointment";
+import type { Protocol, TreatmentCycle } from "~/types/treatment";
+import type { LocalizedText } from "~/types/treatment";
+
+export interface DerivedAppointment
+  extends Pick<
+    Appointment,
+    | "kind"
+    | "title"
+    | "starts_at"
+    | "ends_at"
+    | "status"
+    | "derived_from_cycle"
+    | "cycle_id"
+    | "ics_uid"
+    | "notes"
+  > {
+  kind: "chemo";
+}
+
+// Deterministic ids. One per (cycle, dose day) — any change to cycle
+// start date just rewrites the same slot instead of accumulating ghosts.
+export function cycleDayIcsUid(cycleId: number, day: number): string {
+  return `anchor-cycle-${cycleId}-day-${day}`;
+}
+
+function addDaysISO(isoDate: string, days: number, startTime = "09:00"): string {
+  // `isoDate` is an ISO date like "2026-05-13" (or "2026-05-13T…"); we
+  // want start_date + (days) at `startTime` local — we just write an
+  // offset-free ISO so downstream consumers render in the user's tz.
+  const dayStr = isoDate.slice(0, 10);
+  const [y, m, d] = dayStr.split("-").map(Number);
+  if (!y || !m || !d) return isoDate;
+  const base = new Date(Date.UTC(y, m - 1, d));
+  base.setUTCDate(base.getUTCDate() + days);
+  const iso = base.toISOString().slice(0, 10);
+  return `${iso}T${startTime}:00`;
+}
+
+function localizedEn(text: LocalizedText | string | undefined): string {
+  if (!text) return "";
+  return typeof text === "string" ? text : (text.en ?? "");
+}
+
+export function deriveCycleAppointments(
+  cycle: TreatmentCycle,
+  protocol: Protocol,
+  defaultStartTime = "09:00",
+  defaultDurationMinutes = 240,
+): DerivedAppointment[] {
+  if (!cycle.id) return [];
+  if (cycle.status === "cancelled") return [];
+  const seen = new Set<number>();
+  const doseDays = [
+    ...(protocol.dose_days ?? []),
+    ...protocol.agents.flatMap((a) => a.dose_days ?? []),
+  ]
+    .filter((d) => {
+      if (!Number.isFinite(d) || d < 1) return false;
+      if (seen.has(d)) return false;
+      seen.add(d);
+      return true;
+    })
+    .sort((a, b) => a - b);
+
+  const out: DerivedAppointment[] = [];
+  for (const day of doseDays) {
+    const startsAt = addDaysISO(cycle.start_date, day - 1, defaultStartTime);
+    const endsAt = (() => {
+      const start = new Date(startsAt);
+      if (Number.isNaN(start.getTime())) return undefined;
+      const end = new Date(start.getTime() + defaultDurationMinutes * 60_000);
+      // Match the offset-free "YYYY-MM-DDTHH:MM:SS" shape of starts_at
+      // so the two align visually in the schedule form.
+      const pad = (n: number) => String(n).padStart(2, "0");
+      return `${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(
+        end.getDate(),
+      )}T${pad(end.getHours())}:${pad(end.getMinutes())}:00`;
+    })();
+    const record = cycle.day_records?.find((r) => r.day === day);
+    out.push({
+      kind: "chemo",
+      title: `${protocol.short_name} · Cycle ${cycle.cycle_number} · Day ${day}`,
+      starts_at: startsAt,
+      ends_at: endsAt,
+      status: record?.administered ? "attended" : "scheduled",
+      derived_from_cycle: true,
+      cycle_id: cycle.id,
+      ics_uid: cycleDayIcsUid(cycle.id, day),
+      notes: [
+        localizedEn(protocol.name),
+        protocol.agents
+          .map((a) => `${a.name}${a.typical_dose ? ` (${a.typical_dose})` : ""}`)
+          .join(" + "),
+      ]
+        .filter(Boolean)
+        .join(" — "),
+    });
+  }
+  return out;
+}
+
+export interface SyncResult {
+  added: number;
+  skipped: number;
+}
+
+export async function syncCycleToCalendar(
+  cycle: TreatmentCycle,
+): Promise<SyncResult> {
+  if (!cycle.id) return { added: 0, skipped: 0 };
+  const protocol =
+    cycle.protocol_id === "custom" && cycle.custom_protocol
+      ? cycle.custom_protocol
+      : PROTOCOL_BY_ID[cycle.protocol_id];
+  if (!protocol) return { added: 0, skipped: 0 };
+
+  const derived = deriveCycleAppointments(cycle, protocol);
+  if (derived.length === 0) return { added: 0, skipped: 0 };
+
+  const uids = derived.map((d) => d.ics_uid!).filter(Boolean);
+  const existing = await db.appointments
+    .where("ics_uid")
+    .anyOf(uids)
+    .toArray()
+    .catch(async () => {
+      // Fallback if `ics_uid` isn't indexed in this Dexie version.
+      const all = await db.appointments.toArray();
+      return all.filter((a) => a.ics_uid && uids.includes(a.ics_uid));
+    });
+  const existingUids = new Set(
+    existing.map((a) => a.ics_uid).filter((v): v is string => !!v),
+  );
+
+  let added = 0;
+  let skipped = 0;
+  for (const row of derived) {
+    if (row.ics_uid && existingUids.has(row.ics_uid)) {
+      skipped += 1;
+      continue;
+    }
+    const ts = now();
+    await db.appointments.add({
+      ...row,
+      created_at: ts,
+      updated_at: ts,
+    } as Appointment);
+    added += 1;
+  }
+  return { added, skipped };
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,12 @@ import { type Config } from "tailwindcss";
 
 export default {
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
-  darkMode: "media",
+  // `class` (not `media`) so Tailwind's `dark:` variant only fires when
+  // <html class="dark"> is present — the app currently locks to light mode
+  // via data-theme and nothing sets that class, so no `dark:` rules apply.
+  // Prevents legacy dark: overrides from flipping inputs on OS dark-mode
+  // users while our CSS-var theme stays light.
+  darkMode: "class",
   theme: {
     extend: {
       colors: {

--- a/tests/unit/cycle-calendar-sync.test.ts
+++ b/tests/unit/cycle-calendar-sync.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  cycleDayIcsUid,
+  deriveCycleAppointments,
+} from "~/lib/treatment/calendar-sync";
+import type { Protocol, TreatmentCycle } from "~/types/treatment";
+
+const GNP: Protocol = {
+  id: "gnp_weekly",
+  name: { en: "Gemcitabine + nab-paclitaxel", zh: "吉西他滨 + 白蛋白紫杉醇" },
+  short_name: "GnP",
+  description: { en: "", zh: "" },
+  cycle_length_days: 28,
+  dose_days: [1, 8, 15],
+  agents: [
+    {
+      id: "nab_paclitaxel",
+      name: "nab-paclitaxel",
+      display: { en: "nab-paclitaxel", zh: "白蛋白紫杉醇" },
+      typical_dose: "125 mg/m²",
+      dose_days: [1, 8, 15],
+      route: "IV",
+    },
+  ],
+  phase_windows: [],
+  side_effect_profile: { en: "", zh: "" },
+  typical_supportive: [],
+};
+
+function cycle(overrides: Partial<TreatmentCycle> = {}): TreatmentCycle {
+  return {
+    id: 42,
+    protocol_id: "gnp_weekly",
+    cycle_number: 3,
+    start_date: "2026-05-04",
+    status: "active",
+    dose_level: 0,
+    created_at: "2026-05-04T00:00:00Z",
+    updated_at: "2026-05-04T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("deriveCycleAppointments", () => {
+  it("emits one chemo appointment per protocol dose day", () => {
+    const apps = deriveCycleAppointments(cycle(), GNP);
+    expect(apps).toHaveLength(3);
+    expect(apps.every((a) => a.kind === "chemo")).toBe(true);
+    expect(apps.every((a) => a.derived_from_cycle === true)).toBe(true);
+    expect(apps.every((a) => a.cycle_id === 42)).toBe(true);
+  });
+
+  it("anchors dates to cycle.start_date (day 1 = start, day 8 = +7 days)", () => {
+    const apps = deriveCycleAppointments(cycle(), GNP);
+    expect(apps[0]!.starts_at.slice(0, 10)).toBe("2026-05-04");
+    expect(apps[1]!.starts_at.slice(0, 10)).toBe("2026-05-11");
+    expect(apps[2]!.starts_at.slice(0, 10)).toBe("2026-05-18");
+  });
+
+  it("assigns a deterministic ics_uid per dose day so re-sync is idempotent", () => {
+    const apps = deriveCycleAppointments(cycle(), GNP);
+    expect(apps.map((a) => a.ics_uid)).toEqual([
+      cycleDayIcsUid(42, 1),
+      cycleDayIcsUid(42, 8),
+      cycleDayIcsUid(42, 15),
+    ]);
+  });
+
+  it("marks a dose day attended when the cycle.day_records flag it administered", () => {
+    const apps = deriveCycleAppointments(
+      cycle({
+        day_records: [
+          { day: 1, date: "2026-05-04", administered: true },
+          { day: 8, date: "2026-05-11", administered: false },
+        ],
+      }),
+      GNP,
+    );
+    expect(apps[0]!.status).toBe("attended");
+    expect(apps[1]!.status).toBe("scheduled");
+    expect(apps[2]!.status).toBe("scheduled");
+  });
+
+  it("returns an empty list for cancelled cycles so the calendar doesn't fill with ghosts", () => {
+    const apps = deriveCycleAppointments(cycle({ status: "cancelled" }), GNP);
+    expect(apps).toHaveLength(0);
+  });
+
+  it("dedupes overlapping dose_days coming from the protocol root and from agents", () => {
+    const apps = deriveCycleAppointments(cycle(), GNP);
+    // GNP has [1,8,15] on both the protocol and its agent — we must
+    // still only emit three appointments, not six.
+    expect(apps).toHaveLength(3);
+  });
+});

--- a/tests/unit/ics.test.ts
+++ b/tests/unit/ics.test.ts
@@ -79,6 +79,32 @@ describe("parseIcs", () => {
     ].join("\r\n");
     expect(parseIcs(raw)).toHaveLength(0);
   });
+
+  it("resolves TZID to the correct UTC instant (Australia/Melbourne in May = UTC+10)", () => {
+    const events = parseIcs(ICS_SAMPLE);
+    const pet = events.find((e) => e.uid?.startsWith("abc-124"));
+    expect(pet).toBeDefined();
+    // 07:00 Melbourne on 2026-05-06 is UTC+10 (AEST, not summer time)
+    // → 21:00 UTC the previous day.
+    expect(pet!.starts_at).toBe("2026-05-05T21:00:00.000Z");
+    expect(pet!.ends_at).toBe("2026-05-05T22:00:00.000Z");
+  });
+
+  it("interprets floating times against the supplied fallback timezone, not UTC", () => {
+    const raw = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "UID:floating@example",
+      "SUMMARY:Clinic floating time",
+      "DTSTART:20260506T090000",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    // Pass the patient's home zone as the fallback — 09:00 Melbourne
+    // in May is 23:00 UTC the previous day, NOT 09:00 UTC.
+    const [event] = parseIcs(raw, "Australia/Melbourne");
+    expect(event!.starts_at).toBe("2026-05-05T23:00:00.000Z");
+  });
 });
 
 describe("guessAppointmentKind", () => {


### PR DESCRIPTION
## Summary

Three mid-size slices that sat on the deferred list from #67, plus the "build out family user care team accounts and collaboration" ask.

### 1. Family / care-team onboarding (invitee side)

When someone accepts an invite today, they land on `/family` with an empty profile — the call-list shows placeholders and appointment times render in whatever zone the browser reports. This PR adds a post-accept wizard so new members are useful team members by the time they see the family view.

- `updateMyProfile` writes `relationship`, `timezone`, and `notification_preference` (Supabase columns already existed via Slice M; the client helper just wasn't writing them).
- New `/invite/welcome` route: greeting → name + relationship chips (Son / Daughter / Nurse / custom) → locale + IANA timezone → `/family`.
- `/invite/[token]` routes to `/invite/welcome` after `acceptInvite()` when `isProfileComplete(profile)` is false; returning members with complete profiles go straight to `/family` as before.
- `ProfileCompletionBanner` on `/family` nags anyone who skipped until they finish setup.

### 2. Calendar: TZID-aware ICS import

`parseIcsDate` previously read the TZID parameter but threw it away — floating times silently became UTC, so an Apple / Google export of a Melbourne clinic at 09:00 appeared as 09:00 UTC (19:00 Melbourne the same day). The fix uses a small `Intl.DateTimeFormat`-based `zonedTimeToUtc` helper (handles DST, no deps).

- Explicit TZID: converted to real UTC.
- Floating DTSTART: falls back to the patient's home zone (passed through from `settings.home_timezone` by `calendar-subscribe`) rather than UTC.
- Two new tests lock both behaviours.

### 3. Treatment cycle → calendar sync

`/schedule` had no idea a chemo day was coming up unless the user manually created an appointment for it — despite `cycle.dose_days` and `protocol.dose_days` already living in Dexie. `src/lib/treatment/calendar-sync.ts`:

- `deriveCycleAppointments(cycle, protocol)` — pure function returning one chemo appointment per dose day, with a deterministic `ics_uid` (`anchor-cycle-<id>-day-<d>`) so re-sync is idempotent.
- `syncCycleToCalendar` writes only missing rows (user edits survive).
- Runs automatically on `/prescriptions` (after cycle creation) and `/medications/log` when a cycle is active.
- Dexie v15 adds `ics_uid` to the `appointments` index so dedupe is O(k).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 382 / 382 passing (includes new TZID + cycle-sync coverage)
- [x] `pnpm lint` — only pre-existing `<img>` warnings
- [ ] Manual: open an invite link in an incognito browser, accept, confirm the welcome wizard runs and lands on `/family` with a complete profile.
- [ ] Manual: paste an Apple Calendar ICS with `DTSTART;TZID=Australia/Melbourne:...` and confirm the imported event renders at the correct wall time in the schedule.
- [ ] Manual: start a new GnP cycle from `/treatment/new`, confirm three chemo appointments (Day 1, 8, 15) appear on `/schedule` without any duplicate on re-visit.

https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY)_