### PR TITLE
Agent-skill registry + handlers + dispatcher

### DIFF
--- a/src/agents/skills/dispatch.ts
+++ b/src/agents/skills/dispatch.ts
@@ -1,0 +1,73 @@
+import { skillsByName } from "./registry";
+import { addDiscussionItemHandler } from "./handlers/add-discussion-item";
+import { addTaskHandler } from "./handlers/add-task";
+import { readAppointmentsHandler } from "./handlers/read-appointments";
+import { readCareTeamHandler } from "./handlers/read-care-team";
+import { readDailyHandler } from "./handlers/read-daily";
+import { readLabsHandler } from "./handlers/read-labs";
+
+// Dispatcher: maps a tool_use call ("name" + input object) to the matching
+// handler and returns the tool_result payload. Lives alongside the
+// registry so adding a new skill is name → schema → handler in three
+// adjacent edits.
+//
+// Handlers can throw; the dispatcher catches and wraps into a typed
+// error result so the tool_use loop never kills the whole agent run.
+
+const handlers: Record<
+  string,
+  (input: unknown) => Promise<unknown>
+> = {
+  read_labs: (i) => readLabsHandler(i as never),
+  read_daily_entries: (i) => readDailyHandler(i as never),
+  read_appointments: (i) => readAppointmentsHandler(i as never),
+  read_care_team: (i) => readCareTeamHandler(i as never),
+  add_discussion_item: (i) => addDiscussionItemHandler(i as never),
+  add_task: (i) => addTaskHandler(i as never),
+};
+
+export interface DispatchResult {
+  ok: boolean;
+  output?: unknown;
+  error?: string;
+}
+
+export async function dispatchSkill(
+  name: string,
+  input: unknown,
+): Promise<DispatchResult> {
+  if (!skillsByName[name]) {
+    return { ok: false, error: `unknown_skill:${name}` };
+  }
+  const handler = handlers[name];
+  if (!handler) {
+    return { ok: false, error: `handler_missing:${name}` };
+  }
+  if (!validateAgainstSchema(input, skillsByName[name]!.input_schema)) {
+    return { ok: false, error: `bad_input_for:${name}` };
+  }
+  try {
+    const output = await handler(input);
+    return { ok: true, output };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// Minimal runtime JSONSchema check — just enough to catch the "agent
+// forgot a required field" case. For anything more, reach for Zod.
+function validateAgainstSchema(
+  input: unknown,
+  schema: { type?: string; required?: readonly string[]; properties?: Record<string, unknown> },
+): boolean {
+  if (schema.type === "object") {
+    if (input === null || typeof input !== "object" || Array.isArray(input)) {
+      return false;
+    }
+    const obj = input as Record<string, unknown>;
+    for (const req of schema.required ?? []) {
+      if (obj[req] === undefined) return false;
+    }
+  }
+  return true;
+}

--- a/src/agents/skills/handlers/add-discussion-item.ts
+++ b/src/agents/skills/handlers/add-discussion-item.ts
@@ -1,0 +1,55 @@
+import { db } from "~/lib/db/dexie";
+import { addDiscussionItem } from "~/lib/appointments/discussion-items";
+
+export interface AddDiscussionItemInput {
+  appointment_id: number;
+  text: string;
+}
+
+export interface AddDiscussionItemOutput {
+  ok: boolean;
+  duplicate?: boolean;
+  appointment_id: number;
+  text?: string;
+  error?: string;
+}
+
+export async function addDiscussionItemHandler(
+  input: AddDiscussionItemInput,
+): Promise<AddDiscussionItemOutput> {
+  const appt = await db.appointments.get(input.appointment_id);
+  if (!appt?.id) {
+    return {
+      ok: false,
+      appointment_id: input.appointment_id,
+      error: "appointment_not_found",
+    };
+  }
+  // Don't emit duplicates — agents rerun, and we don't want the same
+  // sentence queued five times. Trim + case-insensitive match.
+  const normalised = input.text.trim();
+  if (
+    (appt.discussion_items ?? []).some(
+      (d) =>
+        d.text.trim().toLowerCase() === normalised.toLowerCase() &&
+        !d.resolved_at,
+    )
+  ) {
+    return {
+      ok: true,
+      duplicate: true,
+      appointment_id: input.appointment_id,
+      text: normalised,
+    };
+  }
+  await addDiscussionItem(input.appointment_id, {
+    text: normalised,
+    source: "agent",
+  });
+  return {
+    ok: true,
+    duplicate: false,
+    appointment_id: input.appointment_id,
+    text: normalised,
+  };
+}

--- a/src/agents/skills/handlers/add-task.ts
+++ b/src/agents/skills/handlers/add-task.ts
@@ -1,0 +1,64 @@
+import { db, now } from "~/lib/db/dexie";
+import type { PatientTask, TaskCategory } from "~/types/task";
+
+export interface AddTaskInput {
+  title: string;
+  due_date?: string;
+  category?: string;
+  notes?: string;
+}
+
+export interface AddTaskOutput {
+  ok: boolean;
+  id?: number;
+  title: string;
+  error?: string;
+}
+
+const VALID_CATEGORIES: readonly TaskCategory[] = [
+  "environmental",
+  "dental",
+  "nutrition",
+  "pharmacy",
+  "physio",
+  "clinical",
+  "admin",
+  "vaccine",
+  "self_care",
+  "household",
+  "other",
+];
+
+function coerceCategory(raw: string | undefined): TaskCategory {
+  if (!raw) return "other";
+  const lower = raw.toLowerCase();
+  return (VALID_CATEGORIES as readonly string[]).includes(lower)
+    ? (lower as TaskCategory)
+    : "other";
+}
+
+export async function addTaskHandler(
+  input: AddTaskInput,
+): Promise<AddTaskOutput> {
+  const title = input.title.trim();
+  if (!title) {
+    return { ok: false, title: "", error: "empty_title" };
+  }
+  const ts = now();
+  const row: PatientTask = {
+    title,
+    notes: input.notes?.trim() || undefined,
+    category: coerceCategory(input.category),
+    priority: "normal",
+    schedule_kind: input.due_date ? "once" : "once",
+    due_date: input.due_date,
+    lead_time_days: 3,
+    surface_dashboard: true,
+    surface_daily: false,
+    active: true,
+    created_at: ts,
+    updated_at: ts,
+  };
+  const id = (await db.patient_tasks.add(row)) as number;
+  return { ok: true, id, title };
+}

--- a/src/agents/skills/handlers/read-appointments.ts
+++ b/src/agents/skills/handlers/read-appointments.ts
@@ -1,0 +1,57 @@
+import { db } from "~/lib/db/dexie";
+import type { Appointment, AppointmentKind } from "~/types/appointment";
+
+export interface ReadAppointmentsInput {
+  kind?: AppointmentKind;
+  include_past?: boolean;
+  limit?: number;
+}
+
+export interface ReadAppointmentsOutput {
+  rows: Array<
+    Pick<
+      Appointment,
+      | "id"
+      | "kind"
+      | "title"
+      | "starts_at"
+      | "ends_at"
+      | "location"
+      | "doctor"
+      | "status"
+      | "cycle_id"
+    >
+  >;
+  total_matched: number;
+}
+
+export async function readAppointmentsHandler(
+  input: ReadAppointmentsInput,
+): Promise<ReadAppointmentsOutput> {
+  const limit = Math.min(30, Math.max(1, input.limit ?? 5));
+  const nowMs = Date.now();
+  const thirtyDaysAgoMs = nowMs - 30 * 86_400_000;
+
+  let rows = (await db.appointments.orderBy("starts_at").toArray())
+    .filter((a) => a.status !== "cancelled")
+    .filter((a) => {
+      const t = new Date(a.starts_at).getTime();
+      if (!Number.isFinite(t)) return false;
+      if (input.include_past) return t >= thirtyDaysAgoMs;
+      return t >= nowMs;
+    });
+  if (input.kind) rows = rows.filter((a) => a.kind === input.kind);
+
+  const shaped = rows.slice(0, limit).map((a) => ({
+    id: a.id,
+    kind: a.kind,
+    title: a.title,
+    starts_at: a.starts_at,
+    ends_at: a.ends_at,
+    location: a.location,
+    doctor: a.doctor,
+    status: a.status,
+    cycle_id: a.cycle_id,
+  }));
+  return { rows: shaped, total_matched: rows.length };
+}

--- a/src/agents/skills/handlers/read-care-team.ts
+++ b/src/agents/skills/handlers/read-care-team.ts
@@ -1,0 +1,45 @@
+import { db } from "~/lib/db/dexie";
+import type { CareTeamMember, CareTeamRole } from "~/types/care-team";
+
+export interface ReadCareTeamInput {
+  role?: CareTeamRole;
+}
+
+export interface ReadCareTeamOutput {
+  rows: Array<
+    Pick<
+      CareTeamMember,
+      | "id"
+      | "name"
+      | "role"
+      | "specialty"
+      | "organisation"
+      | "phone"
+      | "email"
+      | "is_lead"
+    >
+  >;
+  total_matched: number;
+}
+
+export async function readCareTeamHandler(
+  input: ReadCareTeamInput,
+): Promise<ReadCareTeamOutput> {
+  let rows = await db.care_team.toArray();
+  if (input.role) rows = rows.filter((m) => m.role === input.role);
+  // Leads first within each role — agent usually wants the lead by default.
+  rows = rows.sort((a, b) => Number(b.is_lead) - Number(a.is_lead));
+  return {
+    rows: rows.map((m) => ({
+      id: m.id,
+      name: m.name,
+      role: m.role,
+      specialty: m.specialty,
+      organisation: m.organisation,
+      phone: m.phone,
+      email: m.email,
+      is_lead: m.is_lead,
+    })),
+    total_matched: rows.length,
+  };
+}

--- a/src/agents/skills/handlers/read-daily.ts
+++ b/src/agents/skills/handlers/read-daily.ts
@@ -1,0 +1,23 @@
+import { db } from "~/lib/db/dexie";
+import type { DailyEntry } from "~/types/clinical";
+
+export interface ReadDailyInput {
+  since?: string;
+  until?: string;
+  limit?: number;
+}
+
+export interface ReadDailyOutput {
+  rows: Array<Partial<DailyEntry> & { id?: number; date: string }>;
+  total_matched: number;
+}
+
+export async function readDailyHandler(
+  input: ReadDailyInput,
+): Promise<ReadDailyOutput> {
+  const limit = Math.min(60, Math.max(1, input.limit ?? 14));
+  let rows = await db.daily_entries.orderBy("date").reverse().toArray();
+  if (input.since) rows = rows.filter((r) => r.date >= input.since!);
+  if (input.until) rows = rows.filter((r) => r.date <= input.until!);
+  return { rows: rows.slice(0, limit), total_matched: rows.length };
+}

--- a/src/agents/skills/handlers/read-labs.ts
+++ b/src/agents/skills/handlers/read-labs.ts
@@ -1,0 +1,45 @@
+import { db } from "~/lib/db/dexie";
+import type { LabResult } from "~/types/clinical";
+
+export interface ReadLabsInput {
+  analyte?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+}
+
+export interface ReadLabsOutput {
+  rows: Array<Partial<LabResult> & { id?: number; date: string }>;
+  total_matched: number;
+}
+
+export async function readLabsHandler(
+  input: ReadLabsInput,
+): Promise<ReadLabsOutput> {
+  const limit = Math.min(50, Math.max(1, input.limit ?? 10));
+  let rows = await db.labs.orderBy("date").reverse().toArray();
+  if (input.since) rows = rows.filter((r) => r.date >= input.since!);
+  if (input.until) rows = rows.filter((r) => r.date <= input.until!);
+  if (input.analyte) {
+    const k = input.analyte;
+    rows = rows.filter(
+      (r) => (r as unknown as Record<string, unknown>)[k] !== undefined,
+    );
+  }
+  const total = rows.length;
+  const slice = rows.slice(0, limit);
+  // Narrow the returned shape if an analyte was requested — the agent
+  // doesn't need every field, and smaller tool results keep the prompt
+  // budget happy.
+  const projected = input.analyte
+    ? slice.map((r) => ({
+        id: r.id,
+        date: r.date,
+        source: r.source,
+        [input.analyte!]: (r as unknown as Record<string, unknown>)[
+          input.analyte!
+        ],
+      }))
+    : slice;
+  return { rows: projected as ReadLabsOutput["rows"], total_matched: total };
+}

--- a/src/agents/skills/registry.ts
+++ b/src/agents/skills/registry.ts
@@ -1,0 +1,235 @@
+// Declarative skill registry for Claude agents.
+//
+// Each skill is a named capability the agent can invoke via tool-use to
+// read or mutate the patient's state. The registry is the single source
+// of truth: it feeds the `tools` parameter on the Anthropic SDK call AND
+// drives the client-side dispatcher that actually runs the handler
+// against Dexie. New capabilities are added by declaring a new skill
+// entry here and a handler in `./handlers/<skill>.ts`.
+//
+// Runtime split — every skill runs *client-side*. Dexie is browser-only
+// and source-of-truth, so the agent's tool loop lives in the client
+// harness: it posts messages to a thin server proxy, receives an
+// assistant message, executes any tool_use blocks via these handlers,
+// and sends the tool_result back. The server never touches Dexie.
+
+import type {
+  AddDiscussionItemInput,
+  AddDiscussionItemOutput,
+} from "./handlers/add-discussion-item";
+import type {
+  ReadLabsInput,
+  ReadLabsOutput,
+} from "./handlers/read-labs";
+import type {
+  ReadDailyInput,
+  ReadDailyOutput,
+} from "./handlers/read-daily";
+import type {
+  ReadAppointmentsInput,
+  ReadAppointmentsOutput,
+} from "./handlers/read-appointments";
+import type {
+  ReadCareTeamInput,
+  ReadCareTeamOutput,
+} from "./handlers/read-care-team";
+import type {
+  AddTaskInput,
+  AddTaskOutput,
+} from "./handlers/add-task";
+import type { JSONSchema } from "./schema";
+
+export interface SkillDefinition<I = unknown, O = unknown> {
+  name: string;
+  description: string;
+  // JSON Schema for the input — Anthropic's tool_use contract consumes
+  // this verbatim. Keep it conservative; require the fewest fields an
+  // agent needs to decide on a safe call.
+  input_schema: JSONSchema;
+  // Phantom marker so the TS compiler can check input / output pairs at
+  // dispatch time without forcing every skill to share a generic.
+  _io?: { input: I; output: O };
+}
+
+// -----------------------------------------------------------------------
+// Skill definitions
+// -----------------------------------------------------------------------
+
+export const readLabs: SkillDefinition<ReadLabsInput, ReadLabsOutput> = {
+  name: "read_labs",
+  description:
+    "Return patient lab results. Optionally filter by a single analyte (e.g. 'glucose', 'ca199', 'neutrophils') and/or an ISO date range. Returns at most `limit` rows, newest first. Use this before flagging a value as trending up/down.",
+  input_schema: {
+    type: "object",
+    properties: {
+      analyte: {
+        type: "string",
+        description:
+          "Optional. A single field name on LabResult (e.g. 'glucose', 'neutrophils', 'ca199'). Omit to get every analyte on the row.",
+      },
+      since: {
+        type: "string",
+        description: "Optional ISO date (YYYY-MM-DD). Exclude rows before this.",
+      },
+      until: {
+        type: "string",
+        description: "Optional ISO date. Exclude rows after this.",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 50,
+        description: "Max rows to return. Defaults to 10.",
+      },
+    },
+  },
+};
+
+export const readDaily: SkillDefinition<ReadDailyInput, ReadDailyOutput> = {
+  name: "read_daily_entries",
+  description:
+    "Return recent daily check-in entries (energy, sleep, nausea, fever, weight, steps, etc.) newest first. Use to quote recent data rather than inventing it.",
+  input_schema: {
+    type: "object",
+    properties: {
+      since: { type: "string", description: "Optional ISO date lower bound." },
+      until: { type: "string", description: "Optional ISO date upper bound." },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 60,
+        description: "Max rows. Defaults to 14 (two weeks).",
+      },
+    },
+  },
+};
+
+export const readAppointments: SkillDefinition<
+  ReadAppointmentsInput,
+  ReadAppointmentsOutput
+> = {
+  name: "read_appointments",
+  description:
+    "Return upcoming appointments the agent should know about, optionally filtered by `kind` ('clinic' | 'chemo' | 'scan' | 'blood_test' | 'procedure' | 'other'). Returns next N in time order.",
+  input_schema: {
+    type: "object",
+    properties: {
+      kind: {
+        type: "string",
+        enum: ["clinic", "chemo", "scan", "blood_test", "procedure", "other"],
+      },
+      include_past: {
+        type: "boolean",
+        description:
+          "If true, include past appointments within the last 30 days. Default false.",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 30,
+        description: "Max rows. Defaults to 5.",
+      },
+    },
+  },
+};
+
+export const readCareTeam: SkillDefinition<
+  ReadCareTeamInput,
+  ReadCareTeamOutput
+> = {
+  name: "read_care_team",
+  description:
+    "Return the household's care-team roster (name, role, phone, email, is_lead). Use when drafting a 'message the nurse' or 'escalate to oncologist' suggestion so the right member is named.",
+  input_schema: {
+    type: "object",
+    properties: {
+      role: {
+        type: "string",
+        enum: [
+          "family",
+          "oncologist",
+          "surgeon",
+          "gp",
+          "nurse",
+          "allied_health",
+          "other",
+        ],
+        description:
+          "Optional. If set, only return members with this role (lead first).",
+      },
+    },
+  },
+};
+
+export const addDiscussionItem: SkillDefinition<
+  AddDiscussionItemInput,
+  AddDiscussionItemOutput
+> = {
+  name: "add_discussion_item",
+  description:
+    "Queue a plain-language item to raise at a future clinic appointment. Used when the agent notices something worth flagging but that isn't urgent. Never emits duplicates — if the same text is already queued on that appointment, no-op.",
+  input_schema: {
+    type: "object",
+    required: ["appointment_id", "text"],
+    properties: {
+      appointment_id: {
+        type: "integer",
+        description: "Dexie id of the target appointment (from read_appointments).",
+      },
+      text: {
+        type: "string",
+        minLength: 3,
+        maxLength: 240,
+        description: "One short sentence. Specific, quotable by the patient.",
+      },
+    },
+  },
+};
+
+export const addTask: SkillDefinition<AddTaskInput, AddTaskOutput> = {
+  name: "add_task",
+  description:
+    "Add a task to the patient's task list. Use sparingly — the patient sees every task, so only things they actually need to do.",
+  input_schema: {
+    type: "object",
+    required: ["title"],
+    properties: {
+      title: {
+        type: "string",
+        minLength: 3,
+        maxLength: 120,
+        description: "Imperative phrasing. 'Book blood test by Tue', not 'reminder'.",
+      },
+      due_date: {
+        type: "string",
+        description: "Optional ISO date.",
+      },
+      category: {
+        type: "string",
+        description: "Optional free-text category.",
+      },
+      notes: {
+        type: "string",
+        maxLength: 500,
+      },
+    },
+  },
+};
+
+// The authoritative ordered registry. `allSkills` is what the Anthropic
+// `tools` payload is derived from; `skillsByName` is the dispatcher
+// lookup. New skills: append to `allSkills` — the array's order is the
+// order they appear in the agent's system prompt.
+
+export const allSkills = [
+  readLabs,
+  readDaily,
+  readAppointments,
+  readCareTeam,
+  addDiscussionItem,
+  addTask,
+] as const;
+
+export const skillsByName: Record<string, SkillDefinition> = Object.fromEntries(
+  allSkills.map((s) => [s.name, s]),
+);

--- a/src/agents/skills/schema.ts
+++ b/src/agents/skills/schema.ts
@@ -1,0 +1,16 @@
+// Tiny JSONSchema subset that mirrors what the Anthropic tool_use contract
+// accepts as `input_schema`. Kept narrow on purpose: if we need more we
+// should reach for a proper JSONSchema type rather than growing this one.
+
+export interface JSONSchema {
+  type?: "object" | "string" | "integer" | "number" | "boolean" | "array";
+  description?: string;
+  required?: readonly string[];
+  properties?: Record<string, JSONSchema>;
+  items?: JSONSchema;
+  enum?: readonly string[];
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  maximum?: number;
+}

--- a/tests/unit/agent-skills.test.ts
+++ b/tests/unit/agent-skills.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import "fake-indexeddb/auto";
+import { db } from "~/lib/db/dexie";
+import { allSkills, skillsByName } from "~/agents/skills/registry";
+import { dispatchSkill } from "~/agents/skills/dispatch";
+
+const TODAY = "2026-05-06";
+const ts = () => new Date().toISOString();
+
+beforeEach(async () => {
+  // Wipe all tables the skill handlers touch so tests are isolated.
+  await db.labs.clear();
+  await db.daily_entries.clear();
+  await db.appointments.clear();
+  await db.care_team.clear();
+  await db.patient_tasks.clear();
+});
+
+describe("agent skill registry", () => {
+  it("has a unique name per skill and every skill has a schema", () => {
+    const names = allSkills.map((s) => s.name);
+    expect(new Set(names).size).toBe(names.length);
+    for (const s of allSkills) {
+      expect(s.description.length).toBeGreaterThan(10);
+      expect(s.input_schema).toBeDefined();
+    }
+  });
+
+  it("skillsByName matches allSkills", () => {
+    for (const s of allSkills) {
+      expect(skillsByName[s.name]).toBe(s);
+    }
+  });
+});
+
+describe("dispatchSkill — errors", () => {
+  it("rejects an unknown skill name", async () => {
+    const r = await dispatchSkill("does_not_exist", {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/unknown_skill/);
+  });
+
+  it("rejects a call missing a required field", async () => {
+    const r = await dispatchSkill("add_discussion_item", {
+      // missing appointment_id + text
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/bad_input/);
+  });
+});
+
+describe("read_labs", () => {
+  it("returns newest-first with analyte projection", async () => {
+    await db.labs.bulkAdd([
+      {
+        date: "2026-05-01",
+        glucose: 6.2,
+        source: "patient_self_report",
+        created_at: ts(),
+        updated_at: ts(),
+      },
+      {
+        date: "2026-05-05",
+        glucose: 7.9,
+        source: "patient_self_report",
+        created_at: ts(),
+        updated_at: ts(),
+      },
+      {
+        date: "2026-05-03",
+        ca199: 42,
+        source: "external",
+        created_at: ts(),
+        updated_at: ts(),
+      },
+    ]);
+
+    const r = await dispatchSkill("read_labs", { analyte: "glucose" });
+    expect(r.ok).toBe(true);
+    const rows = (r.output as { rows: Array<{ date: string; glucose: number }> }).rows;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.date).toBe("2026-05-05");
+    expect(rows[0]!.glucose).toBe(7.9);
+  });
+
+  it("filters by since / until", async () => {
+    await db.labs.bulkAdd([
+      { date: "2026-04-01", glucose: 5, source: "patient_self_report", created_at: ts(), updated_at: ts() },
+      { date: "2026-05-01", glucose: 6, source: "patient_self_report", created_at: ts(), updated_at: ts() },
+      { date: "2026-06-01", glucose: 7, source: "patient_self_report", created_at: ts(), updated_at: ts() },
+    ]);
+    const r = await dispatchSkill("read_labs", {
+      analyte: "glucose",
+      since: "2026-05-01",
+      until: "2026-05-31",
+    });
+    const rows = (r.output as { rows: unknown[] }).rows;
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("read_appointments", () => {
+  it("returns only upcoming, filterable by kind", async () => {
+    const soon = new Date(Date.now() + 3 * 86_400_000).toISOString();
+    const past = new Date(Date.now() - 3 * 86_400_000).toISOString();
+    await db.appointments.bulkAdd([
+      { kind: "clinic", title: "Upcoming clinic", starts_at: soon, status: "scheduled", created_at: ts(), updated_at: ts() },
+      { kind: "chemo", title: "Upcoming chemo", starts_at: soon, status: "scheduled", created_at: ts(), updated_at: ts() },
+      { kind: "clinic", title: "Past clinic", starts_at: past, status: "attended", created_at: ts(), updated_at: ts() },
+    ]);
+    const r = await dispatchSkill("read_appointments", { kind: "clinic" });
+    const rows = (r.output as { rows: Array<{ title: string }> }).rows;
+    expect(rows.map((a) => a.title)).toEqual(["Upcoming clinic"]);
+  });
+});
+
+describe("read_care_team", () => {
+  it("returns leads first, filterable by role", async () => {
+    await db.care_team.bulkAdd([
+      { name: "Sumi", role: "nurse", is_lead: true, created_at: ts(), updated_at: ts() },
+      { name: "Other nurse", role: "nurse", is_lead: false, created_at: ts(), updated_at: ts() },
+      { name: "Dr Lee", role: "oncologist", is_lead: true, created_at: ts(), updated_at: ts() },
+    ]);
+    const r = await dispatchSkill("read_care_team", { role: "nurse" });
+    const rows = (r.output as { rows: Array<{ name: string; is_lead?: boolean }> }).rows;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.is_lead).toBe(true);
+    expect(rows[0]!.name).toBe("Sumi");
+  });
+});
+
+describe("add_discussion_item", () => {
+  it("writes to the target appointment and dedupes", async () => {
+    const id = (await db.appointments.add({
+      kind: "clinic",
+      title: "Onc review",
+      starts_at: TODAY + "T09:00:00Z",
+      status: "scheduled",
+      created_at: ts(),
+      updated_at: ts(),
+    })) as number;
+
+    const r1 = await dispatchSkill("add_discussion_item", {
+      appointment_id: id,
+      text: "Fasting glucose 7.9 on 5 May",
+    });
+    expect(r1.ok).toBe(true);
+    expect((r1.output as { duplicate?: boolean }).duplicate).toBe(false);
+
+    const r2 = await dispatchSkill("add_discussion_item", {
+      appointment_id: id,
+      text: "fasting glucose 7.9 on 5 may", // same text, different casing
+    });
+    expect(r2.ok).toBe(true);
+    expect((r2.output as { duplicate?: boolean }).duplicate).toBe(true);
+
+    const appt = await db.appointments.get(id);
+    expect(appt!.discussion_items).toHaveLength(1);
+    expect(appt!.discussion_items![0]!.source).toBe("agent");
+  });
+
+  it("returns an error result when the appointment doesn't exist", async () => {
+    const r = await dispatchSkill("add_discussion_item", {
+      appointment_id: 99999,
+      text: "ghost",
+    });
+    expect(r.ok).toBe(true);
+    expect((r.output as { ok: boolean }).ok).toBe(false);
+    expect((r.output as { error?: string }).error).toMatch(/not_found/);
+  });
+});
+
+describe("add_task", () => {
+  it("inserts a task with coerced category", async () => {
+    const r = await dispatchSkill("add_task", {
+      title: "Book FBE before next cycle",
+      due_date: "2026-05-10",
+      category: "bogus",
+    });
+    expect(r.ok).toBe(true);
+    const id = (r.output as { id: number }).id;
+    const row = await db.patient_tasks.get(id);
+    expect(row!.title).toBe("Book FBE before next cycle");
+    expect(row!.category).toBe("other"); // coerced
+    expect(row!.active).toBe(true);
+    expect(row!.due_date).toBe("2026-05-10");
+  });
+});


### PR DESCRIPTION
## Summary

Foundation for giving Claude agents **actual** read / write access to the patient's state via tool-use, instead of a one-shot snapshot passed at invocation. This PR is the declarative + runtime layer; the multi-turn loop integration is a follow-up.

### What lands

- `src/agents/skills/registry.ts` — ordered list of skill definitions (`name`, `description`, JSONSchema input). Drives the Anthropic `tools` payload. Six skills:
  - `read_labs`, `read_daily_entries`, `read_appointments`, `read_care_team`, `add_discussion_item`, `add_task`
- `src/agents/skills/handlers/*` — Dexie-backed implementation per skill. Runs client-side.
- `src/agents/skills/dispatch.ts` — name → handler map with a runtime JSONSchema check. Unknown skills / missing required fields → structured error, never a crash.
- `src/agents/skills/schema.ts` — tiny JSONSchema subset matching Anthropic's `input_schema`.

### Safety

- `add_discussion_item` is **idempotent**: case-insensitive match on existing unresolved items returns `{ok:true, duplicate:true}` without writing.
- `add_task` coerces unknown categories to `"other"` rather than rejecting — tolerant of loose Claude outputs.

### Tests

`tests/unit/agent-skills.test.ts` — 11 new tests: registry shape, dispatcher error paths, each handler's happy path + dedupe / filter. **414 / 414** overall.

## Not in this PR (next workstream)

Tool-use loop integration on `/api/agent/[id]/run` — requires switching from `messages.parse` with structured output to a multi-turn `messages.create` loop with tool results fed back in between, plus client harness changes. Landing that separately keeps this foundational PR reviewable.

https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY)_