### PR TITLE
Mobile chrome — let document body scroll so iOS URL bar collapses

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,9 +52,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" data-theme="light" style={{ colorScheme: "light" }}>
       <body>
         <Providers>
-          <div className="flex min-h-[100dvh] bg-paper md:pt-[env(safe-area-inset-top)]">
+          <div className="flex min-h-[100dvh] bg-paper md:h-[100dvh] md:pt-[env(safe-area-inset-top)]">
             <DesktopSidebar />
-            <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex min-w-0 flex-1 flex-col md:h-full">
               {/* Mobile header height is fixed at 3.5rem in normal browser
                * mode and grows by the safe-area inset only when the page is
                * launched as a PWA / Capacitor standalone app — see
@@ -72,7 +72,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 </div>
                 <MobileMoreMenu />
               </header>
-              <main className="flex-1 overflow-y-auto pb-[calc(7rem+env(safe-area-inset-bottom))] md:pb-6">
+              {/* Use document-body scroll on mobile so iOS Safari's URL bar
+               * collapses naturally on scroll. An earlier setup put
+               * `overflow-y-auto` here, which made <main> the scroll context
+               * — Safari only collapses the URL bar in response to body
+               * scroll, so users got stuck with ~50px of permanent URL-bar
+               * chrome on every page. On desktop we keep the internal scroll
+               * (md:overflow-y-auto + md:h-[100dvh] on the column) so the
+               * sidebar stays put while the main pane scrolls. */}
+              <main className="flex-1 pb-[calc(7rem+env(safe-area-inset-bottom))] md:pb-6 md:overflow-y-auto">
                 {children}
               </main>
             </div>


### PR DESCRIPTION
## Problem

User screenshot showed mobile Safari on `/schedule` after scrolling, with the iOS status bar + Safari URL bar (`thomashu.com`) + our Anchor header all stacked at the top — eating ~155 px of permanent vertical chrome on every page. The URL bar never collapsed, even after scrolling, leaving the navbar zone feeling "extra tall".

## Root cause

The layout had `overflow-y-auto` on `<main>`, making `<main>` the scroll context for the page content.

iOS Safari **only collapses its URL bar in response to document-body scroll** — scrolling inside an internal element with its own overflow does not trigger URL-bar collapse. So users were permanently stuck with the URL bar visible, on top of our header, on top of the iOS status bar.

## Fix

Move scrolling back to the document body on mobile, while keeping the internal scroll on desktop (md+ breakpoint) so the sidebar stays put while the right pane scrolls. Concretely:

- `<main>`: `flex-1 ... md:overflow-y-auto` — body scrolls on mobile, internal scroll on desktop.
- Outer flex wrapper: `min-h-[100dvh] md:h-[100dvh]` — at-least viewport on mobile (so content can extend), exactly viewport on desktop (so internal scroll works).
- Column wrapper: `md:h-full` — full column height on desktop only.

The mobile sticky header still sticks to `top: 0` via `position: sticky` (the rule works in either scroll context). Once the URL bar collapses on first scroll, it's gone — the user gets back ~50 px of vertical space.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 561 / 561
- [x] `pnpm build` clean
- [ ] **Manual on iPhone Safari**: open `/schedule`, scroll down — URL bar should collapse, our Anchor header stays sticky, and the chrome budget shrinks visibly.
- [ ] **Manual desktop**: sidebar stays fixed while the right pane scrolls.
- [ ] **Manual standalone PWA / Capacitor iOS**: header height behavior unchanged (status-bar-inset + 44 pt nav row from PR #95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpWRFSFnksEbpJ5c8fnJSW)_