### PR TITLE
PR #100 — full audit pass: error/not-found/loading + dashboard redirect race

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { AlertTriangle, RotateCcw, Home } from "lucide-react";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+
+// Top-level error boundary. Next's app router calls this when any
+// client component in the tree throws during render. Without it, a
+// crash leaves the user staring at a blank screen with no path
+// forward — bad on a phone, especially when the patient is the
+// person looking at the broken view.
+//
+// Strategy:
+//   - Render in the patient's expected paper/ink palette (no system
+//     "Error" alert). The page still feels like Anchor.
+//   - Offer two recovery paths: Try again (calls Next's reset) and
+//     Home. Either should unstick the user.
+//   - Log to console so Vercel / Sentry-equivalent picks it up.
+//   - Bilingual: we don't know the locale here (Zustand state may
+//     not have hydrated past the boundary), so we render side-by-side
+//     EN + ZH copy. Better than gambling on locale and showing the
+//     wrong language to a panicked user.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error("[anchor] unhandled error", error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-md p-6 pt-16">
+      <Card>
+        <CardContent className="space-y-4 pt-5">
+          <div className="flex items-start gap-3">
+            <div
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md"
+              style={{
+                background: "var(--warn-soft)",
+                color: "var(--warn)",
+              }}
+            >
+              <AlertTriangle className="h-4 w-4" />
+            </div>
+            <div>
+              <div className="text-[14px] font-semibold text-ink-900">
+                Something went wrong
+                <span className="ml-2 text-ink-500">出问题了</span>
+              </div>
+              <p className="mt-1 text-[12.5px] text-ink-500">
+                Anchor hit a snag rendering this page. Your data is safe.
+                <br />
+                <span className="text-ink-500/80">
+                  Anchor 在显示这个页面时遇到了问题，您的数据是安全的。
+                </span>
+              </p>
+            </div>
+          </div>
+
+          {error.digest && (
+            <div className="mono rounded-md bg-paper px-2 py-1.5 text-[10.5px] text-ink-500">
+              ref · {error.digest}
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2 pt-1">
+            <Button onClick={reset}>
+              <RotateCcw className="h-4 w-4" />
+              Try again · 重试
+            </Button>
+            <Link href="/">
+              <Button variant="secondary">
+                <Home className="h-4 w-4" />
+                Home · 主页
+              </Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,15 @@
+// App-router loading state. Renders during route segment transitions
+// before the destination page's data has loaded. We deliberately
+// keep this minimal — the patient sees this often, so it should fade
+// in calm and unobtrusive rather than draw attention. A centered
+// "Anchor" wordmark with a slow pulse is enough.
+
+export default function Loading() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="serif animate-pulse text-2xl tracking-tight text-ink-300">
+        Anchor
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { Compass, Home } from "lucide-react";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+
+// 404 fallback. Without this, Next renders the framework-default page
+// which doesn't carry the Anchor palette and breaks the visual
+// continuity for someone who landed on a stale link (e.g. an older
+// invite email or a mistyped URL). Bilingual side-by-side because we
+// don't have access to the user's locale on a not-found render.
+export default function NotFound() {
+  return (
+    <div className="mx-auto max-w-md p-6 pt-16">
+      <Card>
+        <CardContent className="space-y-4 pt-5">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-ink-100 text-ink-700">
+              <Compass className="h-4 w-4" />
+            </div>
+            <div>
+              <div className="text-[14px] font-semibold text-ink-900">
+                Page not found
+                <span className="ml-2 text-ink-500">页面未找到</span>
+              </div>
+              <p className="mt-1 text-[12.5px] text-ink-500">
+                The link may be old or mistyped.
+                <br />
+                <span className="text-ink-500/80">
+                  链接可能已过期或输错了。
+                </span>
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2 pt-1">
+            <Link href="/">
+              <Button>
+                <Home className="h-4 w-4" />
+                Home · 主页
+              </Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,27 +33,37 @@ export default function DashboardPage() {
   const profileName = settings?.[0]?.profile_name;
   const { membership } = useHousehold();
 
+  // Single redirect effect with a clear precedence ladder so two
+  // racing useEffects can't both call router.replace on the same
+  // render. Order:
+  //   1. Settings still loading (undefined) → wait.
+  //   2. No settings row OR no onboarded_at → /onboarding (everyone
+  //      finishes onboarding before any role-based routing).
+  //   3. Caregiver / clinician (per Dexie settings.user_type) →
+  //      /family. Set during onboarding before any sign-in.
+  //   4. Authenticated household member with a non-patient,
+  //      non-primary-carer role (per Supabase) → /family. We wait
+  //      for the household hook to resolve (membership === undefined)
+  //      before acting on this branch so we don't route a
+  //      yet-to-load primary_carer to the family view by accident.
+  //   5. Otherwise (patient / primary carer) → stay on dashboard.
   useEffect(() => {
-    // First-run gate: no settings row (or no onboarded_at) → onboarding.
-    if (settings && !settings[0]?.onboarded_at) {
+    if (!settings) return;
+    const s = settings[0];
+    if (!s?.onboarded_at) {
       router.replace("/onboarding");
+      return;
     }
-  }, [router, settings]);
-
-  // Anyone who isn't acting as the patient sees /family by default —
-  // the clinician-heavy dashboard would overwhelm a visiting carer.
-  // Primary carers keep the full dashboard (they proxy for the patient).
-  // Checks both the Supabase household membership (authoritative once
-  // joined) AND the local Dexie settings.user_type (set during first-
-  // session onboarding before any sign-in).
-  useEffect(() => {
-    const type = settings?.[0]?.user_type;
-    if (type === "caregiver" || type === "clinician") {
+    if (s.user_type === "caregiver" || s.user_type === "clinician") {
       router.replace("/family");
       return;
     }
-    if (!membership) return;
-    if (membership.role !== "primary_carer" && membership.role !== "patient") {
+    if (membership === undefined) return; // hook still resolving
+    if (
+      membership !== null &&
+      membership.role !== "primary_carer" &&
+      membership.role !== "patient"
+    ) {
       router.replace("/family");
     }
   }, [membership, router, settings]);
@@ -80,6 +90,17 @@ export default function DashboardPage() {
   }, [locale]);
 
   const firstName = profileName?.split(" ").slice(-1)[0] ?? "";
+
+  // While the redirect effect is deciding (settings still loading, or
+  // an explicit perspective bounce in flight), render nothing rather
+  // than flash the patient dashboard at a caregiver who's about to be
+  // routed to /family. The app-level loading.tsx covers the visual.
+  if (!settings) return null;
+  const s0 = settings[0];
+  if (!s0?.onboarded_at) return null;
+  if (s0.user_type === "caregiver" || s0.user_type === "clinician") {
+    return null;
+  }
 
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-8">


### PR DESCRIPTION
## Summary

PR #100 — full audit pass and ship-readiness fixes ahead of giving dad the app.

Walked the codebase across UX, UI, design, performance, and DB. Catalogued issues across 54 pages and ~150 components. This PR ships the critical-path fixes; remaining items are noted below for follow-up.

## Critical-path fixes (in this PR)

### 1. App-router error boundary (`src/app/error.tsx`)
Without this, any unhandled render-time exception in a client component left the user on a blank screen — a really bad failure mode on a phone, especially when dad is the one looking at it. Now renders a calm Anchor-palette card with two recovery paths (retry + home) and the digest reference for log lookup. **Bilingual side-by-side** because we can't trust Zustand state inside an error boundary.

### 2. Not-found page (`src/app/not-found.tsx`)
Same blank-screen failure mode for stale invite links / mistyped URLs. Same Anchor-shaped card, bilingual, single Home CTA.

### 3. App-router `loading.tsx`
Minimal centered "Anchor" wordmark with a slow pulse for route-segment transitions before destination data has loaded. Calm and unobtrusive — the patient sees this often.

### 4. Dashboard redirect race fixed
Two `useEffect`s in `src/app/page.tsx` were both reacting to the same `settings` state and both calling `router.replace` — the later one (perspective routing) would override the earlier one (onboarding gate) for a half-onboarded caregiver. **Consolidated into a single effect with an explicit precedence ladder** (settings loaded → onboarding done → perspective). Added a matching **render gate** that returns `null` until the redirect resolves so we don't flash the patient dashboard at a caregiver who's about to be routed to `/family`.

## Audit findings deferred (noted for follow-up PRs)

| Item | Why deferred |
|---|---|
| Per-page loading skeletons | App-level `loading.tsx` covers the visible gap; finer skeletons are polish, not blocking. |
| `next/image` migration on `/ingest`, `/nutrition` meal photos & meal-list | Lint warnings only; non-blocking. |
| Family page onboarding gate | Rare path; usually accessed via redirect from `/`. |

## Audit findings already healthy (no fix needed)

- **Empty-state hiding**: dashboard cards (Emergency, NextClinic, Schedule, ChangeSignals, Medication, Practices, Pillars, PendingInvites) all self-gate when their data sources are empty. First-run patient sees a clean dashboard.
- **Dexie at v19** with healthy index coverage. No stale tables; all migrations additive.
- **Sync init** gates on `isSupabaseConfigured` + auth. Offline-first works.
- **PWA manifest valid**, service worker scoped narrowly to push notifications (no problematic fetch caching).
- No "cheerful" tone violations in user-facing strings.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` 0 errors
- [x] `pnpm test` 585 / 585
- [x] `pnpm build` clean
- [ ] Manual: `throw new Error('test')` in any client component → confirm error boundary renders.
- [ ] Manual: navigate to `/asdf` → confirm not-found renders.
- [ ] Manual: hard-refresh `/` while offline → confirm loading state shows briefly, then dashboard or onboarding.
- [ ] Manual: complete onboarding as caregiver → confirm single redirect to `/family` (no flash of patient dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpWRFSFnksEbpJ5c8fnJSW)_