### PR TITLE
MVP: move baselines out of onboarding into first comprehensive assessment

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -22,18 +22,22 @@ import {
 import { cn } from "~/lib/utils/cn";
 
 // Order is load-bearing: welcome + profile + preferences is the "core" path
-// that gets every user onto the dashboard quickly. Team / baselines /
-// treatment are optional detail — skippable via "Finish setup later" so the
-// patient isn't gated behind data they don't have on hand.
-// Patient onboarding walks the full path: profile + team + baselines +
-// treatment are all about the patient's own situation.
+// that gets every user onto the dashboard quickly. Team / treatment are
+// optional detail — skippable via "Finish setup later" so the patient
+// isn't gated behind data they don't have on hand.
+//
+// Baselines (weight, grip, gait speed, sit-to-stand, MUAC, calf) are
+// deliberately NOT collected here. They belong in the first
+// comprehensive assessment, where they are taken with proper
+// instruments and form part of the pillar baseline that subsequent
+// assessments compare against. Onboarding's job is to get the patient
+// onto the dashboard fast; clinical measurements come later.
 const PATIENT_STEPS = [
   "welcome",
   "user_type",
   "profile",
   "preferences",
   "team",
-  "baselines",
   "treatment",
   "done",
 ] as const;
@@ -60,7 +64,6 @@ const CAN_SKIP_FROM: StepKey[] = [
   "profile",
   "preferences",
   "team",
-  "baselines",
   "treatment",
   "pick_patient",
 ];
@@ -72,7 +75,6 @@ const STEP_LABELS: Record<Locale, Record<StepKey, string>> = {
     pick_patient: "Pick a patient",
     profile: "About you",
     team: "Clinical team",
-    baselines: "Baselines",
     treatment: "Treatment",
     preferences: "Preferences",
     done: "All set",
@@ -83,7 +85,6 @@ const STEP_LABELS: Record<Locale, Record<StepKey, string>> = {
     pick_patient: "选择患者",
     profile: "基本信息",
     team: "医疗团队",
-    baselines: "基线数据",
     treatment: "治疗方案",
     preferences: "偏好设置",
     done: "完成",
@@ -104,14 +105,6 @@ interface FormState {
   oncall_phone: string;
   emergency_instructions: string;
   height_cm: string;
-  baseline_weight_kg: string;
-  baseline_grip_dominant_kg: string;
-  baseline_gait_speed_ms: string;
-  baseline_sit_to_stand: string;       // 30-second count
-  baseline_sts_5x_seconds: string;     // 5× STS time
-  baseline_tug_seconds: string;        // Timed Up-and-Go seconds
-  baseline_muac_cm: string;
-  baseline_calf_cm: string;
   start_cycle: boolean;
   protocol_id: ProtocolId;
   cycle_start_date: string;
@@ -133,14 +126,6 @@ const EMPTY: FormState = {
   oncall_phone: "",
   emergency_instructions: "",
   height_cm: "",
-  baseline_weight_kg: "",
-  baseline_grip_dominant_kg: "",
-  baseline_gait_speed_ms: "",
-  baseline_sit_to_stand: "",
-  baseline_sts_5x_seconds: "",
-  baseline_tug_seconds: "",
-  baseline_muac_cm: "",
-  baseline_calf_cm: "",
   start_cycle: false,
   protocol_id: "gnp_weekly",
   cycle_start_date: todayISO(),
@@ -187,26 +172,6 @@ export default function OnboardingPage() {
         oncall_phone: s.oncall_phone ?? "",
         emergency_instructions: s.emergency_instructions ?? "",
         height_cm: s.height_cm ? String(s.height_cm) : "",
-        baseline_weight_kg: s.baseline_weight_kg
-          ? String(s.baseline_weight_kg)
-          : "",
-        baseline_grip_dominant_kg: s.baseline_grip_dominant_kg
-          ? String(s.baseline_grip_dominant_kg)
-          : "",
-        baseline_gait_speed_ms: s.baseline_gait_speed_ms
-          ? String(s.baseline_gait_speed_ms)
-          : "",
-        baseline_sit_to_stand: s.baseline_sit_to_stand
-          ? String(s.baseline_sit_to_stand)
-          : "",
-        baseline_sts_5x_seconds: s.baseline_sts_5x_seconds
-          ? String(s.baseline_sts_5x_seconds)
-          : "",
-        baseline_tug_seconds: s.baseline_tug_seconds
-          ? String(s.baseline_tug_seconds)
-          : "",
-        baseline_muac_cm: s.baseline_muac_cm ? String(s.baseline_muac_cm) : "",
-        baseline_calf_cm: s.baseline_calf_cm ? String(s.baseline_calf_cm) : "",
         locale: s.locale,
         home_city: s.home_city ?? "",
       }));
@@ -287,26 +252,11 @@ export default function OnboardingPage() {
         dob: isCaregiver ? undefined : form.dob || undefined,
         diagnosis_date: isCaregiver ? undefined : form.diagnosis_date || undefined,
         height_cm: isCaregiver ? undefined : toNum(form.height_cm),
-        baseline_weight_kg: isCaregiver ? undefined : toNum(form.baseline_weight_kg),
-        baseline_date:
-          isCaregiver || !form.baseline_weight_kg ? undefined : todayISO(),
-        baseline_grip_dominant_kg: isCaregiver
-          ? undefined
-          : toNum(form.baseline_grip_dominant_kg),
-        baseline_gait_speed_ms: isCaregiver
-          ? undefined
-          : toNum(form.baseline_gait_speed_ms),
-        baseline_sit_to_stand: isCaregiver
-          ? undefined
-          : toNum(form.baseline_sit_to_stand),
-        baseline_sts_5x_seconds: isCaregiver
-          ? undefined
-          : toNum(form.baseline_sts_5x_seconds),
-        baseline_tug_seconds: isCaregiver
-          ? undefined
-          : toNum(form.baseline_tug_seconds),
-        baseline_muac_cm: isCaregiver ? undefined : toNum(form.baseline_muac_cm),
-        baseline_calf_cm: isCaregiver ? undefined : toNum(form.baseline_calf_cm),
+        // Baselines are deliberately NOT collected during onboarding —
+        // they belong in the first comprehensive assessment, where the
+        // measurements can be taken with proper instruments and form
+        // the pillar baseline. The settings row will pick them up the
+        // first time the patient runs through /assessment.
         locale: form.locale,
         managing_oncologist: isCaregiver
           ? undefined
@@ -445,9 +395,6 @@ export default function OnboardingPage() {
       )}
       {step === "team" && (
         <TeamStep form={form} update={update} locale={locale} />
-      )}
-      {step === "baselines" && (
-        <BaselinesStep form={form} update={update} locale={locale} />
       )}
       {step === "treatment" && (
         <TreatmentStep form={form} update={update} locale={locale} />
@@ -1031,133 +978,6 @@ function TeamStep({
   );
 }
 
-function BaselinesStep({
-  form,
-  update,
-  locale,
-}: {
-  form: FormState;
-  update: <K extends keyof FormState>(k: K, v: FormState[K]) => void;
-  locale: Locale;
-}) {
-  return (
-    <Card className="p-6 space-y-4">
-      <div>
-        <div className="serif text-[22px] leading-tight">
-          {locale === "zh" ? "基线数据" : "Baselines"}
-        </div>
-        <p className="mt-1 text-xs text-ink-500">
-          {locale === "zh"
-            ? "用于后续的体重、握力、步速等对比。没有测量过的可以先跳过。"
-            : "Used to compare weight / grip / gait over time. Skip any you haven't measured."}
-        </p>
-      </div>
-      <div className="grid gap-3 sm:grid-cols-2">
-        <Field label={locale === "zh" ? "身高 (cm)" : "Height (cm)"}>
-          <TextInput
-            type="number"
-            step="0.5"
-            value={form.height_cm}
-            onChange={(e) => update("height_cm", e.target.value)}
-          />
-        </Field>
-        <Field label={locale === "zh" ? "体重 (kg)" : "Weight (kg)"}>
-          <TextInput
-            type="number"
-            step="0.1"
-            value={form.baseline_weight_kg}
-            onChange={(e) => update("baseline_weight_kg", e.target.value)}
-          />
-        </Field>
-        <Field
-          label={
-            locale === "zh"
-              ? "握力 — 惯用手 (kg)"
-              : "Grip — dominant (kg)"
-          }
-        >
-          <TextInput
-            type="number"
-            step="0.5"
-            value={form.baseline_grip_dominant_kg}
-            onChange={(e) =>
-              update("baseline_grip_dominant_kg", e.target.value)
-            }
-          />
-        </Field>
-        <Field
-          label={locale === "zh" ? "4 米步速 (m/s)" : "4 m gait speed (m/s)"}
-        >
-          <TextInput
-            type="number"
-            step="0.05"
-            value={form.baseline_gait_speed_ms}
-            onChange={(e) => update("baseline_gait_speed_ms", e.target.value)}
-          />
-        </Field>
-        <Field
-          label={
-            locale === "zh"
-              ? "30 秒坐立次数"
-              : "30 s sit-to-stand (count)"
-          }
-        >
-          <TextInput
-            type="number"
-            step="1"
-            value={form.baseline_sit_to_stand}
-            onChange={(e) => update("baseline_sit_to_stand", e.target.value)}
-          />
-        </Field>
-        <Field
-          label={
-            locale === "zh" ? "5 次坐立 (秒)" : "5× sit-to-stand (s)"
-          }
-        >
-          <TextInput
-            type="number"
-            step="0.1"
-            value={form.baseline_sts_5x_seconds}
-            onChange={(e) =>
-              update("baseline_sts_5x_seconds", e.target.value)
-            }
-          />
-        </Field>
-        <Field
-          label={
-            locale === "zh" ? "起立行走 TUG (秒)" : "Timed Up-and-Go (s)"
-          }
-        >
-          <TextInput
-            type="number"
-            step="0.1"
-            value={form.baseline_tug_seconds}
-            onChange={(e) => update("baseline_tug_seconds", e.target.value)}
-          />
-        </Field>
-        <Field
-          label={locale === "zh" ? "上臂围 MUAC (cm)" : "Upper arm (MUAC, cm)"}
-        >
-          <TextInput
-            type="number"
-            step="0.5"
-            value={form.baseline_muac_cm}
-            onChange={(e) => update("baseline_muac_cm", e.target.value)}
-          />
-        </Field>
-        <Field label={locale === "zh" ? "小腿围 (cm)" : "Calf (cm)"}>
-          <TextInput
-            type="number"
-            step="0.5"
-            value={form.baseline_calf_cm}
-            onChange={(e) => update("baseline_calf_cm", e.target.value)}
-          />
-        </Field>
-      </div>
-    </Card>
-  );
-}
-
 function TreatmentStep({
   form,
   update,
@@ -1312,14 +1132,6 @@ function DoneStep({ form, locale }: { form: FormState; locale: Locale }) {
     [
       locale === "zh" ? "24 小时值班" : "24/7 on-call",
       form.oncall_phone || (locale === "zh" ? "未填" : "Not set"),
-    ],
-    [
-      locale === "zh" ? "体重基线" : "Weight baseline",
-      form.baseline_weight_kg
-        ? `${form.baseline_weight_kg} kg`
-        : locale === "zh"
-          ? "未填"
-          : "Not set",
     ],
     [
       locale === "zh" ? "方案" : "Protocol",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
 import { PendingInvitesCard } from "~/components/dashboard/pending-invites-card";
 import { InviteFamilyCard } from "~/components/dashboard/invite-family-card";
+import { BaselineNudgeCard } from "~/components/dashboard/baseline-nudge-card";
 import { NextClinicCard } from "~/components/dashboard/next-clinic-card";
 import { ScheduleCard } from "~/components/dashboard/schedule-card";
 import { ChangeSignalsCard } from "~/components/dashboard/change-signals-card";
@@ -109,6 +110,8 @@ export default function DashboardPage() {
       <PendingInvitesCard />
 
       <InviteFamilyCard />
+
+      <BaselineNudgeCard />
 
       <NextClinicCard />
 

--- a/src/components/dashboard/baseline-nudge-card.tsx
+++ b/src/components/dashboard/baseline-nudge-card.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { useLiveQuery } from "dexie-react-hooks";
+import { Stethoscope, ChevronRight } from "lucide-react";
+import { db } from "~/lib/db/dexie";
+import { Card, CardContent } from "~/components/ui/card";
+import { useLocale } from "~/hooks/use-translate";
+
+// Surfaced when the patient has finished onboarding but hasn't done a
+// first comprehensive assessment yet. Baselines (weight, grip, gait,
+// MUAC, calf) are required for the rule engine to detect drift, but
+// they're collected at /assessment, not at onboarding — this card is
+// the bridge that nudges the patient to take that step when it makes
+// sense.
+//
+// Hides itself when:
+//   - the user is still onboarding (no settings row yet)
+//   - a baseline weight is already on file (good-enough proxy for
+//     "first assessment done")
+//   - any complete comprehensive_assessment exists in history
+export function BaselineNudgeCard() {
+  const locale = useLocale();
+  const settings = useLiveQuery(() => db.settings.toArray());
+  const hasComplete = useLiveQuery(async () => {
+    const rows = await db.comprehensive_assessments
+      .orderBy("assessment_date")
+      .reverse()
+      .limit(5)
+      .toArray();
+    return rows.some((r) => r.status === "complete");
+  });
+
+  if (!settings || settings.length === 0) return null;
+  const s = settings[0];
+  if (!s?.onboarded_at) return null;
+  if (s.baseline_weight_kg) return null;
+  if (hasComplete) return null;
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  return (
+    <Card>
+      <CardContent className="flex items-center justify-between gap-3 pt-4">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-[var(--tide-2)]/15 text-[var(--tide-2)]">
+            <Stethoscope className="h-4 w-4" />
+          </div>
+          <div>
+            <div className="text-[13px] font-semibold text-ink-900">
+              {L("Capture your baselines", "记录您的基线数据")}
+            </div>
+            <p className="mt-0.5 text-[11.5px] text-ink-500">
+              {L(
+                "Weight, grip, gait — the comparison points the rule engine watches for drift.",
+                "体重、握力、步速 — 后续比对、监测变化的起点。",
+              )}
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/assessment"
+          className="inline-flex items-center gap-0.5 text-[12px] text-ink-500 hover:text-ink-900"
+        >
+          {L("Open", "开始")}
+          <ChevronRight className="h-3 w-3" />
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

First MVP-polish PR — addresses the explicit feedback that "the full panel of baseline measurements should not be part of onboarding and rather fall in first comprehensive assessment."

## Why

The patient onboarding wizard demanded baselines (weight, grip, gait speed, sit-to-stand, 5×STS, TUG, MUAC, calf circumference) before letting the patient onto the dashboard. Two problems with that:

1. **Wrong moment**. The first-run user typically doesn't have a dynamometer, gait stopwatch, or measuring tape on hand at sign-up — so the step either gates them on data they can't provide, or invites guess-numbers that pollute the rule engine.
2. **Wrong setting, clinically**. Baselines belong in a measurement session with proper instruments. They are the comparison point that subsequent comprehensive assessments are scored against.

## What changed

- **Onboarding** (`src/app/onboarding/page.tsx`): drop the `baselines` step. Patient flow becomes `welcome → user_type → profile → preferences → team → treatment → done`. Strips the corresponding `FormState` fields, defaults, settings load + write, the `BaselinesStep` component, and the review row that printed "Weight baseline" on the final step.
- **Dashboard nudge** (`src/components/dashboard/baseline-nudge-card.tsx`): new card surfaces only when the patient has finished onboarding but has no `baseline_weight_kg` on file and no completed comprehensive assessment in `comprehensive_assessments`. One-tap link to `/assessment`, which already has `BaselinesCard` for capture.

No data migration: the existing `BaselinesCard` on `/assessment` writes to the same `settings` row that onboarding used.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` 0 errors
- [x] `pnpm test` 585 / 585
- [x] `pnpm build` clean
- [ ] Manual: onboard a fresh patient — confirm the wizard skips the baselines step and lands on the dashboard.
- [ ] Manual: confirm the new `BaselineNudgeCard` appears on the dashboard and links to `/assessment`.
- [ ] Manual: capture a baseline weight via `/assessment` → reload dashboard → confirm the nudge disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpWRFSFnksEbpJ5c8fnJSW)_