### PR TITLE
Caregiver perspective: pick-patient onboarding + caregiver-focused app

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -23,7 +23,8 @@
     "settings": "Settings",
     "practices": "Practices",
     "history": "History",
-    "care_team": "Care team"
+    "care_team": "Care team",
+    "log": "Log"
   },
   "zones": {
     "green": "Stable",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -23,7 +23,8 @@
     "settings": "设置",
     "practices": "修习",
     "history": "历史记录",
-    "care_team": "医疗团队"
+    "care_team": "医疗团队",
+    "log": "记录"
   },
   "zones": {
     "green": "稳定",

--- a/src/app/assessment/page.tsx
+++ b/src/app/assessment/page.tsx
@@ -10,8 +10,10 @@ import { EmptyState } from "~/components/ui/empty-state";
 import { PillarRing } from "~/components/assessment/pillar-card";
 import { formatDate } from "~/lib/utils/date";
 import { ChevronRight, Stethoscope, Clock } from "lucide-react";
+import { useRedirectCaregiverAway } from "~/lib/caregiver/guard";
 
 export default function AssessmentListPage() {
+  useRedirectCaregiverAway();
   const t = useT();
   const locale = useLocale();
   const assessments = useLiveQuery(() =>

--- a/src/app/daily/new/page.tsx
+++ b/src/app/daily/new/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { db } from "~/lib/db/dexie";
 import { todayISO } from "~/lib/utils/date";
 import { DailyWizard } from "~/components/daily/daily-wizard";
+import { useRedirectCaregiverAway } from "~/lib/caregiver/guard";
 
 export default function NewDailyPage() {
   return (
@@ -15,6 +16,7 @@ export default function NewDailyPage() {
 }
 
 function Inner() {
+  useRedirectCaregiverAway();
   const params = useSearchParams();
   const date = params.get("date") ?? todayISO();
   const [entryId, setEntryId] = useState<number | null | undefined>(undefined);

--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -10,6 +10,9 @@ import { ZoneBanner } from "~/components/family/zone-banner";
 import { NextUp } from "~/components/family/next-up";
 import { QuickNote } from "~/components/family/quick-note";
 import { CallList } from "~/components/family/call-list";
+import { LogForPatient } from "~/components/family/log-for-patient";
+import { ThingsYouCanHelpWith } from "~/components/family/things-you-can-help-with";
+import { AppointmentsYoureAttending } from "~/components/family/appointments-youre-attending";
 
 // Family-facing landing page. Purpose-built for the carer who isn't
 // Thomas: calm status, what's coming up, a quick way to note what they
@@ -34,7 +37,13 @@ export default function FamilyPage() {
 
       <ZoneBanner />
 
+      <AppointmentsYoureAttending />
+
       <NextUp />
+
+      <LogForPatient />
+
+      <ThingsYouCanHelpWith />
 
       <QuickNote />
 

--- a/src/app/fortnightly/new/page.tsx
+++ b/src/app/fortnightly/new/page.tsx
@@ -4,8 +4,10 @@ import { FortnightlyForm } from "~/components/fortnightly/fortnightly-form";
 import { PageHeader } from "~/components/ui/page-header";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { formatDate, todayISO } from "~/lib/utils/date";
+import { useRedirectCaregiverAway } from "~/lib/caregiver/guard";
 
 export default function NewFortnightlyPage() {
+  useRedirectCaregiverAway();
   const t = useT();
   const locale = useLocale();
   return (

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -25,7 +25,9 @@ import { cn } from "~/lib/utils/cn";
 // that gets every user onto the dashboard quickly. Team / baselines /
 // treatment are optional detail — skippable via "Finish setup later" so the
 // patient isn't gated behind data they don't have on hand.
-const STEPS = [
+// Patient onboarding walks the full path: profile + team + baselines +
+// treatment are all about the patient's own situation.
+const PATIENT_STEPS = [
   "welcome",
   "user_type",
   "profile",
@@ -36,16 +38,38 @@ const STEPS = [
   "done",
 ] as const;
 
+// Caregiver / clinician onboarding: pick the patient they're joining
+// from a list, fill in their own name + preferences, land on /family.
+// Baselines / team / treatment belong to the patient and are skipped.
+const CAREGIVER_STEPS = [
+  "welcome",
+  "user_type",
+  "pick_patient",
+  "profile",
+  "preferences",
+  "done",
+] as const;
+
+type StepKey =
+  | (typeof PATIENT_STEPS)[number]
+  | (typeof CAREGIVER_STEPS)[number];
+
 // Steps the user can "Finish setup later" from — i.e. jump straight to
 // done without filling the remaining steps.
-const CAN_SKIP_FROM: StepKey[] = ["profile", "preferences", "team", "baselines", "treatment"];
-
-type StepKey = (typeof STEPS)[number];
+const CAN_SKIP_FROM: StepKey[] = [
+  "profile",
+  "preferences",
+  "team",
+  "baselines",
+  "treatment",
+  "pick_patient",
+];
 
 const STEP_LABELS: Record<Locale, Record<StepKey, string>> = {
   en: {
     welcome: "Welcome",
     user_type: "Who you are",
+    pick_patient: "Pick a patient",
     profile: "About you",
     team: "Clinical team",
     baselines: "Baselines",
@@ -56,6 +80,7 @@ const STEP_LABELS: Record<Locale, Record<StepKey, string>> = {
   zh: {
     welcome: "欢迎",
     user_type: "您的身份",
+    pick_patient: "选择患者",
     profile: "基本信息",
     team: "医疗团队",
     baselines: "基线数据",
@@ -192,21 +217,29 @@ export default function OnboardingPage() {
     setForm((f) => ({ ...f, [k]: v }));
   }
 
-  const stepIdx = STEPS.indexOf(step);
-  const progress = ((stepIdx + 1) / STEPS.length) * 100;
+  // The visible step sequence follows user type — caregivers don't get
+  // walked through baselines / team / treatment, which are all patient-
+  // authored values.
+  const steps: readonly StepKey[] =
+    form.user_type === "caregiver" || form.user_type === "clinician"
+      ? CAREGIVER_STEPS
+      : PATIENT_STEPS;
+
+  const stepIdx = steps.indexOf(step);
+  const progress = ((Math.max(0, stepIdx) + 1) / steps.length) * 100;
 
   function back() {
-    const i = STEPS.indexOf(step);
+    const i = steps.indexOf(step);
     if (i > 0) {
-      const prev = STEPS[i - 1];
+      const prev = steps[i - 1];
       if (prev) setStep(prev);
     }
   }
 
   function forward() {
-    const i = STEPS.indexOf(step);
-    if (i < STEPS.length - 1) {
-      const next = STEPS[i + 1];
+    const i = steps.indexOf(step);
+    if (i < steps.length - 1) {
+      const next = steps[i + 1];
       if (next) setStep(next);
     }
   }
@@ -242,31 +275,60 @@ export default function OnboardingPage() {
           // geocode failure is non-fatal
         }
       }
+      const isCaregiver =
+        form.user_type === "caregiver" || form.user_type === "clinician";
       const payload: Settings = {
         user_type: form.user_type || undefined,
+        // Caregivers don't own baselines, team contacts, or treatment
+        // data — that's the patient's territory. Write their own name +
+        // locale + timezone only. The Supabase join ensures the patient's
+        // data is still reachable via /family.
         profile_name: form.profile_name.trim() || "Patient",
-        dob: form.dob || undefined,
-        diagnosis_date: form.diagnosis_date || undefined,
-        height_cm: toNum(form.height_cm),
-        baseline_weight_kg: toNum(form.baseline_weight_kg),
-        baseline_date: form.baseline_weight_kg ? todayISO() : undefined,
-        baseline_grip_dominant_kg: toNum(form.baseline_grip_dominant_kg),
-        baseline_gait_speed_ms: toNum(form.baseline_gait_speed_ms),
-        baseline_sit_to_stand: toNum(form.baseline_sit_to_stand),
-        baseline_sts_5x_seconds: toNum(form.baseline_sts_5x_seconds),
-        baseline_tug_seconds: toNum(form.baseline_tug_seconds),
-        baseline_muac_cm: toNum(form.baseline_muac_cm),
-        baseline_calf_cm: toNum(form.baseline_calf_cm),
+        dob: isCaregiver ? undefined : form.dob || undefined,
+        diagnosis_date: isCaregiver ? undefined : form.diagnosis_date || undefined,
+        height_cm: isCaregiver ? undefined : toNum(form.height_cm),
+        baseline_weight_kg: isCaregiver ? undefined : toNum(form.baseline_weight_kg),
+        baseline_date:
+          isCaregiver || !form.baseline_weight_kg ? undefined : todayISO(),
+        baseline_grip_dominant_kg: isCaregiver
+          ? undefined
+          : toNum(form.baseline_grip_dominant_kg),
+        baseline_gait_speed_ms: isCaregiver
+          ? undefined
+          : toNum(form.baseline_gait_speed_ms),
+        baseline_sit_to_stand: isCaregiver
+          ? undefined
+          : toNum(form.baseline_sit_to_stand),
+        baseline_sts_5x_seconds: isCaregiver
+          ? undefined
+          : toNum(form.baseline_sts_5x_seconds),
+        baseline_tug_seconds: isCaregiver
+          ? undefined
+          : toNum(form.baseline_tug_seconds),
+        baseline_muac_cm: isCaregiver ? undefined : toNum(form.baseline_muac_cm),
+        baseline_calf_cm: isCaregiver ? undefined : toNum(form.baseline_calf_cm),
         locale: form.locale,
-        managing_oncologist: form.managing_oncologist.trim() || undefined,
-        managing_oncologist_phone:
-          form.managing_oncologist_phone.trim() || undefined,
-        hospital_name: form.hospital_name.trim() || undefined,
-        hospital_phone: form.hospital_phone.trim() || undefined,
-        hospital_address: form.hospital_address.trim() || undefined,
-        oncall_phone: form.oncall_phone.trim() || undefined,
-        emergency_instructions:
-          form.emergency_instructions.trim() || undefined,
+        managing_oncologist: isCaregiver
+          ? undefined
+          : form.managing_oncologist.trim() || undefined,
+        managing_oncologist_phone: isCaregiver
+          ? undefined
+          : form.managing_oncologist_phone.trim() || undefined,
+        hospital_name: isCaregiver
+          ? undefined
+          : form.hospital_name.trim() || undefined,
+        hospital_phone: isCaregiver
+          ? undefined
+          : form.hospital_phone.trim() || undefined,
+        hospital_address: isCaregiver
+          ? undefined
+          : form.hospital_address.trim() || undefined,
+        oncall_phone: isCaregiver
+          ? undefined
+          : form.oncall_phone.trim() || undefined,
+        emergency_instructions: isCaregiver
+          ? undefined
+          : form.emergency_instructions.trim() || undefined,
         home_city: form.home_city.trim() || undefined,
         home_lat,
         home_lon,
@@ -290,7 +352,7 @@ export default function OnboardingPage() {
             : "hulin",
       );
 
-      if (form.start_cycle && form.cycle_start_date) {
+      if (!isCaregiver && form.start_cycle && form.cycle_start_date) {
         await db.treatment_cycles.add({
           protocol_id: form.protocol_id,
           cycle_number: 1,
@@ -338,7 +400,9 @@ export default function OnboardingPage() {
         // Settings → Household section lets the user finish setup.
       }
 
-      router.replace("/");
+      // Caregivers + clinicians land on /family — the caregiver-focused
+      // shell. Patients stay on / (the full dashboard).
+      router.replace(isCaregiver ? "/family" : "/");
     } finally {
       setSaving(false);
     }
@@ -352,7 +416,7 @@ export default function OnboardingPage() {
           <div className="serif text-lg tracking-tight">Anchor</div>
         </div>
         <div className="eyebrow">
-          {STEP_LABELS[locale][step]} · {stepIdx + 1}/{STEPS.length}
+          {STEP_LABELS[locale][step]} · {stepIdx + 1}/{steps.length}
         </div>
         <div className="h-1 w-full overflow-hidden rounded-full bg-ink-100">
           <div
@@ -365,6 +429,16 @@ export default function OnboardingPage() {
       {step === "welcome" && <WelcomeStep locale={locale} />}
       {step === "user_type" && (
         <UserTypeStep form={form} update={update} locale={locale} />
+      )}
+      {step === "pick_patient" && (
+        <PickPatientStep
+          onJoined={() => setStep("profile")}
+          onStartFresh={() => {
+            update("user_type", "patient");
+            setStep("profile");
+          }}
+          locale={locale}
+        />
       )}
       {step === "profile" && (
         <ProfileStep form={form} update={update} locale={locale} />
@@ -401,17 +475,21 @@ export default function OnboardingPage() {
             </button>
           )}
         </div>
-        {step !== "done" ? (
+        {step === "done" ? (
+          <Button onClick={finish} disabled={saving} size="lg">
+            <Check className="h-4 w-4" />
+            {saving ? t("onboarding.saving") : t("onboarding.saveAndContinue")}
+          </Button>
+        ) : step === "pick_patient" ? (
+          // Pick-patient drives its own navigation (tap a row → joins →
+          // advances), so no Continue button. Skip + Back still work.
+          null
+        ) : (
           <Button onClick={forward} disabled={!canContinue} size="lg">
             {step === "welcome"
               ? t("onboarding.begin")
               : t("onboarding.continue")}
             <ChevronRight className="h-4 w-4" />
-          </Button>
-        ) : (
-          <Button onClick={finish} disabled={saving} size="lg">
-            <Check className="h-4 w-4" />
-            {saving ? t("onboarding.saving") : t("onboarding.saveAndContinue")}
           </Button>
         )}
       </div>
@@ -555,6 +633,152 @@ function UserTypeStep({
           />
         </Field>
       )}
+    </Card>
+  );
+}
+
+function PickPatientStep({
+  onJoined,
+  onStartFresh,
+  locale,
+}: {
+  onJoined: () => void;
+  onStartFresh: () => void;
+  locale: Locale;
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const [rows, setRows] = useState<
+    Array<{
+      id: string;
+      name: string;
+      patient_display_name: string;
+      created_at: string;
+      member_count: number;
+    }>
+  >([]);
+  const [loading, setLoading] = useState(true);
+  const [joining, setJoining] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { listAllHouseholds } = await import(
+          "~/lib/supabase/households"
+        );
+        const all = await listAllHouseholds();
+        if (!cancelled) setRows(all);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function join(id: string) {
+    setJoining(id);
+    setError(null);
+    try {
+      const { joinHouseholdAsFamily } = await import(
+        "~/lib/supabase/households"
+      );
+      await joinHouseholdAsFamily(id);
+      onJoined();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setJoining(null);
+    }
+  }
+
+  return (
+    <Card className="p-6 space-y-4">
+      <div className="serif text-[22px] leading-tight">
+        {L(
+          "Who are you supporting?",
+          "您要支持的是哪位患者?",
+        )}
+      </div>
+      <p className="text-[13px] text-ink-500">
+        {L(
+          "Pick the patient already using Anchor. You'll join their care team — no baselines or clinical setup on your end.",
+          "选择已在使用 Anchor 的患者。您将加入其护理团队 —— 无需输入基线或临床信息。",
+        )}
+      </p>
+
+      {loading && (
+        <div className="rounded-md border border-ink-200 bg-paper-2 p-3 text-[12.5px] text-ink-500">
+          {L("Loading patients…", "加载中…")}
+        </div>
+      )}
+
+      {!loading && rows.length === 0 && (
+        <div className="rounded-md border border-dashed border-ink-300 bg-paper p-4 text-[12.5px] text-ink-600">
+          {L(
+            "No patients have set up Anchor yet. Ask the person you're supporting to create their profile first, or set up a fresh patient yourself.",
+            "尚无患者设置 Anchor。请先请患者本人创建资料,或由您自己开始新患者流程。",
+          )}
+        </div>
+      )}
+
+      {!loading && rows.length > 0 && (
+        <ul className="space-y-2">
+          {rows.map((h) => (
+            <li key={h.id}>
+              <button
+                type="button"
+                onClick={() => void join(h.id)}
+                disabled={joining !== null}
+                className={cn(
+                  "flex w-full items-center justify-between gap-3 rounded-xl border p-4 text-left transition-colors",
+                  joining === h.id
+                    ? "border-[var(--tide-2)] bg-[var(--tide-soft)]"
+                    : "border-ink-200 bg-paper-2 hover:border-ink-400",
+                )}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-[14.5px] font-semibold text-ink-900">
+                    {h.patient_display_name || h.name}
+                  </div>
+                  <div className="mt-0.5 text-[11.5px] text-ink-500">
+                    {h.member_count}{" "}
+                    {h.member_count === 1
+                      ? L("member", "位成员")
+                      : L("members", "位成员")}
+                  </div>
+                </div>
+                <span className="mono text-[10px] uppercase tracking-[0.12em] text-ink-400">
+                  {joining === h.id ? L("Joining…", "加入中…") : L("Join", "加入")}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <div className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2.5 text-[12px] text-[var(--warn)]">
+          {error}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onStartFresh}
+        className="text-[12px] text-ink-500 underline-offset-2 hover:text-ink-900 hover:underline"
+      >
+        {L(
+          "I'm setting up a new patient instead",
+          "我要新建一位患者",
+        )}
+      </button>
     </Card>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,15 +38,23 @@ export default function DashboardPage() {
     }
   }, [router, settings]);
 
-  // Non-primary household members see the family view by default —
+  // Anyone who isn't acting as the patient sees /family by default —
   // the clinician-heavy dashboard would overwhelm a visiting carer.
-  // Primary carers keep the full dashboard.
+  // Primary carers keep the full dashboard (they proxy for the patient).
+  // Checks both the Supabase household membership (authoritative once
+  // joined) AND the local Dexie settings.user_type (set during first-
+  // session onboarding before any sign-in).
   useEffect(() => {
+    const type = settings?.[0]?.user_type;
+    if (type === "caregiver" || type === "clinician") {
+      router.replace("/family");
+      return;
+    }
     if (!membership) return;
-    if (membership.role !== "primary_carer") {
+    if (membership.role !== "primary_carer" && membership.role !== "patient") {
       router.replace("/family");
     }
-  }, [membership, router]);
+  }, [membership, router, settings]);
 
   const { greeting, eyebrow } = useMemo(() => {
     const now = new Date();

--- a/src/app/treatment/new/page.tsx
+++ b/src/app/treatment/new/page.tsx
@@ -7,8 +7,10 @@ import { useLocale } from "~/hooks/use-translate";
 import { todayISO } from "~/lib/utils/date";
 import { PageHeader } from "~/components/ui/page-header";
 import { CycleForm, type CycleFormValues } from "~/components/treatment/cycle-form";
+import { useRedirectCaregiverAway } from "~/lib/caregiver/guard";
 
 export default function NewTreatmentCyclePage() {
+  useRedirectCaregiverAway();
   const locale = useLocale();
   const router = useRouter();
 

--- a/src/app/weekly/new/page.tsx
+++ b/src/app/weekly/new/page.tsx
@@ -3,8 +3,10 @@
 import { WeeklyForm } from "~/components/weekly/weekly-form";
 import { PageHeader } from "~/components/ui/page-header";
 import { useLocale, useT } from "~/hooks/use-translate";
+import { useRedirectCaregiverAway } from "~/lib/caregiver/guard";
 
 export default function NewWeeklyPage() {
+  useRedirectCaregiverAway();
   const t = useT();
   const locale = useLocale();
   return (

--- a/src/components/family/appointments-youre-attending.tsx
+++ b/src/components/family/appointments-youre-attending.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { format, parseISO } from "date-fns";
+import { db } from "~/lib/db/dexie";
+import { getSupabaseBrowser } from "~/lib/supabase/client";
+import { useLocale } from "~/hooks/use-translate";
+import { useHousehold } from "~/hooks/use-household";
+import { Card, CardContent } from "~/components/ui/card";
+import { CalendarClock, ChevronRight } from "lucide-react";
+import { useEffect, useState } from "react";
+
+// Caregiver-facing list of upcoming appointments they've said they'll
+// attend. Filters the shared schedule to rows where the carer's own
+// name (profile.display_name) is in `attendees` OR where they've
+// explicitly claimed attendance via `attendance[].user_id`. Keeps the
+// family view focused on "what am *I* doing today" rather than "every
+// appointment the patient has."
+
+export function AppointmentsYoureAttending() {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const { profile } = useHousehold();
+
+  const [userId, setUserId] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const sb = getSupabaseBrowser();
+      if (!sb) return;
+      const { data } = await sb.auth.getUser();
+      if (!cancelled) setUserId(data.user?.id ?? null);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const rows = useLiveQuery(async () => {
+    const all = await db.appointments.orderBy("starts_at").toArray();
+    const now = Date.now();
+    const myName = profile?.display_name?.trim().toLowerCase();
+    return all
+      .filter((a) => a.status !== "cancelled")
+      .filter((a) => {
+        const t = new Date(a.starts_at).getTime();
+        return Number.isFinite(t) && t >= now - 12 * 3600 * 1000;
+      })
+      .filter((a) => {
+        if (
+          myName &&
+          (a.attendees ?? []).some((n) => n.trim().toLowerCase() === myName)
+        ) {
+          return true;
+        }
+        if (
+          userId &&
+          (a.attendance ?? []).some((at) => at.user_id === userId)
+        ) {
+          return true;
+        }
+        return false;
+      })
+      .slice(0, 5);
+  }, [profile?.display_name, userId]);
+
+  if (!rows || rows.length === 0) return null;
+
+  return (
+    <Card>
+      <CardContent className="space-y-2 pt-5">
+        <div className="flex items-center gap-1.5 text-[12.5px] font-semibold text-ink-900">
+          <CalendarClock className="h-3.5 w-3.5 text-[var(--tide-2)]" />
+          {L("You're going to these", "您将陪同出席")}
+        </div>
+        <ul className="space-y-1.5">
+          {rows.map((a) => (
+            <li key={a.id}>
+              <Link
+                href={`/schedule/${a.id}`}
+                className="flex items-center gap-3 rounded-[var(--r-md)] bg-paper-2 px-3 py-2 transition-colors hover:bg-ink-100/30"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] text-ink-900">
+                    {a.title}
+                  </div>
+                  <div className="mono mt-0.5 text-[10px] uppercase tracking-[0.12em] text-ink-400">
+                    {format(parseISO(a.starts_at), "EEE d MMM · HH:mm")}
+                    {a.location ? ` · ${a.location}` : ""}
+                  </div>
+                </div>
+                <ChevronRight className="h-4 w-4 text-ink-400" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/family/log-for-patient.tsx
+++ b/src/components/family/log-for-patient.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useLocale } from "~/hooks/use-translate";
+import { useUIStore } from "~/stores/ui-store";
+import { parseDirectFile, type DirectFileResult } from "~/lib/log/direct-file";
+import { applyDirectFile } from "~/lib/log/direct-file-apply";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, Textarea } from "~/components/ui/field";
+import { Check, MessageSquarePlus, Sparkles } from "lucide-react";
+import { todayISO } from "~/lib/utils/date";
+import { FollowUpsCard } from "~/components/log/follow-ups-card";
+
+// Caregiver-flavoured log form on /family. Uses the direct-file path
+// from PR #72 so a short entry like "blood sugar 7.9 this morning"
+// files straight into labs and the FollowUpsCard surfaces next steps.
+// For longer narrative entries the existing /log page is one tap away.
+
+export function LogForPatient() {
+  const locale = useLocale();
+  const enteredBy = useUIStore((s) => s.enteredBy);
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const [text, setText] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [filed, setFiled] = useState<DirectFileResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const parsed: DirectFileResult | null = useMemo(
+    () => parseDirectFile(text, todayISO()),
+    [text],
+  );
+
+  async function submit() {
+    setError(null);
+    if (!parsed) return;
+    setSaving(true);
+    try {
+      await applyDirectFile(parsed, enteredBy);
+      setFiled(parsed);
+      setText("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function reset() {
+    setFiled(null);
+    setError(null);
+  }
+
+  return (
+    <>
+      <Card>
+        <CardContent className="space-y-3 pt-5">
+          <div className="flex items-center gap-1.5 text-[12.5px] font-semibold text-ink-900">
+            <MessageSquarePlus className="h-3.5 w-3.5 text-[var(--tide-2)]" />
+            {L("Log something for dad", "代记录")}
+          </div>
+          <p className="text-[12px] text-ink-500">
+            {L(
+              "A quick reading or note you just observed. Simple vitals are filed directly; longer narratives go to the log page.",
+              "您刚观察到的数值或备注。简短指标会直接归档,较长叙述请使用「记录」页。",
+            )}
+          </p>
+          <Field label={L("Observation", "记录")}>
+            <Textarea
+              rows={3}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder={L(
+                "e.g. blood sugar 7.9 this morning · weight 64.5 kg · walked 20 min",
+                "例如:血糖 7.9 今早 · 体重 64.5 kg · 步行 20 分钟",
+              )}
+              disabled={saving}
+            />
+          </Field>
+          {parsed && !filed && (
+            <div className="flex items-start gap-1.5 text-[11px] text-[var(--tide-2)]">
+              <Check className="mt-[1px] h-3 w-3 shrink-0" />
+              <span>
+                {L("Will file directly as: ", "将直接归档为: ")}
+                <span className="font-medium">{parsed.summary[locale]}</span>
+              </span>
+            </div>
+          )}
+          <div className="flex items-center justify-between">
+            <Link
+              href="/log"
+              className="text-[11.5px] text-ink-500 hover:text-ink-900"
+            >
+              {L("Longer note → /log", "长记录 → /log")}
+            </Link>
+            <Button
+              onClick={() => void submit()}
+              disabled={!parsed || saving}
+              size="sm"
+            >
+              {saving
+                ? L("Saving…", "保存中…")
+                : parsed
+                  ? L("Save", "保存")
+                  : L("Type a reading", "请输入")}
+            </Button>
+          </div>
+          {error && (
+            <div className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2 text-[12px] text-[var(--warn)]">
+              {error}
+            </div>
+          )}
+          {filed && (
+            <div className="flex items-start gap-2 rounded-md border border-[var(--ok)]/40 bg-[var(--ok-soft)] p-2.5 text-[12.5px]">
+              <Sparkles className="mt-0.5 h-3.5 w-3.5 text-[var(--ok)]" />
+              <div className="flex-1">
+                <div className="text-ink-900">{filed.summary[locale]}</div>
+                <div className="mt-0.5 text-[11px] text-ink-500">
+                  {L("Filed. Agents were not called.", "已归档。智能体未参与。")}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={reset}
+                className="text-[11px] text-ink-500 hover:text-ink-900"
+              >
+                {L("Add another", "再记一条")}
+              </button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      {filed && <FollowUpsCard filed={filed} />}
+    </>
+  );
+}

--- a/src/components/family/things-you-can-help-with.tsx
+++ b/src/components/family/things-you-can-help-with.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import { ChevronRight, ListChecks } from "lucide-react";
+import type { TaskCategory } from "~/types/task";
+
+// Caregiver-actionable subset of the patient's task list. Household,
+// admin, pharmacy, dental, vaccine — the items a family member
+// realistically closes on the patient's behalf. Self-care tasks stay
+// out of this view; they're the patient's to do.
+
+const CAREGIVER_CATEGORIES: readonly TaskCategory[] = [
+  "household",
+  "admin",
+  "pharmacy",
+  "dental",
+  "vaccine",
+  "environmental",
+];
+
+export function ThingsYouCanHelpWith() {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const tasks = useLiveQuery(async () => {
+    const all = await db.patient_tasks.toArray();
+    return all
+      .filter((t) => t.active)
+      .filter((t) => CAREGIVER_CATEGORIES.includes(t.category))
+      .filter((t) => !t.last_completed_date)
+      .sort((a, b) => (a.due_date ?? "9999").localeCompare(b.due_date ?? "9999"))
+      .slice(0, 6);
+  }, []);
+
+  if (!tasks || tasks.length === 0) return null;
+
+  return (
+    <Card>
+      <CardContent className="space-y-2 pt-5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5 text-[12.5px] font-semibold text-ink-900">
+            <ListChecks className="h-3.5 w-3.5 text-[var(--tide-2)]" />
+            {L("Things you can help with", "您可以协助的事项")}
+          </div>
+          <Link
+            href="/tasks"
+            className="text-[11px] text-ink-500 hover:text-ink-900"
+          >
+            {L("All", "全部")}
+          </Link>
+        </div>
+        <ul className="space-y-1.5">
+          {tasks.map((t) => (
+            <li key={t.id}>
+              <Link
+                href={`/tasks/${t.id}`}
+                className="flex items-center gap-3 rounded-[var(--r-md)] bg-paper-2 px-3 py-2 transition-colors hover:bg-ink-100/30"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] text-ink-900">
+                    {locale === "zh" && t.title_zh ? t.title_zh : t.title}
+                  </div>
+                  <div className="mono mt-0.5 text-[10px] uppercase tracking-[0.12em] text-ink-400">
+                    {t.category}
+                    {t.due_date ? ` · ${t.due_date}` : ""}
+                  </div>
+                </div>
+                <ChevronRight className="h-4 w-4 text-ink-400" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/shared/add-fab.tsx
+++ b/src/components/shared/add-fab.tsx
@@ -21,6 +21,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import { useIngestModal } from "~/components/ingest/ingest-modal";
+import { useAppPerspective } from "~/lib/caregiver/scope";
 
 interface FabItem {
   href?: string;
@@ -32,6 +33,51 @@ interface FabItem {
   icon: React.ComponentType<{ className?: string }>;
   tone?: "tide" | "sand";
 }
+
+// Caregiver-friendly FAB — only the verbs a supporting family member
+// reaches for. Patient-authored captures (daily wizard, weekly / fort.
+// assessments, meal photo, practice toggle) are hidden.
+const CAREGIVER_ITEMS: FabItem[] = [
+  {
+    href: "/log",
+    label: { en: "Log for dad", zh: "代记录" },
+    hint: {
+      en: "A note or vital you just observed",
+      zh: "刚观察到的情况或数值",
+    },
+    icon: MessageSquarePlus,
+    tone: "sand",
+  },
+  {
+    href: "/schedule/new",
+    label: { en: "New appointment", zh: "新建预约" },
+    hint: {
+      en: "Clinic / chemo / scan / blood test",
+      zh: "门诊 / 化疗 / 检查 / 化验",
+    },
+    icon: CalendarClock,
+    tone: "tide",
+  },
+  {
+    href: "/tasks/new",
+    label: { en: "Add task", zh: "新建任务" },
+    hint: {
+      en: "Something you'll chase up",
+      zh: "您要跟进的事项",
+    },
+    icon: ListTodo,
+  },
+  {
+    action: "ingest",
+    label: { en: "Upload clinic letter", zh: "上传就诊函" },
+    hint: {
+      en: "Photo or paste — the team sees it too",
+      zh: "拍照或粘贴 —— 团队也可看到",
+    },
+    icon: Sparkles,
+    tone: "tide",
+  },
+];
 
 const ITEMS: FabItem[] = [
   {
@@ -132,6 +178,8 @@ const ITEMS: FabItem[] = [
 export function AddFab() {
   const locale = useLocale();
   const pathname = usePathname();
+  const perspective = useAppPerspective();
+  const items = perspective === "patient" ? ITEMS : CAREGIVER_ITEMS;
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -168,7 +216,7 @@ export function AddFab() {
             </div>
           </div>
           <ul className="max-h-[70vh] overflow-y-auto">
-            {ITEMS.map((item, idx) => {
+            {items.map((item, idx) => {
               const Icon = item.icon;
               const inner = (
                 <>

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -21,14 +21,11 @@ import {
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { useT, useLocale } from "~/hooks/use-translate";
+import { useAppPerspective } from "~/lib/caregiver/scope";
 
-// Schedule replaces Tasks as the canonical "what's coming up / what
-// needs doing" surface — the /schedule page owns both upcoming
-// appointments and their derived prep + follow-up tasks. The /tasks
-// route still exists for one-off reminders but is no longer in primary
-// nav. Medications is accessed contextually (treatment detail, logging
-// FAB) rather than via top-level nav — it's cross-cutting.
-const ITEMS = [
+// Patient nav: everything. Patient owns self-reporting, treatment,
+// assessment, bridge strategy, reports.
+const PATIENT_ITEMS = [
   { href: "/", key: "nav.dashboard", icon: LayoutDashboard },
   { href: "/schedule", key: "nav.schedule", icon: CalendarDays },
   { href: "/family", key: "nav.family", icon: Users },
@@ -44,14 +41,36 @@ const ITEMS = [
   { href: "/settings", key: "nav.settings", icon: SettingsIcon },
 ] as const;
 
+// Caregiver nav: the things a supporting family member actually uses
+// — the family view, the shared schedule, the care-team call list, a
+// place to log what they observed. Patient-authored surfaces (daily
+// wizard, weekly/fortnightly, treatment cycle, assessment, bridge,
+// reports) are hidden.
+const CAREGIVER_ITEMS = [
+  { href: "/family", key: "nav.family", icon: Users },
+  { href: "/schedule", key: "nav.schedule", icon: CalendarDays },
+  { href: "/care-team", key: "nav.care_team", icon: Users },
+  { href: "/log", key: "nav.log", icon: Sparkles },
+  { href: "/history", key: "nav.history", icon: HistoryIcon },
+  { href: "/settings", key: "nav.settings", icon: SettingsIcon },
+] as const;
+
+type NavItem = (typeof PATIENT_ITEMS)[number] | (typeof CAREGIVER_ITEMS)[number];
+
 function isAuthRoute(pathname: string | null): boolean {
   if (!pathname) return false;
   return pathname === "/login" || pathname.startsWith("/auth/");
 }
 
+function useNavItems(): readonly NavItem[] {
+  const perspective = useAppPerspective();
+  return perspective === "patient" ? PATIENT_ITEMS : CAREGIVER_ITEMS;
+}
+
 export function DesktopSidebar() {
   const t = useT();
   const pathname = usePathname();
+  const items = useNavItems();
   if (isAuthRoute(pathname)) return null;
   return (
     <aside className="hidden md:flex md:w-60 flex-col border-r border-ink-100/60 bg-paper-2/60">
@@ -60,7 +79,7 @@ export function DesktopSidebar() {
         <div className="mt-1 text-[11px] text-ink-400">{t("app.tagline")}</div>
       </div>
       <nav className="flex-1 space-y-0.5 px-2 pb-4">
-        {ITEMS.map((item) => {
+        {items.map((item) => {
           const Icon = item.icon;
           const active = pathname === item.href;
           return (
@@ -93,10 +112,15 @@ export function DesktopSidebar() {
 export function MobileBottomNav() {
   const t = useT();
   const pathname = usePathname();
+  const items = useNavItems();
   if (isAuthRoute(pathname)) return null;
-  const mobileItems = ITEMS.filter((i) =>
-    ["/", "/schedule", "/assessment", "/treatment", "/labs"].includes(i.href),
-  );
+  // Mobile bottom nav keeps 4–5 most-used slots. Patients get the
+  // dashboard + schedule + key axes; caregivers get family + schedule +
+  // care team + log.
+  const patientHrefs = ["/", "/schedule", "/assessment", "/treatment", "/labs"];
+  const caregiverHrefs = ["/family", "/schedule", "/care-team", "/log"];
+  const selected = items === PATIENT_ITEMS ? patientHrefs : caregiverHrefs;
+  const mobileItems = items.filter((i) => selected.includes(i.href));
   return (
     <nav className="a-glass fixed inset-x-3 bottom-3 z-40 flex justify-around rounded-[22px] px-2 py-2.5 shadow-lg md:hidden">
       {mobileItems.map((item) => {
@@ -130,6 +154,7 @@ export function MobileMoreMenu() {
   const t = useT();
   const locale = useLocale();
   const pathname = usePathname();
+  const items = useNavItems();
   const [open, setOpen] = useState(false);
 
   // Close the menu whenever navigation happens so the overlay doesn't linger.
@@ -174,7 +199,7 @@ export function MobileMoreMenu() {
               </button>
             </div>
             <nav className="mt-3 grid grid-cols-2 gap-2">
-              {ITEMS.map((item) => {
+              {items.map((item) => {
                 const Icon = item.icon;
                 const active = pathname === item.href;
                 return (

--- a/src/lib/caregiver/guard.ts
+++ b/src/lib/caregiver/guard.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAppPerspective } from "./scope";
+
+// Hook for pages that are patient-only (daily wizard, weekly/fortnightly,
+// new treatment cycle, assessment wizard). Caregivers hitting them
+// directly get bounced to /family. Patient path is untouched.
+//
+// Does nothing until perspective resolves, so we never redirect in the
+// brief window before Supabase auth + Dexie settings hydrate.
+export function useRedirectCaregiverAway(to: string = "/family"): void {
+  const perspective = useAppPerspective();
+  const router = useRouter();
+  useEffect(() => {
+    if (perspective === "caregiver" || perspective === "clinician") {
+      router.replace(to);
+    }
+  }, [perspective, router, to]);
+}

--- a/src/lib/caregiver/scope.ts
+++ b/src/lib/caregiver/scope.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { useHousehold } from "~/hooks/use-household";
+import type { HouseholdRole } from "~/types/household";
+
+export type AppPerspective = "patient" | "caregiver" | "clinician";
+
+const CAREGIVER_ROLES: readonly HouseholdRole[] = [
+  "family",
+  "clinician",
+  "observer",
+];
+
+// Single source of truth for "what kind of user is this?" when we need
+// to fork UI on role. Reads:
+//   (1) Supabase household membership.role when available — authoritative
+//       once the user has joined a household.
+//   (2) Dexie settings.user_type as a fallback — captures the choice
+//       made during local-first onboarding before any Supabase sign-in.
+//   (3) `"patient"` as the default when nothing is set — keeps the
+//       existing single-user install behaviour.
+export function useAppPerspective(): AppPerspective {
+  const { membership } = useHousehold();
+  const settings = useLiveQuery(() => db.settings.toArray(), [], []);
+
+  if (membership?.role) {
+    if (membership.role === "primary_carer" || membership.role === "patient") {
+      // Primary carer still sees the full dashboard — they act as the
+      // patient's proxy when the patient isn't present. Only non-primary
+      // family / clinician / observer roles get the caregiver shell.
+      return "patient";
+    }
+    if (CAREGIVER_ROLES.includes(membership.role)) {
+      return membership.role === "clinician" ? "clinician" : "caregiver";
+    }
+  }
+
+  const userType = settings?.[0]?.user_type;
+  if (userType === "caregiver") return "caregiver";
+  if (userType === "clinician") return "clinician";
+  return "patient";
+}
+
+// Synchronous variant for non-React callers (route guards, narrative
+// builders). Uses only the Dexie settings row — misses Supabase-only
+// caregivers, which is fine for guards since they'd already be
+// redirected to /family by the root dashboard effect.
+export function perspectiveFromSettings(
+  userType: string | undefined,
+): AppPerspective {
+  if (userType === "caregiver") return "caregiver";
+  if (userType === "clinician") return "clinician";
+  return "patient";
+}

--- a/src/lib/supabase/households.ts
+++ b/src/lib/supabase/households.ts
@@ -5,6 +5,7 @@ import type {
   HouseholdMembership,
   HouseholdMemberWithProfile,
   HouseholdRole,
+  HouseholdSummary,
   Profile,
 } from "~/types/household";
 
@@ -122,6 +123,35 @@ export async function createHousehold(args: {
   });
   if (error) throw error;
   if (typeof data !== "string") throw new Error("create_household_failed");
+  return data;
+}
+
+// RPC: list every household as a lightweight summary. Backed by the
+// SECURITY DEFINER function `public.list_all_households` — lets
+// caregiver onboarding show a patient picker without the caller being
+// a member yet. Safe under the product assumption that "all patients
+// are public within this family app"; tighten with a `discoverable`
+// flag if that ever changes.
+export async function listAllHouseholds(): Promise<HouseholdSummary[]> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return [];
+  const { data, error } = await sb.rpc("list_all_households");
+  if (error) throw error;
+  return (data ?? []) as HouseholdSummary[];
+}
+
+// RPC: join an existing household as `family`. Idempotent — calls with
+// a pre-existing membership return without writing.
+export async function joinHouseholdAsFamily(
+  householdId: string,
+): Promise<string> {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("supabase_not_configured");
+  const { data, error } = await sb.rpc("join_household_as_family", {
+    target_id: householdId,
+  });
+  if (error) throw error;
+  if (typeof data !== "string") throw new Error("join_household_failed");
   return data;
 }
 

--- a/src/types/household.ts
+++ b/src/types/household.ts
@@ -62,3 +62,15 @@ export interface HouseholdInvite {
 export interface HouseholdMemberWithProfile extends HouseholdMembership {
   profile: Profile;
 }
+
+// Lightweight household-picker shape — what `list_all_households()`
+// returns. Caregiver onboarding renders this in a tap-list; the full
+// household row isn't fetched until after the user joins and RLS opens
+// the regular `households` SELECT to them.
+export interface HouseholdSummary {
+  id: string;
+  name: string;
+  patient_display_name: string;
+  created_at: string;
+  member_count: number;
+}

--- a/supabase/migrations/2026_04_24_slice_p_caregiver_onboarding.sql
+++ b/supabase/migrations/2026_04_24_slice_p_caregiver_onboarding.sql
@@ -1,0 +1,97 @@
+-- Slice P: caregiver onboarding path. Two RPCs that let a new family
+-- member pick an existing patient's household from a list and join it
+-- directly, without needing the primary_carer to generate an invite
+-- token. Installed as SECURITY DEFINER because the existing RLS
+-- policies scope household SELECTs to existing members and restrict
+-- membership INSERTs to primary_carers.
+--
+-- The design choice is deliberate: per the product owner, "this app is
+-- for our family only" — every patient in the database is discoverable
+-- to every authenticated user. If that assumption changes later, add a
+-- `discoverable boolean` on households and filter here; the signatures
+-- below don't need to change.
+
+SET check_function_bodies = false;
+
+-- ---------------------------------------------------------------------
+-- list_all_households — returns a lightweight summary of every household
+-- (patient display name + member count) for picker UIs.
+-- ---------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.list_all_households()
+  RETURNS TABLE (
+    id uuid,
+    name text,
+    patient_display_name text,
+    created_at timestamptz,
+    member_count integer
+  )
+  LANGUAGE sql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+  SELECT
+    h.id,
+    h.name,
+    h.patient_display_name,
+    h.created_at,
+    (
+      SELECT count(*)::integer
+      FROM public.household_memberships hm
+      WHERE hm.household_id = h.id
+    ) AS member_count
+  FROM public.households h
+  ORDER BY h.created_at DESC
+$$;
+
+REVOKE ALL ON FUNCTION public.list_all_households() FROM public;
+GRANT EXECUTE ON FUNCTION public.list_all_households() TO authenticated;
+
+-- ---------------------------------------------------------------------
+-- join_household_as_family — inserts a `family` membership for the
+-- calling user against `target_id`. Idempotent: re-calls with an
+-- existing membership are a no-op and return the original row's
+-- household id.
+-- ---------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.join_household_as_family(target_id uuid)
+  RETURNS uuid
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+DECLARE
+  caller uuid := auth.uid();
+  existing_household uuid;
+BEGIN
+  IF caller IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.households WHERE id = target_id) THEN
+    RAISE EXCEPTION 'household_not_found';
+  END IF;
+
+  SELECT household_id
+    INTO existing_household
+  FROM public.household_memberships
+  WHERE household_id = target_id AND user_id = caller;
+
+  IF existing_household IS NOT NULL THEN
+    RETURN existing_household;
+  END IF;
+
+  INSERT INTO public.household_memberships (
+    household_id,
+    user_id,
+    role,
+    invited_by,
+    joined_at
+  )
+  VALUES (target_id, caller, 'family', NULL, now());
+
+  RETURN target_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.join_household_as_family(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.join_household_as_family(uuid) TO authenticated;


### PR DESCRIPTION
## Summary

**User ask:** "Care team should not have to add baseline tests or clinical team details, and should have option first to click existing treatment plan for existing patient." + "When caretaker signs in they should have a redesigned app that focuses the perspective on caretaker role for patient."

Plan at `/root/.claude/plans/streamed-snuggling-garden.md`. Two tightly-linked changes.

### 1. Shorter caregiver onboarding

Onboarding `STEPS` split by user type. Patient path unchanged (welcome → user_type → profile → preferences → team → baselines → treatment → done). Caregiver / clinician path:

```
welcome → user_type → pick_patient → profile → preferences → done
```

`finish()` skips baselines / team / treatment writes for caregiver types, and lands them on `/family` rather than `/`.

### 2. Pick an existing patient from a list

New migration `supabase/migrations/2026_04_24_slice_p_caregiver_onboarding.sql`:

- `list_all_households()` (SECURITY DEFINER) — returns `{id, name, patient_display_name, created_at, member_count}` for every household. Bypasses the "households read (members)" RLS. Safe under the "app is for our family only" scope; trivial to gate with a `discoverable` column later.
- `join_household_as_family(target_id)` (SECURITY DEFINER) — inserts a `family` membership for the calling user. Idempotent.

New `pick_patient` step renders the list; tap-row calls `joinHouseholdAsFamily` and advances to the carer's own profile. Escape hatch: "I'm setting up a new patient instead".

### 3. Caregiver-focused app shell

- `src/lib/caregiver/scope.ts` — `useAppPerspective()` reads Supabase membership (authoritative once joined) with a Dexie `settings.user_type` fallback. Primary carers stay on the patient path (they proxy for the patient).
- `src/lib/caregiver/guard.ts` — `useRedirectCaregiverAway()` hook wired into `/daily/new`, `/weekly/new`, `/fortnightly/new`, `/treatment/new`, `/assessment`.
- `src/components/shared/nav.tsx` — `PATIENT_ITEMS` (full 13) vs `CAREGIVER_ITEMS` (Family · Schedule · Care team · Log · History · Settings). Desktop sidebar, mobile bottom nav, and "more" menu all select via perspective.
- `src/components/shared/add-fab.tsx` — caregiver FAB: Log for dad · New appointment · Add task · Upload clinic letter. Hides patient-authored captures.
- `src/app/page.tsx` — root redirect forwards caregivers + clinicians (by membership **or** `settings.user_type`) to `/family`.

### 4. Three new caregiver cards on `/family`

- **LogForPatient** — textarea + Save, uses direct-file (#72); FollowUpsCard (#73) fires on success. Longer-note escape hatch → `/log`.
- **ThingsYouCanHelpWith** — active `patient_tasks` filtered to caregiver-actionable categories (household, admin, pharmacy, dental, vaccine, environmental). Hides self-care.
- **AppointmentsYoureAttending** — appointments where the carer's `profile.display_name` ∈ `attendees` **or** `auth.uid()` ∈ `attendance[].user_id`. Reads existing fields; no schema change.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — **414 / 414**
- [x] `pnpm build` — clean
- [ ] Apply migration: `supabase migration up`.
- [ ] Fresh caregiver onboarding: sign in → pick "I'm family" → see Hu Lin's household → tap → `pick_patient` advances to profile. No baselines / team / treatment steps. Lands on `/family`.
- [ ] Shell: nav shows Family · Schedule · Care team · Log · History · Settings only. FAB shows caregiver items. `/daily/new` redirects back to `/family`.
- [ ] LogForPatient: "blood sugar 7.9 this morning" → Filed + FollowUpsCard suggests Add-to-clinic / Message nurse / Engage dietician.
- [ ] Patient (Hu Lin) sign-in: nothing regresses — full dashboard, full nav, full onboarding path.

## Not in this PR

- Role-aware headings ("Dad's schedule" etc.) — cosmetic, deferred.
- Tool-use loop on `/api/agent/[id]/run` that consumes #74's skill registry.

https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY)_