### PR TITLE
Ingest polish + calendar event spacing + split clinical/casual capture

### DIFF
--- a/src/app/capture/page.tsx
+++ b/src/app/capture/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { ChevronRight, NotebookPen, Utensils } from "lucide-react";
+
+// Quick-snap hub — a dedicated surface for casual camera captures that
+// aren't clinical documents (meal photos, handwritten journal notes).
+// Kept separate from `/ingest` so the clinical ingest page stays focused
+// on medical-document intake; the AddFab routes both flows directly.
+
+export default function CapturePage() {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-4 md:p-8">
+      <PageHeader
+        eyebrow={L("QUICK SNAP", "快拍")}
+        title={L("Quick capture", "快速记录")}
+        subtitle={L(
+          "Casual photos — a meal, a handwritten note. Kept separate from clinical document ingest.",
+          "随手拍照 —— 一餐饭、一页手写笔记。与临床文档导入分开处理。",
+        )}
+      />
+
+      <section className="grid gap-3 sm:grid-cols-2">
+        <Link
+          href="/ingest/meal"
+          className="a-card flex items-start gap-3 p-4 transition-colors hover:border-ink-300"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
+            <Utensils className="h-5 w-5" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-[13.5px] font-semibold text-ink-900">
+              {L("Meal photo → protein + calories", "餐食照片 → 蛋白与热量")}
+            </div>
+            <div className="mt-0.5 text-xs text-ink-500">
+              {L(
+                "Snap the plate; Claude estimates macros and a PERT suggestion.",
+                "拍一张盘中餐；Claude 估算宏量并建议胰酶剂量。",
+              )}
+            </div>
+          </div>
+          <ChevronRight className="mt-1.5 h-4 w-4 text-ink-300" />
+        </Link>
+
+        <Link
+          href="/ingest/notes"
+          className="a-card flex items-start gap-3 p-4 transition-colors hover:border-ink-300"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
+            <NotebookPen className="h-5 w-5" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-[13.5px] font-semibold text-ink-900">
+              {L("Handwritten notes → daily log", "手写笔记 → 今日日志")}
+            </div>
+            <div className="mt-0.5 text-xs text-ink-500">
+              {L(
+                "Photograph a paper note; it's transcribed and structured into today's entry.",
+                "拍一张手写日记；自动转录并整理到今日条目。",
+              )}
+            </div>
+          </div>
+          <ChevronRight className="mt-1.5 h-4 w-4 text-ink-300" />
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/src/app/ingest/page.tsx
+++ b/src/app/ingest/page.tsx
@@ -21,7 +21,7 @@ import {
   saveBulkItem,
   type BulkItem,
 } from "~/lib/ingest/bulk";
-import { Upload, Utensils, NotebookPen, ChevronRight } from "lucide-react";
+import { Upload } from "lucide-react";
 
 function newId(): string {
   return Math.random().toString(36).slice(2, 10);
@@ -108,7 +108,7 @@ export default function IngestPage() {
     <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-8">
       <PageHeader
         eyebrow={locale === "zh" ? "导入" : "Ingest"}
-        title={locale === "zh" ? "报告、照片、手写笔记" : "Reports, photos, handwritten notes"}
+        title={locale === "zh" ? "临床文档导入" : "Clinical document ingest"}
         subtitle={
           locale === "zh"
             ? "本机 OCR，可选 Claude 结构化。一次拖入多个文件。"
@@ -197,49 +197,9 @@ export default function IngestPage() {
         </CardContent>
       </Card>
 
-      <section className="grid gap-3 sm:grid-cols-2">
-        <Link
-          href="/ingest/meal"
-          className="a-card flex items-start gap-3 p-4 transition-colors hover:border-ink-300"
-        >
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
-            <Utensils className="h-5 w-5" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="text-[13.5px] font-semibold text-ink-900">
-              {locale === "zh" ? "餐食照片 → 蛋白与热量" : "Meal photo → protein + calories"}
-            </div>
-            <div className="mt-0.5 text-xs text-ink-500">
-              {locale === "zh"
-                ? "拍一张盘中餐，Claude 估算宏量并建议胰酶剂量。"
-                : "Snap the plate; Claude estimates macros and a PERT suggestion."}
-            </div>
-          </div>
-          <ChevronRight className="mt-1.5 h-4 w-4 text-ink-300" />
-        </Link>
-
-        <Link
-          href="/ingest/notes"
-          className="a-card flex items-start gap-3 p-4 transition-colors hover:border-ink-300"
-        >
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
-            <NotebookPen className="h-5 w-5" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="text-[13.5px] font-semibold text-ink-900">
-              {locale === "zh"
-                ? "手写笔记 → 今日日志"
-                : "Handwritten notes → daily log"}
-            </div>
-            <div className="mt-0.5 text-xs text-ink-500">
-              {locale === "zh"
-                ? "拍一张手写日记，结构化成今日条目。"
-                : "Photograph a paper note; it's transcribed and structured into today's entry."}
-            </div>
-          </div>
-          <ChevronRight className="mt-1.5 h-4 w-4 text-ink-300" />
-        </Link>
-      </section>
+      {/* Meal + handwritten-note tiles moved off clinical ingest
+          (they are not clinical data). They live on /capture now; the
+          AddFab still exposes both shortcuts globally. */}
 
       {recent && recent.length > 0 && (
         <section className="space-y-2">

--- a/src/components/ingest/preview-diff.tsx
+++ b/src/components/ingest/preview-diff.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 import { applyIngestOps } from "~/lib/ingest/operations";
 import type {
   IngestApplyResult,
@@ -127,6 +128,30 @@ export function PreviewDiff({ draft, onApplied, onDiscard }: Props) {
     }
   }
 
+  // Auto-close on a fully-successful save. Users kept staring at the
+  // preview wondering whether anything happened; closing returns them
+  // to the ingest landing which is where the next capture starts.
+  useEffect(() => {
+    if (!results) return;
+    const allOk = results.length > 0 && results.every((r) => r.ok);
+    if (!allOk) return;
+    const t = setTimeout(() => onDiscard(), 1400);
+    return () => clearTimeout(t);
+  }, [results, onDiscard]);
+
+  const savedAppointmentIds = useMemo(() => {
+    if (!results) return [] as number[];
+    return results
+      .filter(
+        (r) =>
+          r.ok &&
+          typeof r.id === "number" &&
+          (r.op.kind === "add_appointment" ||
+            r.op.kind === "update_appointment"),
+      )
+      .map((r) => r.id as number);
+  }, [results]);
+
   const okCount = results?.filter((r) => r.ok).length ?? 0;
   const failCount = (results?.length ?? 0) - okCount;
 
@@ -195,20 +220,38 @@ export function PreviewDiff({ draft, onApplied, onDiscard }: Props) {
         </ul>
 
         {results ? (
-          <div className="flex items-center justify-between rounded-md border border-ink-200 bg-paper-2 p-3 text-[13px]">
+          <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-ink-200 bg-paper-2 p-3 text-[13px]">
             <div>
               <span className="font-semibold text-[var(--ok)]">
-                {okCount} {L("applied", "已应用")}
+                {L(
+                  `${okCount} saved`,
+                  `已保存 ${okCount}`,
+                )}
               </span>
               {failCount > 0 && (
                 <span className="ml-2 text-[var(--warn)]">
                   {failCount} {L("failed", "失败")}
                 </span>
               )}
+              {failCount === 0 && (
+                <span className="ml-2 text-[11px] text-ink-500">
+                  {L("closing…", "即将关闭…")}
+                </span>
+              )}
             </div>
-            <Button onClick={onDiscard} variant="ghost">
-              {L("Done", "完成")}
-            </Button>
+            <div className="flex items-center gap-2">
+              {savedAppointmentIds.length > 0 && (
+                <Link
+                  href="/schedule"
+                  className="inline-flex items-center gap-1 rounded-md border border-ink-200 px-2.5 py-1 text-[12px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+                >
+                  {L("View in Schedule", "前往日程")}
+                </Link>
+              )}
+              <Button onClick={onDiscard} variant="ghost">
+                {L("Done", "完成")}
+              </Button>
+            </div>
           </div>
         ) : (
           <div className="flex items-center justify-between gap-2">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -272,16 +272,44 @@ body {
 .anchor-calendar .fc-event {
   border-radius: 5px;
   border-width: 0;
-  padding: 1.5px 5px;
+  padding: 2px 6px;
   font-size: 11px;
   font-weight: 500;
-  line-height: 1.3;
+  line-height: 1.35;
   letter-spacing: 0;
   cursor: pointer;
 }
 
 .anchor-calendar .fc-event:hover {
   filter: brightness(1.06);
+}
+
+/* Month-view event stacks: give every harness a consistent height and
+ * a 2px vertical gap. FullCalendar's default stacks all events at
+ * top:0 of their harness, and our zero-border / tight-padding overrides
+ * caused adjacent pills to visually touch when two+ events land on
+ * the same day. */
+.anchor-calendar .fc-daygrid-event-harness {
+  margin-top: 2px;
+}
+.anchor-calendar .fc-daygrid-event {
+  margin: 0 !important;
+  min-height: 18px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.anchor-calendar .fc-daygrid-day-events {
+  min-height: 0;
+  padding: 1px 2px 3px;
+}
+/* Week / day time-grid events — separate adjacent tiles that would
+ * otherwise paint on top of each other in overlapping time ranges. */
+.anchor-calendar .fc-timegrid-event-harness {
+  margin-right: 1px;
+}
+.anchor-calendar .fc-timegrid-event {
+  box-shadow: 0 0 0 1px var(--paper);
 }
 
 /* List view — soft, readable rather than striped */


### PR DESCRIPTION
## Summary

Three user-reported tweaks rolled together:

### 1. Smart Ingest post-save flow
- `PreviewDiff` auto-closes ~1.4s after a fully-successful save, so the patient isn't stuck on the preview wondering whether items reached the schedule.
- Success footer now shows "N saved" instead of "N applied" and adds a **View in Schedule** link whenever an `add_appointment` / `update_appointment` op succeeded.
- "closing…" countdown text makes the auto-close visible.

### 2. Split clinical ingest from casual capture
- Meal-photo + handwritten-note tiles **removed** from `/ingest` (those aren't clinical data).
- New `/capture` route hosts both as a dedicated **Quick capture** hub.
- `/ingest` header renamed to **Clinical document ingest** for clarity.
- AddFab already exposed both routes directly, so no regression.

### 3. Calendar event-tile spacing
Two+ events on the same day overlapped visually because our zero-border / tight-padding overrides collided with FullCalendar's default harness absolute-positioning:
- `.fc-daygrid-event-harness` gets a 2px top-margin.
- `.fc-daygrid-event` — 18px min-height, margin reset, ellipsis-truncate.
- `.fc-timegrid-event` — 1px paper outline so overlapping time-range tiles keep a visible gap.

## Deferred

- **"Tell the team" direct-file** — glucose / BP / weight strings should skip the agent pipeline and write straight to `labs` / `daily_entries`. Queued for a follow-up PR.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 382 / 382
- [ ] Manual: drop a PDF into Smart Ingest → click Save → preview auto-closes ~1.4s later, items appear on `/schedule`.
- [ ] Manual: open `/capture` → see Meal and Handwritten note tiles; open `/ingest` → no longer shows those tiles.
- [ ] Manual: calendar month view with 2+ events on the same day → each pill is a distinct row with a 2px gap, no overlap.

https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY)_