### PR TITLE
Nutrition: hydration, templates, symptom-aware picker, voice input

### DIFF
--- a/src/app/nutrition/log/page.tsx
+++ b/src/app/nutrition/log/page.tsx
@@ -15,6 +15,7 @@ import {
   type PreviewItem,
 } from "~/components/nutrition/parsed-preview";
 import { FoodPicker } from "~/components/nutrition/food-picker";
+import { TemplatesPicker } from "~/components/nutrition/templates-picker";
 import { createMeal } from "~/lib/nutrition/queries";
 import { sumItems } from "~/lib/nutrition/calculator";
 import type {
@@ -166,6 +167,11 @@ export default function LogMealPage() {
         />
       ) : (
         <>
+          <TemplatesPicker
+            date={todayISO()}
+            onLogged={() => router.push("/nutrition")}
+          />
+
           <MealIngest
             onParsed={(result, src, photo) => {
               setParsed(result);

--- a/src/app/nutrition/page.tsx
+++ b/src/app/nutrition/page.tsx
@@ -8,6 +8,7 @@ import { PageHeader } from "~/components/ui/page-header";
 import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { DailyTotals } from "~/components/nutrition/daily-totals";
+import { HydrationCard } from "~/components/nutrition/hydration-card";
 import { MealTimeline } from "~/components/nutrition/meal-timeline";
 import { MealList } from "~/components/nutrition/meal-list";
 import { WeeklySummary } from "~/components/nutrition/weekly-summary";
@@ -42,6 +43,8 @@ export default function NutritionPage() {
       />
 
       <DailyTotals date={date} />
+
+      <HydrationCard date={date} />
 
       <MealTimeline date={date} />
 

--- a/src/components/nutrition/food-picker.tsx
+++ b/src/components/nutrition/food-picker.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Search, Plus, X } from "lucide-react";
+import { Search, Plus, X, Sparkles } from "lucide-react";
 import { searchFoods } from "~/lib/nutrition/queries";
 import { foodHint, scaleByGrams } from "~/lib/nutrition/calculator";
+import {
+  loadSymptomContext,
+  SYMPTOM_LABEL,
+  type NutritionSymptomContext,
+} from "~/lib/nutrition/symptom-context";
 import { cn } from "~/lib/utils/cn";
 import { useLocale } from "~/hooks/use-translate";
 import type { FoodItem } from "~/types/nutrition";
@@ -42,16 +47,40 @@ export function FoodPicker({
   const [results, setResults] = useState<FoodItem[]>([]);
   const [selected, setSelected] = useState<FoodItem | null>(null);
   const [grams, setGrams] = useState(100);
+  const [symptomCtx, setSymptomCtx] =
+    useState<NutritionSymptomContext | null>(null);
+  const [symptomFilterEnabled, setSymptomFilterEnabled] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
-    searchFoods(query, { limit: 30, ketoOnly, easyDigestOnly }).then((rows) => {
+    void loadSymptomContext().then((ctx) => {
+      if (!cancelled) setSymptomCtx(ctx);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Bias picker to easy-digest foods when today's symptoms suggest the
+  // patient is fragile (nausea, mucositis, diarrhea, low appetite).
+  // Manual `easyDigestOnly` prop still wins; this is the soft default.
+  const effectiveEasyDigest =
+    easyDigestOnly ||
+    (symptomFilterEnabled && symptomCtx?.recommendEasyDigest === true);
+
+  useEffect(() => {
+    let cancelled = false;
+    searchFoods(query, {
+      limit: 30,
+      ketoOnly,
+      easyDigestOnly: effectiveEasyDigest,
+    }).then((rows) => {
       if (!cancelled) setResults(rows);
     });
     return () => {
       cancelled = true;
     };
-  }, [query, ketoOnly, easyDigestOnly]);
+  }, [query, ketoOnly, effectiveEasyDigest]);
 
   useEffect(() => {
     if (selected?.default_serving_g) setGrams(selected.default_serving_g);
@@ -64,6 +93,36 @@ export function FoodPicker({
 
   return (
     <div className={cn("space-y-3", className)}>
+      {symptomCtx?.recommendEasyDigest && !easyDigestOnly && (
+        <div className="flex items-start gap-2 rounded-md bg-[var(--sand)]/30 px-3 py-2 text-[11px] text-ink-700">
+          <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--tide-2)]" />
+          <div className="flex-1">
+            <div>
+              {locale === "zh"
+                ? `今天有 ${symptomCtx.flags
+                    .map((f) => SYMPTOM_LABEL[f].zh)
+                    .join("、")} — 优先显示易消化的食物。`
+                : `Today: ${symptomCtx.flags
+                    .map((f) => SYMPTOM_LABEL[f].en)
+                    .join(", ")} — showing easy-digest first.`}
+            </div>
+            <button
+              type="button"
+              onClick={() => setSymptomFilterEnabled((v) => !v)}
+              className="mt-0.5 text-[10px] text-ink-500 underline-offset-2 hover:text-ink-900 hover:underline"
+            >
+              {symptomFilterEnabled
+                ? locale === "zh"
+                  ? "显示全部"
+                  : "Show all"
+                : locale === "zh"
+                ? "重新启用筛选"
+                : "Re-enable filter"}
+            </button>
+          </div>
+        </div>
+      )}
+
       <div className="relative">
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-400" />
         <TextInput

--- a/src/components/nutrition/hydration-card.tsx
+++ b/src/components/nutrition/hydration-card.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { Droplets, Plus, X } from "lucide-react";
+import {
+  DEFAULT_FLUID_TARGET_ML,
+  FLUID_KIND_LABEL,
+  FLUID_QUICK_ADD,
+  deleteFluid,
+  listFluidsForDate,
+  logFluid,
+  sumFluids,
+} from "~/lib/nutrition/hydration";
+import { Card, CardContent } from "~/components/ui/card";
+import { TargetBar } from "./macro-bar";
+import { useLocale } from "~/hooks/use-translate";
+import { cn } from "~/lib/utils/cn";
+import type { FluidKind } from "~/types/nutrition";
+
+// Daily hydration card. Sits on the nutrition page next to DailyTotals.
+// One row of one-tap quick-adds, the daily total versus a soft 2L
+// target, and a collapsible list of today's swallow events.
+export function HydrationCard({ date }: { date: string }) {
+  const locale = useLocale();
+  const fluidsRaw = useLiveQuery(
+    async () => listFluidsForDate(date),
+    [date],
+  );
+  const fluids = useMemo(() => fluidsRaw ?? [], [fluidsRaw]);
+  const totals = useMemo(() => sumFluids(fluids), [fluids]);
+  const [open, setOpen] = useState(false);
+  const [customMl, setCustomMl] = useState(250);
+  const [customKind, setCustomKind] = useState<FluidKind>("water");
+
+  const pct = (totals.total_ml / DEFAULT_FLUID_TARGET_ML) * 100;
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  return (
+    <Card>
+      <CardContent className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <h2 className="eyebrow flex items-center gap-1.5">
+            <Droplets className="h-3.5 w-3.5 text-[var(--tide-2)]" />
+            {L("Hydration", "饮水")}
+          </h2>
+          <div className="text-right">
+            <div className="serif text-lg leading-none text-ink-900">
+              {(totals.total_ml / 1000).toFixed(1)}
+              <span className="ml-0.5 text-xs font-normal text-ink-500">L</span>
+            </div>
+            <div className="mono mt-0.5 text-[10px] text-ink-400">
+              / {(DEFAULT_FLUID_TARGET_ML / 1000).toFixed(1)} L
+            </div>
+          </div>
+        </div>
+
+        <TargetBar value={pct} target={100} />
+
+        <div className="flex flex-wrap gap-1.5">
+          {FLUID_QUICK_ADD.map((preset, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() =>
+                logFluid({
+                  date,
+                  kind: preset.kind,
+                  volume_ml: preset.volume_ml,
+                  entered_by: "hulin",
+                })
+              }
+              className="inline-flex items-center gap-1.5 rounded-full border border-ink-200 bg-paper px-2.5 py-1 text-[11px] text-ink-700 hover:border-ink-300 hover:bg-paper-2/60"
+            >
+              <span>{FLUID_KIND_LABEL[preset.kind].emoji}</span>
+              <span>{locale === "zh" ? preset.label_zh : preset.label_en}</span>
+              <span className="mono text-[10px] text-ink-400">
+                +{preset.volume_ml} ml
+              </span>
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="inline-flex items-center gap-1 rounded-full border border-ink-200 bg-paper px-2.5 py-1 text-[11px] text-ink-700 hover:border-ink-300"
+          >
+            <Plus className="h-3 w-3" />
+            {L("Custom", "自定义")}
+          </button>
+        </div>
+
+        {open && (
+          <div className="flex items-center gap-2 rounded-md bg-paper-2/60 p-2">
+            <select
+              value={customKind}
+              onChange={(e) => setCustomKind(e.target.value as FluidKind)}
+              className="h-9 rounded-md border border-ink-200 bg-paper px-2 text-xs text-ink-900"
+            >
+              {(Object.keys(FLUID_KIND_LABEL) as FluidKind[]).map((k) => (
+                <option key={k} value={k}>
+                  {FLUID_KIND_LABEL[k].emoji}{" "}
+                  {locale === "zh"
+                    ? FLUID_KIND_LABEL[k].zh
+                    : FLUID_KIND_LABEL[k].en}
+                </option>
+              ))}
+            </select>
+            <input
+              type="number"
+              value={customMl}
+              min={10}
+              step={10}
+              onChange={(e) =>
+                setCustomMl(Math.max(0, Number(e.target.value) || 0))
+              }
+              className="h-9 w-20 rounded-md border border-ink-200 bg-paper px-2 text-xs text-ink-900"
+            />
+            <span className="text-[11px] text-ink-500">ml</span>
+            <button
+              type="button"
+              onClick={() => {
+                if (customMl <= 0) return;
+                void logFluid({
+                  date,
+                  kind: customKind,
+                  volume_ml: customMl,
+                  entered_by: "hulin",
+                });
+                setOpen(false);
+              }}
+              className="ml-auto rounded-md bg-ink-900 px-3 py-1.5 text-[11px] text-paper hover:bg-ink-700"
+            >
+              {L("Log", "记录")}
+            </button>
+          </div>
+        )}
+
+        {fluids.length > 0 && (
+          <details className="group rounded-md bg-paper-2/40 px-3 py-2">
+            <summary className="cursor-pointer list-none text-[11px] text-ink-500">
+              {L(
+                `${fluids.length} entries today — show details`,
+                `今日 ${fluids.length} 条记录 — 查看`,
+              )}
+            </summary>
+            <ul className="mt-2 space-y-1">
+              {fluids.map((f) => (
+                <li
+                  key={f.id}
+                  className="flex items-baseline justify-between gap-2 text-[11px] text-ink-600"
+                >
+                  <span className="flex items-center gap-1.5">
+                    <span>{FLUID_KIND_LABEL[f.kind].emoji}</span>
+                    <span>
+                      {locale === "zh"
+                        ? FLUID_KIND_LABEL[f.kind].zh
+                        : FLUID_KIND_LABEL[f.kind].en}
+                    </span>
+                    <span className="mono text-ink-400">
+                      {new Date(f.logged_at).toLocaleTimeString(undefined, {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="mono text-ink-700">{f.volume_ml} ml</span>
+                    <button
+                      type="button"
+                      onClick={() => deleteFluid(f.id!)}
+                      className={cn(
+                        "rounded p-0.5 text-ink-400",
+                        "hover:bg-ink-100 hover:text-[var(--warn,#d97706)]",
+                      )}
+                      aria-label="Delete"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/nutrition/meal-ingest.tsx
+++ b/src/components/nutrition/meal-ingest.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Camera, Loader2, Sparkles, Type, Mic } from "lucide-react";
+import { Camera, Loader2, Sparkles, Type, Mic, MicOff } from "lucide-react";
 import { prepareImageForVision } from "~/lib/ingest/image";
+import { useSpeechRecognition } from "~/hooks/use-speech-recognition";
 import {
   parseMealPhoto,
   parseMealText,
@@ -26,6 +27,13 @@ export function MealIngest({
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Voice dictation streams interim words into the textarea so the
+  // patient can see what was heard before tapping Parse. Mandarin
+  // routes through `zh-CN`; everything else uses en-US.
+  const speech = useSpeechRecognition({
+    lang: locale === "zh" ? "zh-CN" : "en-US",
+    onFinal: (chunk) => setText((cur) => `${cur} ${chunk}`.trim()),
+  });
   const fileRef = useRef<HTMLInputElement>(null);
 
   async function handleFile(file: File) {
@@ -129,7 +137,30 @@ export function MealIngest({
               }
               disabled={busy}
             />
-            <div className="flex justify-end">
+            <div className="flex items-center justify-between gap-2">
+              {speech ? (
+                <Button
+                  type="button"
+                  variant={speech.listening ? "danger" : "secondary"}
+                  size="sm"
+                  onClick={speech.toggle}
+                  disabled={busy}
+                >
+                  {speech.listening ? (
+                    <>
+                      <MicOff className="h-3.5 w-3.5" />
+                      {locale === "zh" ? "停止" : "Stop"}
+                    </>
+                  ) : (
+                    <>
+                      <Mic className="h-3.5 w-3.5" />
+                      {locale === "zh" ? "说话" : "Speak"}
+                    </>
+                  )}
+                </Button>
+              ) : (
+                <span />
+              )}
               <Button onClick={handleText} disabled={busy || !text.trim()}>
                 {busy ? (
                   <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/components/nutrition/meal-list.tsx
+++ b/src/components/nutrition/meal-list.tsx
@@ -2,12 +2,14 @@
 
 import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { Trash2, ChevronDown } from "lucide-react";
+import { Trash2, ChevronDown, BookmarkPlus, Repeat } from "lucide-react";
 import {
   listMealsForDate,
   listItemsForMeal,
   deleteMeal,
 } from "~/lib/nutrition/queries";
+import { relogMeal, saveMealAsTemplate } from "~/lib/nutrition/templates";
+import { todayISO } from "~/lib/utils/date";
 import { Card } from "~/components/ui/card";
 import { cn } from "~/lib/utils/cn";
 import { useLocale } from "~/hooks/use-translate";
@@ -140,7 +142,42 @@ function MealCard({ mealId }: { mealId: number }) {
               </li>
             ))}
           </ul>
-          <div className="flex justify-end pt-1">
+          <div className="flex flex-wrap items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={async () => {
+                await relogMeal({
+                  source_meal_id: mealId,
+                  date: todayISO(),
+                  entered_by: "hulin",
+                });
+              }}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-ink-500 hover:bg-ink-100 hover:text-ink-900"
+            >
+              <Repeat className="h-3 w-3" />
+              {locale === "zh" ? "再来一次" : "Log again"}
+            </button>
+            <button
+              type="button"
+              onClick={async () => {
+                const name = prompt(
+                  locale === "zh"
+                    ? "给这一餐起个名字 (例如：常吃的早餐)"
+                    : "Save this meal as… (e.g. My usual breakfast)",
+                  meal.notes ?? "",
+                );
+                if (name && name.trim()) {
+                  await saveMealAsTemplate({
+                    meal_entry_id: mealId,
+                    name: name.trim(),
+                  });
+                }
+              }}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-ink-500 hover:bg-ink-100 hover:text-ink-900"
+            >
+              <BookmarkPlus className="h-3 w-3" />
+              {locale === "zh" ? "保存常吃" : "Save as template"}
+            </button>
             <button
               type="button"
               onClick={async () => {

--- a/src/components/nutrition/templates-picker.tsx
+++ b/src/components/nutrition/templates-picker.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { BookmarkPlus, Star, Trash2, Repeat } from "lucide-react";
+import {
+  deleteTemplate,
+  listTemplates,
+  logTemplate,
+} from "~/lib/nutrition/templates";
+import { useLocale } from "~/hooks/use-translate";
+import { Card } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils/cn";
+import type { MealTemplate, MealType } from "~/types/nutrition";
+
+// Saved-meals shortcut. Lets the patient one-tap re-log "my usual
+// breakfast" without going through the food picker. The component is
+// hidden when no templates exist so the new-user flow stays clean.
+export function TemplatesPicker({
+  date,
+  meal_type,
+  onLogged,
+}: {
+  date: string;
+  meal_type?: MealType;
+  onLogged: (meal_id: number) => void;
+}) {
+  const locale = useLocale();
+  const [order, setOrder] = useState<"recent" | "favourites">("recent");
+  const templates =
+    useLiveQuery(
+      async () => listTemplates({ orderBy: order, limit: 12 }),
+      [order],
+    ) ?? [];
+
+  if (templates.length === 0) return null;
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  return (
+    <Card className="space-y-3 px-4 py-3">
+      <div className="flex items-baseline justify-between">
+        <h3 className="eyebrow flex items-center gap-1.5">
+          <BookmarkPlus className="h-3.5 w-3.5 text-[var(--tide-2)]" />
+          {L("Saved meals", "常吃")}
+        </h3>
+        <div className="flex gap-1 text-[10px]">
+          <button
+            type="button"
+            onClick={() => setOrder("recent")}
+            className={cn(
+              "rounded-full px-2 py-0.5",
+              order === "recent"
+                ? "bg-ink-900 text-paper"
+                : "bg-paper text-ink-500 hover:text-ink-900",
+            )}
+          >
+            {L("Recent", "最近")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setOrder("favourites")}
+            className={cn(
+              "rounded-full px-2 py-0.5",
+              order === "favourites"
+                ? "bg-ink-900 text-paper"
+                : "bg-paper text-ink-500 hover:text-ink-900",
+            )}
+          >
+            {L("Favourites", "常用")}
+          </button>
+        </div>
+      </div>
+
+      <ul className="space-y-1.5">
+        {templates.map((t) => (
+          <li key={t.id}>
+            <TemplateRow
+              tpl={t}
+              onLog={async () => {
+                const id = await logTemplate({
+                  template_id: t.id!,
+                  date,
+                  meal_type,
+                  entered_by: "hulin",
+                });
+                onLogged(id);
+              }}
+              onDelete={() => deleteTemplate(t.id!)}
+            />
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}
+
+function TemplateRow({
+  tpl,
+  onLog,
+  onDelete,
+}: {
+  tpl: MealTemplate;
+  onLog: () => Promise<void>;
+  onDelete: () => Promise<void>;
+}) {
+  const locale = useLocale();
+  const totals = tpl.items.reduce(
+    (acc, it) => ({
+      cal: acc.cal + it.calories,
+      p: acc.p + it.protein_g,
+      nc: acc.nc + it.net_carbs_g,
+    }),
+    { cal: 0, p: 0, nc: 0 },
+  );
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-ink-100 bg-paper-2/40 px-3 py-2">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-medium text-ink-900">
+            {locale === "zh" && tpl.name_zh ? tpl.name_zh : tpl.name}
+          </span>
+          {tpl.use_count > 1 && (
+            <span className="inline-flex items-center gap-0.5 rounded-full bg-[var(--sand)]/40 px-1.5 py-0 text-[10px] text-ink-700">
+              <Star className="h-2.5 w-2.5" />
+              {tpl.use_count}×
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 text-[11px] text-ink-500">
+          {tpl.items.length} {L("items", "项")} ·{" "}
+          {Math.round(totals.cal)} kcal · {Math.round(totals.p)}g P ·{" "}
+          {Math.round(totals.nc)}g NC
+        </div>
+      </div>
+      <Button size="sm" variant="secondary" onClick={onLog}>
+        <Repeat className="h-3.5 w-3.5" />
+        {L("Log", "记一次")}
+      </Button>
+      <button
+        type="button"
+        onClick={() => {
+          if (
+            confirm(
+              L("Delete this saved meal?", "删除这个常吃记录？"),
+            )
+          ) {
+            void onDelete();
+          }
+        }}
+        className="text-ink-300 hover:text-[var(--warn,#d97706)]"
+        aria-label="Delete"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/use-speech-recognition.ts
+++ b/src/hooks/use-speech-recognition.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Thin wrapper around the browser's SpeechRecognition Web API. Returns
+// `null` when the browser doesn't support it (older Firefox, some
+// in-app webviews) so callers can hide the mic button cleanly.
+//
+// Usage:
+//   const sr = useSpeechRecognition({ lang: "en-US" });
+//   if (!sr) return null;            // unsupported
+//   <button onClick={sr.toggle}>{sr.listening ? "Stop" : "Speak"}</button>
+//   <p>{sr.transcript}</p>
+
+interface SpeechRecognitionLike {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+  onend: (() => void) | null;
+}
+
+interface SpeechRecognitionEventLike {
+  resultIndex: number;
+  results: ArrayLike<{
+    isFinal: boolean;
+    [index: number]: { transcript: string };
+    length: number;
+  }>;
+}
+
+interface SpeechRecognitionErrorEventLike {
+  error: string;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionLike;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+export interface UseSpeechRecognitionResult {
+  listening: boolean;
+  transcript: string;
+  error: string | null;
+  start: () => void;
+  stop: () => void;
+  toggle: () => void;
+  reset: () => void;
+}
+
+export function useSpeechRecognition(
+  opts: { lang?: string; onFinal?: (text: string) => void } = {},
+): UseSpeechRecognitionResult | null {
+  const { lang = "en-US", onFinal } = opts;
+  const [supported, setSupported] = useState(false);
+  const [listening, setListening] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const recRef = useRef<SpeechRecognitionLike | null>(null);
+  // Capture the latest `onFinal` so we don't have to recreate the
+  // recogniser when the parent re-renders with a new closure.
+  const onFinalRef = useRef(onFinal);
+  onFinalRef.current = onFinal;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const Ctor =
+      window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null;
+    if (!Ctor) return;
+    setSupported(true);
+    const rec = new Ctor();
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.lang = lang;
+    rec.onresult = (e) => {
+      let finalText = "";
+      let interimText = "";
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        const r = e.results[i];
+        if (r.isFinal) finalText += r[0].transcript;
+        else interimText += r[0].transcript;
+      }
+      setTranscript((cur) => {
+        const next = (cur + finalText).trim();
+        if (interimText) return `${next} ${interimText.trim()}`.trim();
+        return next;
+      });
+      if (finalText.trim() && onFinalRef.current) {
+        onFinalRef.current(finalText.trim());
+      }
+    };
+    rec.onerror = (e) => {
+      setError(e.error);
+      setListening(false);
+    };
+    rec.onend = () => setListening(false);
+    recRef.current = rec;
+    return () => {
+      rec.abort();
+      recRef.current = null;
+    };
+  }, [lang]);
+
+  const start = useCallback(() => {
+    if (!recRef.current) return;
+    setError(null);
+    setTranscript("");
+    try {
+      recRef.current.start();
+      setListening(true);
+    } catch {
+      // Already started — ignore.
+    }
+  }, []);
+
+  const stop = useCallback(() => {
+    recRef.current?.stop();
+    setListening(false);
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (listening) stop();
+    else start();
+  }, [listening, start, stop]);
+
+  const reset = useCallback(() => setTranscript(""), []);
+
+  if (!supported) return null;
+  return { listening, transcript, error, start, stop, toggle, reset };
+}

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -50,6 +50,8 @@ import type {
   FoodItem,
   MealEntry,
   MealItem,
+  FluidLog,
+  MealTemplate,
 } from "~/types/nutrition";
 
 export class AnchorDB extends Dexie {
@@ -98,6 +100,9 @@ export class AnchorDB extends Dexie {
   foods!: Table<FoodItem, number>;
   meal_entries!: Table<MealEntry, number>;
   meal_items!: Table<MealItem, number>;
+  // v19: Nutrition enhancements.
+  fluid_logs!: Table<FluidLog, number>;
+  meal_templates!: Table<MealTemplate, number>;
 
   constructor() {
     super("anchor_db");
@@ -304,6 +309,22 @@ export class AnchorDB extends Dexie {
         "[date+meal_type]",
       meal_items:
         "++id, meal_entry_id, food_id, created_at",
+    });
+    // v19: Nutrition enhancements — hydration tracking + meal templates.
+    //
+    // - fluid_logs: one row per swallow event. Indexed by `date` for
+    //   the daily total and `logged_at` for the day-clock view. The
+    //   compound `[date+kind]` lets the dashboard slice "water vs.
+    //   electrolyte vs. broth" cheaply for the 7-day trend.
+    // - meal_templates: saved-meal definitions. Items are stored as a
+    //   JSON-shaped property in the row (not a separate table) since
+    //   templates are immutable snapshots. Indexed by `last_used_at`
+    //   for the recent-templates list and `use_count` for "favourites".
+    this.version(19).stores({
+      fluid_logs:
+        "++id, date, kind, logged_at, [date+kind]",
+      meal_templates:
+        "++id, name, meal_type, last_used_at, use_count, updated_at",
     });
   }
 }

--- a/src/lib/nutrition/hydration.ts
+++ b/src/lib/nutrition/hydration.ts
@@ -1,0 +1,100 @@
+import { db, now } from "~/lib/db/dexie";
+import type { FluidKind, FluidLog } from "~/types/nutrition";
+import type { EnteredBy } from "~/types/clinical";
+
+export const FLUID_KIND_LABEL: Record<
+  FluidKind,
+  { en: string; zh: string; emoji: string }
+> = {
+  water: { en: "Water", zh: "水", emoji: "💧" },
+  tea: { en: "Tea", zh: "茶", emoji: "🍵" },
+  coffee: { en: "Coffee", zh: "咖啡", emoji: "☕" },
+  broth: { en: "Bone broth", zh: "骨头汤", emoji: "🍲" },
+  electrolyte: { en: "Electrolyte", zh: "电解质饮料", emoji: "🥤" },
+  soup: { en: "Soup", zh: "汤", emoji: "🥣" },
+  other: { en: "Other", zh: "其他", emoji: "🥛" },
+};
+
+// Default daily target — patient values doc says ~2L/day baseline,
+// more on infusion days. Not personalised yet; the dashboard surfaces
+// it as a soft target rather than a hard cap.
+export const DEFAULT_FLUID_TARGET_ML = 2000;
+
+export interface LogFluidInput {
+  date: string;
+  logged_at?: string;
+  kind: FluidKind;
+  volume_ml: number;
+  notes?: string;
+  entered_by: EnteredBy;
+  entered_by_user_id?: string;
+}
+
+export async function logFluid(input: LogFluidInput): Promise<number> {
+  const t = now();
+  return (await db.fluid_logs.add({
+    date: input.date,
+    logged_at: input.logged_at ?? t,
+    kind: input.kind,
+    volume_ml: Math.max(0, Math.round(input.volume_ml)),
+    notes: input.notes,
+    entered_by: input.entered_by,
+    entered_by_user_id: input.entered_by_user_id,
+    created_at: t,
+  })) as number;
+}
+
+export async function listFluidsForDate(date: string): Promise<FluidLog[]> {
+  const rows = await db.fluid_logs.where("date").equals(date).toArray();
+  rows.sort((a, b) => a.logged_at.localeCompare(b.logged_at));
+  return rows;
+}
+
+export async function listFluidsBetween(
+  startDate: string,
+  endDate: string,
+): Promise<FluidLog[]> {
+  return db.fluid_logs
+    .where("date")
+    .between(startDate, endDate, true, true)
+    .toArray();
+}
+
+export async function deleteFluid(id: number): Promise<void> {
+  await db.fluid_logs.delete(id);
+}
+
+export interface FluidDailyTotals {
+  total_ml: number;
+  by_kind: Partial<Record<FluidKind, number>>;
+  count: number;
+}
+
+export function sumFluids(
+  rows: ReadonlyArray<FluidLog>,
+): FluidDailyTotals {
+  const by_kind: Partial<Record<FluidKind, number>> = {};
+  let total = 0;
+  for (const r of rows) {
+    total += r.volume_ml;
+    by_kind[r.kind] = (by_kind[r.kind] ?? 0) + r.volume_ml;
+  }
+  return { total_ml: total, by_kind, count: rows.length };
+}
+
+// Common quick-add presets surfaced in the UI as one-tap buttons.
+// Volumes match real-world references (cup ≈ 240 ml, mug ≈ 350 ml,
+// bottle ≈ 500 ml). Tweaking these is harmless — the patient can
+// always edit a row's volume manually.
+export const FLUID_QUICK_ADD: Array<{
+  kind: FluidKind;
+  volume_ml: number;
+  label_en: string;
+  label_zh: string;
+}> = [
+  { kind: "water", volume_ml: 240, label_en: "Cup of water", label_zh: "一杯水" },
+  { kind: "water", volume_ml: 500, label_en: "Bottle of water", label_zh: "一瓶水" },
+  { kind: "tea", volume_ml: 240, label_en: "Cup of tea", label_zh: "一杯茶" },
+  { kind: "broth", volume_ml: 250, label_en: "Mug of broth", label_zh: "一碗汤" },
+  { kind: "electrolyte", volume_ml: 500, label_en: "Electrolyte drink", label_zh: "电解质饮料" },
+];

--- a/src/lib/nutrition/symptom-context.ts
+++ b/src/lib/nutrition/symptom-context.ts
@@ -1,0 +1,83 @@
+import { db } from "~/lib/db/dexie";
+import { todayISO } from "~/lib/utils/date";
+import type { DailyEntry } from "~/types/clinical";
+
+// Symptom-aware context for the food picker. Reads today's
+// DailyEntry (and yesterday's as a fallback so a freshly-loaded picker
+// before the morning check-in still has signal) and decides whether
+// to bias picker results toward easy-digest options.
+//
+// The bar is intentionally permissive — we recommend the easy-digest
+// filter rather than enforce it, because the patient may want to log
+// what they actually ate even on a bad day. Visualised as a soft
+// banner with "Showing easy-digest first" + "Show all" override.
+
+export type SymptomFlag =
+  | "nausea"
+  | "mucositis"
+  | "diarrhoea"
+  | "low_appetite";
+
+export interface NutritionSymptomContext {
+  flags: SymptomFlag[];
+  source_date?: string;        // YYYY-MM-DD the context was derived from
+  recommendEasyDigest: boolean;
+}
+
+const NAUSEA_THRESHOLD = 4;          // 0–10 scale
+const APPETITE_LOW_THRESHOLD = 4;    // 0–10 scale (lower = worse)
+const DIARRHOEA_THRESHOLD = 2;       // count/day
+
+export async function loadSymptomContext(
+  date = todayISO(),
+): Promise<NutritionSymptomContext> {
+  const today = await loadDayEntry(date);
+  const fallback = today ? null : await loadDayEntry(daysAgo(date, 1));
+  const entry = today ?? fallback;
+  if (!entry) {
+    return { flags: [], recommendEasyDigest: false };
+  }
+  const flags = deriveFlags(entry);
+  return {
+    flags,
+    source_date: entry.date,
+    recommendEasyDigest: flags.length > 0,
+  };
+}
+
+export function deriveFlags(entry: DailyEntry): SymptomFlag[] {
+  const flags: SymptomFlag[] = [];
+  if ((entry.nausea ?? 0) >= NAUSEA_THRESHOLD) flags.push("nausea");
+  if (entry.mouth_sores) flags.push("mucositis");
+  if ((entry.diarrhoea_count ?? 0) >= DIARRHOEA_THRESHOLD) flags.push("diarrhoea");
+  if (
+    typeof entry.appetite === "number" &&
+    entry.appetite <= APPETITE_LOW_THRESHOLD
+  ) {
+    flags.push("low_appetite");
+  }
+  return flags;
+}
+
+async function loadDayEntry(date: string): Promise<DailyEntry | undefined> {
+  return db.daily_entries.where("date").equals(date).first();
+}
+
+function daysAgo(iso: string, n: number): string {
+  const d = new Date(iso);
+  d.setDate(d.getDate() - n);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export const SYMPTOM_LABEL: Record<
+  SymptomFlag,
+  { en: string; zh: string }
+> = {
+  nausea: { en: "nausea", zh: "恶心" },
+  mucositis: { en: "mouth sores", zh: "口腔溃疡" },
+  diarrhoea: { en: "diarrhoea", zh: "腹泻" },
+  low_appetite: { en: "low appetite", zh: "食欲不振" },
+};

--- a/src/lib/nutrition/templates.ts
+++ b/src/lib/nutrition/templates.ts
@@ -1,0 +1,179 @@
+import { db, now } from "~/lib/db/dexie";
+import { sumItems } from "./calculator";
+import { createMeal } from "./queries";
+import type {
+  MealEntry,
+  MealItem,
+  MealTemplate,
+  MealTemplateItem,
+  MealType,
+} from "~/types/nutrition";
+import type { EnteredBy } from "~/types/clinical";
+
+// Snapshot a meal entry + its items into a reusable template. The
+// template stores macros that have already been scaled to the
+// serving — re-logging the template applies them verbatim, so the
+// totals are stable even if the source food row is later edited.
+export async function saveMealAsTemplate(args: {
+  meal_entry_id: number;
+  name: string;
+  name_zh?: string;
+  notes?: string;
+}): Promise<number> {
+  const entry = await db.meal_entries.get(args.meal_entry_id);
+  if (!entry) throw new Error("Meal not found");
+  const items = await db.meal_items
+    .where("meal_entry_id")
+    .equals(args.meal_entry_id)
+    .toArray();
+
+  const t = now();
+  return (await db.meal_templates.add({
+    name: args.name,
+    name_zh: args.name_zh,
+    meal_type: entry.meal_type,
+    items: items.map(toTemplateItem),
+    notes: args.notes ?? entry.notes,
+    use_count: 0,
+    created_at: t,
+    updated_at: t,
+  })) as number;
+}
+
+function toTemplateItem(it: MealItem): MealTemplateItem {
+  return {
+    food_id: it.food_id,
+    food_name: it.food_name,
+    food_name_zh: it.food_name_zh,
+    serving_grams: it.serving_grams,
+    calories: it.calories,
+    protein_g: it.protein_g,
+    fat_g: it.fat_g,
+    carbs_total_g: it.carbs_total_g,
+    fiber_g: it.fiber_g,
+    net_carbs_g: it.net_carbs_g,
+  };
+}
+
+// Templates surfaced in the picker. "Recent" first (last_used_at desc),
+// then "favourites" (use_count desc), capped to `limit`. Exposed as a
+// flat list so the UI can render either ordering with a sort flip.
+export async function listTemplates(
+  opts: { limit?: number; orderBy?: "recent" | "favourites" } = {},
+): Promise<MealTemplate[]> {
+  const all = await db.meal_templates.toArray();
+  const order = opts.orderBy ?? "recent";
+  all.sort((a, b) => {
+    if (order === "recent") {
+      const av = a.last_used_at ?? a.updated_at;
+      const bv = b.last_used_at ?? b.updated_at;
+      return bv.localeCompare(av);
+    }
+    if (a.use_count !== b.use_count) return b.use_count - a.use_count;
+    return (b.last_used_at ?? "").localeCompare(a.last_used_at ?? "");
+  });
+  return opts.limit ? all.slice(0, opts.limit) : all;
+}
+
+export async function deleteTemplate(id: number): Promise<void> {
+  await db.meal_templates.delete(id);
+}
+
+// Re-log a template as a fresh meal_entry on `date` / at the current
+// time. Bumps the template's use_count + last_used_at so the UI's
+// "favourites" sort works.
+export async function logTemplate(args: {
+  template_id: number;
+  date: string;
+  meal_type?: MealType;
+  entered_by: EnteredBy;
+  entered_by_user_id?: string;
+}): Promise<number> {
+  const tpl = await db.meal_templates.get(args.template_id);
+  if (!tpl) throw new Error("Template not found");
+
+  const id = await createMeal({
+    date: args.date,
+    meal_type: args.meal_type ?? tpl.meal_type ?? "snack",
+    source: "manual",
+    entered_by: args.entered_by,
+    entered_by_user_id: args.entered_by_user_id,
+    notes: tpl.notes,
+    items: tpl.items.map((it) => ({
+      kind: "inline" as const,
+      name: it.food_name,
+      name_zh: it.food_name_zh,
+      serving_grams: it.serving_grams,
+      // Convert serving-scaled macros back to per-100 g shape so
+      // createMeal's inline branch (which multiplies by g/100) ends up
+      // with the same per-meal totals.
+      macros: macrosPer100g(it),
+    })),
+  });
+
+  await db.meal_templates.update(args.template_id, {
+    use_count: (tpl.use_count ?? 0) + 1,
+    last_used_at: now(),
+    updated_at: now(),
+  });
+  return id;
+}
+
+// Re-log a previous meal under today's date. Useful for "had the same
+// thing as yesterday's lunch" patterns. Doesn't touch the template
+// table — this is the inline copy path.
+export async function relogMeal(args: {
+  source_meal_id: number;
+  date: string;
+  meal_type?: MealType;
+  entered_by: EnteredBy;
+  entered_by_user_id?: string;
+}): Promise<number> {
+  const src = await db.meal_entries.get(args.source_meal_id);
+  if (!src) throw new Error("Meal not found");
+  const items = await db.meal_items
+    .where("meal_entry_id")
+    .equals(args.source_meal_id)
+    .toArray();
+
+  return createMeal({
+    date: args.date,
+    meal_type: args.meal_type ?? src.meal_type,
+    source: "manual",
+    entered_by: args.entered_by,
+    entered_by_user_id: args.entered_by_user_id,
+    notes: src.notes,
+    items: items.map((it) => ({
+      kind: "inline" as const,
+      name: it.food_name,
+      name_zh: it.food_name_zh,
+      serving_grams: it.serving_grams,
+      macros: macrosPer100g(it),
+    })),
+  });
+}
+
+function macrosPer100g(it: MealTemplateItem | MealItem) {
+  const factor = 100 / Math.max(1, it.serving_grams);
+  return {
+    calories: it.calories * factor,
+    protein_g: it.protein_g * factor,
+    fat_g: it.fat_g * factor,
+    carbs_total_g: it.carbs_total_g * factor,
+    fiber_g: it.fiber_g * factor,
+  };
+}
+
+// Convenience: surface a meal_entry's totals from its items, used by
+// the template-detail view and the "log again" preview.
+export async function summariseMeal(
+  meal_entry_id: number,
+): Promise<{ entry: MealEntry; items: MealItem[]; totals: ReturnType<typeof sumItems> } | null> {
+  const entry = await db.meal_entries.get(meal_entry_id);
+  if (!entry) return null;
+  const items = await db.meal_items
+    .where("meal_entry_id")
+    .equals(meal_entry_id)
+    .toArray();
+  return { entry, items, totals: sumItems(items) };
+}

--- a/src/types/nutrition.ts
+++ b/src/types/nutrition.ts
@@ -169,4 +169,68 @@ export interface FoodPickerHint {
   label: LocalizedString;
 }
 
+// ─── Hydration ───────────────────────────────────────────────────────
+//
+// Fluid intake is the nutrition agent's third remit (`role.md`). PDAC +
+// chemo dehydration risk is real — especially during gemcitabine
+// infusion days. We store one row per swallow event so the dashboard
+// can sum a daily total and the timeline can show clustering.
+
+export type FluidKind =
+  | "water"
+  | "tea"
+  | "coffee"
+  | "broth"
+  | "electrolyte"
+  | "soup"
+  | "other";
+
+export interface FluidLog {
+  id?: number;
+  date: string;                    // YYYY-MM-DD (local day)
+  logged_at: string;               // ISO datetime
+  kind: FluidKind;
+  volume_ml: number;
+  notes?: string;
+  entered_by: EnteredBy;
+  entered_by_user_id?: string;
+  created_at: string;
+}
+
+// ─── Meal templates ──────────────────────────────────────────────────
+//
+// "My usual breakfast" — the small-frequent-meal pattern produces
+// repetitive eating, especially on low-appetite days. A template
+// snapshots the items so a one-tap re-log is possible. Items are
+// stored as JSON since they're immutable per template snapshot.
+
+export interface MealTemplateItem {
+  food_id?: number;
+  food_name: string;
+  food_name_zh?: string;
+  serving_grams: number;
+  // Per-item macros (already scaled to serving_grams), stored so a
+  // template logs identically even if the source food row is later
+  // edited.
+  calories: number;
+  protein_g: number;
+  fat_g: number;
+  carbs_total_g: number;
+  fiber_g: number;
+  net_carbs_g: number;
+}
+
+export interface MealTemplate {
+  id?: number;
+  name: string;
+  name_zh?: string;
+  meal_type?: MealType;
+  items: MealTemplateItem[];
+  notes?: string;
+  use_count: number;
+  last_used_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export type { Locale };

--- a/tests/unit/nutrition-hydration.test.ts
+++ b/tests/unit/nutrition-hydration.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { db } from "~/lib/db/dexie";
+import {
+  logFluid,
+  listFluidsForDate,
+  listFluidsBetween,
+  deleteFluid,
+  sumFluids,
+  DEFAULT_FLUID_TARGET_ML,
+} from "~/lib/nutrition/hydration";
+
+beforeEach(async () => {
+  await db.delete();
+  await db.open();
+});
+
+describe("logFluid", () => {
+  it("persists a row with date + kind + volume", async () => {
+    const id = await logFluid({
+      date: "2026-04-25",
+      kind: "water",
+      volume_ml: 250,
+      entered_by: "hulin",
+    });
+    const row = await db.fluid_logs.get(id);
+    expect(row?.kind).toBe("water");
+    expect(row?.volume_ml).toBe(250);
+    expect(row?.date).toBe("2026-04-25");
+  });
+
+  it("rounds and clamps non-positive volumes", async () => {
+    const id = await logFluid({
+      date: "2026-04-25",
+      kind: "water",
+      volume_ml: -50.4,
+      entered_by: "hulin",
+    });
+    const row = await db.fluid_logs.get(id);
+    expect(row?.volume_ml).toBe(0);
+  });
+});
+
+describe("listFluidsForDate", () => {
+  it("returns rows sorted by logged_at", async () => {
+    await logFluid({
+      date: "2026-04-25",
+      kind: "water",
+      volume_ml: 250,
+      entered_by: "hulin",
+      logged_at: "2026-04-25T12:00:00Z",
+    });
+    await logFluid({
+      date: "2026-04-25",
+      kind: "tea",
+      volume_ml: 200,
+      entered_by: "hulin",
+      logged_at: "2026-04-25T08:00:00Z",
+    });
+    const rows = await listFluidsForDate("2026-04-25");
+    expect(rows.map((r) => r.kind)).toEqual(["tea", "water"]);
+  });
+});
+
+describe("listFluidsBetween", () => {
+  it("filters by inclusive date range", async () => {
+    for (const d of ["2026-04-23", "2026-04-24", "2026-04-25", "2026-04-26"]) {
+      await logFluid({
+        date: d,
+        kind: "water",
+        volume_ml: 250,
+        entered_by: "hulin",
+      });
+    }
+    const rows = await listFluidsBetween("2026-04-24", "2026-04-25");
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe("deleteFluid", () => {
+  it("removes the row", async () => {
+    const id = await logFluid({
+      date: "2026-04-25",
+      kind: "water",
+      volume_ml: 250,
+      entered_by: "hulin",
+    });
+    await deleteFluid(id);
+    expect(await db.fluid_logs.get(id)).toBeUndefined();
+  });
+});
+
+describe("sumFluids", () => {
+  it("totals volume and groups by kind", async () => {
+    await logFluid({
+      date: "2026-04-25",
+      kind: "water",
+      volume_ml: 250,
+      entered_by: "hulin",
+    });
+    await logFluid({
+      date: "2026-04-25",
+      kind: "water",
+      volume_ml: 500,
+      entered_by: "hulin",
+    });
+    await logFluid({
+      date: "2026-04-25",
+      kind: "broth",
+      volume_ml: 250,
+      entered_by: "hulin",
+    });
+    const rows = await listFluidsForDate("2026-04-25");
+    const t = sumFluids(rows);
+    expect(t.total_ml).toBe(1000);
+    expect(t.by_kind.water).toBe(750);
+    expect(t.by_kind.broth).toBe(250);
+    expect(t.count).toBe(3);
+  });
+
+  it("returns zero totals for empty input", () => {
+    const t = sumFluids([]);
+    expect(t.total_ml).toBe(0);
+    expect(t.count).toBe(0);
+  });
+});
+
+describe("default target", () => {
+  it("is 2L/day", () => {
+    expect(DEFAULT_FLUID_TARGET_ML).toBe(2000);
+  });
+});

--- a/tests/unit/nutrition-symptom-context.test.ts
+++ b/tests/unit/nutrition-symptom-context.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { db, now } from "~/lib/db/dexie";
+import {
+  deriveFlags,
+  loadSymptomContext,
+} from "~/lib/nutrition/symptom-context";
+import type { DailyEntry } from "~/types/clinical";
+
+beforeEach(async () => {
+  await db.delete();
+  await db.open();
+});
+
+function entry(p: Partial<DailyEntry>): DailyEntry {
+  return {
+    date: "2026-04-25",
+    entered_at: "2026-04-25T08:00:00Z",
+    entered_by: "hulin",
+    created_at: now(),
+    updated_at: now(),
+    ...p,
+  };
+}
+
+describe("deriveFlags", () => {
+  it("flags nausea above threshold", () => {
+    expect(deriveFlags(entry({ nausea: 5 }))).toContain("nausea");
+    expect(deriveFlags(entry({ nausea: 2 }))).not.toContain("nausea");
+  });
+  it("flags mucositis when mouth_sores is true", () => {
+    expect(deriveFlags(entry({ mouth_sores: true }))).toContain("mucositis");
+  });
+  it("flags diarrhoea when count >= threshold", () => {
+    expect(deriveFlags(entry({ diarrhoea_count: 2 }))).toContain("diarrhoea");
+    expect(deriveFlags(entry({ diarrhoea_count: 1 }))).not.toContain("diarrhoea");
+  });
+  it("flags low appetite", () => {
+    expect(deriveFlags(entry({ appetite: 3 }))).toContain("low_appetite");
+    expect(deriveFlags(entry({ appetite: 8 }))).not.toContain("low_appetite");
+  });
+  it("returns empty when nothing concerning", () => {
+    expect(
+      deriveFlags(
+        entry({ nausea: 1, appetite: 8, diarrhoea_count: 0 }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("loadSymptomContext", () => {
+  it("recommendsEasyDigest when today has flags", async () => {
+    await db.daily_entries.add(entry({ date: "2026-04-25", nausea: 7 }));
+    const ctx = await loadSymptomContext("2026-04-25");
+    expect(ctx.recommendEasyDigest).toBe(true);
+    expect(ctx.flags).toContain("nausea");
+    expect(ctx.source_date).toBe("2026-04-25");
+  });
+
+  it("falls back to yesterday when today has no entry", async () => {
+    await db.daily_entries.add(
+      entry({
+        date: "2026-04-24",
+        entered_at: "2026-04-24T08:00:00Z",
+        nausea: 6,
+      }),
+    );
+    const ctx = await loadSymptomContext("2026-04-25");
+    expect(ctx.flags).toContain("nausea");
+    expect(ctx.source_date).toBe("2026-04-24");
+  });
+
+  it("does not recommend when nothing concerning", async () => {
+    await db.daily_entries.add(
+      entry({ date: "2026-04-25", nausea: 1, appetite: 8 }),
+    );
+    const ctx = await loadSymptomContext("2026-04-25");
+    expect(ctx.recommendEasyDigest).toBe(false);
+    expect(ctx.flags).toEqual([]);
+  });
+
+  it("returns empty context with no entries", async () => {
+    const ctx = await loadSymptomContext("2026-04-25");
+    expect(ctx.flags).toEqual([]);
+    expect(ctx.recommendEasyDigest).toBe(false);
+  });
+});

--- a/tests/unit/nutrition-templates.test.ts
+++ b/tests/unit/nutrition-templates.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { db } from "~/lib/db/dexie";
+import {
+  ensureFoodsSeeded,
+  searchFoods,
+  createMeal,
+  listItemsForMeal,
+} from "~/lib/nutrition/queries";
+import {
+  saveMealAsTemplate,
+  listTemplates,
+  logTemplate,
+  relogMeal,
+  deleteTemplate,
+} from "~/lib/nutrition/templates";
+
+beforeEach(async () => {
+  await db.delete();
+  await db.open();
+  await ensureFoodsSeeded();
+});
+
+async function aLoggedMeal(date = "2026-04-25") {
+  const food = (await searchFoods("egg"))[0]!;
+  return createMeal({
+    date,
+    meal_type: "breakfast",
+    source: "manual",
+    entered_by: "hulin",
+    items: [{ kind: "food", food, serving_grams: 100 }],
+    notes: "Morning eggs",
+  });
+}
+
+describe("saveMealAsTemplate", () => {
+  it("snapshots items and totals", async () => {
+    const mealId = await aLoggedMeal();
+    const tplId = await saveMealAsTemplate({
+      meal_entry_id: mealId,
+      name: "Usual breakfast",
+    });
+    const tpl = await db.meal_templates.get(tplId);
+    expect(tpl?.name).toBe("Usual breakfast");
+    expect(tpl?.use_count).toBe(0);
+    expect(tpl?.items.length).toBe(1);
+    expect(tpl?.items[0].food_name.toLowerCase()).toContain("egg");
+    expect(tpl?.items[0].serving_grams).toBe(100);
+    expect(tpl?.items[0].calories).toBeGreaterThan(0);
+  });
+});
+
+describe("listTemplates", () => {
+  it("orders by recent (last_used_at) by default", async () => {
+    const mealId = await aLoggedMeal();
+    const a = await saveMealAsTemplate({
+      meal_entry_id: mealId,
+      name: "A",
+    });
+    const b = await saveMealAsTemplate({
+      meal_entry_id: mealId,
+      name: "B",
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    await db.meal_templates.update(a, {
+      last_used_at: new Date().toISOString(),
+    });
+    const recent = await listTemplates({ orderBy: "recent" });
+    expect(recent[0].id).toBe(a);
+    void b;
+  });
+
+  it("orders by use_count for favourites", async () => {
+    const mealId = await aLoggedMeal();
+    const a = await saveMealAsTemplate({
+      meal_entry_id: mealId,
+      name: "A",
+    });
+    const b = await saveMealAsTemplate({
+      meal_entry_id: mealId,
+      name: "B",
+    });
+    await db.meal_templates.update(b, { use_count: 5 });
+    const favs = await listTemplates({ orderBy: "favourites" });
+    expect(favs[0].id).toBe(b);
+    void a;
+  });
+});
+
+describe("logTemplate", () => {
+  it("creates a fresh meal with template's items + bumps use_count", async () => {
+    const sourceMeal = await aLoggedMeal();
+    const tplId = await saveMealAsTemplate({
+      meal_entry_id: sourceMeal,
+      name: "Usual breakfast",
+    });
+    const newMealId = await logTemplate({
+      template_id: tplId,
+      date: "2026-04-26",
+      entered_by: "hulin",
+    });
+    const items = await listItemsForMeal(newMealId);
+    expect(items).toHaveLength(1);
+    expect(items[0].food_name.toLowerCase()).toContain("egg");
+    expect(items[0].serving_grams).toBe(100);
+
+    const tpl = await db.meal_templates.get(tplId);
+    expect(tpl?.use_count).toBe(1);
+    expect(tpl?.last_used_at).toBeTruthy();
+
+    const newMeal = await db.meal_entries.get(newMealId);
+    expect(newMeal?.date).toBe("2026-04-26");
+  });
+
+  it("preserves macros after re-log (round-trip stability)", async () => {
+    const sourceMeal = await aLoggedMeal();
+    const sourceItems = await listItemsForMeal(sourceMeal);
+    const sourceProtein = sourceItems[0].protein_g;
+
+    const tplId = await saveMealAsTemplate({
+      meal_entry_id: sourceMeal,
+      name: "Usual breakfast",
+    });
+    const newMealId = await logTemplate({
+      template_id: tplId,
+      date: "2026-04-26",
+      entered_by: "hulin",
+    });
+    const newItems = await listItemsForMeal(newMealId);
+    expect(newItems[0].protein_g).toBeCloseTo(sourceProtein, 1);
+    expect(newItems[0].serving_grams).toBe(sourceItems[0].serving_grams);
+  });
+});
+
+describe("relogMeal", () => {
+  it("copies a past meal forward to a new date", async () => {
+    const sourceMeal = await aLoggedMeal("2026-04-24");
+    const newMealId = await relogMeal({
+      source_meal_id: sourceMeal,
+      date: "2026-04-25",
+      entered_by: "hulin",
+    });
+    const newMeal = await db.meal_entries.get(newMealId);
+    expect(newMeal?.date).toBe("2026-04-25");
+    const items = await listItemsForMeal(newMealId);
+    expect(items).toHaveLength(1);
+    expect(items[0].food_name.toLowerCase()).toContain("egg");
+  });
+});
+
+describe("deleteTemplate", () => {
+  it("removes the row", async () => {
+    const mealId = await aLoggedMeal();
+    const id = await saveMealAsTemplate({
+      meal_entry_id: mealId,
+      name: "Usual",
+    });
+    await deleteTemplate(id);
+    expect(await db.meal_templates.get(id)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Five high-impact additions to the nutrition module, all scoped to Hu Lin's function-preservation strategy.

### 1. Hydration tracking (Dexie v19 + `HydrationCard`)

The nutrition agent's third remit (`agents/nutrition/role.md`) — fluid intake — was previously not instrumented. New `fluid_logs` table with one row per swallow event, one-tap quick-add buttons (water / tea / broth / electrolyte), custom volume entry, daily total versus a soft 2 L target, and a collapsible breakdown of today's events. Sits next to `DailyTotals` on `/nutrition`.

### 2. Meal templates / favourites

The 5–6-small-meal pattern produces repetitive eating, especially on low-appetite days. Saving "my usual breakfast" once and re-logging in one tap removes the picker friction every time. New `meal_templates` table, `TemplatesPicker` on `/nutrition/log`, and "Log again" + "Save as template" buttons on each past meal in the list. Sort by recent (`last_used_at`) or favourites (`use_count`).

### 3. Symptom-aware food picker

Reads today's `DailyEntry` (or yesterday's as a fallback) for nausea / mucositis / diarrhea / low-appetite signals and **biases the picker toward easy-digest foods automatically**. The filter is soft — a banner explains the bias and the patient can override with one tap.

### 4. Voice meal entry

Native browser `SpeechRecognition` on the text-input tab of `MealIngest`. Mandarin routes through `zh-CN`; everything else uses `en-US`. The mic button is hidden when the browser doesn't support SR (older Firefox, some in-app webviews) so the UI stays clean.

### 5. Tests + types

- 24 new unit tests across `nutrition-hydration.test.ts`, `nutrition-templates.test.ts`, `nutrition-symptom-context.test.ts`.
- New `FluidLog` / `FluidKind` / `MealTemplate` / `MealTemplateItem` types in `src/types/nutrition.ts`.

## Schema (Dexie v19)

| Table | Purpose | Hot index |
|---|---|---|
| `fluid_logs` | One row per swallow event | `date`, `kind`, `[date+kind]` |
| `meal_templates` | Saved-meal definitions; items as JSON | `name`, `last_used_at`, `use_count` |

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — **585 / 585** (24 new)
- [x] `pnpm build` clean
- [ ] Manual: log meals + water on `/nutrition`, watch totals + day-clock update.
- [ ] Manual: tap "Save as template" → re-open `/nutrition/log` → tap the saved template → confirm re-logged correctly.
- [ ] Manual: trigger nausea ≥ 4 in today's daily entry → open the food picker → confirm the easy-digest banner appears with override.
- [ ] Manual on iPhone Safari: the mic button on the text tab triggers a permission prompt; speak a meal description; tap Stop → Parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpWRFSFnksEbpJ5c8fnJSW)_