### PR TITLE
Clickable cycle days + dose mods + schedule shortcuts + current prescriptions

### DIFF
--- a/src/app/schedule/new/page.tsx
+++ b/src/app/schedule/new/page.tsx
@@ -23,15 +23,25 @@ function NewAppointmentInner() {
   const locale = useLocale();
   const params = useSearchParams();
   const prefillDate = params.get("date");
+  const prefillTime = params.get("time") ?? "09:00";
+  const prefillKind = params.get("kind") as Appointment["kind"] | null;
+  const prefillTitle = params.get("title");
+  const prefillCycleId = params.get("cycle");
 
   const [parsed, setParsed] = useState<Partial<Appointment> | null>(null);
 
   const initial: Partial<Appointment> | undefined = parsed
     ? parsed
-    : prefillDate
+    : prefillDate || prefillKind || prefillTitle || prefillCycleId
       ? {
-          starts_at: new Date(`${prefillDate}T09:00:00`).toISOString(),
+          starts_at: prefillDate
+            ? new Date(`${prefillDate}T${prefillTime}:00`).toISOString()
+            : undefined,
           all_day: false,
+          kind: prefillKind ?? undefined,
+          title: prefillTitle ?? undefined,
+          cycle_id: prefillCycleId ? Number(prefillCycleId) : undefined,
+          derived_from_cycle: prefillCycleId ? true : undefined,
         }
       : undefined;
 

--- a/src/app/treatment/[id]/page.tsx
+++ b/src/app/treatment/[id]/page.tsx
@@ -12,12 +12,21 @@ import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { CycleCalendar } from "~/components/treatment/cycle-calendar";
+import { CycleDayDetail } from "~/components/treatment/cycle-day-detail";
 import { NudgeCard } from "~/components/treatment/nudge-card";
 import { formatDate } from "~/lib/utils/date";
 import { addDays, format, parseISO } from "date-fns";
 import type { NudgeCategory } from "~/types/treatment";
 import type { LabResult } from "~/types/clinical";
-import { CheckCircle2, Pencil, Trash2 } from "lucide-react";
+import {
+  CalendarPlus,
+  CheckCircle2,
+  Pencil,
+  ScanLine,
+  Stethoscope,
+  TimerOff,
+  Trash2,
+} from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import {
   ANALYTES,
@@ -50,6 +59,7 @@ export default function CycleDetailPage() {
   const latestDaily = useLiveQuery(() => latestDailyEntries(1));
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [selectedDay, setSelectedDay] = useState<number | null>(null);
 
   const ctx = useMemo(() => {
     if (!cycle) return null;
@@ -172,14 +182,39 @@ export default function CycleDetailPage() {
           </div>
         </CardHeader>
         <CardContent className="space-y-3">
-          <CycleCalendar cycle={cycle} protocol={protocol} />
-          {ctx.phase?.description[locale] && (
+          <CycleCalendar
+            cycle={cycle}
+            protocol={protocol}
+            selectedDay={selectedDay ?? undefined}
+            onSelectDay={(d) =>
+              setSelectedDay((prev) => (prev === d ? null : d))
+            }
+          />
+          {!selectedDay && ctx.phase?.description[locale] && (
             <div className="text-xs text-ink-600">
               {ctx.phase.description[locale]}
             </div>
           )}
+          {!selectedDay && (
+            <div className="text-[11px] text-ink-400">
+              {locale === "zh"
+                ? "点一下任意一天查看该日详情与日程。"
+                : "Tap any day to see that day's detail and schedule."}
+            </div>
+          )}
         </CardContent>
       </Card>
+
+      {selectedDay !== null && (
+        <CycleDayDetail
+          cycle={cycle}
+          protocol={protocol}
+          dayNumber={selectedDay}
+          onClose={() => setSelectedDay(null)}
+        />
+      )}
+
+      <CycleQuickActions cycle={cycle} protocol={protocol} locale={locale} />
 
       <CycleLabsCard labs={cycleLabs ?? []} locale={locale} />
 
@@ -339,6 +374,132 @@ export default function CycleDetailPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+function CycleQuickActions({
+  cycle,
+  protocol,
+  locale,
+}: {
+  cycle: { id?: number; start_date: string; rest_days_added?: number };
+  protocol: { dose_days: number[]; cycle_length_days: number };
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const today = new Date();
+  const startMs = parseISO(cycle.start_date).getTime();
+
+  // Pre-chemo consult date: one calendar day before the next upcoming
+  // dose day. If all dose days in this cycle have passed, fall back to
+  // the first dose day of a presumptive next cycle (start + cycle_length
+  // + rest_days_added + 1 + protocol.dose_days[0] - 1 ...). Keep it
+  // simple for now — show an inline note if no upcoming dose.
+  const nextDoseDay = useMemo(() => {
+    const dayOffsets = protocol.dose_days.map((d) => d - 1);
+    for (const o of dayOffsets) {
+      const ms = startMs + o * 86_400_000;
+      if (ms >= today.getTime()) return ms;
+    }
+    return null;
+  }, [protocol.dose_days, startMs, today]);
+
+  const preChemoDate = nextDoseDay
+    ? format(addDays(new Date(nextDoseDay), -1), "yyyy-MM-dd")
+    : null;
+
+  // Default re-staging scan at cycle end (day N of protocol).
+  const restageDate = format(
+    addDays(parseISO(cycle.start_date), protocol.cycle_length_days - 1),
+    "yyyy-MM-dd",
+  );
+
+  async function addRestWeek() {
+    if (!cycle.id) return;
+    const { db, now } = await import("~/lib/db/dexie");
+    await db.treatment_cycles.update(cycle.id, {
+      rest_days_added: (cycle.rest_days_added ?? 0) + 7,
+      updated_at: now(),
+    });
+  }
+
+  async function clearRestDays() {
+    if (!cycle.id) return;
+    const { db, now } = await import("~/lib/db/dexie");
+    await db.treatment_cycles.update(cycle.id, {
+      rest_days_added: 0,
+      updated_at: now(),
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          {L("Schedule shortcuts", "日程快捷操作")}
+        </CardTitle>
+        <div className="mt-1 text-xs text-ink-500">
+          {L(
+            "One-tap additions that pre-fill the appointment form for this cycle.",
+            "一键预填适用于本周期的预约表单。",
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-wrap gap-2">
+        {preChemoDate ? (
+          <Link
+            href={`/schedule/new?date=${preChemoDate}&time=10:00&kind=clinic&title=${encodeURIComponent(
+              "Pre-chemo consult",
+            )}&cycle=${cycle.id ?? ""}`}
+          >
+            <Button variant="secondary" size="sm">
+              <Stethoscope className="h-3.5 w-3.5" />
+              {L("Add pre-chemo consult", "新增化疗前复诊")}
+            </Button>
+          </Link>
+        ) : (
+          <span className="text-[11px] text-ink-400">
+            {L(
+              "No upcoming dose day — start a new cycle to schedule a pre-chemo consult.",
+              "本周期无后续用药日 —— 新建周期后可安排化疗前复诊。",
+            )}
+          </span>
+        )}
+        <Link
+          href={`/schedule/new?date=${restageDate}&kind=scan&title=${encodeURIComponent(
+            "Re-staging scan",
+          )}&cycle=${cycle.id ?? ""}`}
+        >
+          <Button variant="secondary" size="sm">
+            <ScanLine className="h-3.5 w-3.5" />
+            {L("Add re-staging scan", "新增再分期检查")}
+          </Button>
+        </Link>
+        <Link
+          href={`/schedule/new?date=${restageDate}&cycle=${cycle.id ?? ""}`}
+        >
+          <Button variant="secondary" size="sm">
+            <CalendarPlus className="h-3.5 w-3.5" />
+            {L("Add other test / visit", "新增其他检查 / 就诊")}
+          </Button>
+        </Link>
+        <Button variant="secondary" size="sm" onClick={() => void addRestWeek()}>
+          <TimerOff className="h-3.5 w-3.5" />
+          {L("+1 rest week", "加一周休息")}
+          {(cycle.rest_days_added ?? 0) > 0 && (
+            <span className="mono ml-1 text-[10px] text-ink-400">
+              ({cycle.rest_days_added}d)
+            </span>
+          )}
+        </Button>
+        {(cycle.rest_days_added ?? 0) > 0 && (
+          <Button variant="ghost" size="sm" onClick={() => void clearRestDays()}>
+            {L("Reset rest days", "重置休息天数")}
+          </Button>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/app/treatment/[id]/page.tsx
+++ b/src/app/treatment/[id]/page.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { CycleCalendar } from "~/components/treatment/cycle-calendar";
 import { CycleDayDetail } from "~/components/treatment/cycle-day-detail";
+import { CycleMedicationsCard } from "~/components/treatment/cycle-medications-card";
 import { NudgeCard } from "~/components/treatment/nudge-card";
 import { formatDate } from "~/lib/utils/date";
 import { addDays, format, parseISO } from "date-fns";
@@ -213,6 +214,8 @@ export default function CycleDetailPage() {
           onClose={() => setSelectedDay(null)}
         />
       )}
+
+      <CycleMedicationsCard cycleId={cycle.id} />
 
       <CycleQuickActions cycle={cycle} protocol={protocol} locale={locale} />
 

--- a/src/components/treatment/cycle-calendar.tsx
+++ b/src/components/treatment/cycle-calendar.tsx
@@ -4,7 +4,11 @@ import { addDays, format, parseISO } from "date-fns";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
-import type { Protocol, TreatmentCycle } from "~/types/treatment";
+import {
+  effectiveCycleLengthDays,
+  type Protocol,
+  type TreatmentCycle,
+} from "~/types/treatment";
 import { cycleDayFor, currentPhase } from "~/lib/treatment/engine";
 import { FlaskConical } from "lucide-react";
 
@@ -63,25 +67,33 @@ const LEGEND_KEYS = [
 export function CycleCalendar({
   cycle,
   protocol,
+  selectedDay,
+  onSelectDay,
 }: {
   cycle: TreatmentCycle;
   protocol: Protocol;
+  selectedDay?: number;
+  onSelectDay?: (day: number) => void;
 }) {
   const locale = useLocale();
   const today = new Date();
   const todayDay = cycleDayFor(cycle.start_date, today);
   const start = parseISO(cycle.start_date);
 
-  const days = Array.from({ length: protocol.cycle_length_days }, (_, i) => {
+  const effectiveLen = effectiveCycleLengthDays(cycle, protocol);
+  const days = Array.from({ length: effectiveLen }, (_, i) => {
     const n = i + 1;
     const date = addDays(start, i);
     const phase = currentPhase(protocol, n);
     const isDose = protocol.dose_days.includes(n);
-    return { n, date, phase, isDose };
+    // Any day past the protocol's natural end that the user added as
+    // extra rest — surfaced with the "rest" swatch regardless of phase.
+    const isExtraRest = n > protocol.cycle_length_days;
+    return { n, date, phase, isDose, isExtraRest };
   });
 
   // Lab draw markers — any lab row whose date falls inside this cycle window.
-  const cycleEnd = addDays(start, protocol.cycle_length_days - 1);
+  const cycleEnd = addDays(start, effectiveLen - 1);
   const cycleStartStr = cycle.start_date;
   const cycleEndStr = format(cycleEnd, "yyyy-MM-dd");
   const labsInCycle = useLiveQuery(
@@ -98,7 +110,7 @@ export function CycleCalendar({
       Math.max(
         1,
         Math.min(
-          protocol.cycle_length_days,
+          effectiveLen,
           Math.floor(
             (parseISO(l.date).getTime() - start.getTime()) / 86400000,
           ) + 1,
@@ -110,28 +122,14 @@ export function CycleCalendar({
   return (
     <div>
       <div className="grid grid-cols-7 gap-1.5">
-        {days.map(({ n, date, phase, isDose }) => {
+        {days.map(({ n, date, phase, isDose, isExtraRest }) => {
           const isToday = n === todayDay;
-          const key = isDose ? "dose_day" : phase?.key ?? "rest";
+          const key = isDose ? "dose_day" : isExtraRest ? "rest" : phase?.key ?? "rest";
           const swatch = SWATCHES[key] ?? SWATCHES.rest!;
           const hasLab = labDays.has(n);
-          return (
-            <div
-              key={n}
-              className="relative flex aspect-square flex-col items-center justify-center rounded-[10px]"
-              style={{
-                background: swatch.bg,
-                color: swatch.color,
-                boxShadow: isToday ? "0 0 0 2px var(--ink-900)" : undefined,
-              }}
-              title={[
-                `Day ${n} · ${format(date, "d MMM")}`,
-                phase?.label[locale],
-                hasLab ? (locale === "zh" ? "化验" : "lab draw") : undefined,
-              ]
-                .filter(Boolean)
-                .join(" · ")}
-            >
+          const isSelected = selectedDay === n;
+          const content = (
+            <>
               <span className="mono text-[9px] uppercase opacity-70">
                 D{n}
               </span>
@@ -150,6 +148,50 @@ export function CycleCalendar({
                   <FlaskConical className="h-2 w-2" strokeWidth={2.5} />
                 </span>
               )}
+            </>
+          );
+          const tooltip = [
+            `Day ${n} · ${format(date, "d MMM")}`,
+            phase?.label[locale],
+            hasLab ? (locale === "zh" ? "化验" : "lab draw") : undefined,
+          ]
+            .filter(Boolean)
+            .join(" · ");
+          const ring = isSelected
+            ? "0 0 0 2px var(--tide-2)"
+            : isToday
+              ? "0 0 0 2px var(--ink-900)"
+              : undefined;
+          const style = {
+            background: swatch.bg,
+            color: swatch.color,
+            boxShadow: ring,
+          } as const;
+
+          if (onSelectDay) {
+            return (
+              <button
+                key={n}
+                type="button"
+                onClick={() => onSelectDay(n)}
+                aria-pressed={isSelected}
+                aria-label={tooltip}
+                title={tooltip}
+                className="relative flex aspect-square flex-col items-center justify-center rounded-[10px] transition-transform hover:scale-[1.03] focus:outline-none"
+                style={style}
+              >
+                {content}
+              </button>
+            );
+          }
+          return (
+            <div
+              key={n}
+              className="relative flex aspect-square flex-col items-center justify-center rounded-[10px]"
+              style={style}
+              title={tooltip}
+            >
+              {content}
             </div>
           );
         })}

--- a/src/components/treatment/cycle-day-detail.tsx
+++ b/src/components/treatment/cycle-day-detail.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { addDays, format, parseISO } from "date-fns";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import {
+  cycleDayDate,
+  getDayRecord,
+  upsertDayRecord,
+} from "~/lib/treatment/day-records";
+import { currentPhase } from "~/lib/treatment/engine";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { TextInput, Textarea } from "~/components/ui/field";
+import {
+  CalendarPlus,
+  Check,
+  ChevronRight,
+  FlaskConical,
+  Pill,
+  Stethoscope,
+  Syringe,
+  ScanLine,
+  X,
+} from "lucide-react";
+import type { Appointment } from "~/types/appointment";
+import type { Protocol, TreatmentCycle } from "~/types/treatment";
+
+// Bottom-anchored detail panel for a selected cycle day. Shows dose /
+// phase / what-to-expect, any appointments the calendar already knows
+// about for that date, any lab rows, and the per-day administered +
+// dose-modification record. Writes back into `cycle.day_records` via
+// upsertDayRecord so the cycle page's main calendar shows the same state.
+
+const APPT_ICON: Partial<Record<Appointment["kind"], React.ComponentType<{ className?: string }>>> =
+  {
+    chemo: Syringe,
+    clinic: Stethoscope,
+    scan: ScanLine,
+    blood_test: FlaskConical,
+  };
+
+export function CycleDayDetail({
+  cycle,
+  protocol,
+  dayNumber,
+  onClose,
+}: {
+  cycle: TreatmentCycle;
+  protocol: Protocol;
+  dayNumber: number;
+  onClose: () => void;
+}) {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const date = cycleDayDate(cycle.start_date, dayNumber);
+  const fullDate = useMemo(
+    () => format(addDays(parseISO(cycle.start_date), dayNumber - 1), "EEEE d MMM"),
+    [cycle.start_date, dayNumber],
+  );
+  const phase = currentPhase(protocol, dayNumber);
+  const isDoseDay = protocol.dose_days.includes(dayNumber);
+  const agentsOnDay = protocol.agents.filter((a) =>
+    a.dose_days.includes(dayNumber),
+  );
+  const record = getDayRecord(cycle, dayNumber);
+
+  // Appointments on this date — match either by `cycle_id` join OR by
+  // date coincidence so manually-added visits show up even if the user
+  // didn't tag them to the cycle.
+  const dayAppts = useLiveQuery(async () => {
+    const rows = await db.appointments.toArray();
+    return rows.filter((a) => {
+      if (a.status === "cancelled") return false;
+      if (a.cycle_id === cycle.id) {
+        return a.starts_at.slice(0, 10) === date;
+      }
+      return a.starts_at.slice(0, 10) === date;
+    });
+  }, [cycle.id, date]);
+
+  const dayLabs = useLiveQuery(
+    () => db.labs.where("date").equals(date).toArray(),
+    [date],
+  );
+
+  const [modifying, setModifying] = useState(false);
+  const [doseText, setDoseText] = useState(record?.dose_modification ?? "");
+  const [notes, setNotes] = useState(record?.notes ?? "");
+
+  async function toggleAdministered() {
+    if (!cycle.id) return;
+    await upsertDayRecord(cycle.id, dayNumber, {
+      administered: !record?.administered,
+    });
+  }
+
+  async function saveModification() {
+    if (!cycle.id) return;
+    await upsertDayRecord(cycle.id, dayNumber, {
+      dose_modification: doseText.trim() || undefined,
+      notes: notes.trim() || undefined,
+    });
+    setModifying(false);
+  }
+
+  return (
+    <Card className="border-[var(--tide-2)]/40">
+      <CardContent className="space-y-4 pt-5">
+        <header className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="eyebrow">
+              {L(`Day ${dayNumber}`, `第 ${dayNumber} 天`)} · {fullDate}
+            </div>
+            <div className="serif mt-0.5 text-[18px] text-ink-900">
+              {isDoseDay
+                ? L("Dose day", "用药日")
+                : phase?.label[locale] ?? L("Rest", "休息")}
+            </div>
+            {phase?.description[locale] && (
+              <p className="mt-1.5 text-[12.5px] leading-relaxed text-ink-600">
+                {phase.description[locale]}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={L("Close", "关闭")}
+            className="flex h-8 w-8 items-center justify-center rounded-md text-ink-500 hover:bg-ink-100"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        {isDoseDay && agentsOnDay.length > 0 && (
+          <section className="space-y-2">
+            <div className="eyebrow">{L("Dosing", "用药")}</div>
+            <ul className="space-y-1.5">
+              {agentsOnDay.map((a) => (
+                <li
+                  key={a.id}
+                  className="flex items-center justify-between rounded-[var(--r-md)] bg-paper-2 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="text-[13px] font-medium text-ink-900">
+                      {a.display[locale]}
+                    </div>
+                    <div className="text-[11px] text-ink-500">
+                      {a.typical_dose}
+                      {a.infusion_time_min
+                        ? ` · ~${a.infusion_time_min} min`
+                        : ""}
+                    </div>
+                  </div>
+                  <Pill className="h-4 w-4 text-ink-400" />
+                </li>
+              ))}
+            </ul>
+            {record?.dose_modification && (
+              <div className="rounded-md border border-[var(--sand-2)]/40 bg-[var(--sand)]/30 p-2 text-[11.5px] text-ink-700">
+                <span className="mono mr-2 text-[9.5px] uppercase tracking-[0.1em] text-ink-400">
+                  {L("Modified", "剂量调整")}
+                </span>
+                {record.dose_modification}
+              </div>
+            )}
+            <div className="flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                variant={record?.administered ? "secondary" : "primary"}
+                onClick={() => void toggleAdministered()}
+              >
+                <Check className="h-3.5 w-3.5" />
+                {record?.administered
+                  ? L("Administered ✓", "已给药 ✓")
+                  : L("Mark administered", "标记已给药")}
+              </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setModifying((v) => !v)}
+              >
+                {modifying
+                  ? L("Cancel", "取消")
+                  : L("Modify dose / note", "调整剂量 / 备注")}
+              </Button>
+            </div>
+            {modifying && (
+              <div className="space-y-2 rounded-[var(--r-md)] border border-ink-100 bg-paper-2 p-3">
+                <label className="block space-y-1">
+                  <span className="mono text-[10px] uppercase tracking-[0.1em] text-ink-400">
+                    {L("Dose change", "剂量改动")}
+                  </span>
+                  <TextInput
+                    value={doseText}
+                    onChange={(e) => setDoseText(e.target.value)}
+                    placeholder={L(
+                      "e.g. 80% dose (ANC 0.9)",
+                      "例如：80% 剂量（ANC 0.9）",
+                    )}
+                  />
+                </label>
+                <label className="block space-y-1">
+                  <span className="mono text-[10px] uppercase tracking-[0.1em] text-ink-400">
+                    {L("Notes", "备注")}
+                  </span>
+                  <Textarea
+                    rows={2}
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                  />
+                </label>
+                <Button size="sm" onClick={() => void saveModification()}>
+                  <Check className="h-3.5 w-3.5" />
+                  {L("Save", "保存")}
+                </Button>
+              </div>
+            )}
+          </section>
+        )}
+
+        <section className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="eyebrow">
+              {L("Scheduled on this day", "这一天的预约")}
+            </div>
+            <Link
+              href={`/schedule/new?date=${date}&cycle=${cycle.id ?? ""}`}
+              className="inline-flex items-center gap-1 rounded-md border border-ink-200 px-2 py-0.5 text-[11px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+            >
+              <CalendarPlus className="h-3 w-3" />
+              {L("Add appointment", "新增预约")}
+            </Link>
+          </div>
+          {dayAppts && dayAppts.length > 0 ? (
+            <ul className="space-y-1.5">
+              {dayAppts.map((a) => {
+                const Icon = APPT_ICON[a.kind] ?? Stethoscope;
+                return (
+                  <li key={a.id}>
+                    <Link
+                      href={`/schedule/${a.id}`}
+                      className="flex items-center gap-2 rounded-[var(--r-md)] border border-ink-100 bg-paper-2 px-3 py-2 transition-colors hover:border-ink-300"
+                    >
+                      <Icon className="h-4 w-4 shrink-0 text-ink-500" />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-[13px] text-ink-900">
+                          {a.title}
+                        </div>
+                        <div className="text-[11px] text-ink-500">
+                          {a.all_day
+                            ? L("All day", "全天")
+                            : format(parseISO(a.starts_at), "HH:mm")}
+                          {a.location ? ` · ${a.location}` : ""}
+                        </div>
+                      </div>
+                      <ChevronRight className="h-3.5 w-3.5 text-ink-400" />
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <div className="rounded-[var(--r-md)] border border-dashed border-ink-200 bg-paper p-3 text-[12px] text-ink-500">
+              {L(
+                "Nothing on the schedule for this day yet.",
+                "这一天的日程暂无安排。",
+              )}
+            </div>
+          )}
+        </section>
+
+        {dayLabs && dayLabs.length > 0 && (
+          <section className="space-y-2">
+            <div className="eyebrow">{L("Labs on this day", "当日化验")}</div>
+            <ul className="space-y-1">
+              {dayLabs.map((l) => (
+                <li
+                  key={l.id}
+                  className="flex items-center gap-2 rounded-[var(--r-md)] bg-paper-2 px-3 py-2 text-[12px] text-ink-700"
+                >
+                  <FlaskConical className="h-3.5 w-3.5 text-ink-500" />
+                  <span className="font-medium">{l.date}</span>
+                  <span className="text-ink-500">
+                    {[
+                      l.neutrophils != null ? `ANC ${l.neutrophils}` : null,
+                      l.platelets != null ? `Plt ${l.platelets}` : null,
+                      l.hemoglobin != null ? `Hb ${l.hemoglobin}` : null,
+                      l.ca199 != null ? `CA19-9 ${l.ca199}` : null,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/treatment/cycle-medications-card.tsx
+++ b/src/components/treatment/cycle-medications-card.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { DRUGS_BY_ID } from "~/config/drug-registry";
+import { scheduleSummary } from "~/lib/medication/practices";
+import type { Medication } from "~/types/medication";
+import { ChevronRight, Pencil, Pill, Plus, Zap } from "lucide-react";
+
+// Summary of the active prescriptions attached to this cycle. Split into
+// regular (scheduled) and PRN so the patient can see at a glance what's
+// running as a daily / cyclical baseline vs. what's available to take as
+// needed. Full edit lives on `/prescriptions?cycle=<id>`; this card is a
+// tight preview with a per-row Edit link.
+
+export function CycleMedicationsCard({ cycleId }: { cycleId?: number }) {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const meds = useLiveQuery(async () => {
+    const all = await db.medications.toArray();
+    return all.filter(
+      (m) =>
+        m.active &&
+        m.category !== "behavioural" &&
+        (m.cycle_id === cycleId || m.cycle_id == null),
+    );
+  }, [cycleId]);
+
+  const { regular, prn } = useMemo(() => {
+    const regular: Medication[] = [];
+    const prn: Medication[] = [];
+    for (const m of meds ?? []) {
+      if (m.schedule?.kind === "prn") prn.push(m);
+      else regular.push(m);
+    }
+    return { regular, prn };
+  }, [meds]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-baseline justify-between gap-3">
+          <CardTitle>{L("Current prescriptions", "当前处方")}</CardTitle>
+          <Link
+            href={`/prescriptions?cycle=${cycleId ?? ""}`}
+            className="inline-flex items-center gap-1 text-[12px] text-ink-500 hover:text-ink-900"
+          >
+            {L("Manage", "管理")}
+            <ChevronRight className="h-3 w-3" />
+          </Link>
+        </div>
+        <div className="mt-1 text-[11.5px] text-ink-500">
+          {L(
+            "Protocol-derived + user-added meds active for this cycle. Tap Edit to change dose, schedule, or stop.",
+            "本周期有效的方案用药 + 自行添加用药。轻点「编辑」可改剂量、用法或停药。",
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <MedSection
+          title={L("Scheduled", "按时服用")}
+          icon={Pill}
+          meds={regular}
+          locale={locale}
+          emptyLabel={L(
+            "No scheduled medications yet.",
+            "暂无按时用药。",
+          )}
+          cycleId={cycleId}
+        />
+        <MedSection
+          title={L("As needed (PRN)", "按需服用（PRN）")}
+          icon={Zap}
+          meds={prn}
+          locale={locale}
+          emptyLabel={L("No PRN medications yet.", "暂无按需用药。")}
+          cycleId={cycleId}
+        />
+        <div className="pt-1">
+          <Link
+            href={`/prescriptions?cycle=${cycleId ?? ""}&new=1`}
+            className="inline-flex items-center gap-1 rounded-md border border-ink-200 px-3 py-1.5 text-[12px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {L("Add medication", "新增用药")}
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MedSection({
+  title,
+  icon: Icon,
+  meds,
+  locale,
+  emptyLabel,
+  cycleId,
+}: {
+  title: string;
+  icon: React.ComponentType<{ className?: string }>;
+  meds: Medication[];
+  locale: "en" | "zh";
+  emptyLabel: string;
+  cycleId?: number;
+}) {
+  return (
+    <section className="space-y-1.5">
+      <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-500">
+        <Icon className="h-3 w-3" />
+        {title}
+        <span className="mono text-[10px] text-ink-400">· {meds.length}</span>
+      </div>
+      {meds.length === 0 ? (
+        <div className="rounded-[var(--r-md)] border border-dashed border-ink-200 bg-paper px-3 py-2 text-[11.5px] text-ink-500">
+          {emptyLabel}
+        </div>
+      ) : (
+        <ul className="space-y-1.5">
+          {meds.map((m) => {
+            const catalogue = DRUGS_BY_ID[m.drug_id];
+            const name =
+              (locale === "zh" ? catalogue?.name.zh : catalogue?.name.en) ??
+              m.display_name ??
+              m.drug_id;
+            return (
+              <li
+                key={m.id}
+                className="flex items-center gap-3 rounded-[var(--r-md)] bg-paper-2 px-3 py-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] font-medium text-ink-900">
+                    {name}
+                  </div>
+                  <div className="text-[11px] text-ink-500">
+                    {[m.dose, m.schedule ? scheduleSummary(m.schedule, locale) : null]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </div>
+                </div>
+                <Link
+                  href={`/prescriptions?cycle=${cycleId ?? ""}&edit=${m.id ?? ""}`}
+                  className="inline-flex shrink-0 items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-[11px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+                >
+                  <Pencil className="h-3 w-3" />
+                  {locale === "zh" ? "编辑" : "Edit"}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/lib/treatment/day-records.ts
+++ b/src/lib/treatment/day-records.ts
@@ -1,0 +1,50 @@
+// Helpers for reading / writing `TreatmentCycle.day_records` — the per-day
+// audit trail of what actually happened (dose administered, any dose
+// modification, free-form notes). The cycle page uses these from the
+// clickable day-detail sheet.
+
+import { addDays, format, parseISO } from "date-fns";
+import { db, now } from "~/lib/db/dexie";
+import type { CycleDoseDayRecord, TreatmentCycle } from "~/types/treatment";
+
+export function cycleDayDate(
+  startISO: string,
+  dayNumber: number,
+): string {
+  const start = parseISO(startISO);
+  return format(addDays(start, dayNumber - 1), "yyyy-MM-dd");
+}
+
+export function getDayRecord(
+  cycle: TreatmentCycle,
+  dayNumber: number,
+): CycleDoseDayRecord | undefined {
+  return (cycle.day_records ?? []).find((r) => r.day === dayNumber);
+}
+
+export async function upsertDayRecord(
+  cycleId: number,
+  dayNumber: number,
+  patch: Partial<CycleDoseDayRecord>,
+): Promise<void> {
+  const cycle = await db.treatment_cycles.get(cycleId);
+  if (!cycle) return;
+  const date = cycleDayDate(cycle.start_date, dayNumber);
+  const existing = cycle.day_records ?? [];
+  const idx = existing.findIndex((r) => r.day === dayNumber);
+  const base: CycleDoseDayRecord = {
+    day: dayNumber,
+    date,
+    administered: false,
+  };
+  const next =
+    idx === -1
+      ? [...existing, { ...base, ...patch }]
+      : existing.map((r, i) =>
+          i === idx ? { ...base, ...r, ...patch, day: dayNumber, date } : r,
+        );
+  await db.treatment_cycles.update(cycleId, {
+    day_records: next,
+    updated_at: now(),
+  });
+}

--- a/src/types/treatment.ts
+++ b/src/types/treatment.ts
@@ -112,11 +112,23 @@ export interface TreatmentCycle {
   dose_level: number;
   dose_modification_notes?: string;
   day_records?: CycleDoseDayRecord[];
+  // Extra rest days appended to the cycle (e.g. a full +7 day gap because
+  // bloods hadn't recovered). Honoured by `effectiveCycleLengthDays` so
+  // the calendar view + linked appointments respect the delay without
+  // mutating the protocol.
+  rest_days_added?: number;
   snoozed_nudge_ids?: string[];
   dismissed_nudge_ids?: string[];
   notes?: string;
   created_at: string;
   updated_at: string;
+}
+
+export function effectiveCycleLengthDays(
+  cycle: TreatmentCycle,
+  protocol: Protocol,
+): number {
+  return protocol.cycle_length_days + Math.max(0, cycle.rest_days_added ?? 0);
 }
 
 export interface CycleContext {


### PR DESCRIPTION
## Summary

Treatment page goes from read-only cycle calendar → working surface for the cycle's day-to-day state.

### Clickable day detail
Each day in `CycleCalendar` is a button now. Tapping opens a detail panel with:
- Day # + full date + phase label + "what to expect" description
- Dose agents + typical dose on dose days, plus **Mark administered** and **Modify dose / note** (writes into `cycle.day_records[n]`)
- Linked calendar appointments on that date + **Add appointment** quick link (pre-fills date + cycle_id)
- Labs recorded for that date

### Per-day record helpers
`src/lib/treatment/day-records.ts` — narrow read/write over `cycle.day_records`: `getDayRecord`, `upsertDayRecord`, `cycleDayDate`.

### Schedule shortcuts card
One-tap appointment seeders for the cycle:
- **Add pre-chemo consult** — one day before the next upcoming dose day, kind=clinic, title + cycle pre-filled
- **Add re-staging scan** — default at cycle end, kind=scan
- **Add other test / visit** — generic
- **+1 rest week** — increments `TreatmentCycle.rest_days_added` by 7; honoured by `effectiveCycleLengthDays()` so the calendar visibly extends with extra Rest swatches. **Reset** resets to zero.

`/schedule/new` now understands `?kind=`, `?title=`, `?time=`, `?cycle=` alongside existing `?date=`.

### Current prescriptions card
Shows active meds (protocol-derived + user-added, excluding behavioural practices) split into **Scheduled** vs **PRN**. Each row has a per-med Edit link into the existing `/prescriptions?cycle=…&edit=<id>` page. "Add medication" shortcut for both.

### Data model
- `TreatmentCycle.rest_days_added?: number` — new optional field. Existing rows read as 0.
- `effectiveCycleLengthDays(cycle, protocol)` — pure helper used by the mini calendar.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 382 / 382
- [ ] Manual: open `/treatment/<id>`, click Day 1 → confirm dose modal shows dosing + "Mark administered" persists. Click Day 14 (nadir) → confirm phase description renders.
- [ ] Manual: click "Add pre-chemo consult" → `/schedule/new` opens with `kind=clinic`, `title=Pre-chemo consult`, and `cycle_id` already set on the form.
- [ ] Manual: click "+1 rest week" → the cycle calendar grows from 28 → 35 days; click **Reset rest days** → shrinks back.

https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY)_