### PR TITLE
Carer onboarding: fix missing-RPC crash + invite-link fallback + success state

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -670,7 +670,14 @@ function PickPatientStep({
   >([]);
   const [loading, setLoading] = useState(true);
   const [joining, setJoining] = useState<string | null>(null);
+  const [joinedName, setJoinedName] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // When the discovery RPC isn't installed (typically because the carer-
+  // onboarding migration hasn't been applied), we fall back to an
+  // invite-token paste box so the user can still complete onboarding.
+  const [pickerUnavailable, setPickerUnavailable] = useState(false);
+  const [inviteInput, setInviteInput] = useState("");
+  const [acceptingInvite, setAcceptingInvite] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -682,7 +689,14 @@ function PickPatientStep({
         const all = await listAllHouseholds();
         if (!cancelled) setRows(all);
       } catch (err) {
-        if (!cancelled) {
+        if (cancelled) return;
+        if (
+          err &&
+          typeof err === "object" &&
+          (err as { code?: string }).code === "caregiver_picker_unavailable"
+        ) {
+          setPickerUnavailable(true);
+        } else {
           setError(errorMessage(err));
         }
       } finally {
@@ -694,7 +708,7 @@ function PickPatientStep({
     };
   }, []);
 
-  async function join(id: string) {
+  async function join(id: string, displayName: string) {
     setJoining(id);
     setError(null);
     try {
@@ -702,7 +716,10 @@ function PickPatientStep({
         "~/lib/supabase/households"
       );
       await joinHouseholdAsFamily(id);
-      onJoined();
+      setJoinedName(displayName);
+      // Brief celebratory beat so the carer sees the join landed before
+      // the wizard pushes them onto the profile step.
+      setTimeout(() => onJoined(), 700);
     } catch (err) {
       setError(errorMessage(err));
     } finally {
@@ -710,13 +727,37 @@ function PickPatientStep({
     }
   }
 
+  async function acceptPastedInvite() {
+    setError(null);
+    const { extractInviteToken, acceptInvite } = await import(
+      "~/lib/supabase/households"
+    );
+    const token = extractInviteToken(inviteInput);
+    if (!token) {
+      setError(
+        L(
+          "That doesn't look like an Anchor invite link. Paste the full URL or just the token.",
+          "这不像是 Anchor 邀请链接。请粘贴完整网址或令牌。",
+        ),
+      );
+      return;
+    }
+    setAcceptingInvite(true);
+    try {
+      await acceptInvite(token);
+      setJoinedName(L("the care team", "护理团队"));
+      setTimeout(() => onJoined(), 700);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setAcceptingInvite(false);
+    }
+  }
+
   return (
     <Card className="p-6 space-y-4">
       <div className="serif text-[22px] leading-tight">
-        {L(
-          "Who are you supporting?",
-          "您要支持的是哪位患者?",
-        )}
+        {L("Who are you supporting?", "您要支持的是哪位患者?")}
       </div>
       <p className="text-[13px] text-ink-500">
         {L(
@@ -725,13 +766,27 @@ function PickPatientStep({
         )}
       </p>
 
-      {loading && (
+      {joinedName && (
+        <div className="flex items-start gap-2 rounded-md border border-[var(--ok)]/40 bg-[var(--ok-soft)] p-3 text-[12.5px] text-ink-700">
+          <Check className="mt-0.5 h-4 w-4 shrink-0 text-[var(--ok)]" />
+          <div>
+            <div className="font-semibold text-ink-900">
+              {L("You're in.", "已加入。")}
+            </div>
+            <div className="text-ink-500">
+              {L(`Joined ${joinedName}'s care team.`, `已加入 ${joinedName} 的护理团队。`)}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {loading && !joinedName && (
         <div className="rounded-md border border-ink-200 bg-paper-2 p-3 text-[12.5px] text-ink-500">
           {L("Loading patients…", "加载中…")}
         </div>
       )}
 
-      {!loading && !error && rows.length === 0 && (
+      {!loading && !joinedName && !pickerUnavailable && !error && rows.length === 0 && (
         <div className="rounded-md border border-dashed border-ink-300 bg-paper p-4 text-[12.5px] text-ink-600">
           {L(
             "No patients have set up Anchor yet. Ask the person you're supporting to create their profile first, or set up a fresh patient yourself.",
@@ -740,57 +795,93 @@ function PickPatientStep({
         </div>
       )}
 
-      {!loading && rows.length > 0 && (
+      {!loading && !joinedName && rows.length > 0 && (
         <ul className="space-y-2">
-          {rows.map((h) => (
-            <li key={h.id}>
-              <button
-                type="button"
-                onClick={() => void join(h.id)}
-                disabled={joining !== null}
-                className={cn(
-                  "flex w-full items-center justify-between gap-3 rounded-xl border p-4 text-left transition-colors",
-                  joining === h.id
-                    ? "border-[var(--tide-2)] bg-[var(--tide-soft)]"
-                    : "border-ink-200 bg-paper-2 hover:border-ink-400",
-                )}
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="text-[14.5px] font-semibold text-ink-900">
-                    {h.patient_display_name || h.name}
+          {rows.map((h) => {
+            const display = h.patient_display_name || h.name;
+            return (
+              <li key={h.id}>
+                <button
+                  type="button"
+                  onClick={() => void join(h.id, display)}
+                  disabled={joining !== null}
+                  className={cn(
+                    "flex w-full items-center justify-between gap-3 rounded-xl border p-4 text-left transition-colors",
+                    joining === h.id
+                      ? "border-[var(--tide-2)] bg-[var(--tide-soft)]"
+                      : "border-ink-200 bg-paper-2 hover:border-ink-400",
+                  )}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-[14.5px] font-semibold text-ink-900">
+                      {display}
+                    </div>
+                    <div className="mt-0.5 text-[11.5px] text-ink-500">
+                      {h.member_count}{" "}
+                      {h.member_count === 1
+                        ? L("member", "位成员")
+                        : L("members", "位成员")}
+                    </div>
                   </div>
-                  <div className="mt-0.5 text-[11.5px] text-ink-500">
-                    {h.member_count}{" "}
-                    {h.member_count === 1
-                      ? L("member", "位成员")
-                      : L("members", "位成员")}
-                  </div>
-                </div>
-                <span className="mono text-[10px] uppercase tracking-[0.12em] text-ink-400">
-                  {joining === h.id ? L("Joining…", "加入中…") : L("Join", "加入")}
-                </span>
-              </button>
-            </li>
-          ))}
+                  <span className="mono text-[10px] uppercase tracking-[0.12em] text-ink-400">
+                    {joining === h.id ? L("Joining…", "加入中…") : L("Join", "加入")}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
         </ul>
       )}
 
-      {error && (
+      {!loading && !joinedName && pickerUnavailable && (
+        <div className="space-y-3 rounded-md border border-ink-200 bg-paper-2 p-4">
+          <div className="text-[12.5px] text-ink-700">
+            {L(
+              "Browsing every patient isn't enabled on this server yet. If the patient already has Anchor set up, paste the invite link they sent you.",
+              "本服务器尚未开启患者浏览功能。如对方已在使用 Anchor,请粘贴 ta 发来的邀请链接。",
+            )}
+          </div>
+          <div className="flex gap-2">
+            <TextInput
+              value={inviteInput}
+              onChange={(e) => setInviteInput(e.target.value)}
+              placeholder={L(
+                "https://anchor.app/invite/…",
+                "https://anchor.app/invite/…",
+              )}
+              disabled={acceptingInvite}
+            />
+            <Button
+              onClick={() => void acceptPastedInvite()}
+              disabled={acceptingInvite || inviteInput.trim().length === 0}
+            >
+              {acceptingInvite ? L("Joining…", "加入中…") : L("Join", "加入")}
+            </Button>
+          </div>
+          <p className="text-[11.5px] text-ink-400">
+            {L(
+              "Server admin: apply migration 2026_04_24_slice_p_caregiver_onboarding_reload.sql in Supabase to enable the picker.",
+              "服务器管理员:在 Supabase 中应用迁移 2026_04_24_slice_p_caregiver_onboarding_reload.sql 即可启用选择器。",
+            )}
+          </p>
+        </div>
+      )}
+
+      {error && !joinedName && (
         <div className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2.5 text-[12px] text-[var(--warn)]">
           {error}
         </div>
       )}
 
-      <button
-        type="button"
-        onClick={onStartFresh}
-        className="text-[12px] text-ink-500 underline-offset-2 hover:text-ink-900 hover:underline"
-      >
-        {L(
-          "I'm setting up a new patient instead",
-          "我要新建一位患者",
-        )}
-      </button>
+      {!joinedName && (
+        <button
+          type="button"
+          onClick={onStartFresh}
+          className="text-[12px] text-ink-500 underline-offset-2 hover:text-ink-900 hover:underline"
+        >
+          {L("I'm setting up a new patient instead", "我要新建一位患者")}
+        </button>
+      )}
     </Card>
   );
 }

--- a/src/lib/supabase/households.ts
+++ b/src/lib/supabase/households.ts
@@ -126,6 +126,32 @@ export async function createHousehold(args: {
   return data;
 }
 
+// PostgREST returns PGRST202 when the requested RPC isn't in its schema
+// cache — typically because the caregiver-onboarding migration hasn't been
+// applied (or applied without a cache reload). We surface this as a typed
+// error so the picker UI can fall back to the invite-token flow with
+// actionable copy instead of dumping the raw PostgREST message.
+export class CaregiverPickerUnavailableError extends Error {
+  readonly code = "caregiver_picker_unavailable";
+  constructor(message = "Caregiver patient picker isn't available yet.") {
+    super(message);
+    this.name = "CaregiverPickerUnavailableError";
+  }
+}
+
+function isMissingRpcError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { code?: string; message?: string };
+  if (e.code === "PGRST202" || e.code === "404") return true;
+  const msg = (e.message ?? "").toLowerCase();
+  return (
+    msg.includes("could not find the function") ||
+    msg.includes("schema cache") ||
+    msg.includes("function public.list_all_households") ||
+    msg.includes("function public.join_household_as_family")
+  );
+}
+
 // RPC: list every household as a lightweight summary. Backed by the
 // SECURITY DEFINER function `public.list_all_households` — lets
 // caregiver onboarding show a patient picker without the caller being
@@ -136,7 +162,10 @@ export async function listAllHouseholds(): Promise<HouseholdSummary[]> {
   const sb = getSupabaseBrowser();
   if (!sb) return [];
   const { data, error } = await sb.rpc("list_all_households");
-  if (error) throw error;
+  if (error) {
+    if (isMissingRpcError(error)) throw new CaregiverPickerUnavailableError();
+    throw error;
+  }
   return (data ?? []) as HouseholdSummary[];
 }
 
@@ -150,9 +179,28 @@ export async function joinHouseholdAsFamily(
   const { data, error } = await sb.rpc("join_household_as_family", {
     target_id: householdId,
   });
-  if (error) throw error;
+  if (error) {
+    if (isMissingRpcError(error)) throw new CaregiverPickerUnavailableError();
+    throw error;
+  }
   if (typeof data !== "string") throw new Error("join_household_failed");
   return data;
+}
+
+// Pull the invite token out of a /invite/<token> URL the patient may have
+// shared. Accepts bare tokens too. Returns null when nothing usable is
+// present so the UI can keep the input controlled.
+export function extractInviteToken(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  // Bare uuid (8-4-4-4-12) — accept as-is.
+  if (/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  // /invite/<token> URL — pull the segment after /invite/.
+  const match = trimmed.match(/\/invite\/([0-9a-fA-F-]{8,})/);
+  if (match && match[1]) return match[1].toLowerCase();
+  return null;
 }
 
 // RPC: accept an invite token, atomically creating a membership and

--- a/supabase/migrations/2026_04_24_slice_p_caregiver_onboarding_reload.sql
+++ b/supabase/migrations/2026_04_24_slice_p_caregiver_onboarding_reload.sql
@@ -1,0 +1,93 @@
+-- Slice P follow-up: re-create the caregiver-onboarding RPCs idempotently
+-- and force PostgREST to reload its schema cache.
+--
+-- The original `2026_04_24_slice_p_caregiver_onboarding.sql` ships the
+-- two functions (`list_all_households`, `join_household_as_family`), but
+-- on instances where the migration was applied without the schema-cache
+-- being refreshed PostgREST keeps returning
+--   "Could not find the function public.list_all_households without
+--    parameters in the schema cache"
+-- (PostgREST PGRST202). This file is safe to apply on any instance:
+-- - if the functions don't exist yet it creates them
+-- - if they already exist `CREATE OR REPLACE` re-installs them
+-- - the trailing `NOTIFY pgrst, 'reload schema'` flushes the cache so
+--   the new definitions are picked up immediately.
+
+SET check_function_bodies = false;
+
+CREATE OR REPLACE FUNCTION public.list_all_households()
+  RETURNS TABLE (
+    id uuid,
+    name text,
+    patient_display_name text,
+    created_at timestamptz,
+    member_count integer
+  )
+  LANGUAGE sql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+  SELECT
+    h.id,
+    h.name,
+    h.patient_display_name,
+    h.created_at,
+    (
+      SELECT count(*)::integer
+      FROM public.household_memberships hm
+      WHERE hm.household_id = h.id
+    ) AS member_count
+  FROM public.households h
+  ORDER BY h.created_at DESC
+$$;
+
+REVOKE ALL ON FUNCTION public.list_all_households() FROM public;
+GRANT EXECUTE ON FUNCTION public.list_all_households() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.join_household_as_family(target_id uuid)
+  RETURNS uuid
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+DECLARE
+  caller uuid := auth.uid();
+  existing_household uuid;
+BEGIN
+  IF caller IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.households WHERE id = target_id) THEN
+    RAISE EXCEPTION 'household_not_found';
+  END IF;
+
+  SELECT household_id
+    INTO existing_household
+  FROM public.household_memberships
+  WHERE household_id = target_id AND user_id = caller;
+
+  IF existing_household IS NOT NULL THEN
+    RETURN existing_household;
+  END IF;
+
+  INSERT INTO public.household_memberships (
+    household_id,
+    user_id,
+    role,
+    invited_by,
+    joined_at
+  )
+  VALUES (target_id, caller, 'family', NULL, now());
+
+  RETURN target_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.join_household_as_family(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.join_household_as_family(uuid) TO authenticated;
+
+-- Force PostgREST to refresh its schema cache so the freshly-installed
+-- functions become callable immediately. Without this the API keeps
+-- returning PGRST202 until something else triggers a reload (e.g. a DDL
+-- in the same transaction or a manual restart in the dashboard).
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Carer onboarding was crashing with PostgREST `PGRST202` ("Could not find the function `public.list_all_households` without parameters in the schema cache") on Supabase instances that hadn't applied — or had applied without a cache refresh — the slice-P caregiver migration.
- New migration `2026_04_24_slice_p_caregiver_onboarding_reload.sql` re-installs both RPCs (`list_all_households`, `join_household_as_family`) idempotently via `CREATE OR REPLACE` and ends with `NOTIFY pgrst, 'reload schema'` so PostgREST picks them up immediately.
- `supabase/households.ts`: detects the missing-RPC error and throws a typed `CaregiverPickerUnavailableError`; new `extractInviteToken` helper accepts either a bare uuid or a `/invite/<token>` URL.
- `/onboarding` `PickPatientStep`:
  - Catches the typed error and renders an invite-link paste box that uses the existing `acceptInvite` RPC, so carers can finish onboarding even when the picker isn't available.
  - Adds a green "You're in. Joined X's care team." confirmation card with a short pause before advancing to the profile step.
  - Empty / error / picker-unavailable / success states are mutually exclusive — no stacked copy anymore.
  - Inline note pointing the server admin at the right migration when the picker is unavailable.

## Test plan
- [ ] Apply `2026_04_24_slice_p_caregiver_onboarding_reload.sql` against the Supabase instance — picker should immediately list every household with no PostgREST error.
- [ ] Hit `/onboarding` as a fresh carer with the migration applied → discovery list renders → tap a patient → success card → routed to profile step.
- [ ] Without the migration applied → invite-link paste box appears → paste a `/invite/<token>` URL → success card → profile step.
- [ ] Paste an obviously bad string into the invite box → friendly inline error, no console spam.

https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdhE1VsPQcW3J82ZPRqveY)_