### PR TITLE
Design polish: align tokens, primitives, remove emoji from patient UI

### DIFF
--- a/src/app/assessment/run/[id]/page.tsx
+++ b/src/app/assessment/run/[id]/page.tsx
@@ -10,7 +10,9 @@ export default function RunAssessmentPage() {
   const params = useParams<{ id: string }>();
   const id = Number(params?.id);
   if (!Number.isFinite(id)) {
-    return <div className="p-6 text-sm text-red-700">Invalid id.</div>;
+    return (
+      <div className="p-6 text-sm text-[var(--warn)]">Invalid id.</div>
+    );
   }
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-8">

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -9,7 +9,7 @@ import { Button } from "~/components/ui/button";
 import { PageHeader } from "~/components/ui/page-header";
 import { EmptyState } from "~/components/ui/empty-state";
 import { Attribution } from "~/components/shared/attribution";
-import { ChevronRight, CalendarDays } from "lucide-react";
+import { ChevronRight, CalendarDays, Check } from "lucide-react";
 
 export default function DailyPage() {
   const t = useT();
@@ -82,8 +82,9 @@ export default function DailyPage() {
                     <span>{e.walking_minutes} min walk</span>
                   )}
                   {e.resistance_training && (
-                    <span className="text-[var(--ok)]">
-                      {locale === "zh" ? "阻力 ✓" : "resistance ✓"}
+                    <span className="inline-flex items-center gap-1 text-[var(--ok)]">
+                      <Check className="h-3 w-3" aria-hidden />
+                      {locale === "zh" ? "阻力" : "resistance"}
                     </span>
                   )}
                 </div>

--- a/src/app/medications/[id]/page.tsx
+++ b/src/app/medications/[id]/page.tsx
@@ -6,8 +6,9 @@ import { useLocale } from "~/hooks/use-translate";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Disclosure } from "~/components/ui/disclosure";
+import { Alert } from "~/components/ui/alert";
 import { DRUGS_BY_ID } from "~/config/drug-registry";
-import { ArrowLeft } from "lucide-react";
+import { AlertTriangle, ArrowLeft, ArrowRight } from "lucide-react";
 import { Button } from "~/components/ui/button";
 
 export default function MedicationDetailPage() {
@@ -41,25 +42,22 @@ export default function MedicationDetailPage() {
 
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-8">
-      <div className="flex items-center gap-2">
-        <Link href="/medications">
-          <Button variant="ghost" size="sm" className="gap-2">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
-        <div>
-          <h1 className="text-2xl font-bold text-ink-900">{displayName}</h1>
-          <p className="text-sm text-ink-500">{displayClass}</p>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow={displayClass}
+        title={displayName}
+        action={
+          <Link href="/medications">
+            <Button variant="ghost" size="sm" className="gap-2">
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+            </Button>
+          </Link>
+        }
+      />
 
       {drug.aliases.length > 0 && (
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-1.5">
           {drug.aliases.map((alias) => (
-            <span
-              key={alias}
-              className="rounded-full bg-paper-1 px-2.5 py-1 text-xs font-medium text-ink-600"
-            >
+            <span key={alias} className="a-chip">
               {alias}
             </span>
           ))}
@@ -91,9 +89,7 @@ export default function MedicationDetailPage() {
         <CardContent className="space-y-3">
           {drug.typical_doses.length > 0 && (
             <div>
-              <p className="mb-2 text-xs font-semibold uppercase text-ink-500">
-                Typical doses
-              </p>
+              <p className="eyebrow mb-2">Typical doses</p>
               <ul className="space-y-1">
                 {drug.typical_doses.map((dose, i) => (
                   <li key={i} className="text-sm text-ink-700">
@@ -106,12 +102,13 @@ export default function MedicationDetailPage() {
 
           {drug.default_schedules.length > 0 && (
             <div className="border-t border-ink-100 pt-3">
-              <p className="mb-2 text-xs font-semibold uppercase text-ink-500">
-                Schedule
-              </p>
+              <p className="eyebrow mb-2">Schedule</p>
               <ul className="space-y-2">
                 {drug.default_schedules.map((sched, i) => (
-                  <li key={i} className="rounded bg-paper-1 p-2 text-sm">
+                  <li
+                    key={i}
+                    className="rounded-[var(--r-sm)] bg-ink-100/60 p-2.5 text-sm"
+                  >
                     <div className="font-medium text-ink-900">
                       {sched.label
                         ? locale === "zh"
@@ -120,8 +117,8 @@ export default function MedicationDetailPage() {
                         : `Schedule ${i + 1}`}
                     </div>
                     {sched.kind && (
-                      <div className="mt-1 text-xs text-ink-500">
-                        Kind: <span className="font-mono">{sched.kind}</span>
+                      <div className="mono mt-1 text-[11px] text-ink-500">
+                        {sched.kind}
                       </div>
                     )}
                   </li>
@@ -163,8 +160,14 @@ export default function MedicationDetailPage() {
             >
               <ul className="space-y-2 text-sm">
                 {drug.side_effects.serious.map((effect, i) => (
-                  <li key={i} className="flex gap-2 text-red-700">
-                    <span className="font-bold text-red-600">⚠</span>
+                  <li
+                    key={i}
+                    className="flex items-start gap-2 text-[var(--warn)]"
+                  >
+                    <AlertTriangle
+                      className="mt-0.5 h-3.5 w-3.5 shrink-0"
+                      aria-hidden
+                    />
                     <span>
                       {locale === "zh" ? effect.zh : effect.en}
                     </span>
@@ -185,8 +188,11 @@ export default function MedicationDetailPage() {
           <CardContent>
             <ul className="space-y-2">
               {drug.monitoring.map((monitor, i) => (
-                <li key={i} className="flex gap-2 text-sm text-ink-700">
-                  <span className="text-ink-300">→</span>
+                <li key={i} className="flex items-start gap-2 text-sm text-ink-700">
+                  <ArrowRight
+                    className="mt-0.5 h-3.5 w-3.5 shrink-0 text-ink-300"
+                    aria-hidden
+                  />
                   <span>
                     {locale === "zh" ? monitor.zh : monitor.en}
                   </span>
@@ -205,25 +211,19 @@ export default function MedicationDetailPage() {
           </CardHeader>
           <CardContent className="space-y-3">
             {drug.diet_interactions.map((interaction, i) => (
-              <div
+              <Alert
                 key={i}
-                className={`rounded border p-3 ${
-                  interaction.severity === "warning"
-                    ? "border-red-200 bg-red-50"
-                    : "border-yellow-200 bg-yellow-50"
-                }`}
-              >
-                <div className="font-medium text-ink-900">
-                  {locale === "zh"
+                variant={interaction.severity === "warning" ? "warn" : "info"}
+                title={
+                  locale === "zh"
                     ? interaction.food.zh
-                    : interaction.food.en}
-                </div>
-                <div className="mt-1 text-sm text-ink-700">
-                  {locale === "zh"
-                    ? interaction.effect.zh
-                    : interaction.effect.en}
-                </div>
-              </div>
+                    : interaction.food.en
+                }
+              >
+                {locale === "zh"
+                  ? interaction.effect.zh
+                  : interaction.effect.en}
+              </Alert>
             ))}
           </CardContent>
         </Card>

--- a/src/app/medications/log/page.tsx
+++ b/src/app/medications/log/page.tsx
@@ -244,7 +244,7 @@ function MedRow({
     <Card
       className={cn(
         "transition-colors",
-        allLogged && "bg-paper-1 opacity-80",
+        allLogged && "bg-ink-100/40 opacity-80",
       )}
     >
       <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:gap-4">
@@ -260,7 +260,7 @@ function MedRow({
                   <span
                     className={cn(
                       logged_count >= due_count
-                        ? "text-green-600"
+                        ? "text-[var(--ok)]"
                         : "text-ink-600",
                     )}
                   >
@@ -424,7 +424,7 @@ function SideEffectSheet({
           value={note}
           onChange={(e) => setNote(e.target.value)}
           placeholder={locale === "zh" ? "备注（可选）" : "Note (optional)"}
-          className="mb-4 w-full rounded border border-ink-200 bg-paper-1 p-2 text-sm"
+          className="mb-4 w-full rounded-[var(--r-sm)] border border-ink-200 bg-paper px-3 py-2 text-sm text-ink-900 placeholder:text-ink-400 focus:border-ink-900 focus:outline-none focus:ring-2 focus:ring-ink-900/10"
           rows={2}
         />
 

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -98,13 +98,11 @@ export default function MedicationsPage() {
 
           return (
             <div key={cat}>
-              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-ink-500">
-                {catLabel}
-              </h2>
+              <h2 className="eyebrow mb-3">{catLabel}</h2>
               <div className="space-y-2">
                 {drugs.map((drug) => (
                   <Link key={drug.id} href={`/medications/${drug.id}`}>
-                    <Card className="transition-colors hover:bg-paper-1">
+                    <Card className="transition-colors hover:bg-ink-100/40">
                       <CardContent className="flex items-center justify-between p-4">
                         <div className="flex-1">
                           <div className="font-medium text-ink-900">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -13,6 +13,9 @@ import { HouseholdSection } from "~/components/settings/household-section";
 import { NotificationsSection } from "~/components/settings/notifications-section";
 import { CareTeamSection } from "~/components/settings/care-team-section";
 import { TrackedSymptomsSection } from "~/components/settings/tracked-symptoms-section";
+import { PageHeader } from "~/components/ui/page-header";
+import { Button } from "~/components/ui/button";
+import { Field, TextInput, Textarea } from "~/components/ui/field";
 
 export default function SettingsPage() {
   const t = useT();
@@ -96,11 +99,7 @@ export default function SettingsPage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 md:p-8 space-y-6">
-      <div>
-        <h1 className="serif text-2xl tracking-tight text-ink-900">
-          {t("settings.title")}
-        </h1>
-      </div>
+      <PageHeader title={t("settings.title")} />
 
       <AccountButton />
 
@@ -118,26 +117,28 @@ export default function SettingsPage() {
         <section className="space-y-3">
           <h2 className="eyebrow">{t("settings.profile")}</h2>
           <Field label={t("settings.profile_name")}>
-            <input className={inputCls} {...register("profile_name")} />
+            <TextInput {...register("profile_name")} />
           </Field>
           <Field label={t("settings.dob")}>
-            <input type="date" className={inputCls} {...register("dob")} />
+            <TextInput type="date" {...register("dob")} />
           </Field>
           <Field label={t("settings.diagnosis_date")}>
-            <input type="date" className={inputCls} {...register("diagnosis_date")} />
+            <TextInput type="date" {...register("diagnosis_date")} />
           </Field>
           <Field label={t("settings.locale")}>
-            <select className={inputCls} {...register("locale")}>
+            <select className={selectCls} {...register("locale")}>
               <option value="en">{t("settings.locale_en")}</option>
               <option value="zh">{t("settings.locale_zh")}</option>
             </select>
           </Field>
-          <Field label="Home city (weather nudges)">
-            <input
-              className={inputCls}
-              placeholder="Melbourne"
-              {...register("home_city")}
-            />
+          <Field
+            label={
+              locale === "zh"
+                ? "居住城市（用于天气提醒）"
+                : "Home city (weather nudges)"
+            }
+          >
+            <TextInput placeholder="Melbourne" {...register("home_city")} />
           </Field>
         </section>
 
@@ -151,38 +152,51 @@ export default function SettingsPage() {
               : "Oncologist, hospital, and 24/7 contacts live in the Care team section above. Use this for the situation-specific guidance the patient should follow when something feels off."}
           </p>
           <div className="grid gap-3 sm:grid-cols-2">
-            <Field label="24/7 on-call (fallback)">
-              <input
-                type="tel"
-                className={inputCls}
-                {...register("oncall_phone")}
-              />
+            <Field
+              label={
+                locale === "zh"
+                  ? "24 小时值班电话（备用）"
+                  : "24/7 on-call (fallback)"
+              }
+            >
+              <TextInput type="tel" {...register("oncall_phone")} />
             </Field>
-            <Field label="Hospital address (fallback)">
-              <input className={inputCls} {...register("hospital_address")} />
+            <Field
+              label={
+                locale === "zh" ? "医院地址（备用）" : "Hospital address (fallback)"
+              }
+            >
+              <TextInput {...register("hospital_address")} />
             </Field>
             <div className="sm:col-span-2">
-              <Field label="When to go straight to hospital">
-                <textarea
-                  rows={3}
-                  className={inputCls}
-                  {...register("emergency_instructions")}
-                />
+              <Field
+                label={
+                  locale === "zh"
+                    ? "什么时候直接去急诊"
+                    : "When to go straight to hospital"
+                }
+              >
+                <Textarea rows={3} {...register("emergency_instructions")} />
               </Field>
             </div>
           </div>
         </section>
 
         <section className="space-y-3">
-          <h2 className="eyebrow">AI model</h2>
+          <h2 className="eyebrow">{locale === "zh" ? "AI 模型" : "AI model"}</h2>
           <p className="text-xs text-ink-500">
-            Claude calls run through Anchor&rsquo;s server (the shared
-            ANTHROPIC_API_KEY configured in Vercel) — no per-device key
-            needed. This field lets you override the default model.
+            {locale === "zh"
+              ? "Claude 调用通过 Anchor 服务器(在 Vercel 中配置的共享 ANTHROPIC_API_KEY)进行 —— 无需每台设备单独配置密钥。此字段用于覆盖默认模型。"
+              : "Claude calls run through Anchor’s server (the shared ANTHROPIC_API_KEY configured in Vercel) — no per-device key needed. This field lets you override the default model."}
           </p>
-          <Field label="Model (default claude-opus-4-7)">
-            <input
-              className={inputCls}
+          <Field
+            label={
+              locale === "zh"
+                ? "模型(默认 claude-opus-4-7)"
+                : "Model (default claude-opus-4-7)"
+            }
+          >
+            <TextInput
               placeholder="claude-opus-4-7"
               {...register("default_ai_model")}
             />
@@ -190,13 +204,9 @@ export default function SettingsPage() {
         </section>
 
         <div className="flex items-center gap-3">
-          <button
-            type="submit"
-            disabled={formState.isSubmitting}
-            className="inline-flex items-center rounded-md bg-ink-900 px-4 py-2 text-sm font-medium text-paper hover:brightness-110 disabled:opacity-50"
-          >
+          <Button type="submit" disabled={formState.isSubmitting}>
             {formState.isSubmitting ? t("common.saving") : t("common.save")}
-          </button>
+          </Button>
           {formState.isSubmitSuccessful && (
             <span className="text-xs text-ink-500">{t("common.saved")}</span>
           )}
@@ -206,22 +216,5 @@ export default function SettingsPage() {
   );
 }
 
-const inputCls =
-  "w-full rounded-md border border-ink-200 bg-paper-2 px-3 py-2 text-sm text-ink-900 placeholder:text-ink-400 focus:outline-none focus:ring-2 focus:ring-ink-900/10 focus:border-ink-900";
-
-const numberOptional = {
-  setValueAs: (v: unknown) => {
-    if (v === "" || v === null || v === undefined) return undefined;
-    const n = Number(v);
-    return Number.isNaN(n) ? undefined : n;
-  },
-};
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <label className="block space-y-1">
-      <span className="text-sm text-ink-700">{label}</span>
-      {children}
-    </label>
-  );
-}
+const selectCls =
+  "h-11 w-full rounded-md border border-ink-200 bg-paper px-3 text-sm text-ink-900 focus:border-ink-900 focus:outline-none focus:ring-2 focus:ring-ink-900/10";

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -10,7 +10,9 @@ export default function EditTaskPage() {
   const params = useParams<{ id: string }>();
   const id = Number(params?.id);
   if (!Number.isFinite(id)) {
-    return <div className="p-6 text-sm text-red-700">Invalid id.</div>;
+    return (
+      <div className="p-6 text-sm text-[var(--warn)]">Invalid id.</div>
+    );
   }
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-4 md:p-8">

--- a/src/components/dashboard/schedule-card.tsx
+++ b/src/components/dashboard/schedule-card.tsx
@@ -18,6 +18,8 @@ import {
   Stethoscope,
   ClipboardList,
   Sparkles,
+  Check,
+  HelpCircle,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 
@@ -199,12 +201,16 @@ function UpcomingRow({
           {chip && (
             <span
               className={
-                "inline-flex shrink-0 items-center rounded-full px-1.5 py-px text-[10px] font-medium " +
+                "inline-flex shrink-0 items-center gap-0.5 rounded-full px-1.5 py-px text-[10px] font-medium " +
                 chipTone
               }
             >
-              {chip.status === "confirmed" && "✓ "}
-              {chip.status === "tentative" && "? "}
+              {chip.status === "confirmed" && (
+                <Check className="h-2.5 w-2.5" aria-hidden />
+              )}
+              {chip.status === "tentative" && (
+                <HelpCircle className="h-2.5 w-2.5" aria-hidden />
+              )}
               {chip.label}
             </span>
           )}

--- a/src/components/family/next-up.tsx
+++ b/src/components/family/next-up.tsx
@@ -16,6 +16,8 @@ import {
   Sparkles,
   ChevronRight,
   MapPin,
+  Check,
+  HelpCircle,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 
@@ -180,21 +182,23 @@ function Row({ appt, locale }: { appt: Appointment; locale: "en" | "zh" }) {
                       : c.status === "declined"
                         ? "bg-ink-100 text-ink-400 line-through"
                         : "bg-ink-100 text-ink-700";
-                const prefix =
+                const StatusIcon =
                   c.status === "confirmed"
-                    ? "✓ "
+                    ? Check
                     : c.status === "tentative"
-                      ? "? "
-                      : "";
+                      ? HelpCircle
+                      : null;
                 return (
                   <span
                     key={`${c.label}-${i}`}
                     className={
-                      "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] " +
+                      "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] " +
                       tone
                     }
                   >
-                    {prefix}
+                    {StatusIcon && (
+                      <StatusIcon className="h-3 w-3" aria-hidden />
+                    )}
                     {c.label}
                   </span>
                 );

--- a/src/components/settings/care-team-section.tsx
+++ b/src/components/settings/care-team-section.tsx
@@ -542,7 +542,7 @@ export function CareTeamSection() {
                       <button
                         type="button"
                         onClick={() => m.id && remove(m.id)}
-                        className="rounded-md p-1.5 text-ink-500 hover:bg-ink-100/40 hover:text-red-700"
+                        className="rounded-md p-1.5 text-ink-500 hover:bg-[var(--warn-soft)] hover:text-[var(--warn)]"
                         aria-label={L("Remove", "移除")}
                       >
                         <Trash2 className="h-3.5 w-3.5" />

--- a/src/components/settings/notifications-section.tsx
+++ b/src/components/settings/notifications-section.tsx
@@ -161,10 +161,13 @@ export function NotificationsSection() {
                     onClick={onTest}
                     disabled={busy !== null}
                   >
+                    {testedOk && busy !== "test" && (
+                      <Check className="h-4 w-4" aria-hidden />
+                    )}
                     {busy === "test"
                       ? L("Sending…", "发送中…")
                       : testedOk
-                        ? L("Sent ✓", "已发送 ✓")
+                        ? L("Sent", "已发送")
                         : L("Send test", "测试一下")}
                   </Button>
                   <Button

--- a/src/components/treatment/cycle-day-detail.tsx
+++ b/src/components/treatment/cycle-day-detail.tsx
@@ -175,9 +175,9 @@ export function CycleDayDetail({
                 variant={record?.administered ? "secondary" : "primary"}
                 onClick={() => void toggleAdministered()}
               >
-                <Check className="h-3.5 w-3.5" />
+                <Check className="h-3.5 w-3.5" aria-hidden />
                 {record?.administered
-                  ? L("Administered ✓", "已给药 ✓")
+                  ? L("Administered", "已给药")
                   : L("Mark administered", "标记已给药")}
               </Button>
               <Button

--- a/src/components/ui/metric-tile.tsx
+++ b/src/components/ui/metric-tile.tsx
@@ -34,7 +34,7 @@ export function MetricTile({
     direction === "up" ? ArrowUp : direction === "down" ? ArrowDown : ArrowRight;
 
   return (
-    <div className={cn("a-card p-4", className)}>
+    <div className={cn("a-card p-5", className)}>
       <div className="eyebrow">{label}</div>
       <div className="mt-2 flex items-baseline gap-2">
         <span className="serif num text-3xl text-ink-900">{value}</span>
@@ -51,7 +51,9 @@ export function MetricTile({
             deltaClass,
           )}
         >
-          {direction && direction !== "none" && <Icon className="h-3 w-3" />}
+          {direction && direction !== "none" && (
+            <Icon className="h-3 w-3" aria-hidden />
+          )}
           {delta}
         </div>
       )}


### PR DESCRIPTION
## Summary

A targeted audit pass against `docs/UX_PRINCIPLES.md` and the design tokens in `src/styles/globals.css` / `tailwind.config.ts`. Every change pulls a screen back to the shared design language without adding new components or behaviour.

### Token alignment
- `bg-paper-1` was used in 5 places but is **not a defined token** (only `paper` and `paper-2` exist) — the fills never rendered. Swapped for `bg-ink-100/60` / `bg-ink-100/40` / `bg-paper`.
- `text-red-700` / `text-red-600` / `bg-red-50` / `bg-yellow-50` / `text-green-600` → `--warn` / `--ok` / `<Alert>` primitive (medications detail / log, tasks/[id], assessment/run/[id], care-team remove button).

### Primitive adoption
- **Settings page** now uses `<PageHeader>`, `<Field>`/`<TextInput>`/`<Textarea>` from `~/components/ui/field`, and `<Button>` instead of a raw `<h1>`, a local `Field` shim, and a bespoke submit button. Also adds Chinese strings to the previously English-only emergency / AI-model copy so the language switcher works on this page.
- **Medications detail page** now uses `<PageHeader>` (was a raw `<h1>`) and `<Alert variant="warn"|"info">` for diet interactions instead of inline coloured divs.

### Emoji removal (UX principle 1)
- `⚠` (medications detail "Serious side effects") → `<AlertTriangle/>`.
- `✓ ` / `? ` chip prefixes on the schedule card and family next-up attendee chips → `<Check/>` / `<HelpCircle/>` icons.
- `Administered ✓` / `Sent ✓` / `阻力 ✓` → `<Check/>` icon + clean text on the treatment, notifications, and daily list surfaces.

### Other consistency
- `MetricTile` padding `p-4` → `p-5` to match the rest of the `.a-card` family (CardContent uses `px-5 pb-5 pt-4`).
- Promoted ad-hoc uppercase headings on the medications detail page to the shared `.eyebrow` class.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 591/591 passing
- [x] `pnpm build` — production build succeeds (settings page slimmed from prior bespoke form to 15.4 kB; medications/[id] still 11 kB)
- [ ] Visual smoke test on Vercel preview: dashboard, settings, medications list/detail/log, daily list, treatment cycle day, family next-up, schedule card.

https://claude.ai/code/session_01FeKLjkaU1fpc8rA7ra2kGE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeKLjkaU1fpc8rA7ra2kGE)_