### PR TITLE
Mobile chrome — fix navbar elongation on scroll and iOS input zoom

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,10 +52,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" data-theme="light" style={{ colorScheme: "light" }}>
       <body>
         <Providers>
-          <div className="flex min-h-[100dvh] bg-paper pwa-safe-top">
+          <div className="flex min-h-[100dvh] bg-paper md:pt-[env(safe-area-inset-top)]">
             <DesktopSidebar />
             <div className="flex min-w-0 flex-1 flex-col">
-              <header className="sticky top-0 z-20 flex h-14 items-center justify-between gap-3 border-b border-ink-100/60 bg-paper-2/70 px-4 backdrop-blur-md md:hidden md:px-6">
+              {/* Mobile header bakes the safe-area inset into its own height
+               * (rather than letting the outer wrapper pad above it) so the
+               * navbar's background always covers the status-bar zone. With
+               * the older outer-padding setup the sticky header would
+               * visually grow on scroll once the wrapper's padding scrolled
+               * away and the translucent status bar exposed the page
+               * underneath. */}
+              <header
+                className="sticky top-0 z-20 flex items-center justify-between gap-3 border-b border-ink-100/60 bg-paper-2/70 px-4 pt-[env(safe-area-inset-top)] backdrop-blur-md md:hidden md:px-6"
+                style={{ height: "calc(3.5rem + env(safe-area-inset-top))" }}
+              >
                 <div className="serif text-[17px] tracking-tight text-ink-900">
                   Anchor
                 </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -97,6 +97,19 @@ body {
   }
 }
 
+/* iOS Safari auto-zooms the layout viewport whenever a focused input has
+ * a computed font-size below 16px, which breaks the standalone /
+ * full-screen feel in both the PWA and the Capacitor WebView. Lock form
+ * fields to 16px on touch devices so the page stops shifting on focus.
+ * Desktop keeps the smaller 14px scale set by component classes. */
+@media (hover: none) and (pointer: coarse) {
+  input,
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+}
+
 /* ─── Utilities used directly in components ──────────────────────── */
 .serif {
   font-family: var(--serif);


### PR DESCRIPTION
## Summary

Two mobile chrome bugs that broke the standalone / full-screen feel:

- **Navbar elongated on scroll.** The mobile sticky header sat below an outer wrapper that carried `padding-top: env(safe-area-inset-top)`. Once the body scrolled past that padding, the translucent status-bar zone exposed the page underneath the header, making the navbar appear to grow by the status-bar height on scroll. The header now bakes the safe-area inset into its own height + padding, so its background always covers the status-bar zone — before and after sticking. Desktop keeps the inset on the outer wrapper behind an `md:` breakpoint so the iPad sidebar still clears the status bar.
- **Page zoomed on input focus in the web app.** Form fields used Tailwind `text-sm` (14px), which trips iOS Safari's auto-zoom-on-focus regardless of `user-scalable`. Added a `(hover: none) and (pointer: coarse)` rule in `globals.css` that locks `input` / `textarea` / `select` to 16px on touch devices. Desktop keeps the 14px scale set by the component classes.

## Test plan

- [ ] iPhone Safari (browser): scroll the dashboard — navbar height stays constant under the status bar
- [ ] iPhone Safari (PWA, added to home screen): tap any text input — page does not zoom in
- [ ] Capacitor iOS shell: same two checks as above
- [ ] iPad / desktop: sidebar layout unchanged, inputs still render at 14px

https://claude.ai/code/session_01P2DCtQQ9up7ok97kV8d9Wi

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2DCtQQ9up7ok97kV8d9Wi)_