### PR TITLE
Nutrition: meal time picker, edit-meal screen, timeline alignment + plan

### DIFF
--- a/src/app/nutrition/[id]/page.tsx
+++ b/src/app/nutrition/[id]/page.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useLiveQuery } from "dexie-react-hooks";
+import { ArrowLeft, Trash2, Save, Clock, X, Pencil } from "lucide-react";
+import { db } from "~/lib/db/dexie";
+import {
+  deleteMeal,
+  deleteMealItem,
+  listItemsForMeal,
+  updateMeal,
+  updateMealItemServing,
+} from "~/lib/nutrition/queries";
+import { sumItems } from "~/lib/nutrition/calculator";
+import { useLocale } from "~/hooks/use-translate";
+import { PageHeader } from "~/components/ui/page-header";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, Textarea, TextInput } from "~/components/ui/field";
+import { cn } from "~/lib/utils/cn";
+import type { MealItem, MealType } from "~/types/nutrition";
+
+// Edit screen for a single meal_entry. Patient can change:
+//   - Approximate eating time (logged_at)
+//   - Date (rare; the meal was eaten yesterday and logged today)
+//   - Meal type (breakfast → snack, etc.)
+//   - Notes
+//   - Per-item serving size (recomputes that item's macros + the
+//     parent meal totals)
+//   - Per-item delete
+//   - PERT taken / units
+//   - Whole-meal delete
+export default function EditMealPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = params?.id ? Number(params.id) : NaN;
+  const locale = useLocale();
+  const meal = useLiveQuery(
+    async () => (Number.isFinite(id) ? db.meal_entries.get(id) : undefined),
+    [id],
+  );
+  const items =
+    useLiveQuery(
+      async () =>
+        Number.isFinite(id) ? listItemsForMeal(id) : ([] as MealItem[]),
+      [id],
+    ) ?? [];
+
+  const [time, setTime] = useState<string>("");
+  const [date, setDate] = useState<string>("");
+  const [type, setType] = useState<MealType>("snack");
+  const [notes, setNotes] = useState<string>("");
+  const [pertTaken, setPertTaken] = useState<boolean>(false);
+  const [pertUnits, setPertUnits] = useState<string>("");
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  // Hydrate the form from the live meal once it loads. Only the first
+  // time — afterwards, edits override.
+  useEffect(() => {
+    if (!meal || dirty) return;
+    const t = new Date(meal.logged_at);
+    setTime(toHHMM(t));
+    setDate(meal.date);
+    setType(meal.meal_type);
+    setNotes(meal.notes ?? "");
+    setPertTaken(!!meal.pert_taken);
+    setPertUnits(meal.pert_units ? String(meal.pert_units) : "");
+  }, [meal, dirty]);
+
+  if (!Number.isFinite(id)) {
+    return (
+      <div className="mx-auto max-w-xl p-6 text-sm text-ink-500">
+        Invalid meal id.
+      </div>
+    );
+  }
+  if (meal === undefined) return null; // loading
+  if (meal === null) {
+    return (
+      <div className="mx-auto max-w-xl p-6 text-sm text-ink-500">
+        {locale === "zh" ? "记录不存在。" : "Meal not found."}
+      </div>
+    );
+  }
+
+  const totals = sumItems(items);
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  async function save() {
+    if (!Number.isFinite(id) || !meal) return;
+    setSaving(true);
+    try {
+      await updateMeal({
+        meal_entry_id: id,
+        date,
+        meal_type: type,
+        logged_at: assembleLoggedAt(date, time),
+        notes: notes.trim() ? notes.trim() : null,
+        pert_taken: pertTaken,
+        pert_units: pertUnits.trim() ? Number(pertUnits) : null,
+      });
+      router.push("/nutrition");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-5 px-4 py-6 sm:px-6">
+      <button
+        type="button"
+        onClick={() => router.back()}
+        className="inline-flex items-center gap-1.5 text-[12px] text-ink-500 hover:text-ink-900"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        {L("Back", "返回")}
+      </button>
+
+      <PageHeader
+        eyebrow={L("EDIT MEAL", "编辑")}
+        title={L("Edit meal", "修改这一餐")}
+        subtitle={L(
+          "Adjust the time eaten, the items, or notes.",
+          "调整时间、分量或备注。",
+        )}
+      />
+
+      <Card>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label={L("Date", "日期")}>
+              <TextInput
+                type="date"
+                value={date}
+                onChange={(e) => {
+                  setDate(e.target.value);
+                  setDirty(true);
+                }}
+              />
+            </Field>
+            <Field label={L("Time eaten", "进餐时间")}>
+              <div className="flex items-center gap-2">
+                <TextInput
+                  type="time"
+                  value={time}
+                  onChange={(e) => {
+                    setTime(e.target.value);
+                    setDirty(true);
+                  }}
+                />
+                <Clock className="h-4 w-4 text-ink-400" />
+              </div>
+            </Field>
+          </div>
+
+          <div className="flex flex-wrap gap-1.5">
+            {(["breakfast", "lunch", "dinner", "snack"] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => {
+                  setType(m);
+                  setDirty(true);
+                }}
+                className={cn(
+                  "rounded-md border px-2.5 py-1 text-[11px] capitalize",
+                  type === m
+                    ? "border-ink-900 bg-ink-900 text-paper"
+                    : "border-ink-200 bg-paper text-ink-700 hover:border-ink-300",
+                )}
+              >
+                {mealLabel(m, locale)}
+              </button>
+            ))}
+          </div>
+
+          <Field label={L("Notes", "备注")}>
+            <Textarea
+              rows={2}
+              value={notes}
+              onChange={(e) => {
+                setNotes(e.target.value);
+                setDirty(true);
+              }}
+            />
+          </Field>
+
+          {totals.total_fat_g >= 15 && (
+            <div className="rounded-md bg-[var(--warn,#d97706)]/10 px-3 py-2 text-[12px] text-[var(--warn,#d97706)]">
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={pertTaken}
+                  onChange={(e) => {
+                    setPertTaken(e.target.checked);
+                    setDirty(true);
+                  }}
+                />
+                {L("PERT taken with this meal", "已配胰酶")}
+              </label>
+              {pertTaken && (
+                <div className="mt-1.5 flex items-center gap-2 text-[11px] text-ink-700">
+                  <span>{L("Units (lipase)", "脂肪酶单位")}</span>
+                  <input
+                    type="number"
+                    placeholder="25000"
+                    value={pertUnits}
+                    onChange={(e) => {
+                      setPertUnits(e.target.value);
+                      setDirty(true);
+                    }}
+                    className="h-8 w-24 rounded-md border border-ink-200 bg-paper px-2 text-[12px]"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-2">
+          <h2 className="eyebrow">{L("Items", "项目")}</h2>
+          {items.length === 0 ? (
+            <p className="rounded-md bg-paper-2/60 px-3 py-3 text-[12px] text-ink-500">
+              {L(
+                "All items removed. Saving will keep the meal record but with zero macros.",
+                "所有项目已删除。保存后这一餐仍保留，但宏量为零。",
+              )}
+            </p>
+          ) : (
+            <ul className="space-y-1.5">
+              {items.map((it) => (
+                <li key={it.id}>
+                  <ItemRow item={it} locale={locale} />
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="flex items-baseline justify-between border-t border-ink-100/60 pt-2 text-[12px]">
+            <span className="text-ink-500">{L("Total", "合计")}</span>
+            <span className="mono text-ink-700">
+              {totals.total_protein_g}g P · {totals.total_fat_g}g F ·{" "}
+              {totals.total_net_carbs_g}g NC ·{" "}
+              {totals.total_calories} kcal
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={async () => {
+            if (
+              confirm(
+                L("Delete this meal log?", "删除这一餐记录？"),
+              )
+            ) {
+              await deleteMeal(id);
+              router.push("/nutrition");
+            }
+          }}
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[12px] text-ink-500 hover:bg-ink-100 hover:text-[var(--warn,#d97706)]"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          {L("Delete meal", "删除这一餐")}
+        </button>
+        <Button onClick={save} disabled={saving}>
+          <Save className="h-4 w-4" />
+          {L("Save changes", "保存修改")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ItemRow({ item, locale }: { item: MealItem; locale: string }) {
+  const [editing, setEditing] = useState(false);
+  const [grams, setGrams] = useState<string>(String(item.serving_grams));
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  return (
+    <div className="rounded-md border border-ink-100 bg-paper-2/40 p-3">
+      <div className="flex items-baseline gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-ink-900">
+            {locale === "zh" && item.food_name_zh
+              ? item.food_name_zh
+              : item.food_name}
+          </div>
+          <div className="mt-0.5 text-[11px] text-ink-500">
+            {item.serving_grams}g · {item.protein_g}g P · {item.fat_g}g F ·{" "}
+            {item.net_carbs_g}g NC · {item.calories} kcal
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setEditing((v) => !v)}
+          className="rounded-md p-1 text-ink-400 hover:bg-ink-100"
+          aria-label="Edit item"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={async () => {
+            if (
+              confirm(L("Remove this item?", "删除这一项？"))
+            ) {
+              await deleteMealItem(item.id!);
+            }
+          }}
+          className="rounded-md p-1 text-ink-400 hover:bg-ink-100 hover:text-[var(--warn,#d97706)]"
+          aria-label="Delete item"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {editing && (
+        <div className="mt-2 flex items-center gap-2">
+          <span className="mono text-[10px] uppercase tracking-wide text-ink-400">
+            g
+          </span>
+          <input
+            type="number"
+            min={0}
+            value={grams}
+            onChange={(e) => setGrams(e.target.value)}
+            className="h-8 w-24 rounded-md border border-ink-200 bg-paper px-2 text-xs"
+          />
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={async () => {
+              const n = Number(grams);
+              if (!Number.isFinite(n) || n < 0) return;
+              await updateMealItemServing({
+                meal_item_id: item.id!,
+                serving_grams: n,
+              });
+              setEditing(false);
+            }}
+          >
+            {L("Apply", "应用")}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function mealLabel(m: MealType, locale: string): string {
+  if (locale !== "zh") return m;
+  return { breakfast: "早餐", lunch: "午餐", dinner: "晚餐", snack: "加餐" }[m];
+}
+
+function toHHMM(d: Date): string {
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function assembleLoggedAt(date: string, hhmm: string): string {
+  const [y, m, d] = date.split("-").map((s) => Number(s));
+  const [hh, mm] = (hhmm || "00:00").split(":").map((s) => Number(s));
+  const dt = new Date(y, (m ?? 1) - 1, d ?? 1, hh ?? 0, mm ?? 0, 0, 0);
+  return dt.toISOString();
+}

--- a/src/app/nutrition/log/page.tsx
+++ b/src/app/nutrition/log/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Check, Sparkles } from "lucide-react";
+import { ArrowLeft, Check, Sparkles, Clock } from "lucide-react";
 import { todayISO } from "~/lib/utils/date";
 import { useLocale } from "~/hooks/use-translate";
 import { Card } from "~/components/ui/card";
@@ -38,6 +38,21 @@ export default function LogMealPage() {
   const [manualItems, setManualItems] = useState<PendingItem[]>([]);
   const [manualNotes, setManualNotes] = useState("");
   const [saving, setSaving] = useState(false);
+  // Approximate time the meal was eaten. Defaults to "now" so the
+  // common case (logging right after eating) stays one tap; the user
+  // can edit it for after-the-fact logging (e.g. logging breakfast
+  // at 11 am after eating it at 7). Stored as a `HH:MM` string
+  // so the <input type="time"> binding is straightforward; we
+  // assemble the full ISO datetime at save time using the date for
+  // the meal (today by default).
+  const [mealTime, setMealTime] = useState<string>(currentHHMM());
+
+  // Whenever the chosen meal-type changes through the auto-detector
+  // (e.g. user opens this page in the morning vs. evening) we keep
+  // mealTime in sync with current time. Manual edits are preserved.
+  function handleMealTypeChange(t: MealType) {
+    setManualMeal(t);
+  }
 
   async function saveFromPreview(data: {
     items: PreviewItem[];
@@ -52,6 +67,7 @@ export default function LogMealPage() {
       await createMeal({
         date: todayISO(),
         meal_type: data.meal_type,
+        logged_at: assembleLoggedAt(todayISO(), mealTime),
         notes: data.description,
         photo_data_url: data.photo_data_url,
         source: parsedSource,
@@ -95,6 +111,7 @@ export default function LogMealPage() {
       await createMeal({
         date: todayISO(),
         meal_type: manualMeal,
+        logged_at: assembleLoggedAt(todayISO(), mealTime),
         notes: manualNotes || undefined,
         source: "manual",
         entered_by: "hulin",
@@ -153,6 +170,32 @@ export default function LogMealPage() {
             : "Snap a photo or describe it. We'll do the math."
         }
       />
+
+      {/* Time of meal. Defaults to "now" so the common case (logging
+       * immediately after eating) is one tap. Editable for after-the-
+       * fact logging — eating breakfast at 7 and logging at 11, for
+       * example. The picker is light-weight on mobile (native
+       * <input type="time">) so the patient doesn't have to scroll
+       * a wheel. */}
+      <div className="flex items-center gap-3 rounded-md border border-ink-100 bg-paper-2/40 px-3 py-2.5 text-[12px] text-ink-700">
+        <Clock className="h-4 w-4 text-ink-400" />
+        <span className="text-ink-500">
+          {locale === "zh" ? "进餐时间" : "Time eaten"}
+        </span>
+        <input
+          type="time"
+          value={mealTime}
+          onChange={(e) => setMealTime(e.target.value)}
+          className="ml-auto h-9 rounded-md border border-ink-200 bg-paper px-2 text-[13px] text-ink-900 focus:border-ink-900 focus:outline-none"
+        />
+        <button
+          type="button"
+          onClick={() => setMealTime(currentHHMM())}
+          className="text-[11px] text-ink-500 underline-offset-2 hover:text-ink-900 hover:underline"
+        >
+          {locale === "zh" ? "现在" : "Now"}
+        </button>
+      </div>
 
       {parsed ? (
         <ParsedPreview
@@ -298,4 +341,23 @@ function mealLabel(m: MealType, locale: string): string {
 
 function round1(n: number): number {
   return Math.round(n * 10) / 10;
+}
+
+// Current local time as "HH:MM" — the value the <input type="time">
+// expects. Padded to two digits in each segment.
+function currentHHMM(): string {
+  const d = new Date();
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+// Combine a YYYY-MM-DD day and a HH:MM time into a local-zone ISO
+// datetime. We avoid `new Date('2026-04-25T21:40')` because that
+// gets interpreted as UTC in some browsers — instead build a Date
+// in the user's zone and call toISOString() so the stored value
+// round-trips correctly through Dexie + Supabase.
+function assembleLoggedAt(date: string, hhmm: string): string {
+  const [y, m, d] = date.split("-").map((s) => Number(s));
+  const [hh, mm] = hhmm.split(":").map((s) => Number(s));
+  const dt = new Date(y, (m ?? 1) - 1, d ?? 1, hh ?? 0, mm ?? 0, 0, 0);
+  return dt.toISOString();
 }

--- a/src/components/nutrition/meal-list.tsx
+++ b/src/components/nutrition/meal-list.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { Trash2, ChevronDown, BookmarkPlus, Repeat } from "lucide-react";
+import Link from "next/link";
+import { Trash2, ChevronDown, BookmarkPlus, Repeat, Pencil } from "lucide-react";
 import {
   listMealsForDate,
   listItemsForMeal,
@@ -143,6 +144,13 @@ function MealCard({ mealId }: { mealId: number }) {
             ))}
           </ul>
           <div className="flex flex-wrap items-center justify-end gap-2 pt-1">
+            <Link
+              href={`/nutrition/${mealId}`}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-ink-500 hover:bg-ink-100 hover:text-ink-900"
+            >
+              <Pencil className="h-3 w-3" />
+              {locale === "zh" ? "编辑" : "Edit"}
+            </Link>
             <button
               type="button"
               onClick={async () => {

--- a/src/components/nutrition/meal-timeline.tsx
+++ b/src/components/nutrition/meal-timeline.tsx
@@ -109,20 +109,29 @@ function DayClock({
           );
         })}
       </div>
-      <div className="mono flex justify-between text-[9px] uppercase tracking-wider text-ink-400">
-        <span>00</span>
-        <span className="inline-flex items-center gap-1">
-          <Sunrise className="h-3 w-3" /> 06
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <Sun className="h-3 w-3" /> 12
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <Sunset className="h-3 w-3" /> 18
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <Moon className="h-3 w-3" /> 24
-        </span>
+      {/* Hour-axis labels positioned absolutely at the same percentages
+       * the ticks above use, so each label's centre lines up with its
+       * tick. The earlier `flex justify-between` distributed by box
+       * edges, which gives unequal-width children (the icons) different
+       * apparent positions than the ticks they label — visually
+       * misaligned at 06 and 18. */}
+      <div className="mono relative h-3.5 text-[9px] uppercase tracking-wider text-ink-400">
+        {([
+          { hour: 0, label: "00", icon: null },
+          { hour: 6, label: "06", icon: Sunrise },
+          { hour: 12, label: "12", icon: Sun },
+          { hour: 18, label: "18", icon: Sunset },
+          { hour: 24, label: "24", icon: Moon },
+        ] as const).map(({ hour, label, icon: Icon }) => (
+          <span
+            key={hour}
+            className="absolute top-0 inline-flex -translate-x-1/2 items-center gap-1 whitespace-nowrap"
+            style={{ left: `${(hour / 24) * 100}%` }}
+          >
+            {Icon && <Icon className="h-3 w-3" />}
+            {label}
+          </span>
+        ))}
       </div>
     </div>
   );

--- a/src/lib/nutrition/queries.ts
+++ b/src/lib/nutrition/queries.ts
@@ -262,6 +262,94 @@ export async function recomputeMealTotals(meal_entry_id: number): Promise<void> 
   });
 }
 
+// Mutate a meal_entry in place. Used by the edit screen to change
+// `logged_at` (the approximate time the food was eaten — distinct
+// from `created_at`, which is when the row was written), `meal_type`,
+// `notes`, `pert_taken` / `pert_units`, and the day stamp `date` if
+// the meal was actually eaten on a different day. Items are edited
+// through their own helpers; this function never touches them.
+export interface UpdateMealInput {
+  meal_entry_id: number;
+  date?: string;
+  meal_type?: MealEntry["meal_type"];
+  logged_at?: string;
+  notes?: string | null;
+  pert_taken?: boolean;
+  pert_units?: number | null;
+}
+
+export async function updateMeal(input: UpdateMealInput): Promise<void> {
+  const patch: Partial<MealEntry> = {
+    updated_at: now(),
+  };
+  if (input.date !== undefined) patch.date = input.date;
+  if (input.meal_type !== undefined) patch.meal_type = input.meal_type;
+  if (input.logged_at !== undefined) patch.logged_at = input.logged_at;
+  if (input.notes !== undefined) patch.notes = input.notes ?? undefined;
+  if (input.pert_taken !== undefined) patch.pert_taken = input.pert_taken;
+  if (input.pert_units !== undefined) {
+    patch.pert_units = input.pert_units ?? undefined;
+  }
+  await db.meal_entries.update(input.meal_entry_id, patch);
+}
+
+// Replace a single item's serving size + recompute its macros from
+// the linked food row. Falls back to scaling the item's stored
+// macros when the food row is gone (food was deleted after the
+// meal was logged). Recomputes the parent meal totals.
+export async function updateMealItemServing(args: {
+  meal_item_id: number;
+  serving_grams: number;
+}): Promise<void> {
+  const item = await db.meal_items.get(args.meal_item_id);
+  if (!item) throw new Error("Meal item not found");
+  const newServing = Math.max(0, args.serving_grams);
+
+  let next: Partial<MealItem>;
+  if (item.food_id) {
+    const food = await db.foods.get(item.food_id);
+    if (food) {
+      const factor = newServing / 100;
+      next = {
+        serving_grams: newServing,
+        calories: round0(food.calories * factor),
+        protein_g: round1(food.protein_g * factor),
+        fat_g: round1(food.fat_g * factor),
+        carbs_total_g: round1(food.carbs_total_g * factor),
+        fiber_g: round1(food.fiber_g * factor),
+        net_carbs_g: round1(food.net_carbs_g * factor),
+      };
+    } else {
+      next = scaleItemFromCurrent(item, newServing);
+    }
+  } else {
+    next = scaleItemFromCurrent(item, newServing);
+  }
+
+  await db.meal_items.update(args.meal_item_id, next);
+  await recomputeMealTotals(item.meal_entry_id);
+}
+
+export async function deleteMealItem(meal_item_id: number): Promise<void> {
+  const item = await db.meal_items.get(meal_item_id);
+  if (!item) return;
+  await db.meal_items.delete(meal_item_id);
+  await recomputeMealTotals(item.meal_entry_id);
+}
+
+function scaleItemFromCurrent(item: MealItem, newServing: number) {
+  const factor = newServing / Math.max(1, item.serving_grams);
+  return {
+    serving_grams: newServing,
+    calories: round0(item.calories * factor),
+    protein_g: round1(item.protein_g * factor),
+    fat_g: round1(item.fat_g * factor),
+    carbs_total_g: round1(item.carbs_total_g * factor),
+    fiber_g: round1(item.fiber_g * factor),
+    net_carbs_g: round1(item.net_carbs_g * factor),
+  };
+}
+
 function round0(n: number): number {
   return Math.round(n);
 }

--- a/tests/unit/nutrition-edit-meal.test.ts
+++ b/tests/unit/nutrition-edit-meal.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { db } from "~/lib/db/dexie";
+import {
+  ensureFoodsSeeded,
+  searchFoods,
+  createMeal,
+  listItemsForMeal,
+  updateMeal,
+  updateMealItemServing,
+  deleteMealItem,
+} from "~/lib/nutrition/queries";
+
+beforeEach(async () => {
+  await db.delete();
+  await db.open();
+  await ensureFoodsSeeded();
+});
+
+async function aMeal(date = "2026-04-25", grams = 100) {
+  const food = (await searchFoods("egg"))[0]!;
+  return createMeal({
+    date,
+    meal_type: "breakfast",
+    logged_at: "2026-04-25T08:00:00Z",
+    source: "manual",
+    entered_by: "hulin",
+    items: [{ kind: "food", food, serving_grams: grams }],
+    notes: "two eggs",
+  });
+}
+
+describe("updateMeal", () => {
+  it("changes logged_at + meal_type + notes + date", async () => {
+    const id = await aMeal("2026-04-25");
+    await updateMeal({
+      meal_entry_id: id,
+      date: "2026-04-24",
+      meal_type: "snack",
+      logged_at: "2026-04-24T15:30:00Z",
+      notes: "actually a snack yesterday",
+    });
+    const row = await db.meal_entries.get(id);
+    expect(row?.date).toBe("2026-04-24");
+    expect(row?.meal_type).toBe("snack");
+    expect(row?.logged_at).toBe("2026-04-24T15:30:00Z");
+    expect(row?.notes).toBe("actually a snack yesterday");
+  });
+
+  it("clears notes when passed null", async () => {
+    const id = await aMeal();
+    await updateMeal({ meal_entry_id: id, notes: null });
+    const row = await db.meal_entries.get(id);
+    expect(row?.notes).toBeUndefined();
+  });
+
+  it("toggles pert_taken + pert_units", async () => {
+    const id = await aMeal();
+    await updateMeal({
+      meal_entry_id: id,
+      pert_taken: true,
+      pert_units: 25000,
+    });
+    let row = await db.meal_entries.get(id);
+    expect(row?.pert_taken).toBe(true);
+    expect(row?.pert_units).toBe(25000);
+
+    await updateMeal({
+      meal_entry_id: id,
+      pert_taken: false,
+      pert_units: null,
+    });
+    row = await db.meal_entries.get(id);
+    expect(row?.pert_taken).toBe(false);
+    expect(row?.pert_units).toBeUndefined();
+  });
+});
+
+describe("updateMealItemServing", () => {
+  it("recomputes per-item macros + parent totals", async () => {
+    const id = await aMeal("2026-04-25", 100);
+    const items = await listItemsForMeal(id);
+    const itemId = items[0].id!;
+    const beforeProtein = items[0].protein_g;
+    const beforeCalories = items[0].calories;
+
+    await updateMealItemServing({ meal_item_id: itemId, serving_grams: 200 });
+
+    const updatedItem = await db.meal_items.get(itemId);
+    expect(updatedItem?.serving_grams).toBe(200);
+    // Macros should roughly double.
+    expect(updatedItem?.protein_g).toBeCloseTo(beforeProtein * 2, 1);
+    expect(updatedItem?.calories).toBeCloseTo(beforeCalories * 2, 0);
+
+    // Parent totals snapshot is recomputed.
+    const meal = await db.meal_entries.get(id);
+    expect(meal?.total_protein_g).toBeCloseTo(updatedItem!.protein_g, 1);
+    expect(meal?.total_calories).toBeCloseTo(updatedItem!.calories, 0);
+  });
+
+  it("falls back to scaling stored macros when food row is gone", async () => {
+    const id = await aMeal("2026-04-25", 100);
+    const items = await listItemsForMeal(id);
+    const itemId = items[0].id!;
+    const foodId = items[0].food_id!;
+    const before = items[0].protein_g;
+
+    // Delete the underlying food row.
+    await db.foods.delete(foodId);
+
+    await updateMealItemServing({ meal_item_id: itemId, serving_grams: 50 });
+
+    const updated = await db.meal_items.get(itemId);
+    expect(updated?.serving_grams).toBe(50);
+    // Halved compared to the previous 100g.
+    expect(updated?.protein_g).toBeCloseTo(before / 2, 1);
+  });
+});
+
+describe("deleteMealItem", () => {
+  it("removes item and recomputes totals", async () => {
+    const id = await aMeal();
+    const items = await listItemsForMeal(id);
+    expect(items).toHaveLength(1);
+
+    await deleteMealItem(items[0].id!);
+    expect(await listItemsForMeal(id)).toHaveLength(0);
+
+    const meal = await db.meal_entries.get(id);
+    expect(meal?.total_protein_g).toBe(0);
+    expect(meal?.total_calories).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Three concrete fixes to the nutrition module + the strategic plan for the broader vision.

## What this PR ships

### 1. Meal time picker on `/nutrition/log`

The patient often logs after the fact (ate breakfast at 7, logs at 11). The logger now defaults `logged_at` to **now**, but exposes a native `<input type="time">` + a "Now" reset link in a row above the ingest panel. `assembleLoggedAt()` builds a local-zone ISO datetime so values round-trip through Dexie + Supabase without UTC drift.

### 2. `/nutrition/[id]` edit screen

Full edit flow for an existing meal entry:
- Date + time eaten
- Meal type
- Notes
- PERT taken / units (revealed for fatty meals)
- Per-item serving edit (recomputes that item's macros + parent totals)
- Per-item delete
- Whole-meal delete

Wired via a new **Edit** link on each meal card in `MealList`.

### 3. Timeline label alignment fix

Hour-axis labels (00, 06, 12, 18, 24) used `flex justify-between`, which distributes children by their **box edges** — so "🌅 06" with its sunrise icon was visually offset from the tick at 25%. Switched to absolute positioning at the same percentage as each tick, with `translate-x-1/2` to centre. Now ticks and labels line up at every hour mark.

### 4. New `nutrition/queries.ts` helpers

- `updateMeal({ meal_entry_id, date?, meal_type?, logged_at?, notes?, pert_taken?, pert_units? })`
- `updateMealItemServing({ meal_item_id, serving_grams })` — recomputes macros from the linked food row when present, falls back to scaling stored macros when the food has been deleted
- `deleteMealItem({ meal_item_id })`

All recompute parent meal totals so list views stay correct.

## The broader "remove all mental lift" plan (for follow-up slices)

This is the architectural picture for where I'd take the nutrition module next, scoped to clinical impact for Hu Lin's strategy. Open to redirection.

### A. Proactive guidance ("what to eat right now")

A `NextMealSuggestion` card on `/nutrition` that synthesises:
- **Time of day** (last meal was 4 h ago → suggest)
- **Protein deficit** ("you're 22 g short — 1 scoop whey + 200 ml milk closes it")
- **Net-carb headroom** ("12 g left in your daily 50 g cap — keep dinner low-carb")
- **Today's symptoms** (nausea → bone broth/congee; mucositis → soft + smooth; diarrhea → BRAT + electrolytes)
- **Treatment cycle context** (chemo day = lower appetite, higher protein urgency; off day = catch up)
- **What's saved as a template** (matches the patient's actual repertoire)

### B. End-of-day protein-gap nudge

A late-afternoon dashboard feed item: *"You've had 60 g protein. Target is 84 g. A scoop of whey + 2 boiled eggs covers the gap."* Specific, low-friction, no shame. Driven by `defaultTargets()` + `sumEntries()` + a time-of-day cutoff.

### C. Symptom-recovery menus

When today's `DailyEntry` flags nausea / mucositis / diarrhea / low-appetite, surface a curated collection page (filtered foods + saved templates + suggested combos), not just a soft picker filter. The current symptom-aware filter is the seed; this is the full menu.

### D. PERT (Creon) tracker

Today the meal-entry has a `pert_taken` flag and `pert_units`. We can:
- Daily PERT total visible on the dashboard
- Auto-prompt "Did you take Creon?" when a meal logs with ≥ 15 g fat
- 7-day adherence trend (matches the way the medications card works)
- Alert when a fatty meal has been logged for > 30 min without confirmation

### E. Family pre-logging

Caregivers cooking the meals (Catherine, Jonalyn) can pre-log on the patient's behalf via `/log` (already works) or a "Plan a meal for dad" CTA on `/family`. The patient just confirms when they eat.

### F. Treatment-cycle awareness

`treatment_cycles` table already tracks chemo day / day-after / recovery. The nutrition card can adapt:
- Day of infusion → smaller portions, hydration emphasis, easy-digest first
- Day 2–3 (nadir) → protein urgency, frequent meals
- Day 7 (recovery) → larger meals OK

### G. Shopping list integration

`docs/SHOPPING_LIST.md` already exists. Loop: meals planned/logged → infer ingredient gaps → caregiver gets a shopping list. Closes the planning ↔ groceries loop.

### H. Visual progress that respects the patient values

No 🎉 / no "fantastic!" / no exclamation marks. Just measured "on track" indicators in the existing palette. The current bars are already this — keep them, don't add cheerful affordances.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` 0 errors
- [x] `pnpm test` — **591 / 591** (6 new edit-meal tests)
- [x] `pnpm build` clean
- [ ] Manual: log a meal at `/nutrition/log` with the time set to 2 hours ago → confirm the timeline dot and meal-list entry both show the back-dated time.
- [ ] Manual: tap "Edit" on a past meal → change items, time, PERT → save → confirm changes propagate to dashboard totals.
- [ ] Manual: open `/nutrition` → confirm timeline labels (00, 06, 12, 18, 24) line up with their ticks above the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpWRFSFnksEbpJ5c8fnJSW)_