### PR TITLE
Direct-file simple data points from /log (skip agent fan-out)

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -8,6 +8,9 @@ import { useLocale, useT } from "~/hooks/use-translate";
 import { tagInput } from "~/lib/log/tag";
 import { agentsForTags } from "~/agents/routing";
 import { runAgentClient } from "~/lib/log/run-agents";
+import { parseDirectFile, type DirectFileResult } from "~/lib/log/direct-file";
+import { applyDirectFile } from "~/lib/log/direct-file-apply";
+import { useUIStore } from "~/stores/ui-store";
 import { LOG_TAGS, type AgentId, type LogTag } from "~/types/agent";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
@@ -41,6 +44,12 @@ type RunState =
   | { kind: "saving" }
   | { kind: "running"; total: number; done: AgentId[]; failed: AgentId[] }
   | { kind: "done"; ran: AgentId[]; failed: AgentId[] }
+  | {
+      kind: "filed";
+      summary: { en: string; zh: string };
+      target: "lab" | "daily";
+      rowId: number;
+    }
   | { kind: "error"; message: string };
 
 export default function LogPage() {
@@ -53,9 +62,21 @@ export default function LogPage() {
   const [overrideTags, setOverrideTags] = useState<Set<LogTag> | null>(null);
   const [run, setRun] = useState<RunState>({ kind: "idle" });
 
+  const enteredBy = useUIStore((s) => s.enteredBy);
+
   const autoTags = useMemo(() => new Set(tagInput(text)), [text]);
   const tags = overrideTags ?? autoTags;
   const agentIds = useMemo(() => agentsForTags(Array.from(tags)), [tags]);
+
+  // If the text is a simple, unambiguous data point (e.g. "blood sugar
+  // 7.9 this morning", "weight 64.5 kg"), bypass the agent fan-out and
+  // file it straight into labs / daily_entries. Keeps routine values out
+  // of the agent pipeline. Only triggers when the user hasn't manually
+  // overridden tags — explicit tag edits imply they want the full run.
+  const directFile: DirectFileResult | null = useMemo(() => {
+    if (overrideTags) return null;
+    return parseDirectFile(text, today);
+  }, [text, today, overrideTags]);
 
   function toggleTag(tag: LogTag) {
     const next = new Set(tags);
@@ -65,8 +86,30 @@ export default function LogPage() {
   }
 
   async function submit() {
-    if (!text.trim() || agentIds.length === 0) return;
+    if (!text.trim()) return;
     setRun({ kind: "saving" });
+
+    // Fast path: a single structured value like "blood sugar 7.9" goes
+    // straight into the right Dexie table and skips the agent run.
+    if (directFile) {
+      try {
+        const applied = await applyDirectFile(directFile, enteredBy);
+        setRun({
+          kind: "filed",
+          summary: directFile.summary,
+          target: applied.kind,
+          rowId: applied.id,
+        });
+      } catch (err) {
+        setRun({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+      return;
+    }
+
+    if (agentIds.length === 0) return;
 
     let logId: number;
     try {
@@ -123,8 +166,11 @@ export default function LogPage() {
     setRun({ kind: "idle" });
   }
 
+  // A direct-filed value bypasses the agent requirement.
   const canSubmit =
-    run.kind === "idle" && text.trim().length > 0 && agentIds.length > 0;
+    run.kind === "idle" &&
+    text.trim().length > 0 &&
+    (directFile !== null || agentIds.length > 0);
 
   return (
     <div className="mx-auto max-w-xl space-y-5 p-4 md:p-8">
@@ -178,11 +224,27 @@ export default function LogPage() {
               );
             })}
           </div>
-          {agentIds.length > 0 && (
-            <p className="mt-3 text-[11px] text-ink-500">
-              {locale === "zh" ? "将通知：" : "Will notify:"}{" "}
-              {agentIds.map((id) => AGENT_LABELS[id][locale]).join(" · ")}
+          {directFile ? (
+            <p className="mt-3 flex items-start gap-1.5 text-[11px] text-[var(--tide-2)]">
+              <Check className="mt-[1px] h-3 w-3 shrink-0" />
+              <span>
+                {locale === "zh"
+                  ? "直接归档为："
+                  : "Will file directly as:"}{" "}
+                <span className="font-medium">
+                  {directFile.summary[locale]}
+                </span>
+                {" · "}
+                {locale === "zh" ? "不调用智能体" : "no agents called"}
+              </span>
             </p>
+          ) : (
+            agentIds.length > 0 && (
+              <p className="mt-3 text-[11px] text-ink-500">
+                {locale === "zh" ? "将通知：" : "Will notify:"}{" "}
+                {agentIds.map((id) => AGENT_LABELS[id][locale]).join(" · ")}
+              </p>
+            )
           )}
         </div>
 
@@ -210,6 +272,30 @@ export default function LogPage() {
                   ? `${run.total} 个智能体在整理…`
                   : `${run.total} agent${run.total === 1 ? "" : "s"} thinking…`}
             </span>
+          </div>
+        )}
+
+        {run.kind === "filed" && (
+          <div
+            role="status"
+            className="mt-4 space-y-2 rounded-md border border-[var(--ok)]/40 bg-[var(--ok-soft)] p-3 text-sm"
+          >
+            <div className="flex items-center gap-2 text-ink-900">
+              <Check className="h-4 w-4 text-[var(--ok)]" />
+              {locale === "zh" ? "已归档" : "Filed"}
+            </div>
+            <div className="text-[13px] text-ink-700">
+              {run.summary[locale]}
+            </div>
+            <div className="text-[11px] text-ink-500">
+              {locale === "zh"
+                ? run.target === "lab"
+                  ? "已加入化验记录。智能体未参与解读。"
+                  : "已加入今日条目。智能体未参与解读。"
+                : run.target === "lab"
+                  ? "Added to labs. Agents were not called."
+                  : "Added to today's entry. Agents were not called."}
+            </div>
           </div>
         )}
 

--- a/src/lib/log/direct-file-apply.ts
+++ b/src/lib/log/direct-file-apply.ts
@@ -1,0 +1,66 @@
+import { db, now } from "~/lib/db/dexie";
+import type { DirectFileResult } from "./direct-file";
+import type { DailyEntry, LabResult } from "~/types/clinical";
+import type { EnteredBy } from "~/types/clinical";
+
+// Writes a direct-file result to the right Dexie table. Returns the row id
+// so the /log confirmation card can link to the detail page. Distinct from
+// the full /labs or /daily wizard — this is the "I just want it recorded"
+// path.
+
+export interface DirectFileApplied {
+  kind: DirectFileResult["kind"];
+  id: number;
+}
+
+export async function applyDirectFile(
+  r: DirectFileResult,
+  enteredBy: EnteredBy,
+): Promise<DirectFileApplied> {
+  const ts = now();
+  if (r.kind === "lab") {
+    // Merge into an existing same-day patient-self-report row so repeated
+    // entries on the same morning don't create ghosts. Otherwise insert.
+    const existing = await db.labs
+      .where("date")
+      .equals(r.date)
+      .filter((l) => l.source === "patient_self_report")
+      .first();
+    if (existing?.id) {
+      await db.labs.update(existing.id, {
+        ...r.patch,
+        updated_at: ts,
+      });
+      return { kind: "lab", id: existing.id };
+    }
+    const id = (await db.labs.add({
+      ...(r.patch as LabResult),
+      created_at: ts,
+      updated_at: ts,
+    })) as number;
+    return { kind: "lab", id };
+  }
+
+  // daily: upsert today's row so partial patches accumulate.
+  const existing = await db.daily_entries
+    .where("date")
+    .equals(r.date)
+    .first();
+  if (existing?.id) {
+    await db.daily_entries.update(existing.id, {
+      ...r.patch,
+      updated_at: ts,
+    });
+    return { kind: "daily", id: existing.id };
+  }
+  const base: Partial<DailyEntry> = {
+    ...r.patch,
+    date: r.date,
+    entered_by: enteredBy,
+    entered_at: ts,
+    created_at: ts,
+    updated_at: ts,
+  };
+  const id = (await db.daily_entries.add(base as DailyEntry)) as number;
+  return { kind: "daily", id };
+}

--- a/src/lib/log/direct-file.ts
+++ b/src/lib/log/direct-file.ts
@@ -1,0 +1,201 @@
+// Lightweight pattern matcher for short, structured log entries. The /log
+// surface normally tags free-text and fans it out to the specialist agents
+// so the super-brain can react. But a lot of what Hu Lin actually types is
+// a single vital or lab value — "blood sugar 7.9 this morning", "weight
+// 64.5 kg", "walked 20 min". Running the full agent fan-out on those
+// wastes latency and tokens; they're just data points.
+//
+// `parseDirectFile(text)` returns a tagged union with the target Dexie
+// table + patch and a human summary of what was filed. Returning `null`
+// means the text isn't a simple data point and should fall through to
+// the normal tag-and-fan-out flow.
+//
+// The parser is deliberately conservative:
+//   - Exactly one readable value per line is required.
+//   - A trailing unit ("kg", "min", "mg/dL", "mmol/L") is required for
+//     anything ambiguous (weight vs glucose would otherwise collide).
+//   - Glucose accepts "blood sugar" / "blood glucose" / "bsl" / "bgl";
+//     pure numbers without a keyword are never inferred as glucose.
+
+import { todayISO } from "~/lib/utils/date";
+import type { DailyEntry, LabResult } from "~/types/clinical";
+
+export type DirectFileResult =
+  | {
+      kind: "lab";
+      date: string;
+      patch: Partial<LabResult> & { date: string; source: "patient_self_report" };
+      summary: { en: string; zh: string };
+      icon: "lab";
+    }
+  | {
+      kind: "daily";
+      date: string;
+      patch: Partial<DailyEntry>;
+      summary: { en: string; zh: string };
+      icon: "daily";
+    };
+
+const DAY_PART_RE = /\b(this morning|morning|am|afternoon|pm|evening|tonight|today|now)\b/i;
+
+function timeOfDay(text: string): { en: string; zh: string } {
+  const m = DAY_PART_RE.exec(text);
+  const hit = m?.[1]?.toLowerCase();
+  if (!hit) return { en: "today", zh: "今日" };
+  if (hit === "this morning" || hit === "morning" || hit === "am")
+    return { en: "this morning", zh: "上午" };
+  if (hit === "afternoon")
+    return { en: "this afternoon", zh: "下午" };
+  if (hit === "pm" || hit === "evening" || hit === "tonight")
+    return { en: "this evening", zh: "晚上" };
+  return { en: "today", zh: "今日" };
+}
+
+function num(s: string | undefined): number | null {
+  if (!s) return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function parseDirectFile(
+  raw: string,
+  today: string = todayISO(),
+): DirectFileResult | null {
+  const text = raw.trim();
+  if (!text) return null;
+  // Too long → probably a multi-topic note; don't try to direct-file.
+  if (text.length > 160) return null;
+
+  // --- Blood glucose ----------------------------------------------------
+  // "blood sugar 7.9", "BGL 5.3 mmol/L", "blood glucose this morning 6.1"
+  const glucose = text.match(
+    /\b(?:blood\s+(?:sugar|glucose)|bsl|bgl|glucose)\b[^\d]{0,30}(\d+(?:\.\d+)?)/i,
+  );
+  if (glucose) {
+    const value = num(glucose[1]);
+    if (value !== null) {
+      const when = timeOfDay(text);
+      return {
+        kind: "lab",
+        date: today,
+        patch: {
+          date: today,
+          glucose: value,
+          source: "patient_self_report",
+        },
+        summary: {
+          en: `Blood glucose — ${value} ${when.en}`,
+          zh: `血糖 —— ${value} ${when.zh}`,
+        },
+        icon: "lab",
+      };
+    }
+  }
+
+  // --- Weight -----------------------------------------------------------
+  // "weight 68.2 kg", "weighed 68.2 kg", "68.2kg"
+  const weight = text.match(
+    /\b(?:weight|weighed|mass)\b[^\d]{0,10}(\d+(?:\.\d+)?)\s*kg\b/i,
+  );
+  if (weight) {
+    const value = num(weight[1]);
+    if (value !== null) {
+      return {
+        kind: "daily",
+        date: today,
+        patch: { weight_kg: value },
+        summary: {
+          en: `Weight — ${value} kg`,
+          zh: `体重 —— ${value} kg`,
+        },
+        icon: "daily",
+      };
+    }
+  }
+
+  // --- Temperature ------------------------------------------------------
+  // "temp 37.8", "temperature 38.1 C"
+  const temp = text.match(
+    /\btemp(?:erature)?\b[^\d]{0,10}(\d+(?:\.\d+)?)/i,
+  );
+  if (temp) {
+    const value = num(temp[1]);
+    if (value !== null && value >= 32 && value <= 42) {
+      return {
+        kind: "daily",
+        date: today,
+        patch: { fever_temp: value, fever: value >= 38 },
+        summary: {
+          en: `Temperature — ${value}°C`,
+          zh: `体温 —— ${value}°C`,
+        },
+        icon: "daily",
+      };
+    }
+  }
+
+  // --- Walking minutes --------------------------------------------------
+  // "walked 20 min", "30 min walk", "walk 25 minutes"
+  const walk = text.match(
+    /(?:\bwalked?\b[^\d]{0,10}(\d+)\s*(?:min|minutes|m)\b|(\d+)\s*(?:min|minutes|m)\s+walk\b)/i,
+  );
+  if (walk) {
+    const value = num(walk[1] ?? walk[2]);
+    if (value !== null && value > 0 && value < 500) {
+      return {
+        kind: "daily",
+        date: today,
+        patch: { walking_minutes: value },
+        summary: {
+          en: `Walking — ${value} min`,
+          zh: `步行 —— ${value} 分钟`,
+        },
+        icon: "daily",
+      };
+    }
+  }
+
+  // --- Steps ------------------------------------------------------------
+  // "4200 steps", "steps 5200"
+  const steps = text.match(
+    /\b(\d{3,6})\s*steps\b|\bsteps\b[^\d]{0,8}(\d{3,6})/i,
+  );
+  if (steps) {
+    const value = num(steps[1] ?? steps[2]);
+    if (value !== null && value > 0 && value < 200000) {
+      return {
+        kind: "daily",
+        date: today,
+        patch: { steps: value },
+        summary: {
+          en: `Steps — ${value.toLocaleString()}`,
+          zh: `步数 —— ${value.toLocaleString()}`,
+        },
+        icon: "daily",
+      };
+    }
+  }
+
+  // --- Protein grams ----------------------------------------------------
+  // "protein 62 g", "had 30g protein"
+  const protein = text.match(
+    /(?:\bprotein\b[^\d]{0,10}(\d+(?:\.\d+)?)\s*g\b|(\d+(?:\.\d+)?)\s*g\s+protein\b)/i,
+  );
+  if (protein) {
+    const value = num(protein[1] ?? protein[2]);
+    if (value !== null && value > 0 && value < 500) {
+      return {
+        kind: "daily",
+        date: today,
+        patch: { protein_grams: value },
+        summary: {
+          en: `Protein — ${value} g`,
+          zh: `蛋白质 —— ${value} g`,
+        },
+        icon: "daily",
+      };
+    }
+  }
+
+  return null;
+}

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -190,7 +190,7 @@ export interface LabResult {
   // Coag / endocrine
   inr?: number;
   tsh?: number;
-  source: "epworth" | "external";
+  source: "epworth" | "external" | "patient_self_report";
   notes?: string;
   created_at: string;
   updated_at: string;

--- a/tests/unit/direct-file.test.ts
+++ b/tests/unit/direct-file.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { parseDirectFile } from "~/lib/log/direct-file";
+
+const TODAY = "2026-05-06";
+
+describe("parseDirectFile", () => {
+  it("files a blood-glucose reading with a time-of-day hint", () => {
+    const r = parseDirectFile("blood sugar this morning 7.9", TODAY);
+    expect(r).not.toBeNull();
+    expect(r!.kind).toBe("lab");
+    if (r!.kind === "lab") {
+      expect(r!.patch.glucose).toBe(7.9);
+      expect(r!.patch.date).toBe(TODAY);
+      expect(r!.patch.source).toBe("patient_self_report");
+      expect(r!.summary.en.toLowerCase()).toContain("blood glucose");
+      expect(r!.summary.en).toContain("7.9");
+      expect(r!.summary.en).toContain("morning");
+    }
+  });
+
+  it("recognises bsl / bgl abbreviations with a unit", () => {
+    const r = parseDirectFile("BGL 5.3 mmol/L", TODAY);
+    expect(r).not.toBeNull();
+    if (r?.kind === "lab") {
+      expect(r.patch.glucose).toBe(5.3);
+    }
+  });
+
+  it("files weight in kg as a daily_entries patch", () => {
+    const r = parseDirectFile("weight 64.5 kg", TODAY);
+    expect(r).not.toBeNull();
+    expect(r!.kind).toBe("daily");
+    if (r!.kind === "daily") {
+      expect(r!.patch.weight_kg).toBe(64.5);
+    }
+  });
+
+  it("files temperature and flags fever above 38", () => {
+    const low = parseDirectFile("temp 37.2", TODAY);
+    expect(low?.kind).toBe("daily");
+    if (low?.kind === "daily") {
+      expect(low.patch.fever_temp).toBe(37.2);
+      expect(low.patch.fever).toBe(false);
+    }
+    const high = parseDirectFile("temperature 38.4", TODAY);
+    if (high?.kind === "daily") {
+      expect(high.patch.fever_temp).toBe(38.4);
+      expect(high.patch.fever).toBe(true);
+    }
+  });
+
+  it("rejects implausible temperature values", () => {
+    expect(parseDirectFile("temp 45.0", TODAY)).toBeNull();
+    expect(parseDirectFile("temp 10.0", TODAY)).toBeNull();
+  });
+
+  it("extracts walking minutes either phrasing", () => {
+    const a = parseDirectFile("walked 22 min", TODAY);
+    expect(a?.kind).toBe("daily");
+    if (a?.kind === "daily") expect(a.patch.walking_minutes).toBe(22);
+
+    const b = parseDirectFile("30 min walk in the park", TODAY);
+    if (b?.kind === "daily") expect(b.patch.walking_minutes).toBe(30);
+  });
+
+  it("extracts step count", () => {
+    const r = parseDirectFile("4200 steps today", TODAY);
+    expect(r?.kind).toBe("daily");
+    if (r?.kind === "daily") expect(r.patch.steps).toBe(4200);
+  });
+
+  it("extracts protein grams", () => {
+    const r = parseDirectFile("had 40 g protein at lunch", TODAY);
+    expect(r?.kind).toBe("daily");
+    if (r?.kind === "daily") expect(r.patch.protein_grams).toBe(40);
+  });
+
+  it("returns null for narrative / multi-topic text", () => {
+    expect(
+      parseDirectFile(
+        "had a rough morning with some nausea and the neuropathy is worse on the right fingertips",
+        TODAY,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for an empty or whitespace-only string", () => {
+    expect(parseDirectFile("", TODAY)).toBeNull();
+    expect(parseDirectFile("   ", TODAY)).toBeNull();
+  });
+
+  it("returns null for pure numbers (no keyword)", () => {
+    // Too ambiguous: 7.9 could be glucose, weight, temperature, anything.
+    expect(parseDirectFile("7.9", TODAY)).toBeNull();
+  });
+
+  it("caps at 160 characters so long notes fall through to agents", () => {
+    const long = "blood sugar 7.9 " + "x".repeat(200);
+    expect(parseDirectFile(long, TODAY)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

"Blood sugar this morning 7.9" shouldn't run the super-brain — it's a data point. This PR adds a small keyword parser that routes those entries straight into `labs` / `daily_entries` and skips the agent fan-out entirely.

### What gets direct-filed

| Input | Written to | Field |
|---|---|---|
| `blood sugar 7.9`, `BGL 5.3 mmol/L`, `blood glucose this morning 6.1` | `labs` | `glucose` |
| `weight 64.5 kg` | `daily_entries` | `weight_kg` |
| `temp 37.8`, `temperature 38.4` | `daily_entries` | `fever_temp` (+ `fever: true` at ≥38 °C) |
| `walked 22 min`, `30 min walk` | `daily_entries` | `walking_minutes` |
| `4200 steps` | `daily_entries` | `steps` |
| `had 40 g protein`, `protein 62 g` | `daily_entries` | `protein_grams` |

Deliberately conservative: all patterns are keyword-anchored (pure numbers never inferred), temperature capped 32–42 °C, weight requires `kg`, anything longer than 160 chars falls through to the normal agent flow. Explicit tag overrides by the user also disable direct-file.

### Persistence

- Labs: merges into an existing same-day `patient_self_report` row if one exists, otherwise inserts. Requires a new `"patient_self_report"` option on `LabResult.source`.
- Daily: upserts today's row so partial patches accumulate.

### UI

- Before submit: **Will file directly as: Blood glucose — 7.9 this morning · no agents called** hint replaces the "Will notify" agent list.
- After submit: a green **Filed** card states the reading + day and notes "Agents were not called."

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 394 / 394 (12 new parser tests)
- [ ] Manual: open `/log`, type `blood sugar 7.9 this morning` → see direct-file hint, press Save → green Filed card appears and `/labs` gets a new row with `glucose = 7.9`.
- [ ] Manual: type a free-form narrative like "rough morning with nausea and more neuropathy" → no direct-file hint, normal agent flow.

https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY)_