### PR TITLE
Family timeline + Legacy module — slice 1: v16 schema

### DIFF
--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -37,6 +37,7 @@ import type {
   LogEventRow,
 } from "~/types/agent";
 import type { Appointment, AppointmentLink } from "~/types/appointment";
+import type { TimelineMedia } from "~/types/timeline";
 
 export class AnchorDB extends Dexie {
   daily_entries!: Table<DailyEntry, number>;
@@ -72,6 +73,7 @@ export class AnchorDB extends Dexie {
   appointments!: Table<Appointment, number>;
   appointment_links!: Table<AppointmentLink, number>;
   care_team!: Table<CareTeamMember, number>;
+  timeline_media!: Table<TimelineMedia, number>;
 
   constructor() {
     super("anchor_db");
@@ -196,6 +198,28 @@ export class AnchorDB extends Dexie {
     this.version(15).stores({
       appointments:
         "++id, starts_at, kind, status, cycle_id, ics_uid, [kind+starts_at]",
+    });
+    // v16: family timeline foundations. `timeline_media` is the single
+    // blob store for photos / short video clips / voice memos attached
+    // to a timeline-visible anchor (life event, family note, or
+    // appointment). Composite [owner_type+owner_id] lets the timeline
+    // renderer pull all media for one anchor in O(k); `taken_at` is
+    // indexed so the chronological stream can merge blobs with events
+    // without a table scan.
+    //
+    // `life_events` and `family_notes` gain optional columns (author,
+    // created_via, is_memory, source_appointment_id on life events;
+    // life_event_id and appointment_id on notes). These are additive —
+    // Dexie only re-declares the stores whose *indexes* change, so we
+    // re-state existing tables only where we want a new index, and
+    // leave the rest to live as schemaless extra fields.
+    this.version(16).stores({
+      timeline_media:
+        "++id, owner_type, owner_id, taken_at, created_at, [owner_type+owner_id]",
+      life_events:
+        "++id, event_date, category, is_memory, created_via, source_appointment_id",
+      family_notes:
+        "++id, created_at, life_event_id, appointment_id",
     });
   }
 }

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -341,6 +341,13 @@ export interface LifeEvent {
   notes?: string;
   pre_event_buffer_days?: number;
   post_event_buffer_days?: number;
+  // Timeline / legacy fields (v16). Additive — existing rows default to
+  // manual-created non-memory events authored by the household's primary
+  // record-keeper.
+  author?: EnteredBy;
+  created_via?: "manual" | "auto_appointment" | "import";
+  is_memory?: boolean;                 // diary entry vs tracked planning event
+  source_appointment_id?: number;      // set when created_via = auto_appointment
   created_at: string;
   updated_at: string;
 }
@@ -382,6 +389,11 @@ export interface FamilyNote {
   updated_at: string;
   author: EnteredBy;
   body: string;
+  // Optional threading onto a timeline anchor (v16). A note can hang off a
+  // life event (family moment) or an appointment (clinical milestone), so
+  // the timeline view can render it as a reply under that anchor.
+  life_event_id?: number;
+  appointment_id?: number;
 }
 
 export interface Settings {

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,0 +1,32 @@
+import type { EnteredBy } from "./clinical";
+
+// Owner of a media blob. Media is attached to a timeline-visible anchor:
+// a life event (family moment), a family note (commentary), or an
+// appointment (clinical milestone). The profile / legacy module will
+// extend this union in v17 when it lands; keep it narrow for now.
+export type TimelineMediaOwnerType =
+  | "life_event"
+  | "family_note"
+  | "appointment";
+
+export type TimelineMediaKind = "photo" | "video" | "voice";
+
+export interface TimelineMedia {
+  id?: number;
+  owner_type: TimelineMediaOwnerType;
+  owner_id: number;
+  kind: TimelineMediaKind;
+  // Raw media, stored locally in IndexedDB. Per product decision, video
+  // clips are capped at 10s at capture time; enforcement lives in the
+  // capture layer, not the schema.
+  blob: Blob;
+  thumbnail_blob?: Blob;             // small JPEG for list rendering
+  mime_type: string;
+  width?: number;
+  height?: number;
+  duration_ms?: number;              // voice + video only
+  caption?: string;
+  taken_at?: string;                 // EXIF-derived when available
+  created_at: string;
+  created_by: EnteredBy;
+}


### PR DESCRIPTION
## Summary

First slice of the family timeline + Legacy ("legacy archive") module. Schema-only, no UI.

- **New table `timeline_media`** — single local blob store for photos, short video clips, and voice memos attached to a timeline anchor (life event, family note, or appointment). Indexed `[owner_type+owner_id]` for fast per-anchor lookup and `taken_at` for chronological merges.
- **`life_events` extensions** — `author`, `created_via` (manual / auto_appointment / import), `is_memory` (diary vs tracked planning event), `source_appointment_id`. Indexes added on `category`, `is_memory`, `created_via`, `source_appointment_id`.
- **`family_notes` extensions** — optional `life_event_id` / `appointment_id` so notes can thread as replies under a timeline anchor. Indexed for both.
- **New `src/types/timeline.ts`** — `TimelineMedia` type.

All additive. Existing rows default cleanly (new fields optional). Video cap (10s) will be enforced in the capture layer, not at schema level.

## Module plan (for PR reviewers)

This branch will build in vertical slices:

1. **v16 schema** ← this PR
2. Native media capture (photo + 10s video + voice Blob, no transcription in v1)
3. `memory` log tag + ingest-modal classification path
4. `/family/timeline` — chronological family-facing view
5. Auto-synthesise timeline rows from completed appointments
6. Note threading under timeline anchors
7. Anniversary resurfacing as low-priority positive feed items (patient-feed, opt-out)
8. Quarterly-review export includes selected timeline range
9. v17 schema — Legacy module (profile_entries, profile_prompts, profile_aspects, biographical_outline)
10. Onward: prompt library (Dignity Therapy / MCP / FGFT / narrative med / Pennebaker), cadence engine, `archivist` + `orchestrator` agents, encrypted export, consent + review screens, psychology-agent coupling.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes (no new warnings)
- [ ] Open the app with an existing v15 IndexedDB; confirm Dexie upgrades to v16 without data loss
- [ ] Confirm new indexes present via devtools (`db.timeline_media`, `db.life_events`, `db.family_notes`)
- [ ] Add a `timeline_media` row with `owner_type='life_event'` and confirm round-trip retrieval

https://claude.ai/code/session_01417eUCrPt89yD2Sr7ube7D

---
_Generated by [Claude Code](https://claude.ai/code/session_01417eUCrPt89yD2Sr7ube7D)_