### PR TITLE
Nutrition timeline + photo upload, fix family/invite confusion

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -87,7 +87,8 @@
     "signupCta": "Create account",
     "pleaseWait": "Please wait…",
     "toggleToSignup": "No account? Create one",
-    "toggleToSignin": "Already have an account? Sign in"
+    "toggleToSignin": "Already have an account? Sign in",
+    "inviteHint": "Joining a family member's care plan? Open the invite link they sent you on this device — it works after you sign in."
   },
   "emergencyCard": {
     "alertActive": "Alert active — call if needed",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -87,7 +87,8 @@
     "signupCta": "创建账户",
     "pleaseWait": "请稍候…",
     "toggleToSignup": "还没有账户？创建一个",
-    "toggleToSignin": "已有账户？登录"
+    "toggleToSignin": "已有账户？登录",
+    "inviteHint": "要加入家人的护理计划？请在这台设备上打开对方发给您的邀请链接 — 登录后即可生效。"
   },
   "emergencyCard": {
     "alertActive": "警示激活 —— 如有需要请立即拨打",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -138,6 +138,10 @@ function LoginForm() {
             ? t("login.toggleToSignup")
             : t("login.toggleToSignin")}
         </button>
+
+        <p className="border-t border-ink-100/60 pt-4 text-center text-xs text-ink-500">
+          {t("login.inviteHint")}
+        </p>
       </form>
     </div>
   );

--- a/src/app/nutrition/foods/page.tsx
+++ b/src/app/nutrition/foods/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { ArrowLeft, Filter, Plus, Search, Trash2 } from "lucide-react";
+import { ArrowLeft, Camera, Filter, Plus, Search, Trash2, X } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { FoodThumb } from "~/components/nutrition/food-thumb";
+import { prepareImageForVision } from "~/lib/ingest/image";
 import { db } from "~/lib/db/dexie";
 import { deleteFood, upsertFood } from "~/lib/nutrition/queries";
 import { foodHint, recalcNetCarbs } from "~/lib/nutrition/calculator";
@@ -157,9 +159,7 @@ export default function FoodsPage() {
             <li key={f.id}>
               <Card className="px-4 py-3">
                 <div className="flex items-start gap-3">
-                  <span className="text-2xl leading-none" aria-hidden>
-                    {f.emoji ?? "🍽"}
-                  </span>
+                  <FoodThumb food={f} />
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-baseline gap-x-2">
                       <span className="text-sm font-medium text-ink-900">
@@ -326,6 +326,10 @@ function FoodEditor({
         </div>
 
         <div className="mt-4 space-y-3">
+          <PhotoField
+            value={draft.image_url}
+            onChange={(v) => set("image_url", v)}
+          />
           <Field label={locale === "zh" ? "名称 (英文)" : "Name (English)"}>
             <TextInput
               value={draft.name ?? ""}
@@ -518,5 +522,84 @@ function Toggle({
     >
       {label}
     </button>
+  );
+}
+
+// Photo upload for a food row. Stored as a resized data URL so it
+// roundtrips through Dexie / Supabase without a separate blob store.
+// The resize caps the long edge at 480 px, which is sufficient for
+// thumbnails in the picker without bloating IndexedDB.
+function PhotoField({
+  value,
+  onChange,
+}: {
+  value?: string;
+  onChange: (v: string | undefined) => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function handleFile(file: File) {
+    setBusy(true);
+    try {
+      const prepared = await prepareImageForVision(file, {
+        maxEdge: 480,
+        quality: 0.78,
+      });
+      onChange(`data:${prepared.mediaType};base64,${prepared.base64}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      {value ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={value}
+          alt=""
+          className="h-16 w-16 shrink-0 rounded-md object-cover"
+        />
+      ) : (
+        <span className="inline-flex h-16 w-16 shrink-0 items-center justify-center rounded-md border border-dashed border-ink-200 bg-paper-2/40 text-ink-400">
+          <Camera className="h-5 w-5" />
+        </span>
+      )}
+      <div className="flex flex-col gap-1.5">
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          disabled={busy}
+          onClick={() => ref.current?.click()}
+        >
+          <Camera className="h-3.5 w-3.5" />
+          {value ? "Replace photo" : "Add photo"}
+        </Button>
+        {value && (
+          <button
+            type="button"
+            onClick={() => onChange(undefined)}
+            className="inline-flex items-center gap-1 text-[11px] text-ink-400 hover:text-[var(--warn,#d97706)]"
+          >
+            <X className="h-3 w-3" />
+            Remove
+          </button>
+        )}
+      </div>
+      <input
+        ref={ref}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        hidden
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) void handleFile(f);
+          e.target.value = "";
+        }}
+      />
+    </div>
   );
 }

--- a/src/app/nutrition/page.tsx
+++ b/src/app/nutrition/page.tsx
@@ -8,6 +8,7 @@ import { PageHeader } from "~/components/ui/page-header";
 import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { DailyTotals } from "~/components/nutrition/daily-totals";
+import { MealTimeline } from "~/components/nutrition/meal-timeline";
 import { MealList } from "~/components/nutrition/meal-list";
 import { WeeklySummary } from "~/components/nutrition/weekly-summary";
 
@@ -41,6 +42,8 @@ export default function NutritionPage() {
       />
 
       <DailyTotals date={date} />
+
+      <MealTimeline date={date} />
 
       <section className="space-y-2">
         <h2 className="eyebrow px-1">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { PillarTiles } from "~/components/dashboard/pillar-tiles";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
 import { PendingInvitesCard } from "~/components/dashboard/pending-invites-card";
+import { InviteFamilyCard } from "~/components/dashboard/invite-family-card";
 import { NextClinicCard } from "~/components/dashboard/next-clinic-card";
 import { ScheduleCard } from "~/components/dashboard/schedule-card";
 import { ChangeSignalsCard } from "~/components/dashboard/change-signals-card";
@@ -106,6 +107,8 @@ export default function DashboardPage() {
       <QuickCheckinCard />
 
       <PendingInvitesCard />
+
+      <InviteFamilyCard />
 
       <NextClinicCard />
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -104,6 +104,8 @@ export default function SettingsPage() {
 
       <AccountButton />
 
+      <div id="care-team" />
+
       <HouseholdSection />
 
       <NotificationsSection />

--- a/src/components/dashboard/invite-family-card.tsx
+++ b/src/components/dashboard/invite-family-card.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { Users, ChevronRight } from "lucide-react";
+import { useHousehold } from "~/hooks/use-household";
+import { isSupabaseConfigured } from "~/lib/supabase/client";
+import { Card, CardContent } from "~/components/ui/card";
+import { useLocale } from "~/hooks/use-translate";
+
+// Shows when the user is signed in but has no household yet (so no
+// caregivers / family can see their data). Surfaces a one-tap path
+// into Settings → Care team where the create-household flow lives.
+//
+// Hidden when:
+// - Supabase isn't configured (offline-only setup, no point inviting)
+// - The hook is still resolving membership (avoid CTA flash)
+// - The user already has a household (PendingInvitesCard handles that)
+export function InviteFamilyCard() {
+  const locale = useLocale();
+  const { membership, profile, loading } = useHousehold();
+
+  if (!isSupabaseConfigured()) return null;
+  if (loading) return null;
+  if (!profile) return null;     // not signed in
+  if (membership) return null;   // already in a household
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  return (
+    <Card>
+      <CardContent className="flex items-center justify-between gap-3 pt-4">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-[var(--tide-2)]/15 text-[var(--tide-2)]">
+            <Users className="h-4 w-4" />
+          </div>
+          <div>
+            <div className="text-[13px] font-semibold text-ink-900">
+              {L("Invite family to your care plan", "邀请家人加入护理计划")}
+            </div>
+            <p className="mt-0.5 text-[11.5px] text-ink-500">
+              {L(
+                "Share this dashboard with someone who helps with care.",
+                "把这个面板分享给参与护理的家人。",
+              )}
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/settings#care-team"
+          className="inline-flex items-center gap-0.5 text-[12px] text-ink-500 hover:text-ink-900"
+        >
+          {L("Set up", "开始")}
+          <ChevronRight className="h-3 w-3" />
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/nutrition/food-picker.tsx
+++ b/src/components/nutrition/food-picker.tsx
@@ -9,6 +9,7 @@ import { useLocale } from "~/hooks/use-translate";
 import type { FoodItem } from "~/types/nutrition";
 import { Button } from "~/components/ui/button";
 import { TextInput } from "~/components/ui/field";
+import { FoodThumb } from "./food-thumb";
 
 const HINT_TONE_CLS: Record<string, string> = {
   good: "bg-[var(--tide-2)]/15 text-[var(--tide-2)]",
@@ -85,9 +86,7 @@ export function FoodPicker({
                   onClick={() => setSelected(f)}
                   className="flex w-full items-center gap-3 rounded-md border border-ink-100 bg-paper-2/40 px-3 py-2.5 text-left transition-colors hover:border-ink-300"
                 >
-                  <span className="text-xl leading-none" aria-hidden>
-                    {f.emoji ?? "🍽"}
-                  </span>
+                  <FoodThumb food={f} size="md" />
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-sm font-medium text-ink-900">
                       {locale === "zh" && f.name_zh ? f.name_zh : f.name}

--- a/src/components/nutrition/food-thumb.tsx
+++ b/src/components/nutrition/food-thumb.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { FoodItem } from "~/types/nutrition";
+import { cn } from "~/lib/utils/cn";
+
+// Visual leading element for a food row. Photo first (data URL or
+// remote), emoji fallback, and an "🍽" default. Sized for both the
+// catalogue list (lg) and the picker tile (md / sm).
+export function FoodThumb({
+  food,
+  size = "lg",
+  className,
+}: {
+  food: Pick<FoodItem, "image_url" | "emoji" | "name">;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}) {
+  const dim = SIZE[size];
+  if (food.image_url) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={food.image_url}
+        alt={food.name}
+        className={cn(
+          "shrink-0 rounded-md bg-paper-2 object-cover",
+          dim.box,
+          className,
+        )}
+      />
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-md bg-paper-2",
+        dim.box,
+        dim.glyph,
+        className,
+      )}
+    >
+      {food.emoji ?? "🍽"}
+    </span>
+  );
+}
+
+const SIZE: Record<"sm" | "md" | "lg", { box: string; glyph: string }> = {
+  sm: { box: "h-7 w-7", glyph: "text-base" },
+  md: { box: "h-9 w-9", glyph: "text-lg" },
+  lg: { box: "h-12 w-12", glyph: "text-2xl" },
+};

--- a/src/components/nutrition/meal-timeline.tsx
+++ b/src/components/nutrition/meal-timeline.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { Clock, Sun, Moon, Sunrise, Sunset } from "lucide-react";
+import { listMealsForDate } from "~/lib/nutrition/queries";
+import { Card, CardContent } from "~/components/ui/card";
+import { useLocale } from "~/hooks/use-translate";
+import { cn } from "~/lib/utils/cn";
+import type { MealEntry, MealType } from "~/types/nutrition";
+
+// Visual day-clock for meal timing. Designed for "small frequent meals"
+// patterns common in PDAC patients (5–6/day): a horizontal 24h ribbon
+// with one dot per logged meal. Tap a dot to see what was eaten.
+//
+// Why this matters clinically: gemcitabine + nab-paclitaxel patients
+// who graze tend to maintain weight + protein better than 3-meal
+// patients (less appetite-fatigue, less single-meal fat load on the
+// pancreas). Surfacing the actual interval pattern helps the patient
+// and dietitian spot long gaps that erode total intake.
+export function MealTimeline({ date }: { date: string }) {
+  const locale = useLocale();
+  const mealsRaw = useLiveQuery(
+    async () => listMealsForDate(date),
+    [date],
+  );
+  const meals = useMemo(() => mealsRaw ?? [], [mealsRaw]);
+
+  const stats = useMemo(() => buildStats(meals), [meals]);
+
+  if (meals.length === 0) return null;
+
+  return (
+    <Card>
+      <CardContent className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <h2 className="eyebrow flex items-center gap-1.5">
+            <Clock className="h-3.5 w-3.5 text-[var(--tide-2)]" />
+            {locale === "zh" ? "进餐时间线" : "Meal timing"}
+          </h2>
+          <span className="mono text-[10px] text-ink-400">
+            {meals.length}{" "}
+            {locale === "zh"
+              ? `餐 · 间隔 ${formatGap(stats.avgGapMin, locale)}`
+              : `meals · avg gap ${formatGap(stats.avgGapMin, locale)}`}
+          </span>
+        </div>
+
+        <DayClock meals={meals} locale={locale} />
+
+        <ul className="space-y-1.5">
+          {meals.map((m, i) => (
+            <li key={m.id}>
+              <TimelineRow
+                meal={m}
+                prev={i > 0 ? meals[i - 1] : null}
+                locale={locale}
+              />
+            </li>
+          ))}
+        </ul>
+
+        {stats.longestGapMin >= 240 && (
+          <p className="rounded-md bg-paper-2/60 px-3 py-2 text-[11px] text-ink-500">
+            {locale === "zh"
+              ? `今天最长间隔约 ${formatGap(stats.longestGapMin, locale)}。少量多餐能让蛋白和热量摄入更稳。`
+              : `Longest gap today: ${formatGap(stats.longestGapMin, locale)}. Smaller, more frequent meals keep intake steadier.`}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DayClock({
+  meals,
+  locale,
+}: {
+  meals: ReadonlyArray<MealEntry>;
+  locale: string;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="relative h-9">
+        {/* Day-shading background. Soft gradient marks daylight hours. */}
+        <div className="absolute inset-0 overflow-hidden rounded-full bg-gradient-to-r from-ink-100 via-paper-2 via-50% to-ink-100" />
+        {/* Hour ticks */}
+        {[0, 6, 12, 18, 24].map((h) => (
+          <span
+            key={h}
+            className="absolute top-1/2 h-1.5 w-px -translate-y-1/2 bg-ink-300"
+            style={{ left: `${(h / 24) * 100}%` }}
+          />
+        ))}
+        {meals.map((m) => {
+          const t = parseLocalDate(m.logged_at);
+          const pct = ((t.getHours() * 60 + t.getMinutes()) / (24 * 60)) * 100;
+          const tone = mealTone(m);
+          return (
+            <span
+              key={m.id}
+              className={cn(
+                "absolute top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-paper",
+                tone,
+              )}
+              style={{ left: `${pct}%` }}
+              title={`${formatTime(t)} · ${m.total_calories} kcal`}
+            />
+          );
+        })}
+      </div>
+      <div className="mono flex justify-between text-[9px] uppercase tracking-wider text-ink-400">
+        <span>00</span>
+        <span className="inline-flex items-center gap-1">
+          <Sunrise className="h-3 w-3" /> 06
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <Sun className="h-3 w-3" /> 12
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <Sunset className="h-3 w-3" /> 18
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <Moon className="h-3 w-3" /> 24
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function TimelineRow({
+  meal,
+  prev,
+  locale,
+}: {
+  meal: MealEntry;
+  prev: MealEntry | null;
+  locale: string;
+}) {
+  const time = formatTime(parseLocalDate(meal.logged_at));
+  const gapMin = prev
+    ? Math.round(
+        (parseLocalDate(meal.logged_at).getTime() -
+          parseLocalDate(prev.logged_at).getTime()) /
+          60000,
+      )
+    : null;
+  return (
+    <div className="flex items-start gap-3 rounded-md bg-paper-2/40 px-3 py-2">
+      <span className="mono w-12 shrink-0 text-[11px] text-ink-500">{time}</span>
+      <span
+        className={cn("mt-1 h-2 w-2 shrink-0 rounded-full", mealTone(meal))}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="text-[12px] text-ink-900">
+          {mealLabel(meal.meal_type, locale)}
+          <span className="ml-1.5 text-ink-500">
+            · {meal.total_calories} kcal · {meal.total_protein_g}g P
+          </span>
+        </div>
+        {meal.notes && (
+          <div className="truncate text-[11px] text-ink-500">{meal.notes}</div>
+        )}
+      </div>
+      {gapMin !== null && (
+        <span className="mono shrink-0 text-[10px] text-ink-400">
+          +{formatGap(gapMin, locale)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function mealTone(meal: MealEntry): string {
+  // Yellow when fatty meal logged without PERT — visually mirrors the
+  // PERT prompt the patient would see in the meal list.
+  if (meal.total_fat_g >= 15 && !meal.pert_taken) {
+    return "bg-[var(--warn,#d97706)]";
+  }
+  if (meal.meal_type === "snack") return "bg-ink-400";
+  return "bg-[var(--tide-2)]";
+}
+
+interface Stats {
+  avgGapMin: number;
+  longestGapMin: number;
+}
+
+function buildStats(meals: ReadonlyArray<MealEntry>): Stats {
+  if (meals.length < 2) return { avgGapMin: 0, longestGapMin: 0 };
+  const sorted = [...meals].sort((a, b) =>
+    a.logged_at.localeCompare(b.logged_at),
+  );
+  let total = 0;
+  let longest = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    const gap =
+      (parseLocalDate(sorted[i].logged_at).getTime() -
+        parseLocalDate(sorted[i - 1].logged_at).getTime()) /
+      60000;
+    total += gap;
+    if (gap > longest) longest = gap;
+  }
+  return {
+    avgGapMin: Math.round(total / (sorted.length - 1)),
+    longestGapMin: Math.round(longest),
+  };
+}
+
+function parseLocalDate(iso: string): Date {
+  return new Date(iso);
+}
+
+function formatTime(d: Date): string {
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+function formatGap(min: number, locale: string): string {
+  if (min < 60) return locale === "zh" ? `${min} 分钟` : `${min}m`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  if (m === 0) return locale === "zh" ? `${h} 小时` : `${h}h`;
+  return locale === "zh" ? `${h}h${m}m` : `${h}h ${m}m`;
+}
+
+function mealLabel(m: MealType, locale: string): string {
+  if (locale !== "zh") {
+    return { breakfast: "Breakfast", lunch: "Lunch", dinner: "Dinner", snack: "Snack" }[m];
+  }
+  return { breakfast: "早餐", lunch: "午餐", dinner: "晚餐", snack: "加餐" }[m];
+}

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -25,11 +25,13 @@ import { useT, useLocale } from "~/hooks/use-translate";
 import { useAppPerspective } from "~/lib/caregiver/scope";
 
 // Patient nav: everything. Patient owns self-reporting, treatment,
-// assessment, bridge strategy, reports.
+// assessment, bridge strategy, reports. The "/family" surface is the
+// caregiver-perspective landing page — patients land on "/" instead and
+// reach household / invites through Settings → Care team, so it's
+// excluded here to avoid a confusing duplicate view.
 const PATIENT_ITEMS = [
   { href: "/", key: "nav.dashboard", icon: LayoutDashboard },
   { href: "/schedule", key: "nav.schedule", icon: CalendarDays },
-  { href: "/family", key: "nav.family", icon: Users },
   { href: "/assessment", key: "nav.assessment", icon: Compass },
   { href: "/treatment", key: "nav.treatment", icon: Syringe },
   { href: "/labs", key: "nav.labs", icon: FlaskConical },


### PR DESCRIPTION
## Summary

Follow-up to PR #93 addressing review feedback on the nutrition module and adjacent family / invite UX.

### Nutrition

- **Meal timeline** (`src/components/nutrition/meal-timeline.tsx`) — horizontal 24-hour day-clock with one dot per logged meal, plus a chronological list with inter-meal gaps. Designed for the patient's "small frequent meals" pattern (5–6/day) — surfaces both the rhythm and any concerning long gaps. Yellow dots flag fatty meals logged without PERT.
- **Photo upload for food catalogue** — new `PhotoField` in the food editor stores a resized (480 px, JPEG q=0.78) data URL on the food row. A new `FoodThumb` component renders photo-first with the existing emoji and 🍽 fallback, used in both the picker tile and the catalogue list.

### Family / invite

- **Remove `/family` from patient nav** — `/family` is the caregiver-perspective landing surface; having it duplicated in the patient sidebar was confusing. Patients now reach household and invite management via Settings → Care team only. (Caregivers still get `/family` as their primary view.)
- **Dashboard `InviteFamilyCard`** — renders only when the user is signed in but has no household yet (so no caregivers can see their data). One-tap to `/settings#care-team`.
- **Settings `#care-team` anchor** — so the dashboard card scrolls straight to the right section.
- **Login page invite hint** (EN + ZH) — "Joining a family member's care plan? Open the invite link they sent you on this device — it works after you sign in."

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — passes (0 errors)
- [x] `pnpm test` — 561 / 561
- [ ] Manual: log 5–6 meals across a day on `/nutrition` and verify the timeline dots, intervals, and the "longest gap" hint render correctly.
- [ ] Manual: open a food in `/nutrition/foods`, add a photo, save, then verify the thumb appears in the picker and catalogue list.
- [ ] Manual: sign in with a fresh account on a device with no household — confirm `InviteFamilyCard` appears on the dashboard and the link scrolls to Care team in Settings.
- [ ] Manual: confirm `/family` is no longer in the patient sidebar but is still in the caregiver sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpWRFSFnksEbpJ5c8fnJSW)_