### PR TITLE
Carer invite flow: preview-before-auth, /household page, role-aware welcome

### DIFF
--- a/src/app/household/page.tsx
+++ b/src/app/household/page.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useHousehold } from "~/hooks/use-household";
+import {
+  getHousehold,
+  listHouseholdMembers,
+  listInvites,
+} from "~/lib/supabase/households";
+import type {
+  Household,
+  HouseholdInvite,
+  HouseholdMemberWithProfile,
+} from "~/types/household";
+import { useLocale } from "~/hooks/use-translate";
+import { isSupabaseConfigured } from "~/lib/supabase/client";
+import { PageHeader, SectionHeader } from "~/components/ui/page-header";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { InviteCarerFlow } from "~/components/invite/invite-carer-flow";
+import { MembersList } from "~/components/invite/members-list";
+import { PendingInvitesList } from "~/components/invite/pending-invites-list";
+import {
+  UserPlus,
+  Loader2,
+  Lock,
+  ExternalLink,
+} from "lucide-react";
+
+// /household — primary carer's home for everything to do with WHO is on
+// the care team in Anchor. Distinct from /care-team (which is the
+// patient's external clinical contacts log) so the two concepts don't
+// conflate. Read-only view for non-primary members; primary_carer gets
+// the issuance flow + role + remove affordances.
+//
+// Why a dedicated page?
+// - Invites buried in /settings#care-team are coupled to the local
+//   call-list and harder to find for a tired carer.
+// - The flow is conceptually a sub-feature of "manage the family", not a
+//   one-time setting tweak. It deserves its own URL.
+// - It's where the primary carer goes when an invite was accepted, when
+//   a new clinician joins, when someone needs to be removed.
+export default function HouseholdPage() {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const { membership, profile, loading } = useHousehold();
+  const householdId = membership?.household_id ?? null;
+  const isPrimary = membership?.role === "primary_carer";
+
+  const [household, setHousehold] = useState<Household | null>(null);
+  const [members, setMembers] = useState<HouseholdMemberWithProfile[]>([]);
+  const [invites, setInvites] = useState<HouseholdInvite[]>([]);
+  const [showInviteFlow, setShowInviteFlow] = useState(false);
+  const [loadingData, setLoadingData] = useState(false);
+
+  const reload = useCallback(async () => {
+    if (!householdId) {
+      setHousehold(null);
+      setMembers([]);
+      setInvites([]);
+      return;
+    }
+    setLoadingData(true);
+    try {
+      const [h, m, inv] = await Promise.all([
+        getHousehold(householdId),
+        listHouseholdMembers(householdId),
+        listInvites(householdId),
+      ]);
+      setHousehold(h);
+      setMembers(m);
+      setInvites(inv);
+    } finally {
+      setLoadingData(false);
+    }
+  }, [householdId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  if (!isSupabaseConfigured()) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+        <PageHeader
+          eyebrow={L("HOUSEHOLD", "家庭")}
+          title={L("Care team members", "护理团队成员")}
+        />
+        <Card>
+          <CardContent className="space-y-2 pt-5 text-[13px] text-ink-500">
+            <div className="flex items-center gap-2 text-ink-700">
+              <Lock className="h-4 w-4" />
+              <span className="font-medium">
+                {L("Sync isn't configured", "尚未配置同步")}
+              </span>
+            </div>
+            <p>
+              {L(
+                "Inviting family requires the cloud sync to be set up. Anchor still works fully offline on this device.",
+                "邀请家人需启用云同步。本设备的 Anchor 在离线模式下仍可使用。",
+              )}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+        <PageHeader
+          eyebrow={L("HOUSEHOLD", "家庭")}
+          title={L("Care team members", "护理团队成员")}
+        />
+        <Card>
+          <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {L("Loading household…", "加载中…")}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+        <PageHeader
+          eyebrow={L("HOUSEHOLD", "家庭")}
+          title={L("Care team members", "护理团队成员")}
+        />
+        <Card>
+          <CardContent className="space-y-3 pt-5 text-[13px] text-ink-500">
+            <p>
+              {L(
+                "Sign in to see who's on the care team.",
+                "登录后即可查看护理团队成员。",
+              )}
+            </p>
+            <Link href="/login?next=%2Fhousehold">
+              <Button size="md">{L("Sign in", "登录")}</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!membership || !householdId) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+        <PageHeader
+          eyebrow={L("HOUSEHOLD", "家庭")}
+          title={L("Care team members", "护理团队成员")}
+        />
+        <Card>
+          <CardContent className="space-y-3 pt-5 text-[13px] text-ink-500">
+            <p>
+              {L(
+                "You aren't part of a household yet. Run through onboarding to create one, or accept an invite link if someone sent you one.",
+                "您尚未加入任何家庭。请完成引导流程创建家庭，或接受他人发来的邀请链接。",
+              )}
+            </p>
+            <div className="flex gap-2">
+              <Link href="/onboarding">
+                <Button size="md">
+                  {L("Set up household", "创建家庭")}
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const activeInvites = invites.filter(
+    (i) => !i.accepted_at && !i.revoked_at && new Date(i.expires_at) > new Date(),
+  );
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={L("HOUSEHOLD", "家庭")}
+        title={
+          household
+            ? L(
+                `${household.patient_display_name}'s care team`,
+                `${household.patient_display_name} 的护理团队`,
+              )
+            : L("Care team members", "护理团队成员")
+        }
+      />
+
+      {household && (
+        <Card>
+          <CardContent className="flex items-center justify-between gap-3 pt-4">
+            <div>
+              <div className="text-[13px] font-semibold text-ink-900">
+                {household.name}
+              </div>
+              <div className="mt-0.5 text-[11.5px] text-ink-500">
+                {L(
+                  `${members.length} ${members.length === 1 ? "member" : "members"}`,
+                  `${members.length} 位成员`,
+                )}
+                {activeInvites.length > 0 && (
+                  <>
+                    {" · "}
+                    {L(
+                      `${activeInvites.length} pending`,
+                      `${activeInvites.length} 份待接受`,
+                    )}
+                  </>
+                )}
+              </div>
+            </div>
+            {isPrimary && !showInviteFlow && (
+              <Button onClick={() => setShowInviteFlow(true)} size="md">
+                <UserPlus className="h-4 w-4" />
+                {L("Invite", "邀请")}
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {!isPrimary && (
+        <Card>
+          <CardContent className="flex items-start gap-2 pt-4 text-[12.5px] text-ink-500">
+            <Lock className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              {L(
+                "Only the primary carer can invite, change roles, or remove members. Ask them if you'd like to add someone.",
+                "仅主要照护者可邀请、修改角色或移除成员。如需新增成员，请联系主要照护者。",
+              )}
+            </span>
+          </CardContent>
+        </Card>
+      )}
+
+      {isPrimary && showInviteFlow && (
+        <InviteCarerFlow
+          householdId={householdId}
+          onClose={() => setShowInviteFlow(false)}
+          onIssued={() => void reload()}
+        />
+      )}
+
+      <section className="space-y-2">
+        <SectionHeader title={L("Members", "成员")} />
+        {loadingData && members.length === 0 ? (
+          <Card>
+            <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {L("Loading members…", "加载成员中…")}
+            </CardContent>
+          </Card>
+        ) : (
+          <MembersList
+            members={members}
+            currentUserId={profile.id}
+            isPrimary={Boolean(isPrimary)}
+            householdId={householdId}
+            onChanged={reload}
+          />
+        )}
+      </section>
+
+      {isPrimary && invites.length > 0 && (
+        <section className="space-y-2">
+          <SectionHeader title={L("Invites", "邀请")} />
+          <PendingInvitesList invites={invites} onChanged={reload} />
+        </section>
+      )}
+
+      <section className="pt-2">
+        <Link
+          href="/care-team"
+          className="inline-flex items-center gap-1 text-[12px] text-ink-500 hover:text-ink-900"
+        >
+          <ExternalLink className="h-3 w-3" />
+          {L(
+            "Looking for the external clinical contacts log? It's at /care-team.",
+            "查找外部临床联系人记录？前往 /care-team。",
+          )}
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -6,79 +6,128 @@ import Link from "next/link";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
 import {
   acceptInvite,
+  daysUntilExpiry,
   friendlyInviteError,
   getCurrentProfile,
+  getInvitePreview,
   isProfileComplete,
 } from "~/lib/supabase/households";
+import { ROLE_LABEL, ROLE_DESCRIPTION } from "~/lib/auth/permissions";
+import type { InvitePreview } from "~/types/household";
 import { useLocale } from "~/hooks/use-translate";
 import { PageHeader } from "~/components/ui/page-header";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
-import { Loader2, Users, Check, AlertCircle } from "lucide-react";
+import {
+  Loader2,
+  Users,
+  Check,
+  AlertCircle,
+  Clock,
+  UserCircle2,
+  Heart,
+} from "lucide-react";
 
-// Landing page for someone following a household invite link. Handles
-// three states:
-//   (1) User is already signed in → accept immediately, redirect to /family
-//   (2) User is signed out → bounce to /login with ?next= set so we come back here
-//   (3) Accept failed (expired / revoked / already accepted) → show the reason
+// Landing page for someone following a household invite link.
 //
-// The token in the URL is a uuid v4. It's not secret in the strict sense
-// (leaks into browser history); security is enforced by expiry, single-
-// use semantics, and revoke. Treat it as a bearer capability for joining
-// one specific household.
+// Three-stage UX:
+//   1. fetch the PUBLIC preview ─ before forcing sign-in we tell the
+//      visitor exactly who invited them, to whose care plan, as what
+//      role, and how long the link is valid. Without this step a
+//      relative who got a bare URL has to take it on faith and sign
+//      in to an unknown app.
+//   2. if signed in ─ accept the invite immediately and route to the
+//      welcome wizard (or /family if the profile is already complete).
+//   3. if signed out ─ show "Sign in" / "Create account" with the
+//      `?next` param wired so the user comes back here after auth.
+//
+// Errors (expired / revoked / already-accepted / not-found) are
+// surfaced from the preview itself so we don't make the user sign in
+// just to learn the link is dead.
 
 type Phase =
-  | { kind: "checking" }
-  | { kind: "needs_signin" }
-  | { kind: "accepting" }
-  | { kind: "accepted" }
-  | { kind: "error"; message: string };
+  | { kind: "loading_preview" }
+  | { kind: "needs_signin"; preview: InvitePreview }
+  | { kind: "accepting"; preview: InvitePreview }
+  | { kind: "accepted"; preview: InvitePreview }
+  | { kind: "preview_error"; preview: InvitePreview }
+  | { kind: "accept_error"; message: string; preview: InvitePreview }
+  | { kind: "no_token" };
 
 export default function InvitePage() {
   const params = useParams<{ token: string }>();
   const token = params?.token;
   const router = useRouter();
   const locale = useLocale();
-  const [phase, setPhase] = useState<Phase>({ kind: "checking" });
   const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const [phase, setPhase] = useState<Phase>(
+    token ? { kind: "loading_preview" } : { kind: "no_token" },
+  );
 
   useEffect(() => {
     if (!token) return;
     let cancelled = false;
 
-    (async () => {
+    void (async () => {
+      let preview: InvitePreview;
+      try {
+        preview = await getInvitePreview(token);
+      } catch {
+        if (cancelled) return;
+        // Preview RPC is best-effort — if it errors out (e.g. cache miss
+        // or migration not yet applied), fall back to attempting the
+        // accept flow with auth, which has its own error handling.
+        preview = {
+          status: "active",
+          household_name: null,
+          patient_display_name: null,
+          role: null,
+          invited_by_name: null,
+          expires_at: null,
+          accepted_at: null,
+          revoked_at: null,
+        };
+      }
+      if (cancelled) return;
+
+      if (preview.status !== "active") {
+        setPhase({ kind: "preview_error", preview });
+        return;
+      }
+
       const sb = getSupabaseBrowser();
       if (!sb) {
-        if (!cancelled)
-          setPhase({
-            kind: "error",
-            message: L(
-              "Supabase is not configured on this build.",
-              "本版本未配置 Supabase。",
-            ),
-          });
+        setPhase({
+          kind: "accept_error",
+          preview,
+          message: L(
+            "Supabase is not configured on this build.",
+            "本版本未配置 Supabase。",
+          ),
+        });
         return;
       }
       const { data: auth } = await sb.auth.getUser();
       if (!auth.user) {
-        if (!cancelled) setPhase({ kind: "needs_signin" });
+        setPhase({ kind: "needs_signin", preview });
         return;
       }
-      if (!cancelled) setPhase({ kind: "accepting" });
+      setPhase({ kind: "accepting", preview });
       try {
         await acceptInvite(token);
         if (cancelled) return;
-        setPhase({ kind: "accepted" });
-        // If the invitee's profile has no relationship / name yet, run
-        // the welcome wizard so the care-team list renders something
-        // useful. If they're returning (re-invite) and everything's set,
-        // drop them straight on /family.
+        setPhase({ kind: "accepted", preview });
         const profile = await getCurrentProfile().catch(() => null);
         const next = isProfileComplete(profile) ? "/family" : "/invite/welcome";
         setTimeout(() => router.replace(next), 1200);
       } catch (err) {
         if (!cancelled)
-          setPhase({ kind: "error", message: friendlyInviteError(err) });
+          setPhase({
+            kind: "accept_error",
+            preview,
+            message: friendlyInviteError(err),
+          });
       }
     })();
 
@@ -89,97 +138,283 @@ export default function InvitePage() {
   }, [token, router]);
 
   return (
-    <div className="mx-auto max-w-md space-y-5 p-6 pt-16">
+    <div className="mx-auto max-w-md space-y-5 p-6 pt-12">
       <PageHeader
         eyebrow={L("CARE TEAM", "护理团队")}
-        title={L("Joining the family", "加入家庭")}
+        title={L("You've been invited", "您收到了一份邀请")}
       />
 
-      {phase.kind === "checking" && (
-        <Spinner label={L("Checking invite…", "正在检查邀请…")} />
-      )}
-
-      {phase.kind === "needs_signin" && (
-        <Card>
-          <CardContent className="space-y-3 pt-5">
-            <div className="flex items-center gap-2">
-              <Users className="h-4 w-4 text-[var(--tide-2)]" />
-              <div className="text-[14px] font-semibold text-ink-900">
-                {L("You've been invited", "您收到了一份邀请")}
-              </div>
-            </div>
-            <p className="text-[13px] text-ink-500">
-              {L(
-                "Sign in or create your account to join this family. After signing in you'll land straight on the family view.",
-                "请登录或注册账户以加入这个家庭。登录后会直接进入家庭视图。",
-              )}
-            </p>
-            <Link
-              href={`/login?next=${encodeURIComponent(`/invite/${token}`)}`}
-            >
-              <Button size="lg" className="w-full">
-                {L("Sign in to accept", "登录以接受邀请")}
-              </Button>
-            </Link>
-          </CardContent>
-        </Card>
-      )}
-
-      {phase.kind === "accepting" && (
-        <Spinner label={L("Accepting invite…", "正在加入…")} />
-      )}
-
-      {phase.kind === "accepted" && (
-        <Card>
-          <CardContent className="flex items-start gap-3 pt-5">
-            <Check className="mt-0.5 h-5 w-5 text-[var(--ok)]" />
-            <div>
-              <div className="text-[14px] font-semibold text-ink-900">
-                {L("Welcome to the team", "欢迎加入")}
-              </div>
-              <p className="mt-1 text-[13px] text-ink-500">
-                {L("Taking you to the family view…", "正在打开家庭视图…")}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {phase.kind === "error" && (
+      {phase.kind === "no_token" && (
         <Card>
           <CardContent className="flex items-start gap-3 pt-5">
             <AlertCircle className="mt-0.5 h-5 w-5 text-[var(--warn)]" />
-            <div className="flex-1">
-              <div className="text-[14px] font-semibold text-ink-900">
-                {L("Can't accept invite", "无法接受邀请")}
-              </div>
-              <p className="mt-1 text-[13px] text-ink-500">{phase.message}</p>
-              <p className="mt-3 text-[12px] text-ink-500">
-                {L(
-                  "Ask the primary carer to send you a new invite link.",
-                  "请联系主要看护者重新发送邀请链接。",
-                )}
-              </p>
-              <Link
-                href="/"
-                className="mt-3 inline-block text-[12px] text-ink-500 underline-offset-2 hover:underline"
-              >
-                {L("Go to dashboard", "返回主页")}
-              </Link>
+            <div className="text-[13px] text-ink-500">
+              {L(
+                "This invite link is missing its token.",
+                "此邀请链接缺少令牌。",
+              )}
             </div>
           </CardContent>
         </Card>
+      )}
+
+      {phase.kind === "loading_preview" && (
+        <Card>
+          <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {L("Checking invite…", "正在检查邀请…")}
+          </CardContent>
+        </Card>
+      )}
+
+      {phase.kind === "needs_signin" && (
+        <>
+          <PreviewCard preview={phase.preview} locale={locale} />
+          <SignInActions token={token!} locale={locale} />
+        </>
+      )}
+
+      {phase.kind === "accepting" && (
+        <>
+          <PreviewCard preview={phase.preview} locale={locale} />
+          <Card>
+            <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {L("Accepting invite…", "正在加入…")}
+            </CardContent>
+          </Card>
+        </>
+      )}
+
+      {phase.kind === "accepted" && (
+        <>
+          <PreviewCard preview={phase.preview} locale={locale} />
+          <Card>
+            <CardContent className="flex items-start gap-3 pt-5">
+              <Check className="mt-0.5 h-5 w-5 text-[var(--ok)]" />
+              <div>
+                <div className="text-[14px] font-semibold text-ink-900">
+                  {L("Welcome to the team", "欢迎加入")}
+                </div>
+                <p className="mt-1 text-[13px] text-ink-500">
+                  {L(
+                    "Setting things up for you…",
+                    "正在为您准备…",
+                  )}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
+
+      {phase.kind === "preview_error" && (
+        <PreviewErrorCard preview={phase.preview} locale={locale} />
+      )}
+
+      {phase.kind === "accept_error" && (
+        <>
+          <PreviewCard preview={phase.preview} locale={locale} />
+          <Card>
+            <CardContent className="flex items-start gap-3 pt-5">
+              <AlertCircle className="mt-0.5 h-5 w-5 text-[var(--warn)]" />
+              <div className="flex-1">
+                <div className="text-[14px] font-semibold text-ink-900">
+                  {L("Couldn't accept the invite", "无法接受邀请")}
+                </div>
+                <p className="mt-1 text-[13px] text-ink-500">
+                  {phase.message}
+                </p>
+                <p className="mt-3 text-[12px] text-ink-500">
+                  {L(
+                    "Ask the primary carer to send a fresh invite link.",
+                    "请联系主要照护者重新发送邀请链接。",
+                  )}
+                </p>
+                <Link
+                  href="/"
+                  className="mt-3 inline-block text-[12px] text-ink-500 underline-offset-2 hover:underline"
+                >
+                  {L("Go to dashboard", "返回主页")}
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
+        </>
       )}
     </div>
   );
 }
 
-function Spinner({ label }: { label: string }) {
+// Trust-building card. Shown for every active invite — pre- and post-
+// auth. The hierarchy is: WHO is being cared for (most personal) →
+// WHO invited you (consent / familiarity) → WHAT role you'll have
+// (sets expectations) → HOW LONG the link is valid (creates a soft
+// deadline without alarm).
+function PreviewCard({
+  preview,
+  locale,
+}: {
+  preview: InvitePreview;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const patientName =
+    preview.patient_display_name?.trim() ||
+    preview.household_name?.trim() ||
+    L("the family", "家庭");
+  const inviterName =
+    preview.invited_by_name?.trim() || L("the primary carer", "主要照护者");
+  const role = preview.role;
+  const days = preview.expires_at ? daysUntilExpiry(preview.expires_at) : null;
+
   return (
     <Card>
-      <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
-        <Loader2 className="h-4 w-4 animate-spin" />
-        {label}
+      <CardContent className="space-y-4 pt-5">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--tide-2)]/15 text-[var(--tide-2)]">
+            <Heart className="h-5 w-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[10.5px] font-medium uppercase tracking-[0.12em] text-ink-400">
+              {L("Joining", "加入")}
+            </div>
+            <div className="serif text-[20px] leading-tight text-ink-900">
+              {L(`${patientName}'s care team`, `${patientName} 的护理团队`)}
+            </div>
+          </div>
+        </div>
+
+        <ul className="space-y-2.5 border-t border-ink-100 pt-3 text-[13px]">
+          <li className="flex items-start gap-2.5">
+            <UserCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-ink-400" />
+            <div>
+              <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-400">
+                {L("Invited by", "邀请人")}
+              </div>
+              <div className="text-ink-900">{inviterName}</div>
+            </div>
+          </li>
+          {role && (
+            <li className="flex items-start gap-2.5">
+              <Users className="mt-0.5 h-4 w-4 shrink-0 text-ink-400" />
+              <div>
+                <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-400">
+                  {L("Your role", "您的角色")}
+                </div>
+                <div className="font-medium text-ink-900">
+                  {ROLE_LABEL[role][locale]}
+                </div>
+                <div className="mt-0.5 text-[11.5px] leading-relaxed text-ink-500">
+                  {ROLE_DESCRIPTION[role][locale]}
+                </div>
+              </div>
+            </li>
+          )}
+          {days !== null && (
+            <li className="flex items-start gap-2.5">
+              <Clock className="mt-0.5 h-4 w-4 shrink-0 text-ink-400" />
+              <div className="text-ink-700">
+                {days <= 0
+                  ? L("This link expires today.", "此链接今日到期。")
+                  : days === 1
+                    ? L("This link expires tomorrow.", "此链接明日到期。")
+                    : L(
+                        `This link is valid for another ${days} days.`,
+                        `此链接在 ${days} 天内有效。`,
+                      )}
+              </div>
+            </li>
+          )}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SignInActions({
+  token,
+  locale,
+}: {
+  token: string;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const next = `/invite/${token}`;
+  return (
+    <Card>
+      <CardContent className="space-y-3 pt-5">
+        <p className="text-[13px] text-ink-500">
+          {L(
+            "Sign in or create your Anchor account to accept. Your account is yours — you can use it across devices.",
+            "请登录或创建 Anchor 账号以接受邀请。账号属于您本人，可在多设备使用。",
+          )}
+        </p>
+        <Link href={`/login?next=${encodeURIComponent(next)}`}>
+          <Button size="lg" className="w-full">
+            {L("Sign in to accept", "登录以接受邀请")}
+          </Button>
+        </Link>
+        <p className="text-center text-[11.5px] text-ink-400">
+          {L(
+            "New here? The same screen lets you create an account.",
+            "首次使用？同一页面可创建账号。",
+          )}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PreviewErrorCard({
+  preview,
+  locale,
+}: {
+  preview: InvitePreview;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const message = (() => {
+    switch (preview.status) {
+      case "expired":
+        return L(
+          "This invite link has expired. Ask the primary carer to extend it or send a fresh one.",
+          "此邀请链接已过期。请联系主要照护者延长有效期或重新发送。",
+        );
+      case "revoked":
+        return L(
+          "This invite has been revoked. Ask the primary carer to send a fresh link.",
+          "此邀请已被撤销。请联系主要照护者重新发送链接。",
+        );
+      case "accepted":
+        return L(
+          "This invite has already been accepted. If that wasn't you, ask the primary carer for a new link.",
+          "此邀请已被接受。如非您本人接受，请联系主要照护者重新生成链接。",
+        );
+      case "not_found":
+      default:
+        return L(
+          "This invite link doesn't match anything in our records.",
+          "未在系统中找到匹配的邀请链接。",
+        );
+    }
+  })();
+  return (
+    <Card>
+      <CardContent className="flex items-start gap-3 pt-5">
+        <AlertCircle className="mt-0.5 h-5 w-5 text-[var(--warn)]" />
+        <div className="flex-1 space-y-2">
+          <div className="text-[14px] font-semibold text-ink-900">
+            {L("Can't accept this invite", "无法接受此邀请")}
+          </div>
+          <p className="text-[13px] text-ink-500">{message}</p>
+          <Link
+            href="/"
+            className="inline-block text-[12px] text-ink-500 underline-offset-2 hover:underline"
+          >
+            {L("Go to dashboard", "返回主页")}
+          </Link>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/app/invite/welcome/page.tsx
+++ b/src/app/invite/welcome/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useLiveQuery } from "dexie-react-hooks";
 import {
   getCurrentProfile,
   getHousehold,
@@ -18,12 +17,18 @@ import { Field, TextInput } from "~/components/ui/field";
 import type { Household, Profile } from "~/types/household";
 import type { Locale } from "~/types/clinical";
 import {
+  ACTION_LABEL,
+  actionsFor,
+  ROLE_LABEL,
+} from "~/lib/auth/permissions";
+import {
   ChevronRight,
   ChevronLeft,
   Check,
   Heart,
   Loader2,
   Users,
+  ShieldCheck,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 
@@ -33,9 +38,20 @@ import { cn } from "~/lib/utils/cn";
 // before they're dropped into /family. Skippable by design — anything left
 // blank falls back to sensible defaults and can be edited later from
 // Settings → Household → Your profile.
+//
+// New in the carer-invite-flow PR: a role-specific "what you can do here"
+// step (after preferences). Pulls from the permission matrix so the new
+// member knows which surfaces are theirs to use and which are read-only,
+// without having to discover it by hitting a disabled button.
 
-type Step = "welcome" | "about" | "preferences" | "done";
-const STEPS: Step[] = ["welcome", "about", "preferences", "done"];
+type Step = "welcome" | "about" | "preferences" | "permissions" | "done";
+const STEPS: Step[] = [
+  "welcome",
+  "about",
+  "preferences",
+  "permissions",
+  "done",
+];
 
 const RELATIONSHIP_SUGGESTIONS: Array<{ id: string; en: string; zh: string }> = [
   { id: "son", en: "Son", zh: "儿子" },
@@ -270,6 +286,10 @@ export default function InviteWelcomePage() {
         </Card>
       )}
 
+      {step === "permissions" && membership && (
+        <PermissionsStep role={membership.role} locale={locale} />
+      )}
+
       {step === "preferences" && (
         <Card>
           <CardContent className="space-y-4 pt-5">
@@ -362,7 +382,7 @@ export default function InviteWelcomePage() {
             {L("Skip and finish later", "跳过，稍后再填")}
           </button>
         )}
-        {step === "preferences" ? (
+        {step === "permissions" ? (
           <Button onClick={() => void finish()} disabled={saving} size="lg">
             {saving ? (
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -386,5 +406,93 @@ export default function InviteWelcomePage() {
         )}
       </div>
     </div>
+  );
+}
+
+// Role-specific "what you can do here" step. Pulls labels from the
+// permission matrix so the screen stays in sync with the actual
+// authorisation rules — adding a new action only needs the matrix
+// row + label, this component picks it up automatically.
+//
+// Splits actions into "you can" (the role's allow-list) and "you
+// won't" (notable actions explicitly denied) so the new member knows
+// both their capability and their limits. We deliberately don't
+// show every denied action — only ones a person could reasonably
+// expect to be able to do (editing the treatment plan, inviting
+// people, logging clinical notes).
+function PermissionsStep({
+  role,
+  locale,
+}: {
+  role: import("~/types/household").HouseholdRole;
+  locale: Locale;
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const allowed = actionsFor(role);
+  const allActions = Object.keys(ACTION_LABEL) as Array<
+    keyof typeof ACTION_LABEL
+  >;
+  // The handful of "you'd reasonably expect to be able to" actions
+  // worth calling out when a role doesn't have them. Listing every
+  // disabled action would be exhausting; this curated list covers
+  // the cases where surprise would feel like a bug.
+  const noteworthyDenials: Array<keyof typeof ACTION_LABEL> = [
+    "edit_treatment_plan",
+    "edit_medications",
+    "log_clinical_note",
+    "invite_members",
+  ];
+  const denied = allActions.filter(
+    (a) => !allowed.includes(a) && noteworthyDenials.includes(a),
+  );
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 pt-5">
+        <div>
+          <div className="eyebrow flex items-center gap-1.5">
+            <ShieldCheck className="h-3.5 w-3.5" />
+            {L("What you can do here", "您能做什么")}
+          </div>
+          <p className="mt-1.5 text-[12.5px] text-ink-500">
+            {L(
+              `As ${ROLE_LABEL[role].en.toLowerCase()}, here's what you can — and can't — do. The primary carer can change your role later.`,
+              `作为${ROLE_LABEL[role].zh}，您可以做以下事项。日后由主要照护者调整角色。`,
+            )}
+          </p>
+        </div>
+
+        <ul className="space-y-1.5">
+          {allowed.map((a) => (
+            <li
+              key={`allow-${a}`}
+              className="flex items-start gap-2 text-[12.5px]"
+            >
+              <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--ok)]" />
+              <span className="text-ink-900">{ACTION_LABEL[a][locale]}</span>
+            </li>
+          ))}
+        </ul>
+
+        {denied.length > 0 && (
+          <div>
+            <div className="eyebrow text-ink-400">
+              {L("Not yours to change", "无修改权限")}
+            </div>
+            <ul className="mt-1.5 space-y-1.5">
+              {denied.map((a) => (
+                <li
+                  key={`deny-${a}`}
+                  className="flex items-start gap-2 text-[12.5px] text-ink-500"
+                >
+                  <span className="mt-0.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-ink-200" />
+                  <span>{ACTION_LABEL[a][locale]}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { QuickCheckinCard } from "~/components/dashboard/quick-checkin-card";
 import { PendingInvitesCard } from "~/components/dashboard/pending-invites-card";
 import { InviteFamilyCard } from "~/components/dashboard/invite-family-card";
+import { RecentlyAcceptedCard } from "~/components/dashboard/recently-accepted-card";
 import { BaselineNudgeCard } from "~/components/dashboard/baseline-nudge-card";
 import { NextClinicCard } from "~/components/dashboard/next-clinic-card";
 import { ScheduleCard } from "~/components/dashboard/schedule-card";
@@ -149,6 +150,8 @@ export default function DashboardPage() {
       <TodayFeed excludeIds={EXCLUDE_IDS} />
 
       <BaselineNudgeCard />
+
+      <RecentlyAcceptedCard />
 
       <PendingInvitesCard />
 

--- a/src/components/dashboard/invite-family-card.tsx
+++ b/src/components/dashboard/invite-family-card.tsx
@@ -46,7 +46,7 @@ export function InviteFamilyCard() {
           </div>
         </div>
         <Link
-          href="/settings#care-team"
+          href="/household"
           className="inline-flex items-center gap-0.5 text-[12px] text-ink-500 hover:text-ink-900"
         >
           {L("Set up", "开始")}

--- a/src/components/dashboard/pending-invites-card.tsx
+++ b/src/components/dashboard/pending-invites-card.tsx
@@ -71,7 +71,7 @@ export function PendingInvitesCard() {
           </div>
         </div>
         <Link
-          href="/settings#care-team"
+          href="/household"
           className="inline-flex items-center gap-0.5 text-[12px] text-ink-500 hover:text-ink-900"
         >
           {L("Manage", "管理")}

--- a/src/components/dashboard/recently-accepted-card.tsx
+++ b/src/components/dashboard/recently-accepted-card.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useCan } from "~/hooks/use-can";
+import { useHousehold } from "~/hooks/use-household";
+import { listInvites } from "~/lib/supabase/households";
+import { ROLE_LABEL } from "~/lib/auth/permissions";
+import type { HouseholdInvite } from "~/types/household";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import { UserCheck, ChevronRight } from "lucide-react";
+
+// Closes the invite loop for the primary carer. When a relative
+// accepts an invite, Thomas wants to know without having to dig.
+// This surfaces a glanceable card for invites accepted in the last
+// 72 hours, then quietly disappears.
+//
+// Auto-dismisses (per-token) once Thomas opens /household so the
+// dashboard doesn't keep nagging about something he's already
+// reviewed. The dismiss state lives in localStorage — these are
+// transient acknowledgements, not data we need synced cross-device.
+
+const DISMISS_KEY = "anchor.invite.recently_accepted.dismissed";
+const RECENT_WINDOW_HOURS = 72;
+
+function readDismissed(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(DISMISS_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    return new Set(Array.isArray(parsed) ? parsed : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeDismissed(ids: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(DISMISS_KEY, JSON.stringify([...ids]));
+  } catch {
+    // Storage can be disabled (Safari private mode); silently ignore.
+  }
+}
+
+export function RecentlyAcceptedCard() {
+  const locale = useLocale();
+  const canSee = useCan("see_pending_invites"); // primary_carer-gated
+  const { membership } = useHousehold();
+  const [recent, setRecent] = useState<HouseholdInvite[] | null>(null);
+
+  useEffect(() => {
+    if (!canSee || !membership) {
+      setRecent(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const rows = await listInvites(membership.household_id);
+      if (cancelled) return;
+      const cutoff = Date.now() - RECENT_WINDOW_HOURS * 60 * 60 * 1000;
+      const dismissed = readDismissed();
+      setRecent(
+        rows.filter(
+          (i) =>
+            i.accepted_at &&
+            new Date(i.accepted_at).getTime() >= cutoff &&
+            !dismissed.has(i.id),
+        ),
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [canSee, membership]);
+
+  if (!canSee || !recent || recent.length === 0) return null;
+
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  // Most-recent first.
+  const sorted = [...recent].sort(
+    (a, b) =>
+      new Date(b.accepted_at!).getTime() - new Date(a.accepted_at!).getTime(),
+  );
+  const newest = sorted[0]!;
+  const extras = sorted.length - 1;
+
+  function dismiss() {
+    const ids = readDismissed();
+    for (const inv of sorted) ids.add(inv.id);
+    writeDismissed(ids);
+    setRecent([]);
+  }
+
+  return (
+    <Card className="border-[var(--ok)]/40 bg-[var(--ok-soft)]">
+      <CardContent className="flex items-start justify-between gap-3 pt-4">
+        <div className="flex min-w-0 items-start gap-2.5">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--ok)]/15 text-[var(--ok)]">
+            <UserCheck className="h-4 w-4" />
+          </div>
+          <div className="min-w-0">
+            <div className="text-[13px] font-semibold text-ink-900">
+              {extras === 0
+                ? L(
+                    `${newest.email_hint?.trim() || "A new member"} just joined`,
+                    `${newest.email_hint?.trim() || "新成员"} 刚刚加入`,
+                  )
+                : L(
+                    `${sorted.length} new members joined`,
+                    `${sorted.length} 位新成员加入`,
+                  )}
+            </div>
+            <p className="mt-0.5 truncate text-[11.5px] text-ink-500">
+              {extras === 0
+                ? L(
+                    `Joined as ${ROLE_LABEL[newest.role].en}.`,
+                    `角色：${ROLE_LABEL[newest.role].zh}。`,
+                  )
+                : L(
+                    "Tap manage to see who and confirm their roles.",
+                    "点击「管理」查看成员并确认角色。",
+                  )}
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-1.5">
+          <Link
+            href="/household"
+            onClick={dismiss}
+            className="inline-flex items-center gap-0.5 text-[12px] text-ink-700 hover:text-ink-900"
+          >
+            {L("Manage", "管理")}
+            <ChevronRight className="h-3 w-3" />
+          </Link>
+          <button
+            type="button"
+            onClick={dismiss}
+            className="text-[10.5px] text-ink-400 hover:text-ink-700"
+          >
+            {L("Dismiss", "忽略")}
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/family/household-header.tsx
+++ b/src/components/family/household-header.tsx
@@ -45,7 +45,7 @@ export function HouseholdHeader() {
 
   return (
     <Link
-      href="/settings"
+      href="/household"
       className="flex items-center gap-3 rounded-[var(--r-md)] border border-ink-100 bg-paper-2 px-3 py-2.5 hover:border-ink-300"
     >
       <Users className="h-4 w-4 shrink-0 text-[var(--tide-2)]" />

--- a/src/components/invite/invite-carer-flow.tsx
+++ b/src/components/invite/invite-carer-flow.tsx
@@ -1,0 +1,492 @@
+"use client";
+
+import { useState } from "react";
+import {
+  createInvite,
+  inviteUrl,
+  friendlyInviteError,
+} from "~/lib/supabase/households";
+import {
+  ROLE_LABEL,
+  ROLE_DESCRIPTION,
+} from "~/lib/auth/permissions";
+import type { HouseholdRole, HouseholdInvite } from "~/types/household";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Field, TextInput } from "~/components/ui/field";
+import {
+  ChevronLeft,
+  Check,
+  Copy,
+  Loader2,
+  Share2,
+  X,
+  AlertCircle,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+// Focused, three-step issuance wizard for the primary carer:
+//
+//   1. pick a role  → with one-line description so Thomas can pick by
+//      meaning, not by jargon
+//   2. add an optional name + email hint  → email isn't required since
+//      a generated link is the actual delivery mechanism, but stashing
+//      a hint helps Thomas remember which link he sent to whom
+//   3. share the generated link  → native share sheet on phones,
+//      copy-to-clipboard everywhere, and a "send via SMS / WhatsApp /
+//      email" deep-link bar so non-technical relatives don't have to
+//      think about how to forward a URL
+//
+// Designed to live inline on `/household` and as a modal on the
+// dashboard — pass `onCancel` to render a "back" affordance, or omit
+// it for a self-contained card.
+
+type Step = "pick_role" | "details" | "share";
+
+interface Props {
+  householdId: string;
+  // Roles the primary carer is allowed to assign on this surface. Defaults
+  // to the four "non-self" roles — patient is intentionally excluded
+  // because in practice the patient signs themselves up first, then Thomas
+  // accepts them as primary_carer is already set up.
+  allowedRoles?: HouseholdRole[];
+  defaultRole?: HouseholdRole;
+  onIssued?: (invite: HouseholdInvite) => void;
+  onClose?: () => void;
+}
+
+const DEFAULT_ROLES: HouseholdRole[] = [
+  "family",
+  "clinician",
+  "observer",
+  "patient",
+];
+
+export function InviteCarerFlow({
+  householdId,
+  allowedRoles = DEFAULT_ROLES,
+  defaultRole = "family",
+  onIssued,
+  onClose,
+}: Props) {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const [step, setStep] = useState<Step>("pick_role");
+  const [role, setRole] = useState<HouseholdRole>(defaultRole);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [issuing, setIssuing] = useState(false);
+  const [issued, setIssued] = useState<HouseholdInvite | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const url =
+    issued && typeof window !== "undefined"
+      ? inviteUrl(issued.token, window.location.origin)
+      : null;
+
+  async function issue() {
+    setIssuing(true);
+    setError(null);
+    try {
+      const inv = await createInvite({
+        household_id: householdId,
+        email_hint: email.trim() || undefined,
+        role,
+      });
+      setIssued(inv);
+      setStep("share");
+      onIssued?.(inv);
+    } catch (err) {
+      setError(friendlyInviteError(err));
+    } finally {
+      setIssuing(false);
+    }
+  }
+
+  async function copy() {
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Some browsers block clipboard outside HTTPS or on unfocused
+      // documents. Fall through silently — the link is still visible
+      // and selectable in the textbox below.
+    }
+  }
+
+  async function nativeShare() {
+    if (!url || typeof navigator === "undefined" || !navigator.share) return;
+    const recipientName = name.trim();
+    const shareText = recipientName
+      ? L(
+          `${recipientName}, you've been invited to the family's Anchor care plan. Tap the link to join.`,
+          `${recipientName}，您被邀请加入家人的 Anchor 护理计划。点击链接即可加入。`,
+        )
+      : L(
+          "You've been invited to the family's Anchor care plan. Tap the link to join.",
+          "您被邀请加入家人的 Anchor 护理计划。点击链接即可加入。",
+        );
+    try {
+      await navigator.share({
+        title: L("Join the care plan", "加入护理计划"),
+        text: shareText,
+        url,
+      });
+    } catch {
+      // User dismissed the share sheet — non-fatal.
+    }
+  }
+
+  function reset() {
+    setStep("pick_role");
+    setRole(defaultRole);
+    setName("");
+    setEmail("");
+    setIssued(null);
+    setError(null);
+    setCopied(false);
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 pt-5">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <div className="eyebrow">{L("Invite", "邀请")}</div>
+            <div className="serif mt-1 text-[18px] text-ink-900">
+              {step === "pick_role"
+                ? L("Add someone to the care team", "添加护理团队成员")
+                : step === "details"
+                  ? L("A few details", "再填几项")
+                  : L("Share the link", "分享链接")}
+            </div>
+          </div>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="-mr-1 -mt-1 inline-flex h-8 w-8 items-center justify-center rounded-md text-ink-400 hover:bg-ink-100/40 hover:text-ink-900"
+              aria-label={L("Close", "关闭")}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2.5 text-[12px] text-[var(--warn)]"
+          >
+            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {step === "pick_role" && (
+          <RolePicker
+            value={role}
+            onChange={setRole}
+            options={allowedRoles}
+            locale={locale}
+          />
+        )}
+
+        {step === "details" && (
+          <DetailsStep
+            role={role}
+            name={name}
+            email={email}
+            onName={setName}
+            onEmail={setEmail}
+            locale={locale}
+          />
+        )}
+
+        {step === "share" && url && issued && (
+          <ShareStep
+            url={url}
+            name={name}
+            role={role}
+            copied={copied}
+            onCopy={copy}
+            onNativeShare={nativeShare}
+            onAnother={reset}
+            locale={locale}
+          />
+        )}
+
+        <div className="flex items-center justify-between gap-2 pt-1">
+          {step === "details" && (
+            <Button variant="ghost" onClick={() => setStep("pick_role")}>
+              <ChevronLeft className="h-4 w-4" />
+              {L("Back", "上一步")}
+            </Button>
+          )}
+          {step === "pick_role" && <span />}
+          {step === "share" && <span />}
+
+          {step === "pick_role" && (
+            <Button onClick={() => setStep("details")} size="md">
+              {L("Continue", "继续")}
+            </Button>
+          )}
+          {step === "details" && (
+            <Button
+              onClick={() => void issue()}
+              disabled={issuing}
+              size="md"
+            >
+              {issuing ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+              {issuing
+                ? L("Generating link…", "正在生成链接…")
+                : L("Generate invite link", "生成邀请链接")}
+            </Button>
+          )}
+          {step === "share" && (
+            <Button variant="secondary" onClick={() => onClose?.() ?? reset()}>
+              {L("Done", "完成")}
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RolePicker({
+  value,
+  onChange,
+  options,
+  locale,
+}: {
+  value: HouseholdRole;
+  onChange: (r: HouseholdRole) => void;
+  options: HouseholdRole[];
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  return (
+    <div className="space-y-2">
+      <p className="text-[12.5px] text-ink-500">
+        {L(
+          "Roles control what the new member sees and can edit. You can change this later.",
+          "角色决定新成员能看到和编辑的内容。日后可随时调整。",
+        )}
+      </p>
+      <ul className="space-y-2">
+        {options.map((r) => {
+          const active = value === r;
+          return (
+            <li key={r}>
+              <button
+                type="button"
+                onClick={() => onChange(r)}
+                aria-pressed={active}
+                className={cn(
+                  "w-full rounded-xl border px-4 py-3 text-left transition-colors",
+                  active
+                    ? "border-ink-900 bg-ink-900 text-paper"
+                    : "border-ink-200 bg-paper-2 hover:border-ink-400",
+                )}
+              >
+                <div className="text-[14px] font-semibold">
+                  {ROLE_LABEL[r][locale]}
+                </div>
+                <div
+                  className={cn(
+                    "mt-1 text-[12px] leading-relaxed",
+                    active ? "text-paper/80" : "text-ink-500",
+                  )}
+                >
+                  {ROLE_DESCRIPTION[r][locale]}
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function DetailsStep({
+  role,
+  name,
+  email,
+  onName,
+  onEmail,
+  locale,
+}: {
+  role: HouseholdRole;
+  name: string;
+  email: string;
+  onName: (v: string) => void;
+  onEmail: (v: string) => void;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border border-ink-100 bg-paper-2 p-2.5 text-[12px] text-ink-700">
+        <span className="font-medium">{L("Inviting as: ", "邀请角色：")}</span>
+        {ROLE_LABEL[role][locale]}
+      </div>
+      <Field
+        label={L("Their name (optional)", "对方姓名（可选）")}
+        hint={L(
+          "Helps you remember who this link was for. They'll set their own display name on first sign-in.",
+          "便于您记住此链接发给了谁。对方首次登录时会自行设置显示名称。",
+        )}
+      >
+        <TextInput
+          value={name}
+          onChange={(e) => onName(e.target.value)}
+          placeholder={L("e.g. Catherine", "例如：王女士")}
+          autoFocus
+        />
+      </Field>
+      <Field
+        label={L("Their email (optional)", "对方邮箱（可选）")}
+        hint={L(
+          "Stored as a hint on the invite — not auto-emailed. The link itself is the delivery channel.",
+          "仅作为邀请的备注，系统不会自动发送邮件。请通过其他渠道分享链接。",
+        )}
+      >
+        <TextInput
+          type="email"
+          value={email}
+          onChange={(e) => onEmail(e.target.value)}
+          placeholder="catherine@example.com"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function ShareStep({
+  url,
+  name,
+  role,
+  copied,
+  onCopy,
+  onNativeShare,
+  onAnother,
+  locale,
+}: {
+  url: string;
+  name: string;
+  role: HouseholdRole;
+  copied: boolean;
+  onCopy: () => void;
+  onNativeShare: () => void;
+  onAnother: () => void;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const recipientName = name.trim();
+  const subject = L(
+    "Join the family's Anchor care plan",
+    "加入家人的 Anchor 护理计划",
+  );
+  const body = recipientName
+    ? L(
+        `Hi ${recipientName} — I've added you to dad's Anchor care plan as ${ROLE_LABEL[role].en}. Tap this link to join: ${url}`,
+        `${recipientName}，我已把您加入到爸爸的 Anchor 护理计划，角色是${ROLE_LABEL[role].zh}。点击此链接加入：${url}`,
+      )
+    : L(
+        `I've added you to the family's Anchor care plan. Tap this link to join: ${url}`,
+        `我已把您加入到家人的 Anchor 护理计划。点击此链接加入：${url}`,
+      );
+
+  const mailto = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  const sms = `sms:?&body=${encodeURIComponent(body)}`;
+  const whatsapp = `https://wa.me/?text=${encodeURIComponent(body)}`;
+
+  const canNativeShare =
+    typeof navigator !== "undefined" && typeof navigator.share === "function";
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border border-[var(--ok)]/40 bg-[var(--ok-soft)] p-3 text-[12.5px] text-ink-900">
+        <div className="flex items-center gap-2 font-semibold">
+          <Check className="h-4 w-4 text-[var(--ok)]" />
+          {L("Link is ready", "链接已就绪")}
+        </div>
+        <p className="mt-1 text-ink-700">
+          {L(
+            "Valid for 14 days, single use. The new member will sign in (or create an account) and land on the family view.",
+            "14 天内有效，仅可使用一次。对方登录（或注册）后会直接进入家庭视图。",
+          )}
+        </p>
+      </div>
+
+      <div className="rounded-md border border-ink-200 bg-paper-2 p-3">
+        <div className="text-[10.5px] font-medium uppercase tracking-[0.12em] text-ink-400">
+          {L("Invite link", "邀请链接")}
+        </div>
+        <div className="mt-1 break-all font-mono text-[11.5px] text-ink-700">
+          {url}
+        </div>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Button onClick={onCopy} size="md" variant="secondary">
+          <Copy className="h-4 w-4" />
+          {copied ? L("Copied", "已复制") : L("Copy link", "复制链接")}
+        </Button>
+        {canNativeShare ? (
+          <Button onClick={onNativeShare} size="md">
+            <Share2 className="h-4 w-4" />
+            {L("Share…", "分享…")}
+          </Button>
+        ) : (
+          <Button onClick={onCopy} size="md">
+            <Copy className="h-4 w-4" />
+            {L("Copy & paste anywhere", "复制后粘贴到任意位置")}
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <a
+          href={sms}
+          className="rounded-md border border-ink-200 bg-paper-2 px-3 py-2 text-center text-[12px] font-medium text-ink-700 hover:border-ink-400"
+        >
+          {L("Text", "短信")}
+        </a>
+        <a
+          href={whatsapp}
+          target="_blank"
+          rel="noreferrer"
+          className="rounded-md border border-ink-200 bg-paper-2 px-3 py-2 text-center text-[12px] font-medium text-ink-700 hover:border-ink-400"
+        >
+          WhatsApp
+        </a>
+        <a
+          href={mailto}
+          className="rounded-md border border-ink-200 bg-paper-2 px-3 py-2 text-center text-[12px] font-medium text-ink-700 hover:border-ink-400"
+        >
+          {L("Email", "邮件")}
+        </a>
+      </div>
+
+      <button
+        type="button"
+        onClick={onAnother}
+        className="text-[12px] text-ink-500 underline-offset-2 hover:text-ink-900 hover:underline"
+      >
+        {L("Invite someone else", "再邀请一位")}
+      </button>
+    </div>
+  );
+}

--- a/src/components/invite/members-list.tsx
+++ b/src/components/invite/members-list.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useState } from "react";
+import {
+  removeMember,
+  updateMemberRole,
+  friendlyInviteError,
+} from "~/lib/supabase/households";
+import { ROLE_LABEL } from "~/lib/auth/permissions";
+import type {
+  HouseholdMemberWithProfile,
+  HouseholdRole,
+} from "~/types/household";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import {
+  Crown,
+  Stethoscope,
+  Users as UsersIcon,
+  Eye,
+  User as UserIcon,
+  Pencil,
+  Trash2,
+  Loader2,
+  AlertCircle,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+const ROLE_ICON: Record<HouseholdRole, React.ComponentType<{ className?: string }>> = {
+  primary_carer: Crown,
+  patient: UserIcon,
+  family: UsersIcon,
+  clinician: Stethoscope,
+  observer: Eye,
+};
+
+interface Props {
+  members: HouseholdMemberWithProfile[];
+  currentUserId: string | null;
+  isPrimary: boolean;
+  householdId: string;
+  onChanged?: () => void;
+}
+
+export function MembersList({
+  members,
+  currentUserId,
+  isPrimary,
+  householdId,
+  onChanged,
+}: Props) {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+
+  const [editing, setEditing] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Render the primary_carer first, then patient, then everyone else
+  // alphabetically — so the household admin and patient stay top-of-list
+  // even as the team grows.
+  const sorted = [...members].sort((a, b) => {
+    const order: Record<HouseholdRole, number> = {
+      primary_carer: 0,
+      patient: 1,
+      family: 2,
+      clinician: 3,
+      observer: 4,
+    };
+    if (a.role !== b.role) return order[a.role] - order[b.role];
+    return (a.profile.display_name || "").localeCompare(
+      b.profile.display_name || "",
+    );
+  });
+
+  if (sorted.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-4 text-center text-[12.5px] text-ink-500">
+          {L(
+            "No one's joined yet. Send the first invite below.",
+            "暂无成员。请在下方发送第一份邀请。",
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2.5 text-[12px] text-[var(--warn)]"
+        >
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+      <ul className="divide-y divide-ink-100 rounded-md border border-ink-100 bg-paper">
+        {sorted.map((m) => (
+          <MemberRow
+            key={m.user_id}
+            member={m}
+            isSelf={m.user_id === currentUserId}
+            isPrimary={isPrimary}
+            householdId={householdId}
+            isEditing={editing === m.user_id}
+            onStartEdit={() => {
+              setEditing(m.user_id);
+              setError(null);
+            }}
+            onCancelEdit={() => setEditing(null)}
+            onChanged={async () => {
+              setEditing(null);
+              await onChanged?.();
+            }}
+            onError={setError}
+            locale={locale}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function MemberRow({
+  member,
+  isSelf,
+  isPrimary,
+  householdId,
+  isEditing,
+  onStartEdit,
+  onCancelEdit,
+  onChanged,
+  onError,
+  locale,
+}: {
+  member: HouseholdMemberWithProfile;
+  isSelf: boolean;
+  isPrimary: boolean;
+  householdId: string;
+  isEditing: boolean;
+  onStartEdit: () => void;
+  onCancelEdit: () => void;
+  onChanged: () => Promise<void>;
+  onError: (msg: string) => void;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const Icon = ROLE_ICON[member.role];
+  const [saving, setSaving] = useState(false);
+  const [pendingRole, setPendingRole] = useState<HouseholdRole>(member.role);
+
+  // Self-edit + remove are forbidden via the server too, but we hide
+  // the affordances here so the carer doesn't accidentally lock
+  // themselves out of their own household.
+  const canManage = isPrimary && !isSelf;
+
+  async function saveRole() {
+    if (pendingRole === member.role) {
+      onCancelEdit();
+      return;
+    }
+    setSaving(true);
+    try {
+      await updateMemberRole({
+        household_id: householdId,
+        user_id: member.user_id,
+        new_role: pendingRole,
+      });
+      await onChanged();
+    } catch (err) {
+      onError(friendlyInviteError(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function remove() {
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(
+        L(
+          `Remove ${member.profile.display_name || "this member"} from the household? They'll lose access immediately.`,
+          `从家庭中移除 ${member.profile.display_name || "该成员"}？对方将立即失去访问权限。`,
+        ),
+      )
+    ) {
+      return;
+    }
+    setSaving(true);
+    try {
+      await removeMember({
+        household_id: householdId,
+        user_id: member.user_id,
+      });
+      await onChanged();
+    } catch (err) {
+      onError(friendlyInviteError(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <li className="flex items-start gap-3 px-3 py-3 text-[13px]">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-paper-2 text-ink-700">
+        <Icon className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-semibold text-ink-900">
+            {member.profile.display_name?.trim() ||
+              L("Unnamed member", "未命名成员")}
+          </span>
+          {isSelf && (
+            <span className="text-[10.5px] font-medium uppercase tracking-[0.08em] text-ink-400">
+              {L("you", "你")}
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 flex flex-wrap items-center gap-2 text-[11.5px] text-ink-500">
+          {!isEditing && (
+            <span className="rounded-full bg-paper-2 px-2 py-0.5 font-medium text-ink-700">
+              {ROLE_LABEL[member.role][locale]}
+            </span>
+          )}
+          {member.profile.relationship && (
+            <span>· {member.profile.relationship}</span>
+          )}
+          {member.profile.timezone && (
+            <span className="mono">· {member.profile.timezone}</span>
+          )}
+        </div>
+
+        {isEditing && (
+          <div className="mt-2 space-y-2">
+            <div className="text-[10.5px] font-medium uppercase tracking-[0.08em] text-ink-400">
+              {L("Change role", "修改角色")}
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {(
+                [
+                  "primary_carer",
+                  "patient",
+                  "family",
+                  "clinician",
+                  "observer",
+                ] as HouseholdRole[]
+              ).map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => setPendingRole(r)}
+                  className={cn(
+                    "rounded-full border px-2.5 py-1 text-[11.5px] transition-colors",
+                    pendingRole === r
+                      ? "border-ink-900 bg-ink-900 text-paper"
+                      : "border-ink-200 bg-paper-2 text-ink-700 hover:border-ink-400",
+                  )}
+                >
+                  {ROLE_LABEL[r][locale]}
+                </button>
+              ))}
+            </div>
+            <div className="flex items-center gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => void saveRole()}
+                disabled={saving}
+                className="inline-flex items-center gap-1 rounded-md bg-ink-900 px-3 py-1.5 text-[12px] font-medium text-paper hover:bg-ink-700 disabled:opacity-50"
+              >
+                {saving && <Loader2 className="h-3 w-3 animate-spin" />}
+                {L("Save", "保存")}
+              </button>
+              <button
+                type="button"
+                onClick={onCancelEdit}
+                disabled={saving}
+                className="text-[12px] text-ink-500 hover:text-ink-900"
+              >
+                {L("Cancel", "取消")}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+      {canManage && !isEditing && (
+        <div className="flex shrink-0 gap-1">
+          <button
+            type="button"
+            onClick={onStartEdit}
+            className="rounded-md p-1.5 text-ink-500 hover:bg-ink-100/40 hover:text-ink-900"
+            aria-label={L("Edit role", "编辑角色")}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => void remove()}
+            disabled={saving}
+            className="rounded-md p-1.5 text-ink-500 hover:bg-[var(--warn-soft)] hover:text-[var(--warn)] disabled:opacity-50"
+            aria-label={L("Remove member", "移除成员")}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/components/invite/pending-invites-list.tsx
+++ b/src/components/invite/pending-invites-list.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useState } from "react";
+import {
+  daysUntilExpiry,
+  extendInviteExpiry,
+  friendlyInviteError,
+  inviteStatusBucket,
+  inviteUrl,
+  revokeInvite,
+} from "~/lib/supabase/households";
+import { ROLE_LABEL } from "~/lib/auth/permissions";
+import type { HouseholdInvite } from "~/types/household";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import {
+  Clock,
+  Copy,
+  RotateCw,
+  X,
+  Check,
+  AlertCircle,
+} from "lucide-react";
+import { cn } from "~/lib/utils/cn";
+
+interface Props {
+  invites: HouseholdInvite[];
+  onChanged?: () => void;
+}
+
+// Pending-and-recent invites view used on /household. Shows live
+// (active), expired, accepted, and revoked invites separately so the
+// primary carer can tell at a glance which links are still hot. Only
+// renders when there's actually something to show — no empty state,
+// because the issuance UI lives directly above this list.
+export function PendingInvitesList({ invites, onChanged }: Props) {
+  const locale = useLocale();
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const buckets = {
+    active: [] as HouseholdInvite[],
+    expired: [] as HouseholdInvite[],
+    accepted: [] as HouseholdInvite[],
+    revoked: [] as HouseholdInvite[],
+  };
+  for (const inv of invites) {
+    buckets[inviteStatusBucket(inv)].push(inv);
+  }
+
+  if (invites.length === 0) return null;
+
+  async function copy(token: string) {
+    if (typeof window === "undefined") return;
+    try {
+      await navigator.clipboard.writeText(
+        inviteUrl(token, window.location.origin),
+      );
+      setCopiedToken(token);
+      setTimeout(() => setCopiedToken(null), 1500);
+    } catch {
+      // ignore — clipboard can fail on insecure origins
+    }
+  }
+
+  async function revoke(invite: HouseholdInvite) {
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(L("Revoke this invite link?", "撤销此邀请链接？"))
+    )
+      return;
+    setBusy(invite.id);
+    setError(null);
+    try {
+      await revokeInvite(invite.id);
+      await onChanged?.();
+    } catch (err) {
+      setError(friendlyInviteError(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function extend(invite: HouseholdInvite) {
+    setBusy(invite.id);
+    setError(null);
+    try {
+      await extendInviteExpiry({ invite_id: invite.id, days: 14 });
+      await onChanged?.();
+    } catch (err) {
+      setError(friendlyInviteError(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2.5 text-[12px] text-[var(--warn)]"
+        >
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {buckets.active.length > 0 && (
+        <Group title={L("Waiting", "等待接受")} count={buckets.active.length}>
+          {buckets.active.map((inv) => (
+            <ActiveRow
+              key={inv.id}
+              invite={inv}
+              copied={copiedToken === inv.token}
+              busy={busy === inv.id}
+              onCopy={() => void copy(inv.token)}
+              onRevoke={() => void revoke(inv)}
+              onExtend={() => void extend(inv)}
+              locale={locale}
+            />
+          ))}
+        </Group>
+      )}
+
+      {buckets.expired.length > 0 && (
+        <Group title={L("Expired", "已过期")} count={buckets.expired.length}>
+          {buckets.expired.map((inv) => (
+            <SimpleRow
+              key={inv.id}
+              invite={inv}
+              tone="warn"
+              right={
+                <button
+                  type="button"
+                  onClick={() => void extend(inv)}
+                  disabled={busy === inv.id}
+                  className="text-[11.5px] text-ink-500 hover:text-ink-900 disabled:opacity-50"
+                >
+                  <RotateCw className="mr-1 inline h-3 w-3" />
+                  {L("Extend 14 days", "延长 14 天")}
+                </button>
+              }
+              locale={locale}
+            />
+          ))}
+        </Group>
+      )}
+
+      {buckets.accepted.length > 0 && (
+        <Group title={L("Accepted", "已接受")} count={buckets.accepted.length}>
+          {buckets.accepted.map((inv) => (
+            <SimpleRow
+              key={inv.id}
+              invite={inv}
+              tone="ok"
+              right={
+                <span className="text-[11px] text-ink-500">
+                  {inv.accepted_at &&
+                    new Date(inv.accepted_at).toLocaleDateString(
+                      locale === "zh" ? "zh-CN" : undefined,
+                      { day: "numeric", month: "short" },
+                    )}
+                </span>
+              }
+              locale={locale}
+            />
+          ))}
+        </Group>
+      )}
+
+      {buckets.revoked.length > 0 && (
+        <Group title={L("Revoked", "已撤销")} count={buckets.revoked.length}>
+          {buckets.revoked.map((inv) => (
+            <SimpleRow
+              key={inv.id}
+              invite={inv}
+              tone="muted"
+              right={null}
+              locale={locale}
+            />
+          ))}
+        </Group>
+      )}
+    </div>
+  );
+}
+
+function Group({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-baseline gap-2 text-[10.5px] font-medium uppercase tracking-[0.12em] text-ink-400">
+        <span>{title}</span>
+        <span className="mono text-ink-500">{count}</span>
+      </div>
+      <Card>
+        <CardContent className="p-0">
+          <ul className="divide-y divide-ink-100">{children}</ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ActiveRow({
+  invite,
+  copied,
+  busy,
+  onCopy,
+  onRevoke,
+  onExtend,
+  locale,
+}: {
+  invite: HouseholdInvite;
+  copied: boolean;
+  busy: boolean;
+  onCopy: () => void;
+  onRevoke: () => void;
+  onExtend: () => void;
+  locale: "en" | "zh";
+}) {
+  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
+  const days = daysUntilExpiry(invite.expires_at);
+  const nearExpiry = days <= 3;
+  return (
+    <li className="space-y-2 px-3 py-3 text-[13px]">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <div className="min-w-0">
+          <div className="font-medium text-ink-900">
+            {invite.email_hint?.trim() || L("Unnamed invite", "未命名邀请")}
+          </div>
+          <div className="mt-0.5 flex flex-wrap items-center gap-2 text-[11.5px] text-ink-500">
+            <span className="rounded-full bg-paper-2 px-2 py-0.5 font-medium text-ink-700">
+              {ROLE_LABEL[invite.role][locale]}
+            </span>
+            <Clock className="h-3 w-3" />
+            <span className={cn(nearExpiry && "text-[var(--warn)]")}>
+              {days <= 0
+                ? L("Expires today", "今天到期")
+                : days === 1
+                  ? L("Expires tomorrow", "明天到期")
+                  : L(
+                      `Expires in ${days} days`,
+                      `${days} 天后到期`,
+                    )}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 text-[11.5px]">
+        <button
+          type="button"
+          onClick={onCopy}
+          className="inline-flex items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-ink-700 hover:bg-ink-100/40"
+        >
+          {copied ? (
+            <Check className="h-3 w-3 text-[var(--ok)]" />
+          ) : (
+            <Copy className="h-3 w-3" />
+          )}
+          {copied ? L("Copied", "已复制") : L("Copy link", "复制链接")}
+        </button>
+        {nearExpiry && (
+          <button
+            type="button"
+            onClick={onExtend}
+            disabled={busy}
+            className="inline-flex items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-ink-700 hover:bg-ink-100/40 disabled:opacity-50"
+          >
+            <RotateCw className="h-3 w-3" />
+            {L("Extend 14 days", "延长 14 天")}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onRevoke}
+          disabled={busy}
+          className="inline-flex items-center gap-1 text-ink-500 hover:text-[var(--warn)] disabled:opacity-50"
+        >
+          <X className="h-3 w-3" />
+          {L("Revoke", "撤销")}
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function SimpleRow({
+  invite,
+  tone,
+  right,
+  locale,
+}: {
+  invite: HouseholdInvite;
+  tone: "warn" | "ok" | "muted";
+  right: React.ReactNode;
+  locale: "en" | "zh";
+}) {
+  return (
+    <li className="flex items-center justify-between gap-3 px-3 py-2.5 text-[12.5px]">
+      <div className="min-w-0">
+        <div
+          className={cn(
+            "truncate font-medium",
+            tone === "warn"
+              ? "text-[var(--warn)]"
+              : tone === "ok"
+                ? "text-ink-900"
+                : "text-ink-500 line-through",
+          )}
+        >
+          {invite.email_hint?.trim() ||
+            (locale === "zh" ? "未命名邀请" : "Unnamed invite")}
+        </div>
+        <div className="mt-0.5 text-[11px] text-ink-500">
+          {ROLE_LABEL[invite.role][locale]}
+        </div>
+      </div>
+      {right}
+    </li>
+  );
+}

--- a/src/lib/supabase/households.ts
+++ b/src/lib/supabase/households.ts
@@ -6,6 +6,8 @@ import type {
   HouseholdMemberWithProfile,
   HouseholdRole,
   HouseholdSummary,
+  InvitePreview,
+  InvitePreviewStatus,
   Profile,
 } from "~/types/household";
 
@@ -308,5 +310,156 @@ export function friendlyInviteError(err: unknown): string {
     return "This invite has already been accepted.";
   if (msg.includes("invite_expired")) return "This invite has expired.";
   if (msg.includes("not_signed_in")) return "Please sign in first.";
+  if (msg.includes("not_authenticated")) return "Please sign in first.";
+  if (msg.includes("not_authorised"))
+    return "Only the primary carer can do that.";
+  // target_not_a_member is checked BEFORE not_a_member because the
+  // latter is a substring of the former — flipping the order
+  // misclassifies "the invitee" errors as "the caller" errors.
+  if (msg.includes("target_not_a_member"))
+    return "That person isn't a member of this household.";
+  if (msg.includes("not_a_member"))
+    return "You're not a member of this household.";
+  if (msg.includes("last_primary_carer"))
+    return "You can't change the role of the last primary carer — promote someone else first.";
+  if (msg.includes("invalid_extension"))
+    return "Invite extension must be between 1 and 90 days.";
   return msg;
+}
+
+// RPC: fetch a public preview of an invite token. Used by /invite/<token>
+// to render trust copy ("You've been invited to Hu Lin's care team as
+// Family by Thomas") BEFORE bouncing an unauthenticated visitor to
+// /login. Falls back to a not_found preview when Supabase isn't
+// configured so the UI can still render an error state instead of
+// blank-screening.
+export async function getInvitePreview(
+  token: string,
+): Promise<InvitePreview> {
+  const sb = getSupabaseBrowser();
+  if (!sb) {
+    return {
+      status: "not_found",
+      household_name: null,
+      patient_display_name: null,
+      role: null,
+      invited_by_name: null,
+      expires_at: null,
+      accepted_at: null,
+      revoked_at: null,
+    };
+  }
+  const { data, error } = await sb.rpc("get_invite_preview", {
+    invite_token: token,
+  });
+  if (error) throw error;
+  // Supabase returns rows from a SETOF / TABLE function as an array.
+  // We expect zero or one row; pull the first or surface not_found.
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row || typeof row !== "object") {
+    return {
+      status: "not_found",
+      household_name: null,
+      patient_display_name: null,
+      role: null,
+      invited_by_name: null,
+      expires_at: null,
+      accepted_at: null,
+      revoked_at: null,
+    };
+  }
+  const r = row as {
+    status: string;
+    household_name: string | null;
+    patient_display_name: string | null;
+    role: HouseholdRole | null;
+    invited_by_name: string | null;
+    expires_at: string | null;
+    accepted_at: string | null;
+    revoked_at: string | null;
+  };
+  const status: InvitePreviewStatus =
+    r.status === "active" ||
+    r.status === "expired" ||
+    r.status === "revoked" ||
+    r.status === "accepted"
+      ? r.status
+      : "not_found";
+  return {
+    status,
+    household_name: r.household_name,
+    patient_display_name: r.patient_display_name,
+    role: r.role,
+    invited_by_name: r.invited_by_name,
+    expires_at: r.expires_at,
+    accepted_at: r.accepted_at,
+    revoked_at: r.revoked_at,
+  };
+}
+
+// RPC: change a member's role inside a household. Primary-carer-only.
+// Refuses to demote the last primary_carer so the household can never
+// be left without an admin.
+export async function updateMemberRole(args: {
+  household_id: string;
+  user_id: string;
+  new_role: HouseholdRole;
+}): Promise<HouseholdRole> {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("supabase_not_configured");
+  const { data, error } = await sb.rpc("update_member_role", {
+    target_household: args.household_id,
+    target_user: args.user_id,
+    new_role: args.new_role,
+  });
+  if (error) throw error;
+  return data as HouseholdRole;
+}
+
+// RPC: extend an invite's expires_at by N days (default 14). Useful
+// when a relative drags their feet — saves the carer from having to
+// revoke + recreate + reshare a fresh URL.
+export async function extendInviteExpiry(args: {
+  invite_id: string;
+  days?: number;
+}): Promise<string> {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("supabase_not_configured");
+  const { data, error } = await sb.rpc("extend_invite_expiry", {
+    target_invite: args.invite_id,
+    days_to_add: args.days ?? 14,
+  });
+  if (error) throw error;
+  if (typeof data !== "string") throw new Error("extend_invite_failed");
+  return data;
+}
+
+// Bucket an invite's lifecycle for UI rendering. Single source of
+// truth — keep CSS / copy keyed off this rather than scattering the
+// `accepted_at && !revoked_at && expires_at > now` checks across a
+// dozen components.
+export type InviteStatusBucket =
+  | "active"
+  | "expired"
+  | "accepted"
+  | "revoked";
+
+export function inviteStatusBucket(
+  invite: Pick<HouseholdInvite, "accepted_at" | "revoked_at" | "expires_at">,
+  now: Date = new Date(),
+): InviteStatusBucket {
+  if (invite.revoked_at) return "revoked";
+  if (invite.accepted_at) return "accepted";
+  if (new Date(invite.expires_at).getTime() <= now.getTime()) return "expired";
+  return "active";
+}
+
+// Days until an invite expires, rounded down. Negative for already-
+// expired invites. Used in the "expires in 12 days" hint copy.
+export function daysUntilExpiry(
+  expiresAt: string,
+  now: Date = new Date(),
+): number {
+  const ms = new Date(expiresAt).getTime() - now.getTime();
+  return Math.floor(ms / (24 * 60 * 60 * 1000));
 }

--- a/src/types/household.ts
+++ b/src/types/household.ts
@@ -74,3 +74,25 @@ export interface HouseholdSummary {
   created_at: string;
   member_count: number;
 }
+
+// Public-readable invite preview returned by `get_invite_preview` —
+// the minimum needed for the /invite/<token> landing page to show a
+// trustworthy "you've been invited to X as Y" card BEFORE forcing
+// the visitor to sign in. Status mirrors the SQL function's enum.
+export type InvitePreviewStatus =
+  | "active"
+  | "expired"
+  | "revoked"
+  | "accepted"
+  | "not_found";
+
+export interface InvitePreview {
+  status: InvitePreviewStatus;
+  household_name: string | null;
+  patient_display_name: string | null;
+  role: HouseholdRole | null;
+  invited_by_name: string | null;
+  expires_at: string | null;
+  accepted_at: string | null;
+  revoked_at: string | null;
+}

--- a/supabase/migrations/2026_04_26_carer_invite_flow.sql
+++ b/supabase/migrations/2026_04_26_carer_invite_flow.sql
@@ -1,0 +1,241 @@
+-- Carer invite flow — preview, role updates, and expiry extension.
+--
+-- Slice A laid down the household_invites table, an `accept_household_invite`
+-- RPC, and RLS policies that scope SELECT/INSERT/UPDATE to existing members.
+-- This migration fills three gaps that the polished invite UX needs:
+--
+--  (1) `get_invite_preview(token)` — lets an unauthenticated invitee see
+--      WHO invited them, to WHICH household, and AS WHAT role, BEFORE
+--      they're asked to sign in. Without this the /invite/<token> page
+--      bounces straight to /login with no reassurance the link is real
+--      or pointed at the right family. Returns just the fields needed
+--      to render trust copy; no clinical data.
+--
+--  (2) `update_member_role(target_household, target_user, new_role)` —
+--      lets the primary_carer change a member's role after the fact
+--      (e.g. a relative joined as `family` and later took on more of a
+--      clinical-coordination role). The RLS policies on
+--      household_memberships allow primary_carer UPDATEs in spirit, but
+--      to keep call-sites simple we wrap it in a SECURITY DEFINER RPC
+--      with explicit error codes. Prevents removing the last
+--      primary_carer (so a household can't be orphaned).
+--
+--  (3) `extend_invite_expiry(invite_id, days)` — re-arms an unaccepted
+--      invite for another N days (default 14). Saves the carer from
+--      having to revoke + re-create + re-share a fresh URL when a
+--      relative drags their feet.
+--
+-- All three functions are SECURITY DEFINER with `search_path = public`
+-- per Supabase guidance, REVOKEd from public, and GRANTed to either
+-- `anon, authenticated` (preview) or `authenticated` (mutations).
+-- Idempotent — safe to re-run.
+
+SET check_function_bodies = false;
+
+-- ─── invite preview (PUBLIC — no auth required) ─────────────────────
+-- Returns the minimal trust info an invitee needs before deciding
+-- whether to sign in / sign up. Status is one of:
+--   'active' | 'expired' | 'revoked' | 'accepted' | 'not_found'
+-- The function never raises — it surfaces the status field instead so
+-- the client can render a useful error UI. Email_hint is intentionally
+-- omitted (it's PII the carer typed in for their own reference, not
+-- something the invitee needs to see again).
+
+CREATE OR REPLACE FUNCTION public.get_invite_preview(invite_token uuid)
+  RETURNS TABLE (
+    status text,
+    household_name text,
+    patient_display_name text,
+    role public.household_role,
+    invited_by_name text,
+    expires_at timestamptz,
+    accepted_at timestamptz,
+    revoked_at timestamptz
+  )
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+DECLARE
+  invite public.household_invites%ROWTYPE;
+  resolved_status text;
+BEGIN
+  SELECT * INTO invite FROM public.household_invites WHERE token = invite_token;
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT
+      'not_found'::text,
+      NULL::text,
+      NULL::text,
+      NULL::public.household_role,
+      NULL::text,
+      NULL::timestamptz,
+      NULL::timestamptz,
+      NULL::timestamptz;
+    RETURN;
+  END IF;
+
+  IF invite.revoked_at IS NOT NULL THEN
+    resolved_status := 'revoked';
+  ELSIF invite.accepted_at IS NOT NULL THEN
+    resolved_status := 'accepted';
+  ELSIF invite.expires_at < now() THEN
+    resolved_status := 'expired';
+  ELSE
+    resolved_status := 'active';
+  END IF;
+
+  RETURN QUERY
+    SELECT
+      resolved_status,
+      h.name,
+      h.patient_display_name,
+      invite.role,
+      coalesce(p.display_name, ''),
+      invite.expires_at,
+      invite.accepted_at,
+      invite.revoked_at
+    FROM public.households h
+    LEFT JOIN public.profiles p ON p.id = invite.invited_by
+    WHERE h.id = invite.household_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_invite_preview(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.get_invite_preview(uuid) TO anon, authenticated;
+
+-- ─── update a member's role ──────────────────────────────────────────
+-- Primary-carer-only mutation. Refuses to demote the last primary_carer
+-- so a household can never end up admin-less. Idempotent: setting a
+-- member to the role they already have is a no-op.
+
+CREATE OR REPLACE FUNCTION public.update_member_role(
+  target_household uuid,
+  target_user uuid,
+  new_role public.household_role
+)
+  RETURNS public.household_role
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+DECLARE
+  caller uuid := auth.uid();
+  caller_role public.household_role;
+  existing_role public.household_role;
+  remaining_primaries integer;
+BEGIN
+  IF caller IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  SELECT role INTO caller_role
+  FROM public.household_memberships
+  WHERE household_id = target_household AND user_id = caller;
+
+  IF caller_role IS NULL THEN
+    RAISE EXCEPTION 'not_a_member';
+  END IF;
+  IF caller_role <> 'primary_carer' THEN
+    RAISE EXCEPTION 'not_authorised';
+  END IF;
+
+  SELECT role INTO existing_role
+  FROM public.household_memberships
+  WHERE household_id = target_household AND user_id = target_user;
+
+  IF existing_role IS NULL THEN
+    RAISE EXCEPTION 'target_not_a_member';
+  END IF;
+
+  -- No-op when the role is already correct.
+  IF existing_role = new_role THEN
+    RETURN existing_role;
+  END IF;
+
+  -- Demoting the last primary_carer would orphan the household.
+  IF existing_role = 'primary_carer' AND new_role <> 'primary_carer' THEN
+    SELECT count(*)::integer INTO remaining_primaries
+    FROM public.household_memberships
+    WHERE household_id = target_household AND role = 'primary_carer';
+    IF remaining_primaries <= 1 THEN
+      RAISE EXCEPTION 'last_primary_carer';
+    END IF;
+  END IF;
+
+  UPDATE public.household_memberships
+  SET role = new_role
+  WHERE household_id = target_household AND user_id = target_user;
+
+  RETURN new_role;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_member_role(uuid, uuid, public.household_role) FROM public;
+GRANT EXECUTE ON FUNCTION public.update_member_role(uuid, uuid, public.household_role) TO authenticated;
+
+-- ─── extend an invite's expiry ───────────────────────────────────────
+-- Bumps `expires_at` to now() + days_to_add days. Refuses on
+-- already-accepted or revoked invites. Default extension matches the
+-- 14-day initial expiry.
+
+CREATE OR REPLACE FUNCTION public.extend_invite_expiry(
+  target_invite uuid,
+  days_to_add integer DEFAULT 14
+)
+  RETURNS timestamptz
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+DECLARE
+  caller uuid := auth.uid();
+  caller_role public.household_role;
+  invite public.household_invites%ROWTYPE;
+  new_expiry timestamptz;
+BEGIN
+  IF caller IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF days_to_add IS NULL OR days_to_add <= 0 OR days_to_add > 90 THEN
+    RAISE EXCEPTION 'invalid_extension';
+  END IF;
+
+  SELECT * INTO invite FROM public.household_invites WHERE id = target_invite;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'invite_not_found';
+  END IF;
+
+  SELECT role INTO caller_role
+  FROM public.household_memberships
+  WHERE household_id = invite.household_id AND user_id = caller;
+
+  IF caller_role IS NULL THEN
+    RAISE EXCEPTION 'not_a_member';
+  END IF;
+  IF caller_role <> 'primary_carer' THEN
+    RAISE EXCEPTION 'not_authorised';
+  END IF;
+
+  IF invite.revoked_at IS NOT NULL THEN
+    RAISE EXCEPTION 'invite_revoked';
+  END IF;
+  IF invite.accepted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'invite_already_accepted';
+  END IF;
+
+  new_expiry := now() + make_interval(days => days_to_add);
+
+  UPDATE public.household_invites
+  SET expires_at = new_expiry
+  WHERE id = invite.id;
+
+  RETURN new_expiry;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.extend_invite_expiry(uuid, integer) FROM public;
+GRANT EXECUTE ON FUNCTION public.extend_invite_expiry(uuid, integer) TO authenticated;
+
+-- Force PostgREST to refresh its schema cache so the freshly-installed
+-- functions are callable without a server restart.
+NOTIFY pgrst, 'reload schema';

--- a/tests/unit/invite-flow.test.ts
+++ b/tests/unit/invite-flow.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  daysUntilExpiry,
+  friendlyInviteError,
+  inviteStatusBucket,
+  inviteUrl,
+} from "~/lib/supabase/households";
+import type { HouseholdInvite } from "~/types/household";
+
+// Tests for the carer-invite-flow helpers. The Supabase RPCs themselves
+// (get_invite_preview, update_member_role, extend_invite_expiry) are
+// exercised through integration testing — these unit tests cover the
+// pure helpers that drive the UI's status copy and the error mapping
+// for the new failure modes (last_primary_carer, invalid_extension,
+// not_authorised, …).
+
+function makeInvite(overrides: Partial<HouseholdInvite> = {}): HouseholdInvite {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    household_id: "h",
+    token: "00000000-0000-0000-0000-000000000002",
+    email_hint: null,
+    role: "family",
+    invited_by: "u",
+    created_at: "2026-04-01T00:00:00Z",
+    expires_at: "2026-05-01T00:00:00Z",
+    accepted_by: null,
+    accepted_at: null,
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+describe("inviteStatusBucket", () => {
+  const now = new Date("2026-04-15T00:00:00Z");
+
+  it("classifies a fresh, unaccepted, unrevoked invite as active", () => {
+    expect(inviteStatusBucket(makeInvite(), now)).toBe("active");
+  });
+
+  it("classifies an expired invite as expired", () => {
+    const inv = makeInvite({ expires_at: "2026-04-10T00:00:00Z" });
+    expect(inviteStatusBucket(inv, now)).toBe("expired");
+  });
+
+  it("classifies an exactly-now expiry as expired (boundary)", () => {
+    const inv = makeInvite({ expires_at: now.toISOString() });
+    expect(inviteStatusBucket(inv, now)).toBe("expired");
+  });
+
+  it("classifies an accepted invite as accepted regardless of expiry", () => {
+    const inv = makeInvite({
+      accepted_at: "2026-04-10T00:00:00Z",
+      expires_at: "2026-04-10T00:00:00Z",
+    });
+    expect(inviteStatusBucket(inv, now)).toBe("accepted");
+  });
+
+  it("classifies a revoked invite as revoked even if also accepted", () => {
+    // Defensive: shouldn't happen in practice but the precedence matters.
+    const inv = makeInvite({
+      revoked_at: "2026-04-12T00:00:00Z",
+      accepted_at: "2026-04-11T00:00:00Z",
+    });
+    expect(inviteStatusBucket(inv, now)).toBe("revoked");
+  });
+});
+
+describe("daysUntilExpiry", () => {
+  it("returns positive days for a future expiry", () => {
+    const now = new Date("2026-04-15T00:00:00Z");
+    expect(daysUntilExpiry("2026-04-25T00:00:00Z", now)).toBe(10);
+  });
+
+  it("returns 0 for an expiry within the same day", () => {
+    const now = new Date("2026-04-15T00:00:00Z");
+    expect(daysUntilExpiry("2026-04-15T18:00:00Z", now)).toBe(0);
+  });
+
+  it("returns negative days for an already-expired invite", () => {
+    const now = new Date("2026-04-15T00:00:00Z");
+    expect(daysUntilExpiry("2026-04-10T00:00:00Z", now)).toBe(-5);
+  });
+});
+
+describe("friendlyInviteError — new failure modes", () => {
+  const cases: Array<[string, string]> = [
+    ["not_authenticated", "Please sign in first."],
+    ["not_authorised", "Only the primary carer can do that."],
+    ["not_a_member", "You're not a member of this household."],
+    [
+      "target_not_a_member",
+      "That person isn't a member of this household.",
+    ],
+    [
+      "last_primary_carer",
+      "You can't change the role of the last primary carer — promote someone else first.",
+    ],
+    [
+      "invalid_extension",
+      "Invite extension must be between 1 and 90 days.",
+    ],
+  ];
+  for (const [needle, expected] of cases) {
+    it(`maps ${needle} to "${expected}"`, () => {
+      expect(friendlyInviteError(new Error(needle))).toBe(expected);
+    });
+  }
+
+  it("still maps the original Slice A errors", () => {
+    expect(friendlyInviteError(new Error("invite_expired"))).toBe(
+      "This invite has expired.",
+    );
+    expect(friendlyInviteError(new Error("invite_revoked"))).toBe(
+      "This invite has been revoked.",
+    );
+  });
+});
+
+describe("inviteUrl", () => {
+  it("still joins origin and token correctly (regression)", () => {
+    expect(inviteUrl("abc-123", "https://anchor.example.com")).toBe(
+      "https://anchor.example.com/invite/abc-123",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Builds out the full carer invite loop end-to-end. Slice A laid the
schema + accept RPC; Slice M extended the role enum + profile fields;
Slice P added a discovery picker. This PR closes the remaining gaps so
the relative receiving a link, the primary carer issuing them, and the
freshly-accepted member all have a clear, trustworthy path through the
system.

### Three-axis impact (per docs/CLINICAL_FRAMEWORK.md)

The carer invite flow is foundational for the **single channel out** —
every additional carer in the household becomes another pair of eyes
on axis-3 drift (treatment-driven toxicity), and another logger of
quick notes that feed the change detectors. Concretely:

- Catherine and Wendy can be onboarded in under two minutes from a
  shared link, then immediately confirm attendance / log "ate well
  today" — closing the loop on care coordination Thomas currently
  has to do solo.
- An external palliative RN or trial nurse can be invited as
  `clinician`, attach notes to the chart, and stay scoped out of
  family logs by default.
- The patient (Hu Lin) can be enrolled as `patient` so his self-logs
  are attributed correctly, with `edit_medications` for his Creon /
  insulin self-titration.

### What changed

**Database (`2026_04_26_carer_invite_flow.sql`):**
- `get_invite_preview(token)` — public-readable preview returning
  household name, patient name, role, inviter, expiry. Granted to
  `anon, authenticated`. Lets `/invite/<token>` render trust copy
  BEFORE forcing sign-in.
- `update_member_role(...)` — primary-carer-only mutation; refuses to
  demote the last primary_carer so a household can never be
  orphaned. Idempotent.
- `extend_invite_expiry(...)` — re-arms an unaccepted invite for
  another N days (default 14, capped at 90) instead of forcing a
  revoke + recreate + reshare.

**`/household` (new page):** primary carer's home for member
management — distinct from `/care-team` (external clinical contacts
log). Composes:
- `InviteCarerFlow` — three-step issuance (pick role with one-line
  description → optional name/email hint → share). Uses
  `navigator.share()` on phones, copy-to-clipboard everywhere, plus
  SMS / WhatsApp / email deep-links so non-technical relatives don't
  have to think about how to forward a URL.
- `MembersList` — role icons, inline change-role with last-primary
  guard, remove with confirmation. Hidden affordances for
  non-primary roles.
- `PendingInvitesList` — bucketed by status (active / expired /
  accepted / revoked). 14-day extend appears on near-expiry invites.

**`/invite/[token]` (refactor):** fetches the public preview first.
Shows who invited you, to which household, as what role, and how long
the link is valid — BEFORE bouncing to `/login`. Expired / revoked /
already-accepted / not-found cases are surfaced inline without forcing
the visitor to sign in just to learn the link is dead.

**`/invite/welcome` (enhanced):** gains a role-specific "what you can
do here" step driven off the permission matrix, so a new family
member or observer knows both their capabilities and their limits
without discovering them through disabled buttons.

**Dashboard:** `RecentlyAcceptedCard` closes the loop for the primary
carer with a 72-hour window and per-token dismiss in localStorage.
`PendingInvitesCard`, `InviteFamilyCard`, and the `/family`
`HouseholdHeader` now link to `/household` instead of
`/settings#care-team`.

### Tests

- 16 new unit tests in `tests/unit/invite-flow.test.ts` covering
  `inviteStatusBucket` (with the revoked-beats-accepted precedence
  case), `daysUntilExpiry`, and the new `friendlyInviteError`
  mappings — including the ordering bug where `target_not_a_member`
  must be checked before `not_a_member` (substring collision).
- All 692 existing tests still pass.
- Typecheck, lint, and `pnpm build` are green; `/household` is in
  the route manifest at 17.7 kB.

## Test plan

- [ ] Apply `supabase/migrations/2026_04_26_carer_invite_flow.sql`
      to Supabase (idempotent, includes `NOTIFY pgrst, 'reload schema'`).
- [ ] As a primary carer, visit `/household`, issue an invite as
      `family`, copy the link, then accept it from a logged-out
      browser. Verify the preview card renders before sign-in.
- [ ] Confirm the post-acceptance welcome wizard now shows a
      role-specific "what you can do" step.
- [ ] Issue an invite, then revoke / extend it from `/household`
      and confirm the bucketed view updates.
- [ ] Try to demote yourself as the only primary_carer — confirm
      the `last_primary_carer` error renders friendly copy.
- [ ] Confirm `RecentlyAcceptedCard` appears on the dashboard
      within 72h of acceptance and dismisses cleanly.

https://claude.ai/code/session_0166RgD8Vg8nA1EvWSdsR4LA

---
_Generated by [Claude Code](https://claude.ai/code/session_0166RgD8Vg8nA1EvWSdsR4LA)_