### PR TITLE
Dashboard UX pass: rank by priority, hide empty cards, tighten capture FAB

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,25 +122,26 @@ export default function DashboardPage() {
         }
       />
 
+      {/* Order = priority. Clinical (zone alert, change signals,
+        medication prompts) sits first because acting on them is
+        time-sensitive. Today's check-in / schedule come next as
+        the "what's now" layer. Behavioural cards (practices,
+        nutrition) and the data overview (PillarTiles, TodayFeed)
+        follow. Setup nudges (invites, baseline, sync) live at the
+        bottom so they never push a clinical alert below the fold
+        — they're low-stakes housekeeping, not the reason the
+        patient opened the app. */}
       <EmergencyCard />
-
-      <SyncPromptCard />
-
-      <QuickCheckinCard />
-
-      <PendingInvitesCard />
-
-      <InviteFamilyCard />
-
-      <BaselineNudgeCard />
-
-      <NextClinicCard />
-
-      <ScheduleCard />
 
       <ChangeSignalsCard />
 
       <MedicationPromptsCard />
+
+      <QuickCheckinCard />
+
+      <NextClinicCard />
+
+      <ScheduleCard />
 
       <PracticesCard />
 
@@ -149,6 +150,14 @@ export default function DashboardPage() {
       <PillarTiles />
 
       <TodayFeed excludeIds={EXCLUDE_IDS} />
+
+      <BaselineNudgeCard />
+
+      <PendingInvitesCard />
+
+      <InviteFamilyCard />
+
+      <SyncPromptCard />
 
       <footer className="pt-6 text-center text-xs text-ink-400">
         {t("common.localOnly")}

--- a/src/components/dashboard/change-signals-card.tsx
+++ b/src/components/dashboard/change-signals-card.tsx
@@ -425,7 +425,15 @@ function ActionRow({
 function safeDeserialize(row: ChangeSignalRow): ChangeSignal | null {
   try {
     return deserializeSignal(row);
-  } catch {
+  } catch (err) {
+    // Schema drift / corrupt persistence would otherwise silently
+    // drop a clinically relevant signal from the dashboard. Log it
+    // so the issue is visible in dev tooling.
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[change-signals] failed to deserialize signal row",
+      { id: row.id, detector: row.detector, err },
+    );
     return null;
   }
 }

--- a/src/components/dashboard/nutrition-card.tsx
+++ b/src/components/dashboard/nutrition-card.tsx
@@ -18,6 +18,12 @@ import { useLocale } from "~/hooks/use-translate";
 // Compact one-card surface for the dashboard. Surfaces protein progress
 // + net carbs against the patient's target. Tapping the card opens
 // the full nutrition surface.
+//
+// Hidden until the patient has logged at least one meal — on a fresh
+// install the "Log a meal" prompt is the FAB / Smart capture, not a
+// dashboard placeholder. Once any meal is logged the card stays
+// visible from then on (today's-meals empty state then becomes a
+// useful "log another" CTA rather than dead UI).
 export function NutritionCard() {
   const locale = useLocale();
   const today = todayISO();
@@ -25,6 +31,7 @@ export function NutritionCard() {
     async () => listMealsForDate(today),
     [today],
   );
+  const totalMealCount = useLiveQuery(() => db.meal_entries.count(), []);
   const meals = useMemo(() => mealsRaw ?? [], [mealsRaw]);
   const settings = useLiveQuery(() => db.settings.toCollection().first(), []);
   const target = useMemo(
@@ -34,6 +41,11 @@ export function NutritionCard() {
   const totals = useMemo(() => sumEntries(meals), [meals]);
   const proteinPct = (totals.total_protein_g / target.protein_g) * 100;
   const carbPct = (totals.total_net_carbs_g / target.net_carbs_g_max) * 100;
+
+  // Wait for the count query so the card doesn't flicker into a
+  // placeholder state before history is known.
+  if (totalMealCount === undefined) return null;
+  if (meals.length === 0 && totalMealCount === 0) return null;
 
   return (
     <Card>

--- a/src/components/dashboard/pending-invites-card.tsx
+++ b/src/components/dashboard/pending-invites-card.tsx
@@ -71,7 +71,7 @@ export function PendingInvitesCard() {
           </div>
         </div>
         <Link
-          href="/settings"
+          href="/settings#care-team"
           className="inline-flex items-center gap-0.5 text-[12px] text-ink-500 hover:text-ink-900"
         >
           {L("Manage", "管理")}

--- a/src/components/dashboard/practices-card.tsx
+++ b/src/components/dashboard/practices-card.tsx
@@ -6,7 +6,6 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
 import { Card } from "~/components/ui/card";
-import { Button } from "~/components/ui/button";
 import { DRUGS_BY_ID } from "~/config/drug-registry";
 import {
   isCustomPractice,
@@ -15,7 +14,7 @@ import {
 import { logMedicationEvent } from "~/lib/medication/log";
 import { expectedDosesToday } from "~/lib/medication/log";
 import type { Medication } from "~/types/medication";
-import { Check, ChevronRight, Pause, Play, Plus, Sparkles, X } from "lucide-react";
+import { Check, ChevronRight, Pause, Play, Sparkles, X } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { todayISO } from "~/lib/utils/date";
 
@@ -88,8 +87,13 @@ export function PracticesCard() {
 
   // Hide the card entirely when nothing is scheduled or logged today — keeps
   // the dashboard quiet until the user has set up at least one practice.
+  // We also drop the card on days where the user has practices configured
+  // but none are due today and none have been logged: a placeholder "no
+  // practices scheduled" panel is dead UI on the dashboard, and the
+  // /practices route + FAB still let the patient add one.
   if (meds === undefined || todaysEvents === undefined) return null;
   if ((meds?.length ?? 0) === 0) return null;
+  if (rows.length === 0) return null;
 
   return (
     <Card className="p-4">
@@ -113,33 +117,17 @@ export function PracticesCard() {
         </Link>
       </div>
 
-      {rows.length === 0 ? (
-        <div className="mt-3 flex items-center justify-between rounded-[var(--r-md)] bg-paper-2 p-3 text-[12px] text-ink-600">
-          <span>
-            {locale === "zh"
-              ? "今日没有已排程的修习。"
-              : "No practices scheduled for today."}
-          </span>
-          <Link href="/practices/new">
-            <Button variant="ghost" size="sm" className="gap-1">
-              <Plus className="h-3.5 w-3.5" />
-              {locale === "zh" ? "添加" : "Add"}
-            </Button>
-          </Link>
-        </div>
-      ) : (
-        <ul className="mt-3 space-y-1.5">
-          {rows.map(({ med, due, logged }) => (
-            <PracticeRow
-              key={med.id}
-              med={med}
-              due={due}
-              logged={logged}
-              locale={locale}
-            />
-          ))}
-        </ul>
-      )}
+      <ul className="mt-3 space-y-1.5">
+        {rows.map(({ med, due, logged }) => (
+          <PracticeRow
+            key={med.id}
+            med={med}
+            due={due}
+            logged={logged}
+            locale={locale}
+          />
+        ))}
+      </ul>
     </Card>
   );
 }
@@ -169,15 +157,21 @@ function PracticeRow({
   const [paused, setPaused] = useState(false);
   const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // Single interval keyed on running/paused state, not on `remaining` —
+  // the previous version re-created the interval every tick, which on
+  // slow renders briefly let two intervals overlap and double-decrement.
+  const isRunning = remaining !== null;
   useEffect(() => {
-    if (remaining === null || paused) return;
-    tickRef.current = setInterval(() => {
+    if (!isRunning || paused) return;
+    const id = setInterval(() => {
       setRemaining((r) => (r === null ? r : r - 1));
     }, 1000);
+    tickRef.current = id;
     return () => {
-      if (tickRef.current) clearInterval(tickRef.current);
+      clearInterval(id);
+      if (tickRef.current === id) tickRef.current = null;
     };
-  }, [remaining, paused]);
+  }, [isRunning, paused]);
 
   useEffect(() => {
     if (remaining !== null && remaining <= 0) {

--- a/src/components/dashboard/schedule-card.tsx
+++ b/src/components/dashboard/schedule-card.tsx
@@ -61,13 +61,13 @@ export function ScheduleCard() {
     [],
   );
 
-  const { upcoming, followUps } = useMemo(() => {
+  const { upcoming, followUps, totalUpcoming, totalFollowUps } = useMemo(() => {
     const list = appointments ?? [];
     const now = new Date();
     const startToday = startOfDay(now).getTime();
     const endTomorrow = startToday + 2 * 24 * 60 * 60 * 1000;
 
-    const upcoming = list
+    const upcomingAll = list
       .filter((a) => {
         const t = new Date(a.starts_at).getTime();
         return (
@@ -80,19 +80,34 @@ export function ScheduleCard() {
       .sort(
         (a, b) =>
           new Date(a.starts_at).getTime() - new Date(b.starts_at).getTime(),
-      )
-      .slice(0, 3);
+      );
 
-    const followUps = deriveFollowUpTasks({ appointments: list, now }).slice(
-      0,
-      3,
-    );
+    const followUpsAll = deriveFollowUpTasks({ appointments: list, now });
 
-    return { upcoming, followUps };
+    return {
+      upcoming: upcomingAll.slice(0, 3),
+      followUps: followUpsAll.slice(0, 3),
+      totalUpcoming: upcomingAll.length,
+      totalFollowUps: followUpsAll.length,
+    };
   }, [appointments]);
 
   if (!appointments) return null;
   if (upcoming.length === 0 && followUps.length === 0) return null;
+
+  // Surface a "+N more" hint when the visible slice is truncated, so
+  // the patient knows the day list isn't already exhaustive without
+  // having to navigate to /schedule to find out.
+  const hiddenUpcoming = Math.max(0, totalUpcoming - upcoming.length);
+  const hiddenFollowUps = Math.max(0, totalFollowUps - followUps.length);
+  const allLabel =
+    locale === "zh"
+      ? totalUpcoming > 3
+        ? `全部 (${totalUpcoming})`
+        : "全部"
+      : totalUpcoming > 3
+        ? `All (${totalUpcoming})`
+        : "All";
 
   return (
     <Card>
@@ -108,7 +123,7 @@ export function ScheduleCard() {
             href="/schedule"
             className="text-[12px] text-ink-500 hover:text-ink-900"
           >
-            {locale === "zh" ? "全部" : "All"}
+            {allLabel}
             <ChevronRight className="ml-0.5 inline h-3 w-3" />
           </Link>
         </div>
@@ -120,6 +135,18 @@ export function ScheduleCard() {
                 <UpcomingRow appt={a} locale={locale} />
               </li>
             ))}
+            {hiddenUpcoming > 0 && (
+              <li>
+                <Link
+                  href="/schedule"
+                  className="block rounded-md px-2.5 py-1 text-[11.5px] text-ink-500 hover:text-ink-900"
+                >
+                  {locale === "zh"
+                    ? `还有 ${hiddenUpcoming} 项 →`
+                    : `+${hiddenUpcoming} more →`}
+                </Link>
+              </li>
+            )}
           </ul>
         )}
 
@@ -145,6 +172,18 @@ export function ScheduleCard() {
                   </Link>
                 </li>
               ))}
+              {hiddenFollowUps > 0 && (
+                <li>
+                  <Link
+                    href="/schedule"
+                    className="block rounded-md px-2.5 py-1 text-[11.5px] text-ink-500 hover:text-ink-900"
+                  >
+                    {locale === "zh"
+                      ? `还有 ${hiddenFollowUps} 项 →`
+                      : `+${hiddenFollowUps} more →`}
+                  </Link>
+                </li>
+              )}
             </ul>
           </div>
         )}

--- a/src/components/dashboard/sync-prompt-card.tsx
+++ b/src/components/dashboard/sync-prompt-card.tsx
@@ -29,8 +29,21 @@ export function SyncPromptCard() {
       return;
     }
     supabase.auth.getUser().then(({ data }) => setSignedIn(Boolean(data.user)));
+    // Sign-in clears the dismiss key so a future sign-out will resurface
+    // the prompt rather than leaving it permanently silenced. Without
+    // this, dismissing once made the nudge invisible for the rest of
+    // the install.
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSignedIn(Boolean(session?.user));
+      const next = Boolean(session?.user);
+      setSignedIn(next);
+      if (next) {
+        try {
+          localStorage.removeItem(DISMISS_KEY);
+        } catch {
+          // ignore — private mode etc.
+        }
+        setDismissed(false);
+      }
     });
     return () => sub.subscription.unsubscribe();
   }, []);

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -144,7 +144,12 @@ export function TodayFeed({
         } catch {
           // ignore
         }
-      } catch {
+      } catch (err) {
+        // Narrative is best-effort — log so we know when the API
+        // gateway / rate limit is biting, but never block the feed
+        // on it.
+        // eslint-disable-next-line no-console
+        console.warn("[today-feed] narrative fetch failed", err);
         setNarrative(null);
       } finally {
         setNarrativeLoading(false);
@@ -184,7 +189,21 @@ export function TodayFeed({
       )}
 
       {narrativeLoading && !narrative && (
-        <div className="eyebrow px-1">{t("todayFeed.aiLoading")}</div>
+        <Card className="p-5" aria-busy="true">
+          <div className="flex items-start gap-3">
+            <div
+              className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
+              style={{ background: "var(--tide-soft)", color: "var(--tide-2)" }}
+            >
+              <Sparkles className="h-3.5 w-3.5 animate-pulse" />
+            </div>
+            <div className="flex-1 space-y-2">
+              <div className="eyebrow">{t("todayFeed.aiLoading")}</div>
+              <div className="h-3 w-3/4 animate-pulse rounded bg-ink-100" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-ink-100" />
+            </div>
+          </div>
+        </Card>
       )}
 
       <ul className="space-y-2">

--- a/src/components/shared/add-fab.tsx
+++ b/src/components/shared/add-fab.tsx
@@ -64,10 +64,10 @@ const CAREGIVER_ITEMS: FabItem[] = [
   },
   {
     action: "ingest",
-    label: { en: "Upload clinic letter", zh: "上传就诊函" },
+    label: { en: "Add a photo or document", zh: "导入照片或文档" },
     hint: {
-      en: "Photo or paste — the team sees it too",
-      zh: "拍照或粘贴 —— 团队也可看到",
+      en: "Clinic letter, lab report, scan result",
+      zh: "就诊函、化验单、影像报告",
     },
     icon: Sparkles,
     tone: "tide",
@@ -82,24 +82,24 @@ const CAREGIVER_ITEMS: FabItem[] = [
 // tired day.
 const ITEMS: FabItem[] = [
   {
-    action: "ingest",
-    label: { en: "Smart capture", zh: "智能导入" },
-    hint: {
-      en: "Photo, paste, voice — Claude files it",
-      zh: "照片 / 粘贴 / 语音 —— Claude 自动归档",
-    },
-    icon: Sparkles,
-    tone: "tide",
-  },
-  {
     href: "/log",
-    label: { en: "Tell the team", zh: "告诉团队" },
+    label: { en: "Say what's happening", zh: "说说现在的情况" },
     hint: {
-      en: "Free text — agents file it",
-      zh: "随手写 —— 智能体整理",
+      en: "Type or speak — agents file it for you",
+      zh: "随手写或语音 —— 智能体整理",
     },
     icon: MessageSquarePlus,
     tone: "sand",
+  },
+  {
+    action: "ingest",
+    label: { en: "Add a photo or document", zh: "导入照片或文档" },
+    hint: {
+      en: "Lab report, clinic letter, scan result",
+      zh: "化验单、就诊函、影像报告",
+    },
+    icon: Sparkles,
+    tone: "tide",
   },
   {
     href: "/daily/new",


### PR DESCRIPTION
## Summary

A targeted pass over the patient dashboard and capture surface to remove dead UI, give clinical signals priority, and clarify the input verbs. No new screens, no schema changes — purely UX polish on existing components.

### What changed, why it matters

- **Dashboard order is now priority-ranked.** Clinical alerts (zone, change signals, medication prompts) lead. "What's now" (today's check-in, schedule) follows. Behavioural cards (practices, nutrition) and the data overview after that. Setup nudges (invite family, sync prompt, baseline nudge) sink to the bottom so a low-stakes housekeeping prompt never pushes a clinical alert below the fold.
- **NutritionCard** hides on a fresh install when no meals have ever been logged. Comes back the moment any meal exists. Removes a placeholder card from day 1.
- **PracticesCard** drops its inline "no practices scheduled" panel — that was dead UI on a 14-card dashboard. The /practices route + FAB still let the patient add one.
- **PracticesCard timer** is keyed on running/paused state instead of `remaining`, so the interval is created once per session instead of every tick (which on slow renders briefly let two intervals stack and double-decrement).
- **ScheduleCard** surfaces a "+N more" inline hint and an "All (n)" count when the day-window slice is truncated, so the patient knows there's more without navigating away to find out.
- **SyncPromptCard** clears its localStorage dismiss key when auth flips to signed-in. Without this, dismissing once silenced the nudge for the life of the install — even after a future sign-out when it's actually relevant again.
- **PendingInvitesCard** links to `/settings#care-team` (matching InviteFamilyCard).
- **AddFab patient items**: the ambiguous "Smart capture" / "Tell the team" pair becomes "Say what's happening" (free-text + agent fan-out) and "Add a photo or document" (lab report / clinic letter ingest). Same verbs, clearer mental model.
- **TodayFeed narrative**: skeleton card replaces the bare "Generating focus…" eyebrow so the layout doesn't jump on reveal. Narrative-fetch failures are now logged instead of silently swallowed.
- **ChangeSignalsCard**: deserialization failures are logged instead of silently dropping a clinically relevant signal from the dashboard.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 591/591 unit tests pass
- [x] `pnpm lint` — only pre-existing warnings (no new ones from this PR)
- [ ] Manual: dashboard on a fresh install shows no NutritionCard / PracticesCard until data exists
- [ ] Manual: dismiss SyncPromptCard, sign in, sign out → prompt re-surfaces
- [ ] Manual: with 5+ appointments today, ScheduleCard shows "+2 more →" and "All (5)"
- [ ] Manual: trigger a clinical signal alongside an invite-family nudge → clinical card sits above the nudge

https://claude.ai/code/session_01SzsMbWwJmHKi4eZmjP5U6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzsMbWwJmHKi4eZmjP5U6A)_