### PR TITLE
Holistic follow-ups from a filed data point

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -10,6 +10,7 @@ import { agentsForTags } from "~/agents/routing";
 import { runAgentClient } from "~/lib/log/run-agents";
 import { parseDirectFile, type DirectFileResult } from "~/lib/log/direct-file";
 import { applyDirectFile } from "~/lib/log/direct-file-apply";
+import { FollowUpsCard } from "~/components/log/follow-ups-card";
 import { useUIStore } from "~/stores/ui-store";
 import { LOG_TAGS, type AgentId, type LogTag } from "~/types/agent";
 import { Button } from "~/components/ui/button";
@@ -49,6 +50,7 @@ type RunState =
       summary: { en: string; zh: string };
       target: "lab" | "daily";
       rowId: number;
+      filed: DirectFileResult;
     }
   | { kind: "error"; message: string };
 
@@ -99,6 +101,7 @@ export default function LogPage() {
           summary: directFile.summary,
           target: applied.kind,
           rowId: applied.id,
+          filed: directFile,
         });
       } catch (err) {
         setRun({
@@ -358,6 +361,8 @@ export default function LogPage() {
           )}
         </div>
       </Card>
+
+      {run.kind === "filed" && <FollowUpsCard filed={run.filed} />}
 
       <p className="text-center text-[11px] text-ink-400">
         {locale === "zh"

--- a/src/app/schedule/[id]/page.tsx
+++ b/src/app/schedule/[id]/page.tsx
@@ -16,7 +16,23 @@ import { useLocale, useT } from "~/hooks/use-translate";
 import { useState } from "react";
 import type { Appointment, AppointmentLink } from "~/types/appointment";
 import { logTagsForKind } from "~/lib/appointments/follow-up-tasks";
-import { ArrowLeft, Link2, Trash2, Pencil, Users, Check, MessageSquarePlus } from "lucide-react";
+import {
+  ArrowLeft,
+  Check,
+  Link2,
+  MessageSquarePlus,
+  Pencil,
+  Plus,
+  Trash2,
+  Users,
+  X,
+} from "lucide-react";
+import {
+  addDiscussionItem,
+  removeDiscussionItem,
+  toggleDiscussionItemResolved,
+} from "~/lib/appointments/discussion-items";
+import { TextInput } from "~/components/ui/field";
 
 export default function AppointmentDetailPage() {
   const router = useRouter();
@@ -112,6 +128,8 @@ export default function AppointmentDetailPage() {
 
           <PrepPanel appt={appt} />
 
+          <DiscussionItemsPanel appt={appt} locale={locale} />
+
           <FollowUpPrompt appt={appt} locale={locale} t={t} />
 
           <Card className="space-y-3 p-5 text-[13px]">
@@ -201,6 +219,137 @@ export default function AppointmentDetailPage() {
         </>
       )}
     </div>
+  );
+}
+
+function DiscussionItemsPanel({
+  appt,
+  locale,
+}: {
+  appt: Appointment;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const [draft, setDraft] = useState("");
+  const items = appt.discussion_items ?? [];
+
+  async function add() {
+    if (!appt.id) return;
+    const text = draft.trim();
+    if (!text) return;
+    await addDiscussionItem(appt.id, { text, source: "manual" });
+    setDraft("");
+  }
+
+  // Hide the card entirely until there's something to show or add —
+  // keeps the appointment detail page quiet for routine visits that
+  // don't need a pre-visit agenda.
+  if (items.length === 0 && !draft) {
+    return (
+      <Card className="flex items-center justify-between gap-3 p-4 text-[12.5px]">
+        <div className="min-w-0">
+          <div className="mb-0.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-ink-500">
+            <MessageSquarePlus className="h-3.5 w-3.5" />
+            {L("Things to raise", "议题")}
+          </div>
+          <p className="text-ink-500">
+            {L(
+              "Nothing queued yet. Filed vitals and agent flags land here.",
+              "暂无议题。所记录的指标与智能体标记会出现在这里。",
+            )}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDraft(" ")}
+          className="shrink-0 rounded-md border border-ink-200 px-2 py-1 text-[11px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+        >
+          <Plus className="h-3 w-3" />
+        </button>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="space-y-2 p-4">
+      <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-ink-500">
+        <MessageSquarePlus className="h-3.5 w-3.5" />
+        {L("Things to raise at this visit", "就诊议题")}
+      </div>
+      {items.length > 0 && (
+        <ul className="space-y-1.5">
+          {items.map((d) => (
+            <li
+              key={d.id}
+              className="flex items-start gap-2 rounded-[var(--r-md)] bg-paper-2 px-3 py-2 text-[12.5px]"
+            >
+              <button
+                type="button"
+                onClick={() => void toggleDiscussionItemResolved(appt.id!, d.id)}
+                aria-label={L("Toggle resolved", "切换完成状态")}
+                className={
+                  "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border " +
+                  (d.resolved_at
+                    ? "border-[var(--ok)] bg-[var(--ok)] text-paper"
+                    : "border-ink-300 bg-paper")
+                }
+              >
+                {d.resolved_at && <Check className="h-2.5 w-2.5" strokeWidth={3} />}
+              </button>
+              <div className="min-w-0 flex-1">
+                <div
+                  className={
+                    d.resolved_at
+                      ? "text-ink-400 line-through"
+                      : "text-ink-900"
+                  }
+                >
+                  {d.text}
+                </div>
+                {d.source && (
+                  <div className="mono mt-0.5 text-[9.5px] uppercase tracking-[0.1em] text-ink-400">
+                    {d.source === "direct_file"
+                      ? L("from log", "来自记录")
+                      : d.source === "agent"
+                        ? L("from agent", "来自智能体")
+                        : d.source === "log"
+                          ? L("from log", "来自记录")
+                          : L("manual", "手动")}
+                  </div>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => void removeDiscussionItem(appt.id!, d.id)}
+                aria-label={L("Remove", "删除")}
+                className="text-ink-400 hover:text-ink-900"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="flex items-center gap-2">
+        <TextInput
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder={L(
+            "Add something to raise…",
+            "补充一项议题…",
+          )}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              void add();
+            }
+          }}
+        />
+        <Button size="sm" onClick={() => void add()} disabled={!draft.trim()}>
+          {L("Add", "加入")}
+        </Button>
+      </div>
+    </Card>
   );
 }
 

--- a/src/components/log/follow-ups-card.tsx
+++ b/src/components/log/follow-ups-card.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { generateFollowUps, type FollowUpItem } from "~/lib/log/follow-ups";
+import { addDiscussionItem } from "~/lib/appointments/discussion-items";
+import type { DirectFileResult } from "~/lib/log/direct-file";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import {
+  Check,
+  MessageCircle,
+  Phone,
+  Mail,
+  Sparkles,
+  CalendarPlus,
+  AlertTriangle,
+  ChevronRight,
+  Loader2,
+} from "lucide-react";
+import type { Appointment } from "~/types/appointment";
+import { cn } from "~/lib/utils/cn";
+
+// Renders ranked next-step suggestions for a direct-filed data point.
+// Actions are one-tap: add to the next clinic's discussion items, open
+// the default SMS / email app for the right care-team member, or kick
+// off a specialist agent. Care-team + next-clinic lookups live on the
+// same card so the caller just passes the DirectFileResult.
+
+const SEVERITY_STYLES: Record<
+  FollowUpItem["severity"],
+  { bg: string; border: string; dot: string; accent: string; iconColor: string }
+> = {
+  urgent: {
+    bg: "bg-[var(--warn-soft)]",
+    border: "border-[var(--warn)]/40",
+    dot: "bg-[var(--warn)]",
+    accent: "text-[var(--warn)]",
+    iconColor: "text-[var(--warn)]",
+  },
+  watch: {
+    bg: "bg-[var(--sand)]/40",
+    border: "border-[var(--sand-2)]/40",
+    dot: "bg-[oklch(55%_0.08_70)]",
+    accent: "text-[oklch(35%_0.04_70)]",
+    iconColor: "text-[oklch(35%_0.04_70)]",
+  },
+  routine: {
+    bg: "bg-[var(--tide-soft)]/60",
+    border: "border-[var(--tide-2)]/30",
+    dot: "bg-[var(--tide-2)]",
+    accent: "text-[var(--tide-2)]",
+    iconColor: "text-[var(--tide-2)]",
+  },
+};
+
+export function FollowUpsCard({ filed }: { filed: DirectFileResult }) {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const team = useLiveQuery(() => db.care_team.toArray(), []);
+  const nextClinic = useLiveQuery(async () => {
+    const rows = await db.appointments
+      .where("[kind+starts_at]")
+      .between(["clinic", ""], ["clinic", "￿"])
+      .toArray();
+    const now = Date.now();
+    return rows
+      .filter((a) => a.status !== "cancelled" && a.status !== "missed")
+      .map((a) => ({ a, t: new Date(a.starts_at).getTime() }))
+      .filter(({ t }) => Number.isFinite(t) && t >= now)
+      .sort((x, y) => x.t - y.t)[0]?.a as Appointment | undefined;
+  }, []);
+
+  const items = useMemo(() => {
+    if (!team) return [];
+    return generateFollowUps({
+      filed,
+      team,
+      nextClinic,
+      locale,
+    });
+  }, [filed, team, nextClinic, locale]);
+
+  if (team === undefined) return null;
+  if (items.length === 0) return null;
+
+  return (
+    <Card className="border-ink-200/60">
+      <CardContent className="space-y-3 pt-5">
+        <div className="flex items-center gap-1.5 text-[12.5px] font-semibold text-ink-900">
+          <Sparkles className="h-3.5 w-3.5 text-[var(--tide-2)]" />
+          {L("Next steps", "后续处理")}
+        </div>
+        <p className="text-[12px] text-ink-500">
+          {L(
+            "Anchor watched what you filed and suggested what to do next. One tap.",
+            "系统根据你刚记录的内容自动建议下一步。一键完成。",
+          )}
+        </p>
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item.id}>
+              <FollowUpRow item={item} locale={locale} />
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FollowUpRow({
+  item,
+  locale,
+}: {
+  item: FollowUpItem;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const style = SEVERITY_STYLES[item.severity];
+  return (
+    <div
+      className={cn(
+        "rounded-[var(--r-md)] border p-3",
+        style.bg,
+        style.border,
+      )}
+    >
+      <div className="flex items-start gap-2.5">
+        {item.severity === "urgent" ? (
+          <AlertTriangle className={cn("mt-0.5 h-4 w-4 shrink-0", style.iconColor)} />
+        ) : (
+          <span
+            className={cn(
+              "mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full",
+              style.dot,
+            )}
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="text-[13.5px] font-semibold text-ink-900">
+            {item.title[locale]}
+          </div>
+          <p className="mt-0.5 text-[12px] leading-relaxed text-ink-700">
+            {item.body[locale]}
+          </p>
+          {item.actions.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {item.actions.map((a, i) => (
+                <ActionChip key={i} action={a} locale={locale} />
+              ))}
+            </div>
+          )}
+        </div>
+        <span
+          className={cn(
+            "mono shrink-0 text-[9.5px] uppercase tracking-[0.12em]",
+            style.accent,
+          )}
+        >
+          {L(
+            item.severity === "urgent"
+              ? "Urgent"
+              : item.severity === "watch"
+                ? "Watch"
+                : "Routine",
+            item.severity === "urgent"
+              ? "紧急"
+              : item.severity === "watch"
+                ? "留意"
+                : "常规",
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function ActionChip({
+  action,
+  locale,
+}: {
+  action: FollowUpItem["actions"][number];
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const [status, setStatus] =
+    useState<"idle" | "working" | "done" | "error">("idle");
+
+  async function run() {
+    if (status === "working" || status === "done") return;
+    setStatus("working");
+    try {
+      if (action.kind === "add_to_clinic") {
+        await addDiscussionItem(action.appointment_id, {
+          text: action.text,
+          source: "direct_file",
+        });
+        setStatus("done");
+      } else if (action.kind === "message_care_team") {
+        // Open the default handler for tel:/sms:/mailto:. Not async in the
+        // usual sense — set done immediately after navigating.
+        window.location.href = action.target;
+        setStatus("done");
+      } else if (action.kind === "engage_agent") {
+        const res = await fetch(`/api/agent/${action.agent_id}/run`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            date: new Date().toISOString().slice(0, 10),
+            locale,
+            trigger: "on_demand",
+            referrals: [{ kind: "text", text: action.prompt }],
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        setStatus("done");
+      }
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  const Icon = iconFor(action);
+  const busyLabel = L("…", "…");
+  const doneLabel = L("Done", "已完成");
+
+  return (
+    <button
+      type="button"
+      onClick={() => void run()}
+      disabled={status === "working" || status === "done"}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11.5px] transition-colors",
+        status === "done"
+          ? "border-[var(--ok)]/40 bg-[var(--ok-soft)] text-[var(--ok)]"
+          : status === "error"
+            ? "border-[var(--warn)]/40 bg-[var(--warn-soft)] text-[var(--warn)]"
+            : "border-ink-200 bg-paper text-ink-700 hover:border-ink-400",
+      )}
+    >
+      {status === "working" ? (
+        <Loader2 className="h-3 w-3 animate-spin" />
+      ) : status === "done" ? (
+        <Check className="h-3 w-3" />
+      ) : (
+        <Icon className="h-3 w-3" />
+      )}
+      {status === "working"
+        ? busyLabel
+        : status === "done"
+          ? doneLabel
+          : action.label[locale]}
+      {status === "idle" && <ChevronRight className="h-3 w-3 opacity-60" />}
+    </button>
+  );
+}
+
+function iconFor(action: FollowUpItem["actions"][number]) {
+  if (action.kind === "add_to_clinic") return CalendarPlus;
+  if (action.kind === "engage_agent") return Sparkles;
+  if (action.kind === "message_care_team") {
+    if (action.channel === "email") return Mail;
+    if (action.channel === "phone") return Phone;
+    return MessageCircle;
+  }
+  return Sparkles;
+}

--- a/src/lib/appointments/discussion-items.ts
+++ b/src/lib/appointments/discussion-items.ts
@@ -1,0 +1,65 @@
+import { db, now } from "~/lib/db/dexie";
+import type { AppointmentDiscussionItem } from "~/types/appointment";
+
+// Append a discussion item to an appointment. Used by the /log direct-file
+// follow-ups ("Add to next clinic") and any agent that decides something
+// should be raised at a future visit.
+
+export async function addDiscussionItem(
+  appointmentId: number,
+  item: Omit<AppointmentDiscussionItem, "id" | "added_at"> & {
+    id?: string;
+    added_at?: string;
+  },
+): Promise<void> {
+  const appt = await db.appointments.get(appointmentId);
+  if (!appt) return;
+  const next: AppointmentDiscussionItem = {
+    id:
+      item.id ??
+      Math.random().toString(36).slice(2, 10) +
+        "-" +
+        Date.now().toString(36),
+    text: item.text,
+    source: item.source,
+    source_ref: item.source_ref,
+    added_at: item.added_at ?? now(),
+    resolved_at: item.resolved_at,
+  };
+  const list = appt.discussion_items ?? [];
+  await db.appointments.update(appointmentId, {
+    discussion_items: [...list, next],
+    updated_at: now(),
+  });
+}
+
+export async function toggleDiscussionItemResolved(
+  appointmentId: number,
+  itemId: string,
+): Promise<void> {
+  const appt = await db.appointments.get(appointmentId);
+  if (!appt) return;
+  const ts = now();
+  const next = (appt.discussion_items ?? []).map((d) =>
+    d.id === itemId
+      ? { ...d, resolved_at: d.resolved_at ? undefined : ts }
+      : d,
+  );
+  await db.appointments.update(appointmentId, {
+    discussion_items: next,
+    updated_at: ts,
+  });
+}
+
+export async function removeDiscussionItem(
+  appointmentId: number,
+  itemId: string,
+): Promise<void> {
+  const appt = await db.appointments.get(appointmentId);
+  if (!appt) return;
+  const next = (appt.discussion_items ?? []).filter((d) => d.id !== itemId);
+  await db.appointments.update(appointmentId, {
+    discussion_items: next,
+    updated_at: now(),
+  });
+}

--- a/src/lib/log/follow-ups.ts
+++ b/src/lib/log/follow-ups.ts
@@ -1,0 +1,274 @@
+// Rule-based follow-up engine. When a direct-filed value lands (glucose,
+// weight, temperature, ...), this turns it into a ranked list of
+// "next steps" — things the system can either do automatically (add to
+// the next clinic's discussion items, surface in the feed) or offer to
+// the user as a one-tap action (message the lead oncology nurse, engage
+// the dietician agent).
+//
+// Kept deliberately rule-based and cheap to run — no LLM round-trip for
+// the common cases. More nuanced reasoning can be layered later by
+// invoking a specialist agent when the rules flag an ambiguous case.
+
+import type { DirectFileResult } from "./direct-file";
+import type { AppointmentDiscussionItem } from "~/types/appointment";
+import type { Appointment } from "~/types/appointment";
+import type { CareTeamMember } from "~/types/care-team";
+
+export type FollowUpSeverity = "routine" | "watch" | "urgent";
+
+export interface FollowUpItem {
+  id: string;
+  severity: FollowUpSeverity;
+  title: { en: string; zh: string };
+  body: { en: string; zh: string };
+  actions: FollowUpAction[];
+}
+
+export type FollowUpAction =
+  | {
+      kind: "add_to_clinic";
+      appointment_id: number;
+      text: string;
+      label: { en: string; zh: string };
+    }
+  | {
+      kind: "message_care_team";
+      member_id: number;
+      channel: "phone" | "sms" | "email";
+      target: string;          // tel:+…, sms:+…, mailto:…
+      draft?: string;
+      label: { en: string; zh: string };
+    }
+  | {
+      kind: "engage_agent";
+      agent_id: "nutrition" | "toxicity" | "clinical" | "psychology" | "rehabilitation" | "treatment";
+      prompt: string;
+      label: { en: string; zh: string };
+    };
+
+function slug(s: string): string {
+  return Math.random().toString(36).slice(2, 8) + "-" + s.slice(0, 8);
+}
+
+function leadMemberByRole(
+  team: CareTeamMember[],
+  roles: Array<CareTeamMember["role"]>,
+): CareTeamMember | undefined {
+  for (const role of roles) {
+    const hit = team.find((m) => m.role === role && m.is_lead);
+    if (hit) return hit;
+  }
+  for (const role of roles) {
+    const hit = team.find((m) => m.role === role);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+function messageAction(
+  member: CareTeamMember | undefined,
+  draft: string,
+  locale: "en" | "zh",
+): FollowUpAction | null {
+  if (!member?.id) return null;
+  if (member.phone) {
+    return {
+      kind: "message_care_team",
+      member_id: member.id,
+      channel: "sms",
+      target: `sms:${member.phone.replace(/\s+/g, "")}?body=${encodeURIComponent(
+        draft,
+      )}`,
+      draft,
+      label: {
+        en: `Message ${member.name}`,
+        zh: `发短信给 ${member.name}`,
+      },
+    };
+  }
+  if (member.email) {
+    return {
+      kind: "message_care_team",
+      member_id: member.id,
+      channel: "email",
+      target: `mailto:${member.email}?body=${encodeURIComponent(draft)}`,
+      draft,
+      label: {
+        en: `Email ${member.name}`,
+        zh: `发邮件给 ${member.name}`,
+      },
+    };
+  }
+  return null;
+}
+
+function addToClinicAction(
+  clinic: Appointment | undefined,
+  text: string,
+): FollowUpAction | null {
+  if (!clinic?.id) return null;
+  return {
+    kind: "add_to_clinic",
+    appointment_id: clinic.id,
+    text,
+    label: {
+      en: "Add to next clinic",
+      zh: "加入下次就诊议题",
+    },
+  };
+}
+
+export interface GenerateArgs {
+  filed: DirectFileResult;
+  team: CareTeamMember[];
+  nextClinic?: Appointment;
+  locale?: "en" | "zh";
+}
+
+export function generateFollowUps(args: GenerateArgs): FollowUpItem[] {
+  const { filed, team, nextClinic, locale = "en" } = args;
+  const out: FollowUpItem[] = [];
+
+  // -------- Blood glucose ----------------------------------------------
+  if (filed.kind === "lab" && typeof filed.patch.glucose === "number") {
+    const g = filed.patch.glucose;
+    if (g >= 11.1) {
+      const nurse = leadMemberByRole(team, ["nurse", "oncologist", "gp"]);
+      const actions: FollowUpAction[] = [];
+      const msg = messageAction(
+        nurse,
+        `Hu Lin's blood glucose is ${g} mmol/L (hyperglycaemia). Asking whether to do anything today.`,
+        locale,
+      );
+      if (msg) actions.push(msg);
+      const clinic = addToClinicAction(
+        nextClinic,
+        `Hyperglycaemia ${g} mmol/L on ${filed.date}`,
+      );
+      if (clinic) actions.push(clinic);
+      actions.push({
+        kind: "engage_agent",
+        agent_id: "nutrition",
+        prompt: `Glucose ${g} mmol/L logged on ${filed.date}. Suggest a response and whether diet changes are warranted given current chemo cycle.`,
+        label: { en: "Engage dietician", zh: "请营养师关注" },
+      });
+      out.push({
+        id: slug("gluc-hi"),
+        severity: "urgent",
+        title: {
+          en: `High blood glucose — ${g} mmol/L`,
+          zh: `血糖偏高 —— ${g} mmol/L`,
+        },
+        body: {
+          en: "Above 11 is in the call-your-team range. Reach out today, flag at the next clinic.",
+          zh: "超过 11 属于需当天联系医疗团队的范围。今日联系,并在下次就诊时提出。",
+        },
+        actions,
+      });
+    } else if (g >= 7.8) {
+      const actions: FollowUpAction[] = [];
+      const clinic = addToClinicAction(
+        nextClinic,
+        `Fasting / random glucose ${g} on ${filed.date}`,
+      );
+      if (clinic) actions.push(clinic);
+      actions.push({
+        kind: "engage_agent",
+        agent_id: "nutrition",
+        prompt: `Glucose ${g} mmol/L logged on ${filed.date}. Worth raising with dietician?`,
+        label: { en: "Engage dietician", zh: "请营养师关注" },
+      });
+      out.push({
+        id: slug("gluc-mid"),
+        severity: "watch",
+        title: {
+          en: `Elevated blood glucose — ${g} mmol/L`,
+          zh: `血糖升高 —— ${g} mmol/L`,
+        },
+        body: {
+          en: "Above 7.8 isn't urgent but worth raising at the next clinic and flagging to the dietician.",
+          zh: "高于 7.8 并非急症,但值得在下次就诊提出,并告知营养师。",
+        },
+        actions,
+      });
+    } else if (g < 4.0) {
+      const nurse = leadMemberByRole(team, ["nurse", "oncologist", "gp"]);
+      const actions: FollowUpAction[] = [];
+      const msg = messageAction(
+        nurse,
+        `Hu Lin's blood glucose is ${g} mmol/L (hypoglycaemia). Checking on next steps.`,
+        locale,
+      );
+      if (msg) actions.push(msg);
+      out.push({
+        id: slug("gluc-lo"),
+        severity: "urgent",
+        title: {
+          en: `Low blood glucose — ${g} mmol/L`,
+          zh: `低血糖 —— ${g} mmol/L`,
+        },
+        body: {
+          en: "Below 4.0 — treat the low first (15 g fast carbs), then contact the team.",
+          zh: "低于 4.0 —— 先处理低血糖(15 g 快速碳水),再联系团队。",
+        },
+        actions,
+      });
+    }
+  }
+
+  // -------- Temperature ------------------------------------------------
+  if (
+    filed.kind === "daily" &&
+    typeof filed.patch.fever_temp === "number" &&
+    filed.patch.fever_temp >= 38
+  ) {
+    const nurse = leadMemberByRole(team, ["nurse", "oncologist"]);
+    const actions: FollowUpAction[] = [];
+    const msg = messageAction(
+      nurse,
+      `Hu Lin has a fever of ${filed.patch.fever_temp}°C on ${filed.date}.`,
+      locale,
+    );
+    if (msg) actions.push(msg);
+    out.push({
+      id: slug("fever"),
+      severity: "urgent",
+      title: {
+        en: `Fever — ${filed.patch.fever_temp}°C`,
+        zh: `发热 —— ${filed.patch.fever_temp}°C`,
+      },
+      body: {
+        en: "On chemo, ≥38°C is oncology-emergency territory if neutropenic. Call the oncology line now.",
+        zh: "化疗期间 ≥38°C,若有中性粒细胞减少即为肿瘤急症。立即联系肿瘤科。",
+      },
+      actions,
+    });
+  }
+
+  // -------- Weight -----------------------------------------------------
+  // Direct-file only knows today's number, not a trend. Flag the clinic
+  // so the weight is reviewed against baselines on the next visit.
+  if (filed.kind === "daily" && typeof filed.patch.weight_kg === "number") {
+    const clinic = addToClinicAction(
+      nextClinic,
+      `Weight ${filed.patch.weight_kg} kg on ${filed.date}`,
+    );
+    if (clinic) {
+      out.push({
+        id: slug("weight"),
+        severity: "routine",
+        title: {
+          en: `Weight — ${filed.patch.weight_kg} kg`,
+          zh: `体重 —— ${filed.patch.weight_kg} kg`,
+        },
+        body: {
+          en: "Added as a discussion point for the next clinic so the trend is reviewed against baseline.",
+          zh: "已作为下次就诊讨论项加入,以便与基线比对。",
+        },
+        actions: [clinic],
+      });
+    }
+  }
+
+  return out;
+}

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -141,8 +141,22 @@ export interface Appointment {
   // `followup_logged_at` and a past `starts_at` emit a "log what
   // happened" task; setting this dismisses the task.
   followup_logged_at?: string;
+  // Ad-hoc items to raise at this visit — populated by the /log direct-
+  // file flow (e.g. "blood sugar 7.9 fasting") and by the patient / carer
+  // manually. Each entry is a short plain-language line; optional `source`
+  // lets the UI surface provenance ("from Tue's glucose log").
+  discussion_items?: AppointmentDiscussionItem[];
   created_at: string;
   updated_at: string;
+}
+
+export interface AppointmentDiscussionItem {
+  id: string;                     // local uuid-ish, just a client slug
+  text: string;                   // e.g. "Fasting glucose 7.9 on 5 May"
+  source?: "log" | "direct_file" | "manual" | "agent";
+  source_ref?: string;            // e.g. labs:123, daily_entries:45
+  added_at: string;               // ISO
+  resolved_at?: string;           // tick-off on the detail page
 }
 
 // Slice K: cross-module links from an appointment to any domain row

--- a/tests/unit/log-follow-ups.test.ts
+++ b/tests/unit/log-follow-ups.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import { generateFollowUps } from "~/lib/log/follow-ups";
+import type { DirectFileResult } from "~/lib/log/direct-file";
+import type { Appointment } from "~/types/appointment";
+import type { CareTeamMember } from "~/types/care-team";
+
+const TODAY = "2026-05-06";
+
+function lab(glucose: number): DirectFileResult {
+  return {
+    kind: "lab",
+    date: TODAY,
+    patch: {
+      date: TODAY,
+      glucose,
+      source: "patient_self_report",
+    },
+    summary: { en: `Blood glucose — ${glucose}`, zh: `血糖 —— ${glucose}` },
+    icon: "lab",
+  };
+}
+
+function daily(patch: Record<string, unknown>): DirectFileResult {
+  return {
+    kind: "daily",
+    date: TODAY,
+    patch: patch as DirectFileResult["patch"],
+    summary: { en: "", zh: "" },
+    icon: "daily",
+  };
+}
+
+const team: CareTeamMember[] = [
+  {
+    id: 1,
+    name: "Sumi",
+    role: "nurse",
+    is_lead: true,
+    phone: "+61 400 111 222",
+    created_at: TODAY,
+    updated_at: TODAY,
+  },
+  {
+    id: 2,
+    name: "Dr Lee",
+    role: "oncologist",
+    is_lead: true,
+    email: "dr.lee@example.com",
+    created_at: TODAY,
+    updated_at: TODAY,
+  },
+];
+
+const clinic: Appointment = {
+  id: 99,
+  kind: "clinic",
+  title: "Oncology review",
+  starts_at: "2026-05-10T09:00:00+10:00",
+  status: "scheduled",
+  created_at: TODAY,
+  updated_at: TODAY,
+};
+
+describe("generateFollowUps", () => {
+  it("escalates glucose ≥ 11.1 with a message-nurse + clinic + dietician triad", () => {
+    const r = generateFollowUps({ filed: lab(12.4), team, nextClinic: clinic });
+    expect(r).toHaveLength(1);
+    expect(r[0]!.severity).toBe("urgent");
+    const kinds = r[0]!.actions.map((a) => a.kind);
+    expect(kinds).toContain("message_care_team");
+    expect(kinds).toContain("add_to_clinic");
+    expect(kinds).toContain("engage_agent");
+    const msg = r[0]!.actions.find((a) => a.kind === "message_care_team")!;
+    if (msg.kind === "message_care_team") {
+      expect(msg.channel).toBe("sms");
+      expect(msg.target).toMatch(/^sms:\+61/);
+    }
+  });
+
+  it("flags glucose 7.8–11.0 as watch, adds to clinic + dietician (no nurse message)", () => {
+    const r = generateFollowUps({ filed: lab(8.2), team, nextClinic: clinic });
+    expect(r).toHaveLength(1);
+    expect(r[0]!.severity).toBe("watch");
+    const kinds = r[0]!.actions.map((a) => a.kind);
+    expect(kinds).toContain("add_to_clinic");
+    expect(kinds).toContain("engage_agent");
+    expect(kinds).not.toContain("message_care_team");
+  });
+
+  it("ignores a normal glucose (4.0–7.7)", () => {
+    const r = generateFollowUps({ filed: lab(5.6), team, nextClinic: clinic });
+    expect(r).toHaveLength(0);
+  });
+
+  it("escalates hypoglycaemia < 4.0 with a message-nurse action", () => {
+    const r = generateFollowUps({ filed: lab(3.2), team, nextClinic: clinic });
+    expect(r).toHaveLength(1);
+    expect(r[0]!.severity).toBe("urgent");
+    expect(r[0]!.actions.map((a) => a.kind)).toContain("message_care_team");
+  });
+
+  it("flags fever ≥ 38 as urgent with a nurse-message action", () => {
+    const r = generateFollowUps({
+      filed: daily({ fever_temp: 38.6, fever: true }),
+      team,
+      nextClinic: clinic,
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0]!.severity).toBe("urgent");
+    expect(r[0]!.actions[0]!.kind).toBe("message_care_team");
+  });
+
+  it("files weight as a routine clinic discussion item", () => {
+    const r = generateFollowUps({
+      filed: daily({ weight_kg: 64.5 }),
+      team,
+      nextClinic: clinic,
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0]!.severity).toBe("routine");
+    expect(r[0]!.actions[0]!.kind).toBe("add_to_clinic");
+  });
+
+  it("skips Message-nurse actions when the care-team has no phone or email", () => {
+    const teamNoContact: CareTeamMember[] = [
+      {
+        id: 1,
+        name: "Sumi",
+        role: "nurse",
+        is_lead: true,
+        created_at: TODAY,
+        updated_at: TODAY,
+      },
+    ];
+    const r = generateFollowUps({
+      filed: lab(12.1),
+      team: teamNoContact,
+      nextClinic: clinic,
+    });
+    expect(r[0]!.actions.map((a) => a.kind)).not.toContain("message_care_team");
+  });
+
+  it("falls back to email when phone is missing", () => {
+    const teamEmail: CareTeamMember[] = [
+      {
+        id: 1,
+        name: "Dr Lee",
+        role: "oncologist",
+        is_lead: true,
+        email: "dr.lee@example.com",
+        created_at: TODAY,
+        updated_at: TODAY,
+      },
+    ];
+    const r = generateFollowUps({
+      filed: lab(12.1),
+      team: teamEmail,
+      nextClinic: clinic,
+    });
+    const msg = r[0]!.actions.find((a) => a.kind === "message_care_team");
+    expect(msg).toBeDefined();
+    if (msg?.kind === "message_care_team") {
+      expect(msg.channel).toBe("email");
+      expect(msg.target).toMatch(/^mailto:dr\.lee@/);
+    }
+  });
+
+  it("skips Add-to-clinic actions when no upcoming clinic appointment is supplied", () => {
+    const r = generateFollowUps({ filed: lab(8.2), team });
+    // Only engage_agent remains — no clinic to add to.
+    expect(r[0]!.actions.map((a) => a.kind)).toEqual(["engage_agent"]);
+  });
+});


### PR DESCRIPTION
## Summary

**User ask:** "Ingesting something like 'Blood sugar tested today 7.9' by any family member should update the system and trigger next step reminders — entering it into the metrics module, linking event to next clinic appointment to bring up, suggesting messaging Sumi's office, engaging dietician. AI-powered holistic care and system filing."

This PR wires the post-file follow-up behaviour on top of the direct-file shortcut that landed in #72.

### Follow-up engine (`src/lib/log/follow-ups.ts`)

Rule-based, keyed to the filed value + care-team + next clinic:

| Trigger | Severity | Actions |
|---|---|---|
| Glucose ≥ 11.1 mmol/L | **Urgent** | Message lead nurse (SMS w/ draft), add to next clinic, engage dietician |
| Glucose 7.8–11.0 | Watch | Add to next clinic + engage dietician |
| Glucose < 4.0 | **Urgent** | Message lead nurse (hypoglycaemia) |
| Temp ≥ 38 °C | **Urgent** | Message lead nurse with pre-filled draft |
| Weight | Routine | Add to next clinic for trend review |

Action kinds are typed: `add_to_clinic` | `message_care_team` | `engage_agent`. SMS falls back to email when phone isn't on file. No upcoming clinic → the Add-to-clinic action is dropped (never a dead button).

### Schema

- `Appointment.discussion_items?: AppointmentDiscussionItem[]` — `{ id, text, source, source_ref, added_at, resolved_at }`. Optional — existing rows unaffected.
- `src/lib/appointments/discussion-items.ts` — `addDiscussionItem`, `toggleDiscussionItemResolved`, `removeDiscussionItem`. Narrow CRUD.

### UI

- **`/log`** — after a direct-file Save, a `FollowUpsCard` renders the generated items as severity-coloured cards. One-tap action chips (idle → working → done). Message chips navigate to tel:/sms:/mailto:. Engage chips POST to `/api/agent/<id>/run`.
- **`/schedule/[id]`** — new `DiscussionItemsPanel` lists every queued item, tick-to-resolve, delete, inline add. Source tag ("from log", "from agent", "manual") shows provenance.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — **403 / 403** (9 new follow-up generator tests)
- [ ] Manual: on `/log`, type `blood sugar 12.1 this morning` → green Filed card + follow-up card showing Urgent high-glucose with 3 actions (Message Sumi, Add to next clinic, Engage dietician). Tap Add to next clinic → confirm `/schedule/[clinic]` now has the item in Discussion Items.
- [ ] Manual: on `/log`, type `temp 38.4` → urgent fever card with a Message Sumi chip. Tap it → phone's SMS app opens with a pre-filled draft.
- [ ] Manual: on `/log`, `weight 64.5 kg` → routine follow-up, adds the weight as a clinic discussion item.

## Deferred

- **Agent-skill system access** — expose read/add/edit/link Dexie operations as a toolset Claude can call directly. Substantial architecture change; next workstream.

https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY)_