### PR TITLE
DRY refactor: API route helpers, useSettings hook, zone-rules cleanup

### DIFF
--- a/src/agents/run.ts
+++ b/src/agents/run.ts
@@ -9,6 +9,7 @@ import type {
 } from "~/types/agent";
 import type { Locale } from "~/types/clinical";
 import { AgentOutputSchema } from "./schema";
+import { DEFAULT_AI_MODEL } from "~/lib/anthropic/model";
 
 // Server-side runtime for one specialist invocation. Takes the batch of
 // log events that routed to this agent (a day's worth, typically) plus the
@@ -18,7 +19,7 @@ import { AgentOutputSchema } from "./schema";
 // The caller is responsible for reading state.md from Dexie before, and
 // writing the returned `state_diff` + persisting the AgentRunRow after.
 
-const MODEL = process.env.ANTHROPIC_LOG_MODEL || "claude-opus-4-7";
+const MODEL = process.env.ANTHROPIC_LOG_MODEL || DEFAULT_AI_MODEL;
 
 function roleFor(id: AgentId): string {
   // Role files are committed to the repo. We resolve them relative to the

--- a/src/app/api/agent/[id]/run/route.ts
+++ b/src/app/api/agent/[id]/run/route.ts
@@ -9,6 +9,7 @@ import type {
 } from "~/types/agent";
 import { AGENT_IDS, LOG_TAGS } from "~/types/agent";
 import { runAgent } from "~/agents/run";
+import { readJsonBody } from "~/lib/anthropic/route-helpers";
 
 export const runtime = "nodejs";
 // Specialist agents chew through referrals + state and emit up to 2k tokens
@@ -71,14 +72,10 @@ export async function POST(
     );
   }
 
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const json = await readJsonBody<unknown>(req);
+  if (json.error) return json.error;
 
-  const parsed = RequestSchema.safeParse(body);
+  const parsed = RequestSchema.safeParse(json.body);
   if (!parsed.success) {
     return NextResponse.json(
       { error: "Invalid request", detail: parsed.error.flatten() },

--- a/src/app/api/ai/assessment-summary/route.ts
+++ b/src/app/api/ai/assessment-summary/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import { z } from "zod/v4";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+  withAnthropicErrorBoundary,
+} from "~/lib/anthropic/route-helpers";
 import { SUMMARY_SYSTEM } from "~/lib/ai/coach";
 
 export const runtime = "nodejs";
@@ -19,20 +24,13 @@ interface RequestBody {
 }
 
 export async function POST(req: Request) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY is not configured on the server." },
-      { status: 503 },
-    );
-  }
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
 
-  let body: RequestBody;
-  try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody<RequestBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
+
   if (!body?.assessment) {
     return NextResponse.json(
       { error: "assessment required" },
@@ -40,10 +38,9 @@ export async function POST(req: Request) {
     );
   }
 
-  const client = new Anthropic({ apiKey });
-  try {
-    const response = await client.messages.parse({
-      model: body.model ?? "claude-opus-4-7",
+  const result = await withAnthropicErrorBoundary(() =>
+    gate.client.messages.parse({
+      model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 800,
       system: [
         {
@@ -67,16 +64,15 @@ export async function POST(req: Request) {
           ],
         },
       ],
-    });
-    if (!response.parsed_output) {
-      return NextResponse.json(
-        { error: "No summary returned" },
-        { status: 502 },
-      );
-    }
-    return NextResponse.json({ result: response.parsed_output });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 502 });
+    }),
+  );
+  if (result.error) return result.error;
+
+  if (!result.value.parsed_output) {
+    return NextResponse.json(
+      { error: "No summary returned" },
+      { status: 502 },
+    );
   }
+  return NextResponse.json({ result: result.value.parsed_output });
 }

--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -1,10 +1,15 @@
 import { NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import {
   COACH_SYSTEM,
   type CoachContext,
   type CoachMessage,
 } from "~/lib/ai/coach";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+  withAnthropicErrorBoundary,
+} from "~/lib/anthropic/route-helpers";
 import type { Locale } from "~/types/clinical";
 
 export const runtime = "nodejs";
@@ -18,20 +23,13 @@ interface RequestBody {
 }
 
 export async function POST(req: Request) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY is not configured on the server." },
-      { status: 503 },
-    );
-  }
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
 
-  let body: RequestBody;
-  try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody<RequestBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
+
   if (!body?.context || !Array.isArray(body?.history)) {
     return NextResponse.json(
       { error: "context and history[] required" },
@@ -39,12 +37,11 @@ export async function POST(req: Request) {
     );
   }
 
-  const { model = "claude-opus-4-7", context, history, locale = "en" } = body;
+  const { model = DEFAULT_AI_MODEL, context, history, locale = "en" } = body;
   const contextBlock = `Current step: ${context.stepTitle}\nKey: ${context.stepKey}\nInstructions shown to the user:\n${context.stepInstructions}\n\nRespond in ${locale === "zh" ? "Simplified Chinese (简体中文)" : "English"}.`;
 
-  const client = new Anthropic({ apiKey });
-  try {
-    const response = await client.messages.create({
+  const result = await withAnthropicErrorBoundary(() =>
+    gate.client.messages.create({
       model,
       max_tokens: 600,
       system: [
@@ -59,17 +56,16 @@ export async function POST(req: Request) {
         role: m.role,
         content: [{ type: "text", text: m.content }],
       })),
-    });
-    const block = response.content.find((b) => b.type === "text");
-    if (!block || block.type !== "text") {
-      return NextResponse.json(
-        { error: "Empty response from coach" },
-        { status: 502 },
-      );
-    }
-    return NextResponse.json({ reply: block.text });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 502 });
+    }),
+  );
+  if (result.error) return result.error;
+
+  const block = result.value.content.find((b) => b.type === "text");
+  if (!block || block.type !== "text") {
+    return NextResponse.json(
+      { error: "Empty response from coach" },
+      { status: 502 },
+    );
   }
+  return NextResponse.json({ reply: block.text });
 }

--- a/src/app/api/ai/feed-narrative/route.ts
+++ b/src/app/api/ai/feed-narrative/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import { NARRATIVE_SYSTEM } from "~/lib/nudges/ai-narrative";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+  withAnthropicErrorBoundary,
+} from "~/lib/anthropic/route-helpers";
 import type { FeedItem } from "~/types/feed";
 import type { Locale } from "~/types/clinical";
 
@@ -14,25 +19,18 @@ interface RequestBody {
 }
 
 export async function POST(req: Request) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY is not configured on the server." },
-      { status: 503 },
-    );
-  }
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
 
-  let body: RequestBody;
-  try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody<RequestBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
+
   if (!Array.isArray(body?.items)) {
     return NextResponse.json({ error: "items[] required" }, { status: 400 });
   }
 
-  const { locale = "en", items, model = "claude-opus-4-7" } = body;
+  const { locale = "en", items, model = DEFAULT_AI_MODEL } = body;
   const signals = items
     .slice(0, 8)
     .map((item, i) => {
@@ -42,9 +40,8 @@ export async function POST(req: Request) {
     })
     .join("\n");
 
-  const client = new Anthropic({ apiKey });
-  try {
-    const response = await client.messages.create({
+  const result = await withAnthropicErrorBoundary(() =>
+    gate.client.messages.create({
       model,
       max_tokens: 300,
       system: [
@@ -65,17 +62,16 @@ export async function POST(req: Request) {
           ],
         },
       ],
-    });
-    const block = response.content.find((b) => b.type === "text");
-    if (!block || block.type !== "text") {
-      return NextResponse.json(
-        { error: "No narrative returned" },
-        { status: 502 },
-      );
-    }
-    return NextResponse.json({ narrative: block.text.trim() });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 502 });
+    }),
+  );
+  if (result.error) return result.error;
+
+  const block = result.value.content.find((b) => b.type === "text");
+  if (!block || block.type !== "text") {
+    return NextResponse.json(
+      { error: "No narrative returned" },
+      { status: 502 },
+    );
   }
+  return NextResponse.json({ narrative: block.text.trim() });
 }

--- a/src/app/api/ai/ingest-meal/route.ts
+++ b/src/app/api/ai/ingest-meal/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+  withAnthropicErrorBoundary,
+} from "~/lib/anthropic/route-helpers";
 import { MealSchema, MEAL_SYSTEM } from "~/lib/ingest/meal-vision";
 import type { PreparedImage } from "~/lib/ingest/image";
 
@@ -13,28 +18,20 @@ interface RequestBody {
 }
 
 export async function POST(req: Request) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY is not configured on the server." },
-      { status: 503 },
-    );
-  }
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
 
-  let body: RequestBody;
-  try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody<RequestBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
+
   if (!body?.image?.base64 || !body.image.mediaType) {
     return NextResponse.json({ error: "image required" }, { status: 400 });
   }
 
-  const client = new Anthropic({ apiKey });
-  try {
-    const response = await client.messages.parse({
-      model: body.model ?? "claude-opus-4-7",
+  const result = await withAnthropicErrorBoundary(() =>
+    gate.client.messages.parse({
+      model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 1024,
       system: [
         { type: "text", text: MEAL_SYSTEM, cache_control: { type: "ephemeral" } },
@@ -59,16 +56,15 @@ export async function POST(req: Request) {
           ],
         },
       ],
-    });
-    if (!response.parsed_output) {
-      return NextResponse.json(
-        { error: "No meal estimate returned" },
-        { status: 502 },
-      );
-    }
-    return NextResponse.json({ result: response.parsed_output });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 502 });
+    }),
+  );
+  if (result.error) return result.error;
+
+  if (!result.value.parsed_output) {
+    return NextResponse.json(
+      { error: "No meal estimate returned" },
+      { status: 502 },
+    );
   }
+  return NextResponse.json({ result: result.value.parsed_output });
 }

--- a/src/app/api/ai/ingest-notes/route.ts
+++ b/src/app/api/ai/ingest-notes/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+  withAnthropicErrorBoundary,
+} from "~/lib/anthropic/route-helpers";
 import {
   NotesStructureSchema,
   NOTES_SYSTEM,
@@ -16,28 +21,20 @@ interface RequestBody {
 }
 
 export async function POST(req: Request) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY is not configured on the server." },
-      { status: 503 },
-    );
-  }
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
 
-  let body: RequestBody;
-  try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody<RequestBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
+
   if (!body?.image?.base64 || !body.image.mediaType) {
     return NextResponse.json({ error: "image required" }, { status: 400 });
   }
 
-  const client = new Anthropic({ apiKey });
-  try {
-    const response = await client.messages.parse({
-      model: body.model ?? "claude-opus-4-7",
+  const result = await withAnthropicErrorBoundary(() =>
+    gate.client.messages.parse({
+      model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 1500,
       system: [
         { type: "text", text: NOTES_SYSTEM, cache_control: { type: "ephemeral" } },
@@ -62,16 +59,15 @@ export async function POST(req: Request) {
           ],
         },
       ],
-    });
-    if (!response.parsed_output) {
-      return NextResponse.json(
-        { error: "No notes structure returned" },
-        { status: 502 },
-      );
-    }
-    return NextResponse.json({ result: response.parsed_output });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 502 });
+    }),
+  );
+  if (result.error) return result.error;
+
+  if (!result.value.parsed_output) {
+    return NextResponse.json(
+      { error: "No notes structure returned" },
+      { status: 502 },
+    );
   }
+  return NextResponse.json({ result: result.value.parsed_output });
 }

--- a/src/app/api/ai/ingest-report/route.ts
+++ b/src/app/api/ai/ingest-report/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+  withAnthropicErrorBoundary,
+} from "~/lib/anthropic/route-helpers";
 import {
   ExtractionSchema,
   EXTRACTION_SYSTEM,
@@ -18,20 +23,13 @@ interface RequestBody {
 }
 
 export async function POST(req: Request) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY is not configured on the server." },
-      { status: 503 },
-    );
-  }
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
 
-  let body: RequestBody;
-  try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody<RequestBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
+
   if (!body?.text && !body?.image) {
     return NextResponse.json(
       { error: "text or image required" },
@@ -39,7 +37,6 @@ export async function POST(req: Request) {
     );
   }
 
-  const client = new Anthropic({ apiKey });
   const content: Array<
     | { type: "text"; text: string }
     | {
@@ -75,9 +72,9 @@ export async function POST(req: Request) {
     });
   }
 
-  try {
-    const response = await client.messages.parse({
-      model: body.model ?? "claude-opus-4-7",
+  const result = await withAnthropicErrorBoundary(() =>
+    gate.client.messages.parse({
+      model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 2048,
       system: [
         {
@@ -88,16 +85,15 @@ export async function POST(req: Request) {
       ],
       output_config: { format: jsonOutputFormat(ExtractionSchema) },
       messages: [{ role: "user", content }],
-    });
-    if (!response.parsed_output) {
-      return NextResponse.json(
-        { error: "Claude returned no parsed output" },
-        { status: 502 },
-      );
-    }
-    return NextResponse.json({ result: response.parsed_output });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 502 });
+    }),
+  );
+  if (result.error) return result.error;
+
+  if (!result.value.parsed_output) {
+    return NextResponse.json(
+      { error: "Claude returned no parsed output" },
+      { status: 502 },
+    );
   }
+  return NextResponse.json({ result: result.value.parsed_output });
 }

--- a/src/app/api/ai/ingest-universal/route.ts
+++ b/src/app/api/ai/ingest-universal/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+  withAnthropicErrorBoundary,
+} from "~/lib/anthropic/route-helpers";
 import {
   INGEST_SYSTEM,
   ingestDraftSchema,
@@ -27,20 +32,13 @@ interface RequestBody {
 }
 
 export async function POST(req: Request) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY is not configured on the server." },
-      { status: 503 },
-    );
-  }
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
 
-  let body: RequestBody;
-  try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody<RequestBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
+
   if (!body?.text && !body?.image) {
     return NextResponse.json(
       { error: "text or image required" },
@@ -90,10 +88,9 @@ export async function POST(req: Request) {
     });
   }
 
-  const client = new Anthropic({ apiKey });
-  try {
-    const response = await client.messages.parse({
-      model: body.model ?? "claude-opus-4-7",
+  const result = await withAnthropicErrorBoundary(() =>
+    gate.client.messages.parse({
+      model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 4096,
       system: [
         {
@@ -104,20 +101,19 @@ export async function POST(req: Request) {
       ],
       output_config: { format: jsonOutputFormat(ingestDraftSchema) },
       messages: [{ role: "user", content }],
-    });
-    if (!response.parsed_output) {
-      return NextResponse.json(
-        { error: "No draft returned" },
-        { status: 502 },
-      );
-    }
-    const draft: IngestDraft = {
-      source: body.source,
-      ...response.parsed_output,
-    };
-    return NextResponse.json({ draft });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 502 });
+    }),
+  );
+  if (result.error) return result.error;
+
+  if (!result.value.parsed_output) {
+    return NextResponse.json(
+      { error: "No draft returned" },
+      { status: 502 },
+    );
   }
+  const draft: IngestDraft = {
+    source: body.source,
+    ...result.value.parsed_output,
+  };
+  return NextResponse.json({ draft });
 }

--- a/src/app/api/ai/parse-meal/route.ts
+++ b/src/app/api/ai/parse-meal/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+  withAnthropicErrorBoundary,
+} from "~/lib/anthropic/route-helpers";
 import {
   ParsedMealSchema,
   NUTRITION_SYSTEM,
@@ -25,20 +30,13 @@ interface TextBody {
 type RequestBody = PhotoBody | TextBody;
 
 export async function POST(req: Request) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: "ANTHROPIC_API_KEY is not configured on the server." },
-      { status: 503 },
-    );
-  }
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
 
-  let body: RequestBody;
-  try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody<RequestBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
+
   if (!body || (body.kind !== "photo" && body.kind !== "text")) {
     return NextResponse.json(
       { error: "kind must be 'photo' or 'text'" },
@@ -52,15 +50,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "text required" }, { status: 400 });
   }
 
-  const client = new Anthropic({ apiKey });
   const localeNote =
     body.locale === "zh"
       ? "Reply in English keys, but populate name_zh for every item."
       : "name_zh is optional; only populate when obvious (e.g. Chinese dish).";
 
-  try {
-    const response = await client.messages.parse({
-      model: body.model ?? "claude-opus-4-7",
+  const result = await withAnthropicErrorBoundary(() =>
+    gate.client.messages.parse({
+      model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 1500,
       system: [
         {
@@ -102,16 +99,15 @@ export async function POST(req: Request) {
                 ],
               },
             ],
-    });
-    if (!response.parsed_output) {
-      return NextResponse.json(
-        { error: "No meal estimate returned" },
-        { status: 502 },
-      );
-    }
-    return NextResponse.json({ result: response.parsed_output });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 502 });
+    }),
+  );
+  if (result.error) return result.error;
+
+  if (!result.value.parsed_output) {
+    return NextResponse.json(
+      { error: "No meal estimate returned" },
+      { status: 502 },
+    );
   }
+  return NextResponse.json({ result: result.value.parsed_output });
 }

--- a/src/app/api/ingest-ics/route.ts
+++ b/src/app/api/ingest-ics/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { icsEventsToOps, parseIcs } from "~/lib/ingest/ics";
+import { readJsonBody } from "~/lib/anthropic/route-helpers";
 import type { IngestDraft } from "~/types/ingest";
 
 export const runtime = "nodejs";
@@ -34,12 +35,9 @@ function normaliseUrl(raw: string): string {
 }
 
 export async function POST(req: Request) {
-  let body: RequestBody;
-  try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
+  const parsed = await readJsonBody<RequestBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
 
   let raw: string | null = null;
   let sourceHint = "pasted ICS text";

--- a/src/app/api/parse-appointment/route.ts
+++ b/src/app/api/parse-appointment/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { parsedAppointmentSchema } from "~/lib/appointments/schema";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+} from "~/lib/anthropic/route-helpers";
 
 // Server-side vision/text parser for appointment letters, cards, and
 // pasted emails. Accepts either an image (data URL or https URL) or a
@@ -55,13 +60,10 @@ Fields:
 Return nothing for fields you can't see. Never fabricate. If the input clearly isn't an appointment, still return an object but with confidence "low" and title="Unable to parse".`;
 
 export async function POST(req: Request) {
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-  const parsed = RequestSchema.safeParse(body);
+  const json = await readJsonBody<unknown>(req);
+  if (json.error) return json.error;
+
+  const parsed = RequestSchema.safeParse(json.body);
   if (!parsed.success) {
     return NextResponse.json(
       { error: "Invalid request", detail: parsed.error.flatten() },
@@ -76,22 +78,10 @@ export async function POST(req: Request) {
     );
   }
 
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json(
-      {
-        error:
-          "ANTHROPIC_API_KEY is not configured on the server. Set it in Vercel env.",
-      },
-      { status: 503 },
-    );
-  }
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
 
-  const [{ default: Anthropic }, { jsonOutputFormat }] = await Promise.all([
-    import("@anthropic-ai/sdk"),
-    import("~/lib/anthropic/json-output"),
-  ]);
-  const client = new Anthropic({ apiKey });
+  const { jsonOutputFormat } = await import("~/lib/anthropic/json-output");
 
   const userContent: Array<
     | { type: "text"; text: string }
@@ -126,8 +116,8 @@ export async function POST(req: Request) {
   });
 
   try {
-    const response = await client.messages.parse({
-      model: process.env.ANTHROPIC_LOG_MODEL || "claude-opus-4-7",
+    const response = await gate.client.messages.parse({
+      model: process.env.ANTHROPIC_LOG_MODEL || DEFAULT_AI_MODEL,
       max_tokens: 800,
       system: [
         {

--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { useLiveQuery } from "dexie-react-hooks";
 import { format } from "date-fns";
 import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
+import { useDefaultAiModel } from "~/hooks/use-settings";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -22,8 +22,7 @@ import { Sparkles, Check, Loader2 } from "lucide-react";
 
 export default function MealIngestPage() {
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+  const model = useDefaultAiModel();
 
   const [prepared, setPrepared] = useState<PreparedImage | null>(null);
   const [preview, setPreview] = useState<string | null>(null);

--- a/src/app/ingest/notes/page.tsx
+++ b/src/app/ingest/notes/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
+import { useDefaultAiModel } from "~/hooks/use-settings";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -23,8 +23,7 @@ type DailyPatch = NonNullable<NotesStructure["daily_patch"]>;
 
 export default function NotesIngestPage() {
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+  const model = useDefaultAiModel();
 
   const [prepared, setPrepared] = useState<PreparedImage | null>(null);
   const [preview, setPreview] = useState<string | null>(null);

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { todayISO } from "~/lib/utils/date";
 import { useLocale, useT } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { useUIStore } from "~/stores/ui-store";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -145,7 +145,7 @@ export default function OnboardingPage() {
   const router = useRouter();
   const setUILocale = useUIStore((s) => s.setLocale);
   const setEnteredBy = useUIStore((s) => s.setEnteredBy);
-  const existingSettings = useLiveQuery(() => db.settings.toArray());
+  const existingSettings = useSettings();
 
   const [form, setForm] = useState<FormState>({ ...EMPTY, locale });
   const [step, setStep] = useState<StepKey>("welcome");
@@ -153,7 +153,7 @@ export default function OnboardingPage() {
 
   // If already onboarded, bounce back to dashboard.
   useEffect(() => {
-    const s = existingSettings?.[0];
+    const s = existingSettings;
     if (s?.onboarded_at) {
       router.replace("/");
     } else if (s) {
@@ -284,10 +284,10 @@ export default function OnboardingPage() {
         home_lon,
         home_timezone,
         onboarded_at: ts,
-        created_at: existingSettings?.[0]?.created_at ?? ts,
+        created_at: existingSettings?.created_at ?? ts,
         updated_at: ts,
       };
-      const existing = existingSettings?.[0];
+      const existing = existingSettings;
       if (existing?.id) {
         await db.settings.put({ ...payload, id: existing.id });
       } else {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,8 @@
 
 import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { useLiveQuery } from "dexie-react-hooks";
 import { format } from "date-fns";
-import { db } from "~/lib/db/dexie";
+import { useSettings } from "~/hooks/use-settings";
 import { PillarTiles } from "~/components/dashboard/pillar-tiles";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
@@ -30,8 +29,8 @@ export default function DashboardPage() {
   const t = useT();
   const locale = useLocale();
   const router = useRouter();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const profileName = settings?.[0]?.profile_name;
+  const settings = useSettings();
+  const profileName = settings?.profile_name;
   const { membership } = useHousehold();
 
   // Single redirect effect with a clear precedence ladder so two
@@ -49,13 +48,12 @@ export default function DashboardPage() {
   //      yet-to-load primary_carer to the family view by accident.
   //   5. Otherwise (patient / primary carer) → stay on dashboard.
   useEffect(() => {
-    if (!settings) return;
-    const s = settings[0];
-    if (!s?.onboarded_at) {
+    if (settings === undefined) return; // still loading
+    if (!settings?.onboarded_at) {
       router.replace("/onboarding");
       return;
     }
-    if (s.user_type === "caregiver" || s.user_type === "clinician") {
+    if (settings.user_type === "caregiver" || settings.user_type === "clinician") {
       router.replace("/family");
       return;
     }
@@ -96,10 +94,9 @@ export default function DashboardPage() {
   // an explicit perspective bounce in flight), render nothing rather
   // than flash the patient dashboard at a caregiver who's about to be
   // routed to /family. The app-level loading.tsx covers the visual.
-  if (!settings) return null;
-  const s0 = settings[0];
-  if (!s0?.onboarded_at) return null;
-  if (s0.user_type === "caregiver" || s0.user_type === "clinician") {
+  if (settings === undefined) return null;
+  if (!settings?.onboarded_at) return null;
+  if (settings.user_type === "caregiver" || settings.user_type === "clinician") {
     return null;
   }
 

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
 import { useLocale, useT } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -18,7 +19,7 @@ export default function ReportsPage() {
   const [generating, setGenerating] = useState(false);
   const [exporting, setExporting] = useState(false);
 
-  const settings = useLiveQuery(() => db.settings.toArray());
+  const settings = useSettings();
   const dailyCount = useLiveQuery(() => db.daily_entries.count());
   const fortnightlyCount = useLiveQuery(() =>
     db.fortnightly_assessments.count(),
@@ -142,7 +143,7 @@ export default function ReportsPage() {
                 ? "生成 PDF"
                 : "Generate PDF"}
           </Button>
-          {settings && settings.length === 0 && (
+          {settings === null && (
             <div className="mt-3 text-xs text-[oklch(45%_0.09_70)]">
               {locale === "zh"
                 ? "先在设置里填写基本信息，生成的小结会更完整。"

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,10 +3,10 @@
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { settingsSchema, type SettingsInput } from "~/lib/validators/schemas";
 import { useLocale, useT } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { useUIStore } from "~/stores/ui-store";
 import { AccountButton } from "~/components/shared/account-button";
 import { HouseholdSection } from "~/components/settings/household-section";
@@ -18,8 +18,7 @@ export default function SettingsPage() {
   const t = useT();
   const locale = useLocale();
   const setLocale = useUIStore((s) => s.setLocale);
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const current = settings?.[0];
+  const current = useSettings();
 
   const { register, handleSubmit, reset, formState } = useForm<SettingsInput>({
     resolver: zodResolver(settingsSchema),

--- a/src/components/assessment/baselines-card.tsx
+++ b/src/components/assessment/baselines-card.tsx
@@ -3,10 +3,10 @@
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { settingsSchema, type SettingsInput } from "~/lib/validators/schemas";
 import { useT } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { Card, CardContent } from "~/components/ui/card";
 
 // Baseline anthropometrics + functional benchmarks. Lives next to the
@@ -26,8 +26,7 @@ const numberOptional = {
 
 export function BaselinesCard() {
   const t = useT();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const current = settings?.[0];
+  const current = useSettings();
 
   const { register, handleSubmit, reset, formState } = useForm<SettingsInput>({
     resolver: zodResolver(settingsSchema),

--- a/src/components/assessment/coach-drawer.tsx
+++ b/src/components/assessment/coach-drawer.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import { useState } from "react";
-import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils/cn";
 import { useLocale } from "~/hooks/use-translate";
+import { useDefaultAiModel } from "~/hooks/use-settings";
 import { askCoach, type CoachContext, type CoachMessage } from "~/lib/ai/coach";
 import { Sparkles, X, Send, Loader2 } from "lucide-react";
 
 export function CoachDrawer({ context }: { context: CoachContext }) {
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+  const model = useDefaultAiModel();
 
   const [open, setOpen] = useState(false);
   const [history, setHistory] = useState<CoachMessage[]>([]);

--- a/src/components/assessment/wizard.tsx
+++ b/src/components/assessment/wizard.tsx
@@ -4,8 +4,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
+import { getSettings } from "~/lib/db/queries";
 import { useLocale } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { useUIStore } from "~/stores/ui-store";
+import { DEFAULT_AI_MODEL } from "~/lib/anthropic/model";
 import {
   TEST_CATALOG,
   testById,
@@ -80,8 +83,7 @@ export function AssessmentWizard({ assessmentId }: WizardProps) {
     () => db.comprehensive_assessments.get(assessmentId),
     [assessmentId],
   );
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const baseline = settings?.[0] ?? null;
+  const baseline = useSettings() ?? null;
 
   const [draft, setDraft] = useState<AssessmentDraft>({});
   const [tests, setTests] = useState<TestId[]>([]);
@@ -349,9 +351,11 @@ function ReviewView({
     setSaving(true);
     try {
       const { computePillars } = await import("~/lib/calculations/pillars");
-      const settings = await db.settings.toArray();
-      const baselineWeight = settings[0]?.baseline_weight_kg;
-      const scores = computePillars(assessment, baselineWeight);
+      const existingSettings = await getSettings();
+      const scores = computePillars(
+        assessment,
+        existingSettings?.baseline_weight_kg,
+      );
       await db.comprehensive_assessments.update(assessmentId, {
         ...scores,
         status: "complete",
@@ -359,7 +363,6 @@ function ReviewView({
         updated_at: now(),
       });
       // Populate baselines on first comprehensive assessment
-      const existingSettings = settings[0];
       if (existingSettings && existingSettings.id) {
         const patches: Record<string, number | undefined> = {};
         if (!existingSettings.baseline_weight_kg && assessment.weight_kg) {
@@ -413,7 +416,7 @@ function ReviewView({
   }
 
   async function generateAiSummary() {
-    const settings = await db.settings.toArray();
+    const settings = await getSettings();
     setAiBusy(true);
     setAiError(null);
     try {
@@ -421,13 +424,9 @@ function ReviewView({
         import("~/lib/ai/coach"),
         import("~/lib/calculations/pillars"),
       ]);
-      const scores = computePillars(
-        assessment,
-        settings[0]?.baseline_weight_kg,
-      );
+      const scores = computePillars(assessment, settings?.baseline_weight_kg);
       const filled: ComprehensiveAssessment = { ...assessment, ...scores };
-      const model =
-        settings[0]?.default_ai_model ?? "claude-opus-4-7";
+      const model = settings?.default_ai_model ?? DEFAULT_AI_MODEL;
       const summary = await summariseAssessment({
         model,
         assessment: filled,

--- a/src/components/dashboard/baseline-nudge-card.tsx
+++ b/src/components/dashboard/baseline-nudge-card.tsx
@@ -6,6 +6,7 @@ import { Stethoscope, ChevronRight } from "lucide-react";
 import { db } from "~/lib/db/dexie";
 import { Card, CardContent } from "~/components/ui/card";
 import { useLocale } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 
 // Surfaced when the patient has finished onboarding but hasn't done a
 // first comprehensive assessment yet. Baselines (weight, grip, gait,
@@ -21,7 +22,7 @@ import { useLocale } from "~/hooks/use-translate";
 //   - any complete comprehensive_assessment exists in history
 export function BaselineNudgeCard() {
   const locale = useLocale();
-  const settings = useLiveQuery(() => db.settings.toArray());
+  const s = useSettings();
   const hasComplete = useLiveQuery(async () => {
     const rows = await db.comprehensive_assessments
       .orderBy("assessment_date")
@@ -31,9 +32,8 @@ export function BaselineNudgeCard() {
     return rows.some((r) => r.status === "complete");
   });
 
-  if (!settings || settings.length === 0) return null;
-  const s = settings[0];
-  if (!s?.onboarded_at) return null;
+  if (!s) return null;
+  if (!s.onboarded_at) return null;
   if (s.baseline_weight_kg) return null;
   if (hasComplete) return null;
 

--- a/src/components/dashboard/emergency-card.tsx
+++ b/src/components/dashboard/emergency-card.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useLiveQuery } from "dexie-react-hooks";
 import { useState } from "react";
-import { db } from "~/lib/db/dexie";
 import { useZoneStatus } from "~/hooks/use-zone-status";
 import { useT } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { Phone, AlertOctagon, MapPin, ChevronDown, ChevronUp } from "lucide-react";
 
 // Only rendered when zone is red/orange — on green/yellow days this stays
@@ -12,8 +11,7 @@ import { Phone, AlertOctagon, MapPin, ChevronDown, ChevronUp } from "lucide-reac
 // /settings; the feed surfaces them when zone changes trigger a review.
 export function EmergencyCard() {
   const t = useT();
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const s = settings?.[0];
+  const s = useSettings();
   const { zone } = useZoneStatus();
 
   const hasAnyContact =

--- a/src/components/dashboard/medication-prompts-card.tsx
+++ b/src/components/dashboard/medication-prompts-card.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { useActiveCycleContext } from "~/hooks/use-active-cycle";
 import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -244,9 +245,8 @@ function CallClinicAction({
   variant: "primary" | "tide";
   onAck: () => void | Promise<void>;
 }) {
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const phone =
-    settings?.[0]?.oncall_phone ?? settings?.[0]?.managing_oncologist_phone;
+  const settings = useSettings();
+  const phone = settings?.oncall_phone ?? settings?.managing_oncologist_phone;
   if (phone) {
     return (
       <a href={`tel:${phone.replace(/\s/g, "")}`} onClick={() => void onAck()}>

--- a/src/components/dashboard/pillar-tiles.tsx
+++ b/src/components/dashboard/pillar-tiles.tsx
@@ -8,7 +8,7 @@ import {
   format,
   parseISO,
 } from "date-fns";
-import { db } from "~/lib/db/dexie";
+import { useSettings } from "~/hooks/use-settings";
 import {
   latestDailyEntries,
   latestLabs,
@@ -59,14 +59,14 @@ export function PillarTiles() {
   const dailies = useLiveQuery(() => latestDailyEntries(7));
   const labs = useLiveQuery(() => latestLabs(7));
   const cycles = useLiveQuery(() => latestTreatmentCycles(1));
-  const settings = useLiveQuery(() => db.settings.toArray());
+  const settings = useSettings();
 
   const ordered = (dailies ?? []).slice().reverse();
   const todayISO = format(new Date(), "yyyy-MM-dd");
   const todayEntry = ordered.find((d) => d.date === todayISO);
   const recentCycle = (cycles ?? [])[0];
   const latestLab = (labs ?? [])[0];
-  const baselineWeight = settings?.[0]?.baseline_weight_kg;
+  const baselineWeight = settings?.baseline_weight_kg;
 
   // -- Symptoms 7d -------------------------------------------------------
   const symptomSeries = useMemo(

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -2,11 +2,10 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
 import { useTodayFeed } from "~/hooks/use-today-feed";
 import { useWeather } from "~/hooks/use-weather";
 import { useLocale, useT } from "~/hooks/use-translate";
+import { useDefaultAiModel } from "~/hooks/use-settings";
 import { generateNarrative } from "~/lib/nudges/ai-narrative";
 import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
@@ -93,8 +92,7 @@ export function TodayFeed({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [rawFeed, excludeKey],
   );
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const model = settings?.[0]?.default_ai_model ?? "claude-opus-4-7";
+  const model = useDefaultAiModel();
 
   const [expanded, setExpanded] = useState(false);
   const [narrative, setNarrative] = useState<string | null>(null);

--- a/src/components/fortnightly/fortnightly-form.tsx
+++ b/src/components/fortnightly/fortnightly-form.tsx
@@ -6,6 +6,7 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
 import { useUIStore } from "~/stores/ui-store";
 import { useLocale, useT } from "~/hooks/use-translate";
+import { useSettings } from "~/hooks/use-settings";
 import { runEngineAndPersist } from "~/lib/rules/engine";
 import { fortnightlyAssessmentSchema } from "~/lib/validators/schemas";
 import { todayISO } from "~/lib/utils/date";
@@ -49,8 +50,7 @@ export function FortnightlyForm({ entryId }: { entryId?: number }) {
   const locale = useLocale();
   const router = useRouter();
   const enteredBy = useUIStore((s) => s.enteredBy);
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const baseline = settings?.[0];
+  const baseline = useSettings();
 
   const existing = useLiveQuery(
     () => (entryId ? db.fortnightly_assessments.get(entryId) : undefined),

--- a/src/hooks/use-metrics.ts
+++ b/src/hooks/use-metrics.ts
@@ -2,8 +2,8 @@
 
 import { useMemo } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
 import { latestDailyEntries } from "~/lib/db/queries";
+import { useSettings } from "~/hooks/use-settings";
 import type { DailyEntry, Settings } from "~/types/clinical";
 
 export interface BodyMetrics {
@@ -29,8 +29,7 @@ function bmiCategory(b: number): string {
 
 export function useBodyMetrics(): BodyMetrics {
   const entries = useLiveQuery(() => latestDailyEntries(28));
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const baseline = settings?.[0];
+  const baseline = useSettings() ?? undefined;
 
   return useMemo(
     () => computeMetrics(entries ?? [], baseline),
@@ -40,7 +39,7 @@ export function useBodyMetrics(): BodyMetrics {
 
 function computeMetrics(
   entries: DailyEntry[],
-  baseline: Settings | undefined,
+  baseline: Settings | null | undefined,
 ): BodyMetrics {
   const ordered = entries.slice().reverse();
   const last7 = ordered.slice(-7);

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { DEFAULT_AI_MODEL } from "~/lib/anthropic/model";
+import type { Settings } from "~/types/clinical";
+
+// Single canonical hook for the singleton Settings row. Replaces the
+// ~20 callsites that did `useLiveQuery(() => db.settings.toArray())` and
+// then took `[0]`. Returns `undefined` while Dexie is loading and
+// `null` once we know the row doesn't exist yet (pre-onboarding).
+export function useSettings(): Settings | null | undefined {
+  return useLiveQuery(async () => {
+    const row = await db.settings.toCollection().first();
+    return row ?? null;
+  });
+}
+
+// Convenience helper: the configured default Claude model, falling back
+// to the global default when settings isn't loaded yet or the user
+// hasn't overridden it.
+export function useDefaultAiModel(): string {
+  const settings = useSettings();
+  return settings?.default_ai_model ?? DEFAULT_AI_MODEL;
+}

--- a/src/hooks/use-today-feed.ts
+++ b/src/hooks/use-today-feed.ts
@@ -10,6 +10,7 @@ import {
   latestLabs,
   latestTreatmentCycles,
 } from "~/lib/db/queries";
+import { useSettings } from "~/hooks/use-settings";
 import { composeTodayFeed } from "~/lib/nudges/compose";
 import { PROTOCOL_BY_ID } from "~/config/protocols";
 import { NUDGE_LIBRARY } from "~/config/treatment-nudges";
@@ -23,7 +24,7 @@ export function useTodayFeed({
 }: {
   weather: CurrentWeather | null;
 }): FeedItem[] {
-  const settings = useLiveQuery(() => db.settings.toArray());
+  const settings = useSettings();
   const dailies = useLiveQuery(() => latestDailyEntries(28));
   const labs = useLiveQuery(() => latestLabs(10));
   const tasks = useLiveQuery(() => db.patient_tasks.toArray());
@@ -32,7 +33,7 @@ export function useTodayFeed({
   const agentRuns = useLiveQuery(() => latestAgentRuns(40));
 
   return useMemo(() => {
-    const s = settings?.[0] ?? null;
+    const s = settings ?? null;
     const orderedDailies = (dailies ?? []).slice().reverse();
     const orderedLabs = (labs ?? []).slice().reverse();
     const openAlerts = (alerts ?? []).filter((a) => !a.resolved);

--- a/src/hooks/use-translate.ts
+++ b/src/hooks/use-translate.ts
@@ -11,3 +11,10 @@ export function useT() {
 export function useLocale() {
   return useUIStore((s) => s.locale);
 }
+
+// Inline en/zh chooser used by ~50 components. Exported here so each
+// component doesn't need to redefine `const L = (en, zh) => ...` in scope.
+export function useL() {
+  const locale = useUIStore((s) => s.locale);
+  return (en: string, zh: string) => (locale === "zh" ? zh : en);
+}

--- a/src/hooks/use-weather.ts
+++ b/src/hooks/use-weather.ts
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
+import { useSettings } from "~/hooks/use-settings";
 import {
   fetchCurrentWeather,
   type CurrentWeather,
@@ -11,8 +10,7 @@ import {
 const CACHE_MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 export function useWeather(): CurrentWeather | null {
-  const settings = useLiveQuery(() => db.settings.toArray());
-  const s = settings?.[0];
+  const s = useSettings();
   const city = s?.home_city;
   const lat = s?.home_lat;
   const lon = s?.home_lon;

--- a/src/lib/ai/coach.ts
+++ b/src/lib/ai/coach.ts
@@ -1,4 +1,5 @@
 import type { ComprehensiveAssessment } from "~/types/clinical";
+import { DEFAULT_AI_MODEL } from "~/lib/anthropic/model";
 
 export interface CoachContext {
   stepKey: string;
@@ -30,7 +31,7 @@ export const SUMMARY_SYSTEM = `You summarise a single comprehensive baseline ass
 Respond ONLY with JSON: {"patient": "...", "clinician": "..."}`;
 
 export async function askCoach({
-  model = "claude-opus-4-7",
+  model = DEFAULT_AI_MODEL,
   context,
   history,
   locale = "en",
@@ -56,7 +57,7 @@ export interface AssessmentSummary {
 }
 
 export async function summariseAssessment({
-  model = "claude-opus-4-7",
+  model = DEFAULT_AI_MODEL,
   assessment,
   priorAssessment,
 }: {

--- a/src/lib/anthropic/model.ts
+++ b/src/lib/anthropic/model.ts
@@ -1,0 +1,5 @@
+// Default Claude model used by every Claude-backed call (server route or
+// client-side helper). Override per-user via Settings.default_ai_model.
+// Kept in its own module so client code can import it without pulling in
+// the server-only Anthropic SDK from route-helpers.ts.
+export const DEFAULT_AI_MODEL = "claude-opus-4-7";

--- a/src/lib/anthropic/route-helpers.ts
+++ b/src/lib/anthropic/route-helpers.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+
+export { DEFAULT_AI_MODEL } from "./model";
+
+// Discriminated result so callers can `if ("error" in r) return r.error;`
+// without losing the `Anthropic` client type on the success branch.
+export type AnthropicGate =
+  | { client: Anthropic; error?: undefined }
+  | { error: NextResponse; client?: undefined };
+
+// Returns either an Anthropic client or a 503 NextResponse to return directly.
+// All Claude-backed routes share this gate so the missing-key error surface
+// stays consistent (and tested by api-agent-run.test.ts).
+export function getAnthropicClient(): AnthropicGate {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return {
+      error: NextResponse.json(
+        { error: "ANTHROPIC_API_KEY is not configured on the server." },
+        { status: 503 },
+      ),
+    };
+  }
+  return { client: new Anthropic({ apiKey }) };
+}
+
+export type JsonBodyResult<T> =
+  | { body: T; error?: undefined }
+  | { error: NextResponse; body?: undefined };
+
+// Reads and JSON-parses a Request body, returning a 400 NextResponse on
+// failure. The shape `{ error: "Invalid JSON body" }` is asserted by
+// api-agent-run.test.ts and must not change.
+export async function readJsonBody<T>(req: Request): Promise<JsonBodyResult<T>> {
+  try {
+    const body = (await req.json()) as T;
+    return { body };
+  } catch {
+    return {
+      error: NextResponse.json(
+        { error: "Invalid JSON body" },
+        { status: 400 },
+      ),
+    };
+  }
+}
+
+// Wraps a Claude SDK call. On thrown error, returns a 502 with the error
+// message. Callers pass the work as a closure so the helper can keep the
+// try/catch boilerplate out of every route.
+export async function withAnthropicErrorBoundary<T>(
+  work: () => Promise<T>,
+): Promise<{ value: T; error?: undefined } | { error: NextResponse; value?: undefined }> {
+  try {
+    return { value: await work() };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      error: NextResponse.json({ error: message }, { status: 502 }),
+    };
+  }
+}

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -1,5 +1,6 @@
 import { db } from "~/lib/db/dexie";
 import type { Table } from "dexie";
+import type { Settings } from "~/types/clinical";
 
 // Canonical "newest-first" queries for each table. Each helper fixes the
 // table-to-index pairing in one place so ad-hoc callsites can't drift from
@@ -12,6 +13,12 @@ function latest<T>(
 ): Promise<T[]> {
   const q = table.orderBy(indexField).reverse();
   return (typeof limit === "number" ? q.limit(limit) : q).toArray();
+}
+
+// Non-reactive read of the singleton Settings row. For React components
+// use the `useSettings()` hook instead.
+export async function getSettings(): Promise<Settings | null> {
+  return (await db.settings.toCollection().first()) ?? null;
 }
 
 export const latestDailyEntries = (limit?: number) =>

--- a/src/lib/ingest/claude-parser.ts
+++ b/src/lib/ingest/claude-parser.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import type { PreparedImage } from "~/lib/ingest/image";
+import { DEFAULT_AI_MODEL } from "~/lib/anthropic/model";
 
 const LabsSchema = z.object({
   // Tumour markers
@@ -112,7 +113,7 @@ Your job is to extract structured fields into the given schema. Rules:
 export async function extractWithClaude({
   text,
   image,
-  model = "claude-opus-4-7",
+  model = DEFAULT_AI_MODEL,
 }: {
   text?: string;
   image?: PreparedImage;

--- a/src/lib/ingest/meal-vision.ts
+++ b/src/lib/ingest/meal-vision.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import type { PreparedImage } from "./image";
+import { DEFAULT_AI_MODEL } from "~/lib/anthropic/model";
 
 export const MealSchema = z.object({
   description: z
@@ -45,7 +46,7 @@ Rules:
 // the server-side ANTHROPIC_API_KEY. Kept as a named export with the
 // same signature as before, minus the apiKey parameter.
 export async function estimateMeal({
-  model = "claude-opus-4-7",
+  model = DEFAULT_AI_MODEL,
   image,
 }: {
   model?: string;

--- a/src/lib/ingest/notes-vision.ts
+++ b/src/lib/ingest/notes-vision.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import type { PreparedImage } from "./image";
+import { DEFAULT_AI_MODEL } from "~/lib/anthropic/model";
 
 export const NotesStructureSchema = z.object({
   transcription: z
@@ -52,7 +53,7 @@ Rules:
 7. Put any free-text reflection (non-metric sentences) into the 'reflection' field.`;
 
 export async function structureNotes({
-  model = "claude-opus-4-7",
+  model = DEFAULT_AI_MODEL,
   image,
 }: {
   model?: string;

--- a/src/lib/nudges/ai-narrative.ts
+++ b/src/lib/nudges/ai-narrative.ts
@@ -1,5 +1,6 @@
 import type { FeedItem } from "~/types/feed";
 import type { Locale } from "~/types/clinical";
+import { DEFAULT_AI_MODEL } from "~/lib/anthropic/model";
 
 export const NARRATIVE_SYSTEM = `You write a single 2–3 sentence opening line for Hu Lin's dashboard on a pancreatic cancer tracking app.
 
@@ -18,7 +19,7 @@ export interface NarrativeInput {
 }
 
 export async function generateNarrative({
-  model = "claude-opus-4-7",
+  model = DEFAULT_AI_MODEL,
   locale,
   items,
 }: NarrativeInput): Promise<string> {

--- a/src/lib/nutrition/parser-client.ts
+++ b/src/lib/nutrition/parser-client.ts
@@ -2,6 +2,7 @@
 
 import type { PreparedImage } from "~/lib/ingest/image";
 import type { ParsedMealResult } from "./parser-schema";
+import { DEFAULT_AI_MODEL } from "~/lib/anthropic/model";
 
 // Client-side shims around the /api/ai/parse-meal route. The route holds
 // the server-side ANTHROPIC_API_KEY; the parsers below are the only thing
@@ -9,7 +10,7 @@ import type { ParsedMealResult } from "./parser-schema";
 
 export async function parseMealPhoto({
   image,
-  model = "claude-opus-4-7",
+  model = DEFAULT_AI_MODEL,
   locale = "en",
 }: {
   image: PreparedImage;
@@ -28,7 +29,7 @@ export async function parseMealPhoto({
 
 export async function parseMealText({
   text,
-  model = "claude-opus-4-7",
+  model = DEFAULT_AI_MODEL,
   locale = "en",
 }: {
   text: string;

--- a/src/lib/rules/zone-rules.ts
+++ b/src/lib/rules/zone-rules.ts
@@ -1,360 +1,312 @@
 import thresholds from "~/config/thresholds.json";
 import { percentChange, consecutiveRising } from "~/lib/calculations/trends";
-import type { ZoneRule } from "./types";
+import type { ClinicalSnapshot, ZoneRule } from "./types";
 
-const weightLossYellow: ZoneRule = {
-  id: "weight_loss_5_10_yellow",
-  name: "Weight loss 5–10% from baseline",
-  zone: "yellow",
-  category: "function",
-  triggersReview: true,
-  evaluator: ({ settings, latestDaily }) => {
-    if (!settings?.baseline_weight_kg || !latestDaily?.weight_kg) return false;
-    const pct = Math.abs(
-      percentChange(settings.baseline_weight_kg, latestDaily.weight_kg),
-    );
-    return pct >= thresholds.function.weight_loss_yellow_pct &&
-      pct < thresholds.function.weight_loss_orange_pct;
-  },
-  recommendation:
-    "Consider nutritional intervention, dietitian referral, PERT optimisation.",
-  recommendationZh: "考虑营养干预，转介营养师，优化胰酶替代治疗。",
-  suggestedLevers: ["nutrition.dietitian", "nutrition.supplements", "supportive.pert"],
-};
+// Predicate helpers — `inBand` is the half-open `[lo, hi)` window the
+// rules use for both directions; the rule picks lo/hi to encode whether
+// "lower is worse" (gait/albumin) or "higher is worse" (PHQ-9/GAD-7).
+const inBand = (v: number, lo: number, hi: number) => v >= lo && v < hi;
+const gte = (v: number, t: number) => v >= t;
+const lt = (v: number, t: number) => v < t;
 
-const weightLossOrange: ZoneRule = {
-  id: "weight_loss_10_plus_orange",
-  name: "Weight loss >10% from baseline",
-  zone: "orange",
-  category: "function",
-  triggersReview: true,
-  evaluator: ({ settings, latestDaily }) => {
-    if (!settings?.baseline_weight_kg || !latestDaily?.weight_kg) return false;
-    const pct = Math.abs(
-      percentChange(settings.baseline_weight_kg, latestDaily.weight_kg),
-    );
-    return pct >= thresholds.function.weight_loss_orange_pct;
-  },
-  recommendation:
-    "Urgent nutritional review; consider feeding tube and accelerating bridge discussion.",
-  recommendationZh: "紧急营养评估，考虑管饲和加快过渡到下一线治疗。",
-  suggestedLevers: ["nutrition.feeding_tube", "bridge.accelerate", "intensity.dose_reduce"],
-};
+// Metric accessors. Each returns either the computed value or null when
+// the snapshot doesn't have what's needed — callers fall through to
+// `false` when the value is null.
+function weightLossPct(s: ClinicalSnapshot): number | null {
+  const b = s.settings?.baseline_weight_kg;
+  const c = s.latestDaily?.weight_kg;
+  return b && c ? Math.abs(percentChange(b, c)) : null;
+}
 
-const gripDeclineYellow: ZoneRule = {
-  id: "grip_decline_10_20_yellow",
-  name: "Grip strength decline 10–20% from baseline",
-  zone: "yellow",
-  category: "function",
-  triggersReview: true,
-  evaluator: ({ settings, latestFortnightly }) => {
-    if (
-      !settings?.baseline_grip_dominant_kg ||
-      !latestFortnightly?.grip_dominant_kg
-    ) {
-      return false;
-    }
-    const pct = Math.abs(
-      percentChange(
-        settings.baseline_grip_dominant_kg,
-        latestFortnightly.grip_dominant_kg,
-      ),
-    );
-    return pct >= thresholds.function.grip_decline_yellow_pct &&
-      pct < thresholds.function.grip_decline_orange_pct;
-  },
-  recommendation:
-    "Exercise physiology referral, resistance training intensification.",
-  recommendationZh: "转介运动生理学家，加强抗阻训练。",
-  suggestedLevers: ["physical.exercise_phys", "physical.resistance"],
-};
+function gripDeclinePct(s: ClinicalSnapshot): number | null {
+  const b = s.settings?.baseline_grip_dominant_kg;
+  const c = s.latestFortnightly?.grip_dominant_kg;
+  return b && c ? Math.abs(percentChange(b, c)) : null;
+}
 
-const gripDeclineOrange: ZoneRule = {
-  id: "grip_decline_20_plus_orange",
-  name: "Grip strength decline >20% from baseline",
-  zone: "orange",
-  category: "function",
-  triggersReview: true,
-  evaluator: ({ settings, latestFortnightly }) => {
-    if (
-      !settings?.baseline_grip_dominant_kg ||
-      !latestFortnightly?.grip_dominant_kg
-    ) {
-      return false;
-    }
-    const pct = Math.abs(
-      percentChange(
-        settings.baseline_grip_dominant_kg,
-        latestFortnightly.grip_dominant_kg,
-      ),
-    );
-    return pct >= thresholds.function.grip_decline_orange_pct;
-  },
-  recommendation:
-    "Urgent review; consider dose reduction to preserve function.",
-  recommendationZh: "紧急评估，考虑减量以保留功能。",
-  suggestedLevers: ["intensity.dose_reduce", "physical.exercise_phys"],
-};
+const latestAlbumin = (s: ClinicalSnapshot): number | undefined =>
+  s.recentLabs[s.recentLabs.length - 1]?.albumin;
 
-const gaitYellow: ZoneRule = {
-  id: "gait_0_8_1_0_yellow",
-  name: "Gait speed 0.8–1.0 m/s",
-  zone: "yellow",
-  category: "function",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) => {
-    const v = latestFortnightly?.gait_speed_ms;
-    if (v === undefined) return false;
-    return v >= thresholds.function.gait_yellow_ms &&
-      v < thresholds.function.gait_warning_ms;
-  },
-  recommendation: "Physiotherapy referral, monitor for sarcopenia.",
-  recommendationZh: "转介物理治疗，监测肌少症。",
-  suggestedLevers: ["physical.exercise_phys", "physical.resistance"],
-};
-
-const gaitOrange: ZoneRule = {
-  id: "gait_lt_0_8_orange",
-  name: "Gait speed <0.8 m/s",
-  zone: "orange",
-  category: "function",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) => {
-    const v = latestFortnightly?.gait_speed_ms;
-    if (v === undefined) return false;
-    return v < thresholds.function.gait_yellow_ms;
-  },
-  recommendation:
-    "Frailty territory; consider de-escalation and CGA-guided planning.",
-  recommendationZh: "进入虚弱区间，考虑减量并进行全面老年评估。",
-  suggestedLevers: ["intensity.dose_reduce", "physical.exercise_phys"],
-};
-
-const neuropathyYellow: ZoneRule = {
-  id: "neuropathy_grade_2_yellow",
-  name: "Neuropathy grade 2",
-  zone: "yellow",
-  category: "toxicity",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) =>
-    latestFortnightly?.neuropathy_grade === 2,
-  recommendation:
-    "Consider duloxetine; plan dose reduction of nab-paclitaxel.",
-  recommendationZh: "考虑度洛西汀；计划减量白蛋白紫杉醇。",
-  suggestedLevers: ["supportive.duloxetine", "intensity.dose_reduce"],
-};
-
-const neuropathyOrange: ZoneRule = {
-  id: "neuropathy_grade_3_orange",
-  name: "Neuropathy grade 3",
-  zone: "orange",
-  category: "toxicity",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) => {
-    const g = latestFortnightly?.neuropathy_grade ?? 0;
-    return g >= 3;
-  },
-  recommendation: "Hold offending agent; active neuropathy management.",
-  recommendationZh: "停用相关药物，积极管理神经病变。",
-  suggestedLevers: ["intensity.hold", "supportive.duloxetine"],
-};
-
-const febrileNeutropeniaRed: ZoneRule = {
-  id: "febrile_neutropenia_red",
-  name: "Fever on treatment",
-  zone: "red",
-  category: "toxicity",
-  triggersReview: true,
-  evaluator: ({ latestDaily }) => !!latestDaily?.fever,
-  recommendation:
-    "IMMEDIATE hospital presentation — assume febrile neutropenia until ruled out.",
-  recommendationZh: "立即前往医院 —— 除非排除，否则按发热性中性粒细胞减少处理。",
-  suggestedLevers: ["emergency.hospital", "intensity.hold", "supportive.gcsf_prophylaxis"],
-};
-
-const ca199RisingYellow: ZoneRule = {
-  id: "ca199_rising_3_consecutive_yellow",
-  name: "CA19-9 rising for 3 consecutive measurements",
-  zone: "yellow",
-  category: "disease",
-  triggersReview: true,
-  evaluator: ({ recentLabs }) => {
-    const ca199 = recentLabs
-      .map((l) => l.ca199)
-      .filter((v): v is number => typeof v === "number");
-    if (ca199.length < 3) return false;
-    const last3 = ca199.slice(-3);
-    return consecutiveRising(last3) >= 3;
-  },
-  recommendation: "Consider early imaging review and ctDNA check.",
-  recommendationZh: "考虑提前影像学复查和 ctDNA 检测。",
-  suggestedLevers: ["monitoring.imaging_early", "monitoring.ctdna"],
-};
-
-const phq9ModerateYellow: ZoneRule = {
-  id: "phq9_moderate_yellow",
-  name: "PHQ-9 ≥10",
-  zone: "yellow",
-  category: "psychological",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) =>
-    (latestFortnightly?.phq9_total ?? 0) >= thresholds.psychological.phq9_yellow_threshold &&
-    (latestFortnightly?.phq9_total ?? 0) < thresholds.psychological.phq9_orange_threshold,
-  recommendation: "Psychology referral; consider medication if persistent.",
-  recommendationZh: "转介心理治疗，若持续则考虑药物。",
-  suggestedLevers: ["psychological.psychology", "psychological.medication"],
-};
-
-const phq9SevereOrange: ZoneRule = {
-  id: "phq9_severe_orange",
-  name: "PHQ-9 ≥15",
-  zone: "orange",
-  category: "psychological",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) =>
-    (latestFortnightly?.phq9_total ?? 0) >= thresholds.psychological.phq9_orange_threshold,
-  recommendation: "Urgent psychological support; assess suicide risk.",
-  recommendationZh: "紧急心理支持；评估自杀风险。",
-  suggestedLevers: ["psychological.psychology", "psychological.medication"],
-};
-
-const gad7ModerateYellow: ZoneRule = {
-  id: "gad7_moderate_yellow",
-  name: "GAD-7 ≥10",
-  zone: "yellow",
-  category: "psychological",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) =>
-    (latestFortnightly?.gad7_total ?? 0) >= thresholds.psychological.gad7_yellow_threshold &&
-    (latestFortnightly?.gad7_total ?? 0) < thresholds.psychological.gad7_orange_threshold,
-  recommendation: "Psychology referral; anxiety management techniques.",
-  recommendationZh: "转介心理治疗；焦虑管理策略。",
-  suggestedLevers: ["psychological.psychology"],
-};
-
-const albuminYellow: ZoneRule = {
-  id: "albumin_lt_30_yellow",
-  name: "Albumin <30 g/L",
-  zone: "yellow",
-  category: "nutrition",
-  triggersReview: true,
-  evaluator: ({ recentLabs }) => {
-    const recent = recentLabs[recentLabs.length - 1];
-    if (!recent?.albumin) return false;
-    return recent.albumin < thresholds.nutrition.albumin_yellow &&
-      recent.albumin >= thresholds.nutrition.albumin_orange;
-  },
-  recommendation: "Nutritional intervention; check inflammatory markers.",
-  recommendationZh: "营养干预；检查炎症标志物。",
-  suggestedLevers: ["nutrition.dietitian", "nutrition.supplements"],
-};
-
-const albuminOrange: ZoneRule = {
-  id: "albumin_lt_25_orange",
-  name: "Albumin <25 g/L",
-  zone: "orange",
-  category: "nutrition",
-  triggersReview: true,
-  evaluator: ({ recentLabs }) => {
-    const recent = recentLabs[recentLabs.length - 1];
-    if (!recent?.albumin) return false;
-    return recent.albumin < thresholds.nutrition.albumin_orange;
-  },
-  recommendation: "Severe hypoalbuminaemia; urgent nutrition and cause review.",
-  recommendationZh: "严重低白蛋白血症；紧急营养和病因评估。",
-  suggestedLevers: ["nutrition.feeding_tube", "nutrition.dietitian"],
-};
-
-const sarcFPositiveYellow: ZoneRule = {
-  id: "sarc_f_positive_yellow",
-  name: "SARC-F ≥ 4 (sarcopenia screen positive)",
-  zone: "yellow",
-  category: "function",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) =>
-    (latestFortnightly?.sarc_f_total ?? 0) >= 4,
-  recommendation:
-    "Sarcopenia screen positive. Confirm with grip + calf + gait; refer to exercise physiology; ensure protein intake ≥ 1.2 g/kg/day.",
-  recommendationZh:
-    "肌少症筛查阳性。结合握力、小腿围、步速确认；转介运动生理学家；蛋白摄入 ≥ 1.2 g/kg/天。",
-  suggestedLevers: [
-    "physical.exercise_phys",
-    "physical.resistance",
-    "nutrition.dietitian",
-    "nutrition.supplements",
-  ],
-};
-
-const tugElevatedYellow: ZoneRule = {
-  id: "tug_gt_14_yellow",
-  name: "Timed Up-and-Go > 14 s",
-  zone: "yellow",
-  category: "function",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) =>
-    (latestFortnightly?.tug_seconds ?? 0) > 14,
-  recommendation:
-    "Elevated fall risk. Exercise physiology referral; review home fall hazards.",
-  recommendationZh: "跌倒风险升高。转介运动生理学家；排查居家跌倒隐患。",
-  suggestedLevers: ["physical.exercise_phys", "physical.resistance"],
-};
-
-const pendingResultStaleYellow: ZoneRule = {
-  id: "pending_result_stale_yellow",
-  name: "Pending result / scan overdue",
-  zone: "yellow",
-  category: "disease",
-  triggersReview: true,
-  evaluator: ({ openPendingResults, now }) => {
-    return openPendingResults.some((p) => {
-      if (p.received) return false;
-      const expectedByMs = p.expected_by
-        ? Date.parse(p.expected_by)
-        : Date.parse(p.ordered_date) + 14 * 24 * 3600 * 1000;
-      if (Number.isNaN(expectedByMs)) return false;
-      return now.getTime() - expectedByMs > 0;
-    });
-  },
-  recommendation:
-    "One or more ordered tests or referrals are overdue. Chase the site or the ordering clinician to confirm results or next appointment.",
-  recommendationZh:
-    "有已预约但尚未出结果的检查 / 转诊超期。请与相关机构或医师核实进展。",
-  suggestedLevers: ["monitoring.imaging_early"],
-};
-
-const sts5xSlowYellow: ZoneRule = {
-  id: "sts_5x_gt_15_yellow",
-  name: "5× sit-to-stand > 15 s",
-  zone: "yellow",
-  category: "function",
-  triggersReview: true,
-  evaluator: ({ latestFortnightly }) =>
-    (latestFortnightly?.sts_5x_seconds ?? 0) > 15,
-  recommendation:
-    "Lower-body strength low. Resistance training 2–3×/week, oncology exercise physiology referral.",
-  recommendationZh:
-    "下肢力量低。每周 2–3 次抗阻训练，转介肿瘤运动生理学家。",
-  suggestedLevers: ["physical.resistance", "physical.exercise_phys"],
-};
+const FN = thresholds.function;
+const PSY = thresholds.psychological;
+const NUT = thresholds.nutrition;
 
 export const ZONE_RULES: ZoneRule[] = [
-  weightLossYellow,
-  weightLossOrange,
-  gripDeclineYellow,
-  gripDeclineOrange,
-  gaitYellow,
-  gaitOrange,
-  neuropathyYellow,
-  neuropathyOrange,
-  febrileNeutropeniaRed,
-  ca199RisingYellow,
-  phq9ModerateYellow,
-  phq9SevereOrange,
-  gad7ModerateYellow,
-  albuminYellow,
-  albuminOrange,
-  sarcFPositiveYellow,
-  tugElevatedYellow,
-  sts5xSlowYellow,
-  pendingResultStaleYellow,
+  {
+    id: "weight_loss_5_10_yellow",
+    name: "Weight loss 5–10% from baseline",
+    zone: "yellow",
+    category: "function",
+    triggersReview: true,
+    evaluator: (s) => {
+      const pct = weightLossPct(s);
+      return pct !== null && inBand(pct, FN.weight_loss_yellow_pct, FN.weight_loss_orange_pct);
+    },
+    recommendation:
+      "Consider nutritional intervention, dietitian referral, PERT optimisation.",
+    recommendationZh: "考虑营养干预，转介营养师，优化胰酶替代治疗。",
+    suggestedLevers: ["nutrition.dietitian", "nutrition.supplements", "supportive.pert"],
+  },
+  {
+    id: "weight_loss_10_plus_orange",
+    name: "Weight loss >10% from baseline",
+    zone: "orange",
+    category: "function",
+    triggersReview: true,
+    evaluator: (s) => {
+      const pct = weightLossPct(s);
+      return pct !== null && gte(pct, FN.weight_loss_orange_pct);
+    },
+    recommendation:
+      "Urgent nutritional review; consider feeding tube and accelerating bridge discussion.",
+    recommendationZh: "紧急营养评估，考虑管饲和加快过渡到下一线治疗。",
+    suggestedLevers: ["nutrition.feeding_tube", "bridge.accelerate", "intensity.dose_reduce"],
+  },
+  {
+    id: "grip_decline_10_20_yellow",
+    name: "Grip strength decline 10–20% from baseline",
+    zone: "yellow",
+    category: "function",
+    triggersReview: true,
+    evaluator: (s) => {
+      const pct = gripDeclinePct(s);
+      return pct !== null && inBand(pct, FN.grip_decline_yellow_pct, FN.grip_decline_orange_pct);
+    },
+    recommendation:
+      "Exercise physiology referral, resistance training intensification.",
+    recommendationZh: "转介运动生理学家，加强抗阻训练。",
+    suggestedLevers: ["physical.exercise_phys", "physical.resistance"],
+  },
+  {
+    id: "grip_decline_20_plus_orange",
+    name: "Grip strength decline >20% from baseline",
+    zone: "orange",
+    category: "function",
+    triggersReview: true,
+    evaluator: (s) => {
+      const pct = gripDeclinePct(s);
+      return pct !== null && gte(pct, FN.grip_decline_orange_pct);
+    },
+    recommendation: "Urgent review; consider dose reduction to preserve function.",
+    recommendationZh: "紧急评估，考虑减量以保留功能。",
+    suggestedLevers: ["intensity.dose_reduce", "physical.exercise_phys"],
+  },
+  {
+    id: "gait_0_8_1_0_yellow",
+    name: "Gait speed 0.8–1.0 m/s",
+    zone: "yellow",
+    category: "function",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) => {
+      const v = latestFortnightly?.gait_speed_ms;
+      return v !== undefined && inBand(v, FN.gait_yellow_ms, FN.gait_warning_ms);
+    },
+    recommendation: "Physiotherapy referral, monitor for sarcopenia.",
+    recommendationZh: "转介物理治疗，监测肌少症。",
+    suggestedLevers: ["physical.exercise_phys", "physical.resistance"],
+  },
+  {
+    id: "gait_lt_0_8_orange",
+    name: "Gait speed <0.8 m/s",
+    zone: "orange",
+    category: "function",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) => {
+      const v = latestFortnightly?.gait_speed_ms;
+      return v !== undefined && lt(v, FN.gait_yellow_ms);
+    },
+    recommendation:
+      "Frailty territory; consider de-escalation and CGA-guided planning.",
+    recommendationZh: "进入虚弱区间，考虑减量并进行全面老年评估。",
+    suggestedLevers: ["intensity.dose_reduce", "physical.exercise_phys"],
+  },
+  {
+    id: "neuropathy_grade_2_yellow",
+    name: "Neuropathy grade 2",
+    zone: "yellow",
+    category: "toxicity",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) => latestFortnightly?.neuropathy_grade === 2,
+    recommendation: "Consider duloxetine; plan dose reduction of nab-paclitaxel.",
+    recommendationZh: "考虑度洛西汀；计划减量白蛋白紫杉醇。",
+    suggestedLevers: ["supportive.duloxetine", "intensity.dose_reduce"],
+  },
+  {
+    id: "neuropathy_grade_3_orange",
+    name: "Neuropathy grade 3",
+    zone: "orange",
+    category: "toxicity",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) =>
+      gte(latestFortnightly?.neuropathy_grade ?? 0, 3),
+    recommendation: "Hold offending agent; active neuropathy management.",
+    recommendationZh: "停用相关药物，积极管理神经病变。",
+    suggestedLevers: ["intensity.hold", "supportive.duloxetine"],
+  },
+  {
+    id: "febrile_neutropenia_red",
+    name: "Fever on treatment",
+    zone: "red",
+    category: "toxicity",
+    triggersReview: true,
+    evaluator: ({ latestDaily }) => !!latestDaily?.fever,
+    recommendation:
+      "IMMEDIATE hospital presentation — assume febrile neutropenia until ruled out.",
+    recommendationZh: "立即前往医院 —— 除非排除，否则按发热性中性粒细胞减少处理。",
+    suggestedLevers: ["emergency.hospital", "intensity.hold", "supportive.gcsf_prophylaxis"],
+  },
+  {
+    id: "ca199_rising_3_consecutive_yellow",
+    name: "CA19-9 rising for 3 consecutive measurements",
+    zone: "yellow",
+    category: "disease",
+    triggersReview: true,
+    evaluator: ({ recentLabs }) => {
+      const ca199 = recentLabs
+        .map((l) => l.ca199)
+        .filter((v): v is number => typeof v === "number");
+      return ca199.length >= 3 && consecutiveRising(ca199.slice(-3)) >= 3;
+    },
+    recommendation: "Consider early imaging review and ctDNA check.",
+    recommendationZh: "考虑提前影像学复查和 ctDNA 检测。",
+    suggestedLevers: ["monitoring.imaging_early", "monitoring.ctdna"],
+  },
+  {
+    id: "phq9_moderate_yellow",
+    name: "PHQ-9 ≥10",
+    zone: "yellow",
+    category: "psychological",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) =>
+      inBand(
+        latestFortnightly?.phq9_total ?? 0,
+        PSY.phq9_yellow_threshold,
+        PSY.phq9_orange_threshold,
+      ),
+    recommendation: "Psychology referral; consider medication if persistent.",
+    recommendationZh: "转介心理治疗，若持续则考虑药物。",
+    suggestedLevers: ["psychological.psychology", "psychological.medication"],
+  },
+  {
+    id: "phq9_severe_orange",
+    name: "PHQ-9 ≥15",
+    zone: "orange",
+    category: "psychological",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) =>
+      gte(latestFortnightly?.phq9_total ?? 0, PSY.phq9_orange_threshold),
+    recommendation: "Urgent psychological support; assess suicide risk.",
+    recommendationZh: "紧急心理支持；评估自杀风险。",
+    suggestedLevers: ["psychological.psychology", "psychological.medication"],
+  },
+  {
+    id: "gad7_moderate_yellow",
+    name: "GAD-7 ≥10",
+    zone: "yellow",
+    category: "psychological",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) =>
+      inBand(
+        latestFortnightly?.gad7_total ?? 0,
+        PSY.gad7_yellow_threshold,
+        PSY.gad7_orange_threshold,
+      ),
+    recommendation: "Psychology referral; anxiety management techniques.",
+    recommendationZh: "转介心理治疗；焦虑管理策略。",
+    suggestedLevers: ["psychological.psychology"],
+  },
+  {
+    id: "albumin_lt_30_yellow",
+    name: "Albumin <30 g/L",
+    zone: "yellow",
+    category: "nutrition",
+    triggersReview: true,
+    evaluator: (s) => {
+      const v = latestAlbumin(s);
+      return v !== undefined && inBand(v, NUT.albumin_orange, NUT.albumin_yellow);
+    },
+    recommendation: "Nutritional intervention; check inflammatory markers.",
+    recommendationZh: "营养干预；检查炎症标志物。",
+    suggestedLevers: ["nutrition.dietitian", "nutrition.supplements"],
+  },
+  {
+    id: "albumin_lt_25_orange",
+    name: "Albumin <25 g/L",
+    zone: "orange",
+    category: "nutrition",
+    triggersReview: true,
+    evaluator: (s) => {
+      const v = latestAlbumin(s);
+      return v !== undefined && lt(v, NUT.albumin_orange);
+    },
+    recommendation: "Severe hypoalbuminaemia; urgent nutrition and cause review.",
+    recommendationZh: "严重低白蛋白血症；紧急营养和病因评估。",
+    suggestedLevers: ["nutrition.feeding_tube", "nutrition.dietitian"],
+  },
+  {
+    id: "sarc_f_positive_yellow",
+    name: "SARC-F ≥ 4 (sarcopenia screen positive)",
+    zone: "yellow",
+    category: "function",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) =>
+      gte(latestFortnightly?.sarc_f_total ?? 0, 4),
+    recommendation:
+      "Sarcopenia screen positive. Confirm with grip + calf + gait; refer to exercise physiology; ensure protein intake ≥ 1.2 g/kg/day.",
+    recommendationZh:
+      "肌少症筛查阳性。结合握力、小腿围、步速确认；转介运动生理学家；蛋白摄入 ≥ 1.2 g/kg/天。",
+    suggestedLevers: [
+      "physical.exercise_phys",
+      "physical.resistance",
+      "nutrition.dietitian",
+      "nutrition.supplements",
+    ],
+  },
+  {
+    id: "tug_gt_14_yellow",
+    name: "Timed Up-and-Go > 14 s",
+    zone: "yellow",
+    category: "function",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) =>
+      (latestFortnightly?.tug_seconds ?? 0) > 14,
+    recommendation:
+      "Elevated fall risk. Exercise physiology referral; review home fall hazards.",
+    recommendationZh: "跌倒风险升高。转介运动生理学家；排查居家跌倒隐患。",
+    suggestedLevers: ["physical.exercise_phys", "physical.resistance"],
+  },
+  {
+    id: "sts_5x_gt_15_yellow",
+    name: "5× sit-to-stand > 15 s",
+    zone: "yellow",
+    category: "function",
+    triggersReview: true,
+    evaluator: ({ latestFortnightly }) =>
+      (latestFortnightly?.sts_5x_seconds ?? 0) > 15,
+    recommendation:
+      "Lower-body strength low. Resistance training 2–3×/week, oncology exercise physiology referral.",
+    recommendationZh:
+      "下肢力量低。每周 2–3 次抗阻训练，转介肿瘤运动生理学家。",
+    suggestedLevers: ["physical.resistance", "physical.exercise_phys"],
+  },
+  {
+    id: "pending_result_stale_yellow",
+    name: "Pending result / scan overdue",
+    zone: "yellow",
+    category: "disease",
+    triggersReview: true,
+    evaluator: ({ openPendingResults, now }) =>
+      openPendingResults.some((p) => {
+        if (p.received) return false;
+        const expectedByMs = p.expected_by
+          ? Date.parse(p.expected_by)
+          : Date.parse(p.ordered_date) + 14 * 24 * 3600 * 1000;
+        return !Number.isNaN(expectedByMs) && now.getTime() - expectedByMs > 0;
+      }),
+    recommendation:
+      "One or more ordered tests or referrals are overdue. Chase the site or the ordering clinician to confirm results or next appointment.",
+    recommendationZh:
+      "有已预约但尚未出结果的检查 / 转诊超期。请与相关机构或医师核实进展。",
+    suggestedLevers: ["monitoring.imaging_early"],
+  },
 ];


### PR DESCRIPTION
## Summary

Three behaviour-preserving DRY cleanups across 42 files. No user-facing surface changes. All 591 unit tests pass; typecheck clean; lint shows only pre-existing warnings in files I didn't touch.

### 1. Shared API route helpers — `src/lib/anthropic/route-helpers.ts`

- `getAnthropicClient()` — returns a typed client or a 503 `NextResponse`
- `readJsonBody()` — returns parsed body or a 400 `NextResponse`
- `withAnthropicErrorBoundary()` — wraps the SDK call with a uniform 502

Migrated all 9 Claude-backed routes (`coach`, `feed-narrative`, `ingest-meal`, `ingest-notes`, `ingest-report`, `ingest-universal`, `parse-meal`, `assessment-summary`, `parse-appointment`) plus `ingest-ics` and `agent/[id]/run` for the JSON-parse helper. The contract asserted by `api-agent-run.test.ts` (400 / 503 / 502 status codes and the exact `"Invalid JSON body"` body) is preserved.

### 2. `useSettings()` hook — `src/hooks/use-settings.ts`

Replaces ~18 callsites of `useLiveQuery(() => db.settings.toArray())` followed by `[0]` indexing with a single hook that returns `Settings | null | undefined` (loading vs. no row vs. row are still distinguishable). Added:
- `useDefaultAiModel()` — eliminates 14 hardcoded `"claude-opus-4-7"` literals
- `getSettings()` async helper for non-React contexts (event handlers in the assessment wizard)

`DEFAULT_AI_MODEL` lives in `src/lib/anthropic/model.ts` — separate from `route-helpers.ts` so client modules (`coach.ts`, `meal-vision.ts`, etc.) can import it without pulling the Anthropic SDK into the client bundle.

### 3. `zone-rules.ts` — accessor + predicate cleanup

Extracted `weightLossPct` / `gripDeclinePct` / `latestAlbumin` accessors and `inBand` / `gte` / `lt` predicates. Each rule now reads as a small declarative entry instead of the duplicated evaluator bodies. All rule IDs, zones, recommendations, and `suggestedLevers` are unchanged. All 15 `rules-engine.test.ts` cases still pass.

### Bonus: `useL()` exported from `use-translate.ts`

The `const L = (en, zh) => locale === "zh" ? zh : en` pattern is redefined ~38 times across components. Exported `useL()` so future PRs can migrate them; no callsites converted in this PR to keep scope tight.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 591/591 passed
- [x] `pnpm lint` — only pre-existing warnings (`<img>` usage, unrelated `useMemo` deps)
- [x] `tests/unit/rules-engine.test.ts` (15 cases) — green after the zone-rules refactor
- [x] `tests/unit/api-agent-run.test.ts` — 400 / 503 / 502 contract preserved


---
_Generated by [Claude Code](https://claude.ai/code/session_01T6xMo1Kbx3acsuLyzuRtfZ)_