### PR TITLE
FAB clearance over bottom nav (5rem → 6.5rem + inset)

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -99,12 +99,17 @@ body {
 
 /* Floating add button: clears the mobile bottom nav (which is itself
  * anchored at max(0.75rem, env(safe-area-inset-bottom)) and includes
- * its own internal home-indicator padding). On iOS PWA the nav is
- * ~110px tall once the home-indicator inset is included; the FAB needs
- * to sit above that, otherwise it disappears behind the nav. Desktop
- * (≥md) drops it back to 1.5rem from the viewport bottom. */
+ * its own internal home-indicator padding). The nav's rendered height
+ * is ~74px (icon + label + py-2.5 padding) and its top edge sits
+ * at viewport-bottom + 12px on regular browsers, +34px on iOS PWA
+ * with the home indicator. The FAB needs to clear that with a small
+ * visual gap, otherwise it overlaps the nav rounded corners.
+ *
+ * Math: nav-bottom-offset (max 0.75rem | inset) + nav-height (~74px)
+ *       + visual gap (12px) ≈ 6.5rem + inset.
+ * Desktop (≥md) drops it back to 1.5rem from the viewport bottom. */
 .add-fab {
-  bottom: calc(5rem + env(safe-area-inset-bottom));
+  bottom: calc(6.5rem + env(safe-area-inset-bottom));
 }
 @media (min-width: 768px) {
   .add-fab {


### PR DESCRIPTION
## Problem

User screenshot shows the black `+` FAB visually sitting on the top-right corner of the bottom nav — overlap, not clearance.

## Root cause

PR #99 set the FAB at `bottom: calc(5rem + env(safe-area-inset-bottom))` (80 px + inset). My earlier estimate of the bottom nav height (~64 px) was low — it's actually ~74 px (icon + label + `py-2.5` padding), and its top edge sits at:
- Regular browser: viewport-bottom + 12 px → **86 px**
- iOS PWA with home indicator: + 34 px → **120 px**

So `5rem (80 px)` puts the FAB *into* the nav, with the FAB's body extending up from there. The screenshot confirms it.

## Fix

Bump the FAB bottom to `calc(6.5rem + env(safe-area-inset-bottom))` (104 px + inset). Math: nav-bottom-offset (max 0.75 rem | inset) + nav-height (~74 px) + 12 px visual gap = ~6.5 rem + inset.

Result:
- Regular browser: FAB bottom at 104 px, nav top at 86 px → **18 px clearance**
- iOS PWA: FAB bottom at 138 px, nav top at 120 px → **18 px clearance**

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` 0 errors
- [x] `pnpm test` 585 / 585
- [ ] Manual on iPhone Safari → confirm FAB clearly above the nav with a visible gap.
- [ ] Manual as installed PWA → same clearance with home-indicator inset.
- [ ] Manual on desktop (≥md) → FAB still anchored at 1.5 rem (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpWRFSFnksEbpJ5c8fnJSW)_