### PR TITLE
Design polish rebased onto main (maxDuration stays at 60s)

### DIFF
--- a/src/components/assessment/inputs.tsx
+++ b/src/components/assessment/inputs.tsx
@@ -70,7 +70,7 @@ export function YesNoToggle({
   onChange: (v: boolean) => void;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-900">
+    <div className="flex items-center justify-between gap-3 rounded-md border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-900">
       <span className="text-sm text-slate-800 dark:text-slate-200">{label}</span>
       <div className="flex gap-1">
         {(
@@ -126,7 +126,7 @@ export function OrdinalScale({
               type="button"
               onClick={() => onChange(i)}
               className={cn(
-                "rounded-lg border p-2 text-xs font-medium",
+                "rounded-md border p-2 text-xs font-medium",
                 active
                   ? "border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900"
                   : "border-slate-200 text-slate-700 hover:border-slate-400 dark:border-slate-800 dark:text-slate-300",

--- a/src/components/assessment/questionnaires.tsx
+++ b/src/components/assessment/questionnaires.tsx
@@ -72,7 +72,7 @@ export function PhqGad({
         return (
           <div
             key={i}
-            className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900"
+            className="rounded-md border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900"
           >
             <div className="text-sm text-slate-800 dark:text-slate-200">
               {i + 1}. {q}
@@ -193,7 +193,7 @@ export function FacitSp({
         return (
           <div
             key={i}
-            className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900"
+            className="rounded-md border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900"
           >
             <div className="text-sm text-slate-800 dark:text-slate-200">
               {i + 1}. {q.text}

--- a/src/components/assessment/wizard.tsx
+++ b/src/components/assessment/wizard.tsx
@@ -13,6 +13,7 @@ import {
 } from "~/lib/assessment/catalog";
 import { todayISO } from "~/lib/utils/date";
 import type { ComprehensiveAssessment } from "~/types/clinical";
+import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { CoachDrawer } from "~/components/assessment/coach-drawer";
@@ -500,9 +501,9 @@ function ReviewView({
             </Button>
           </div>
           {aiError && (
-            <div className="mt-3 rounded-lg border border-red-300 bg-red-50 p-2 text-xs text-red-800 dark:bg-red-950/40">
+            <Alert variant="warn" dense className="mt-3">
               {aiError}
-            </div>
+            </Alert>
           )}
         </CardContent>
       </Card>

--- a/src/components/auth/welcome-auth-modal.tsx
+++ b/src/components/auth/welcome-auth-modal.tsx
@@ -100,7 +100,7 @@ export function WelcomeAuthModal() {
       onClick={close}
     >
       <div
-        className="relative w-full max-w-sm rounded-lg border border-ink-100 bg-paper p-6 shadow-xl"
+        className="relative w-full max-w-sm rounded-[var(--r-lg)] border border-ink-100 bg-paper-2 p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button

--- a/src/components/charts/trend-chart.tsx
+++ b/src/components/charts/trend-chart.tsx
@@ -9,10 +9,29 @@ import {
   Tooltip,
   CartesianGrid,
 } from "recharts";
+import { useEffect, useState } from "react";
 
 interface TrendPoint {
   date: string;
   value: number | null;
+}
+
+// Recharts writes `stroke` straight onto the SVG attribute, where
+// `var(--…)` doesn't resolve. Read the tokens off the root once on
+// mount and feed concrete colours in — falls back to sensible defaults
+// before hydration.
+function useTokenColors() {
+  const [colors, setColors] = useState({
+    grid: "oklch(88% 0.006 70)",
+    line: "oklch(22% 0.015 250)",
+  });
+  useEffect(() => {
+    const root = getComputedStyle(document.documentElement);
+    const grid = root.getPropertyValue("--ink-200").trim();
+    const line = root.getPropertyValue("--ink-900").trim();
+    if (grid && line) setColors({ grid, line });
+  }, []);
+  return colors;
 }
 
 export function TrendChart({
@@ -24,13 +43,14 @@ export function TrendChart({
   label: string;
   domain?: [number | "auto", number | "auto"];
 }) {
+  const { grid, line } = useTokenColors();
   return (
-    <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4">
-      <div className="text-sm font-medium mb-2">{label}</div>
+    <div className="a-card p-4">
+      <div className="mb-2 text-sm font-medium text-ink-900">{label}</div>
       <div className="h-40">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ left: -20, right: 8, top: 4, bottom: 4 }}>
-            <CartesianGrid strokeDasharray="2 4" stroke="#e2e8f0" />
+            <CartesianGrid strokeDasharray="2 4" stroke={grid} />
             <XAxis dataKey="date" fontSize={10} tickMargin={4} />
             <YAxis fontSize={10} domain={domain} />
             <Tooltip
@@ -40,7 +60,7 @@ export function TrendChart({
             <Line
               type="monotone"
               dataKey="value"
-              stroke="#0f172a"
+              stroke={line}
               strokeWidth={2}
               dot={{ r: 2 }}
               connectNulls

--- a/src/components/dashboard/quick-checkin-card.tsx
+++ b/src/components/dashboard/quick-checkin-card.tsx
@@ -235,7 +235,7 @@ function FeverRow({
         className="flex h-8 w-8 items-center justify-center rounded-md"
         style={{
           background: fever ? "var(--warn)" : "var(--paper-2)",
-          color: fever ? "#fff" : "var(--ink-500)",
+          color: fever ? "var(--paper)" : "var(--ink-500)",
         }}
       >
         <Thermometer className="h-4 w-4" />

--- a/src/components/fortnightly/fortnightly-form.tsx
+++ b/src/components/fortnightly/fortnightly-form.tsx
@@ -9,6 +9,7 @@ import { useLocale, useT } from "~/hooks/use-translate";
 import { runEngineAndPersist } from "~/lib/rules/engine";
 import { fortnightlyAssessmentSchema } from "~/lib/validators/schemas";
 import { todayISO } from "~/lib/utils/date";
+import { Alert } from "~/components/ui/alert";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { SectionHeader } from "~/components/ui/page-header";
 import { Button } from "~/components/ui/button";
@@ -444,11 +445,7 @@ export function FortnightlyForm({ entryId }: { entryId?: number }) {
         </CardContent>
       </Card>
 
-      {error && (
-        <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200">
-          {error}
-        </div>
-      )}
+      {error && <Alert variant="warn">{error}</Alert>}
 
       <div className="flex items-center justify-between gap-2">
         <Button variant="ghost" onClick={() => router.push("/fortnightly")}>

--- a/src/components/treatment/cycle-calendar.tsx
+++ b/src/components/treatment/cycle-calendar.tsx
@@ -21,7 +21,7 @@ type Swatch = {
 const SWATCHES: Record<string, Swatch> = {
   dose_day: {
     bg: "var(--tide-2)",
-    color: "#fff",
+    color: "var(--paper)",
     label: { en: "Dose", zh: "用药" },
   },
   post_dose: {

--- a/src/components/treatment/nudge-card.tsx
+++ b/src/components/treatment/nudge-card.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useLocale } from "~/hooks/use-translate";
-import { cn } from "~/lib/utils/cn";
 import type { NudgeCategory, NudgeTemplate } from "~/types/treatment";
 import {
   Apple,
@@ -45,23 +44,30 @@ const CATEGORY_LABEL: Record<NudgeCategory, { en: string; zh: string }> = {
   intimacy: { en: "Intimacy", zh: "亲密" },
 };
 
-const SEVERITY_TONE = {
+type SeverityTone = {
+  ringStyle: React.CSSProperties;
+  bgStyle: React.CSSProperties;
+  pillStyle: React.CSSProperties;
+  icon: React.ComponentType<{ className?: string }>;
+};
+
+const SEVERITY_TONE: Record<"warning" | "caution" | "info", SeverityTone> = {
   warning: {
-    ring: "border-red-300 dark:border-red-900",
-    bg: "bg-red-50/70 dark:bg-red-950/30",
-    pill: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200",
+    ringStyle: { borderColor: "color-mix(in oklch, var(--warn), transparent 60%)" },
+    bgStyle: { background: "var(--warn-soft)" },
+    pillStyle: { background: "var(--warn-soft)", color: "var(--warn)" },
     icon: AlertTriangle,
   },
   caution: {
-    ring: "border-amber-300 dark:border-amber-900",
-    bg: "bg-amber-50/70 dark:bg-amber-950/30",
-    pill: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200",
+    ringStyle: { borderColor: "color-mix(in oklch, var(--sand-2), transparent 40%)" },
+    bgStyle: { background: "var(--sand)" },
+    pillStyle: { background: "var(--shell)", color: "oklch(35% 0.04 70)" },
     icon: ShieldAlert,
   },
   info: {
-    ring: "border-slate-200 dark:border-slate-800",
-    bg: "bg-white dark:bg-slate-900",
-    pill: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200",
+    ringStyle: { borderColor: "var(--ink-200)" },
+    bgStyle: { background: "var(--paper-2)" },
+    pillStyle: { background: "var(--ink-100)", color: "var(--ink-700)" },
     icon: Info,
   },
 };
@@ -81,38 +87,31 @@ export function NudgeCard({
 
   return (
     <div
-      className={cn(
-        "rounded-xl border p-3 transition-colors",
-        tone.ring,
-        tone.bg,
-      )}
+      className="rounded-[var(--r-md)] border p-3 transition-colors"
+      style={{ ...tone.ringStyle, ...tone.bgStyle }}
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-start gap-2">
           <div
-            className={cn(
-              "flex h-7 w-7 shrink-0 items-center justify-center rounded-full",
-              tone.pill,
-            )}
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
+            style={tone.pillStyle}
           >
             <CatIcon className="h-3.5 w-3.5" />
           </div>
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-1.5">
-              <span className="text-sm font-semibold leading-tight">
+              <span className="text-sm font-semibold leading-tight text-ink-900">
                 {nudge.title[locale]}
               </span>
               <span
-                className={cn(
-                  "rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
-                  tone.pill,
-                )}
+                className="rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+                style={tone.pillStyle}
               >
                 {CATEGORY_LABEL[nudge.category][locale]}
               </span>
             </div>
             {!compact && (
-              <p className="mt-1 text-xs leading-relaxed text-slate-700 dark:text-slate-300">
+              <p className="mt-1 text-xs leading-relaxed text-ink-700">
                 {nudge.body[locale]}
               </p>
             )}
@@ -123,7 +122,7 @@ export function NudgeCard({
             type="button"
             onClick={() => onSnooze(nudge.id)}
             aria-label="Snooze this nudge"
-            className="rounded-md p-1 text-slate-400 hover:bg-white hover:text-slate-700 dark:hover:bg-slate-800"
+            className="rounded-[var(--r-sm)] p-1 text-ink-400 hover:bg-paper hover:text-ink-700"
           >
             <X className="h-3.5 w-3.5" />
           </button>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,83 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { AlertTriangle, CheckCircle2, Info } from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+type AlertVariant = "warn" | "ok" | "info";
+
+const VARIANT_STYLES: Record<
+  AlertVariant,
+  { background: string; border: string; color: string; icon: typeof Info }
+> = {
+  warn: {
+    background: "var(--warn-soft)",
+    border: "color-mix(in oklch, var(--warn), transparent 70%)",
+    color: "var(--warn)",
+    icon: AlertTriangle,
+  },
+  ok: {
+    background: "var(--ok-soft)",
+    border: "color-mix(in oklch, var(--ok), transparent 70%)",
+    color: "var(--ok)",
+    icon: CheckCircle2,
+  },
+  info: {
+    background: "var(--tide-soft)",
+    border: "color-mix(in oklch, var(--tide-2), transparent 70%)",
+    color: "var(--tide-2)",
+    icon: Info,
+  },
+};
+
+interface AlertProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+  variant?: AlertVariant;
+  title?: ReactNode;
+  icon?: ReactNode | false;
+  dense?: boolean;
+}
+
+export function Alert({
+  variant = "info",
+  title,
+  icon,
+  dense,
+  className,
+  children,
+  ...props
+}: AlertProps) {
+  const tone = VARIANT_STYLES[variant];
+  const IconComponent = tone.icon;
+  return (
+    <div
+      {...props}
+      className={cn(
+        "flex items-start gap-2 rounded-[var(--r-sm)] border px-3",
+        dense ? "py-2 text-xs" : "py-2.5 text-sm",
+        className,
+      )}
+      style={{
+        background: tone.background,
+        borderColor: tone.border,
+        color: tone.color,
+        ...props.style,
+      }}
+    >
+      {icon !== false && (
+        <span
+          aria-hidden
+          className={cn(
+            "flex shrink-0 items-center justify-center",
+            dense ? "mt-[1px]" : "mt-[2px]",
+          )}
+        >
+          {icon ?? <IconComponent className={dense ? "h-3.5 w-3.5" : "h-4 w-4"} />}
+        </span>
+      )}
+      <div className="min-w-0 flex-1 leading-snug">
+        {title && (
+          <div className={cn("font-medium", children && "mb-0.5")}>{title}</div>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -52,7 +52,7 @@ export function Sparkline({
             cx={x}
             cy={y}
             r={i === highlight ? 3 : 1.8}
-            fill={i === highlight ? stroke : "#fff"}
+            fill={i === highlight ? stroke : "var(--paper)"}
             stroke={stroke}
             strokeWidth={1.5}
           />

--- a/src/components/weekly/weekly-form.tsx
+++ b/src/components/weekly/weekly-form.tsx
@@ -9,6 +9,7 @@ import { useLocale, useT } from "~/hooks/use-translate";
 import { weekStartISO, weekDates, formatWeekRange } from "~/lib/utils/week";
 import { weeklyAssessmentSchema } from "~/lib/validators/schemas";
 import { runEngineAndPersist } from "~/lib/rules/engine";
+import { Alert } from "~/components/ui/alert";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils/cn";
@@ -337,11 +338,7 @@ export function WeeklyForm({ entryId }: { entryId?: number }) {
         </CardContent>
       </Card>
 
-      {error && (
-        <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200">
-          {error}
-        </div>
-      )}
+      {error && <Alert variant="warn">{error}</Alert>}
 
       <div className="flex items-center justify-between gap-2">
         <Button variant="ghost" onClick={() => router.push("/weekly")}>


### PR DESCRIPTION
Supersedes #80.

PR #80 branched from `7729c9b` (PR #78, which had `maxDuration = 300`).
Main has since reverted that back to 60 in #81, so #80's base-vs-head
diff silently reintroduces `maxDuration = 300` across 11 API routes.

This branch cherry-picks the single design-polish commit (`52e477c`)
cleanly onto current main, so the only diff is the intended design
changes. `maxDuration` stays at 60 everywhere.

## What changed (design-polish, unchanged from #80)

- New shared `<Alert variant="warn"|"ok"|"info">` in `src/components/ui/alert.tsx` — replaces bespoke `rounded-lg border-red-300 bg-red-50 …` error blocks in `assessment/wizard`, `fortnightly-form`, `weekly-form`.
- `NudgeCard` severity tones rewritten against tokens (warn / sand / paper) instead of red-/amber-/slate-*.
- Charts: `trend-chart` reads `--ink-200` / `--ink-900` off the root at mount and feeds them to Recharts. Card wrapper uses `.a-card`. `Sparkline`, `CycleCalendar` dose-day, and `QuickCheckinCard` thermometer `#fff` → `var(--paper)`.
- `rounded-lg` → `rounded-md` in assessment inputs + questionnaires. `welcome-auth-modal` → `rounded-[var(--r-lg)]` + `bg-paper-2`.

## Verification

- [x] `maxDuration = 60` in all 11 API routes (grep confirmed)
- [x] `pnpm typecheck`
- [x] `pnpm lint` — no new warnings vs main
- [x] `pnpm test` — 414 / 414
- [ ] Visual spot-check `/assessment`, `/fortnightly/new`, `/weekly/new`, `/treatment/[id]`, `/dashboard` before merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vyj9Ak1bQVBzDnFSouSnps)_