### PR TITLE
UX audit: fix 7 new-user clarity issues

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -18,7 +18,7 @@
     "events": "Events",
     "tasks": "Tasks",
     "decisions": "Decisions",
-    "ingest": "Ingest",
+    "ingest": "Upload",
     "reports": "Reports",
     "settings": "Settings",
     "practices": "Practices",
@@ -26,7 +26,25 @@
     "care_team": "Visit log",
     "carers": "Carers",
     "log": "Log",
-    "nutrition": "Nutrition"
+    "nutrition": "Nutrition",
+    "desc": {
+      "dashboard": "Today's summary & alerts",
+      "schedule": "Appointments & prep",
+      "family": "Patient status overview",
+      "assessment": "Functional tests & scores",
+      "treatment": "Chemo cycles & doses",
+      "labs": "Blood test trends",
+      "nutrition": "Meals, protein & hydration",
+      "practices": "Qigong & daily practices",
+      "care_team": "Contacts & call history",
+      "carers": "Family & care circle",
+      "bridge": "Strategy & trial eligibility",
+      "history": "All past entries",
+      "ingest": "Upload documents & records",
+      "reports": "PDF summaries for clinic",
+      "settings": "Profile & preferences",
+      "log": "Log observations for patient"
+    }
   },
   "zones": {
     "green": "Stable",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -26,7 +26,25 @@
     "care_team": "就诊记录",
     "carers": "护理人员",
     "log": "记录",
-    "nutrition": "营养"
+    "nutrition": "营养",
+    "desc": {
+      "dashboard": "今日摘要与警示",
+      "schedule": "预约与准备事项",
+      "family": "患者状态总览",
+      "assessment": "功能测试与评分",
+      "treatment": "化疗周期与剂量",
+      "labs": "化验趋势",
+      "nutrition": "餐食、蛋白质与饮水",
+      "practices": "气功与日常修习",
+      "care_team": "联系方式与通话记录",
+      "carers": "家人与护理圈",
+      "bridge": "策略与试验资格",
+      "history": "所有过往记录",
+      "ingest": "上传文件与记录",
+      "reports": "就诊前 PDF 小结",
+      "settings": "个人资料与偏好",
+      "log": "为患者记录观察"
+    }
   },
   "zones": {
     "green": "稳定",

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -42,6 +42,49 @@ export default function BridgePage() {
     },
   ];
 
+  const ecogLevels = [
+    {
+      grade: "0",
+      label: L("Fully active", "完全活跃"),
+      description: L(
+        "You can carry out all normal activity without restriction.",
+        "可以毫无限制地进行所有日常活动。",
+      ),
+      color: "var(--ok)",
+      soft: "var(--ok-soft)",
+    },
+    {
+      grade: "1",
+      label: L("Restricted but ambulatory", "轻度受限，可自理"),
+      description: L(
+        "You have some restriction in physical activity but can walk and carry out light work. You can care for yourself.",
+        "体力活动有所受限，但可以走动、做轻体力工作，生活可以自理。",
+      ),
+      color: "var(--tide-2)",
+      soft: "var(--tide-soft)",
+    },
+    {
+      grade: "2",
+      label: L("Ambulatory, self-care only", "可走动，仅能自理"),
+      description: L(
+        "You can walk and care for yourself but can't do work. Up and about more than 50% of waking hours.",
+        "可以走动和自我照顾，但无法工作。清醒时间超过 50% 可以起床活动。",
+      ),
+      color: "var(--caution)",
+      soft: "var(--caution-soft)",
+    },
+    {
+      grade: "3–4",
+      label: L("Limited self-care", "自理受限"),
+      description: L(
+        "Limited ability to care for yourself. Confined to bed or chair more than 50% of waking hours.",
+        "自理能力受限。清醒时间超过 50% 需卧床或坐轮椅。",
+      ),
+      color: "var(--warn)",
+      soft: "var(--warn-soft)",
+    },
+  ];
+
   return (
     <div className="max-w-4xl mx-auto p-4 md:p-8 space-y-8">
       <PageHeader
@@ -53,6 +96,48 @@ export default function BridgePage() {
           )
         }
       />
+
+      {/* ECOG plain-language explainer */}
+      <div className="rounded-[var(--r-lg)] border border-ink-100 bg-paper-2 p-5 space-y-3">
+        <div className="flex items-baseline gap-2">
+          <div className="text-[13px] font-semibold text-ink-900">
+            {L("What is ECOG?", "什么是 ECOG？")}
+          </div>
+          <div className="mono text-[10px] uppercase tracking-wider text-ink-400">
+            {L("Performance Status", "功能状态评分")}
+          </div>
+        </div>
+        <p className="text-[12.5px] text-ink-600 leading-relaxed">
+          {L(
+            "ECOG is a 0–4 scale that describes how much a person's daily activities are affected by their illness. Daraxonrasib requires ECOG 0 or 1 — meaning you are largely independent and mobile. Preserving this is the goal of the bridge strategy.",
+            "ECOG 是一个 0–4 分的量表，描述疾病对日常活动的影响程度。Daraxonrasib 要求 ECOG 0 或 1 分——即基本独立、可以走动。维持这一状态是过渡策略的目标。",
+          )}
+        </p>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {ecogLevels.map((level) => (
+            <div
+              key={level.grade}
+              className="flex items-start gap-3 rounded-[var(--r-md)] p-3"
+              style={{ background: level.soft }}
+            >
+              <div
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[12px] font-bold text-paper"
+                style={{ background: level.color }}
+              >
+                {level.grade}
+              </div>
+              <div className="min-w-0">
+                <div className="text-[12.5px] font-semibold text-ink-900">
+                  {level.label}
+                </div>
+                <div className="mt-0.5 text-[11.5px] text-ink-600 leading-relaxed">
+                  {level.description}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
 
       {/* Always-visible strategy explainer */}
       <div className="grid gap-4 md:grid-cols-3">

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -414,13 +414,9 @@ export default function OnboardingPage() {
             </Button>
           )}
           {CAN_SKIP_FROM.includes(step) && (
-            <button
-              type="button"
-              onClick={skipToEnd}
-              className="text-[12px] text-ink-500 underline-offset-2 hover:text-ink-800 hover:underline"
-            >
+            <Button variant="ghost" onClick={skipToEnd} className="text-ink-500 hover:text-ink-800">
               {locale === "zh" ? "其余稍后再填" : "Finish setup later"}
-            </button>
+            </Button>
           )}
         </div>
         {step === "done" ? (
@@ -781,8 +777,8 @@ function PickPatientStep({
         <div className="space-y-3 rounded-md border border-ink-200 bg-paper-2 p-4">
           <div className="text-[12.5px] text-ink-700">
             {L(
-              "Browsing every patient isn't enabled on this server yet. If the patient already has Anchor set up, paste the invite link they sent you.",
-              "本服务器尚未开启患者浏览功能。如对方已在使用 Anchor,请粘贴 ta 发来的邀请链接。",
+              "Paste the invite link the patient sent you to join their care team.",
+              "请粘贴患者发来的邀请链接加入其护理团队。",
             )}
           </div>
           <div className="flex gap-2">
@@ -802,12 +798,6 @@ function PickPatientStep({
               {acceptingInvite ? L("Joining…", "加入中…") : L("Join", "加入")}
             </Button>
           </div>
-          <p className="text-[11.5px] text-ink-400">
-            {L(
-              "Server admin: apply migration 2026_04_24_slice_p_caregiver_onboarding_reload.sql in Supabase to enable the picker.",
-              "服务器管理员:在 Supabase 中应用迁移 2026_04_24_slice_p_caregiver_onboarding_reload.sql 即可启用选择器。",
-            )}
-          </p>
         </div>
       )}
 

--- a/src/components/daily/daily-wizard.tsx
+++ b/src/components/daily/daily-wizard.tsx
@@ -422,8 +422,8 @@ function PickScreen({
         </h1>
         <p className="mt-1 text-sm text-ink-500">
           {locale === "zh"
-            ? "只选今天真正相关的。没有的项目就不用填。"
-            : "Pick only what actually applies today. Anything you don't tap stays unrecorded."}
+            ? "点选今天真正有的项目，然后按「开始」逐一填写。没有的项目不用选。"
+            : "Tap the cards that apply today, then press Start to fill them in one by one. Skip anything that doesn't apply."}
         </p>
         {inChemoWindow && (
           <div className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-[var(--tide-soft)] px-2.5 py-1 text-[11px] text-[var(--tide-2)]">
@@ -503,28 +503,34 @@ function PickScreen({
         </CardContent>
       </Card>
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <Link
           href="/daily"
           className="text-[12px] text-ink-500 hover:text-ink-800"
         >
           {locale === "zh" ? "取消" : t("common.cancel")}
         </Link>
-        <div className="flex flex-col items-end gap-1">
-          {picked.length === 0 && (
-            <p className="text-[11.5px] text-ink-400">
-              {locale === "zh"
-                ? "请先选择至少一项"
-                : "Select at least one category above"}
-            </p>
-          )}
-          <Button onClick={onStart} disabled={picked.length === 0} size="lg">
-            {locale === "zh"
+        <Button
+          onClick={onStart}
+          disabled={picked.length === 0}
+          size="lg"
+          title={
+            picked.length === 0
+              ? locale === "zh"
+                ? "请先点选至少一个类别"
+                : "Tap at least one card above to continue"
+              : undefined
+          }
+        >
+          {picked.length === 0
+            ? locale === "zh"
+              ? "选好后点这里"
+              : "Select cards above"
+            : locale === "zh"
               ? `开始（${picked.length}）`
-              : `Start (${picked.length})`}
-            <ArrowRight className="ml-1 h-4 w-4" />
-          </Button>
-        </div>
+              : `Start (${picked.length} selected)`}
+          <ArrowRight className="ml-1 h-4 w-4" />
+        </Button>
       </div>
     </div>
   );

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -159,7 +159,26 @@ export function TodayFeed({
 
   if (feed.length === 0) {
     return (
-      <Card className="p-5 text-sm text-ink-500">{t("todayFeed.empty")}</Card>
+      <Card className="p-5">
+        <div className="flex items-start gap-3">
+          <div
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
+            style={{ background: "var(--tide-soft)", color: "var(--tide-2)" }}
+          >
+            <Sparkles className="h-4 w-4" />
+          </div>
+          <div className="space-y-1">
+            <div className="text-[13px] font-semibold text-ink-900">
+              {locale === "zh" ? "今天的动态会显示在这里" : "Your feed will appear here"}
+            </div>
+            <p className="text-[12.5px] text-ink-500 leading-relaxed">
+              {locale === "zh"
+                ? "完成今日记录后，这里会显示摘要、提醒和趋势。先从上方的快速记录开始。"
+                : "After you log today's check-in, this feed will show your summary, alerts, and trends. Start with the quick check-in above."}
+            </p>
+          </div>
+        </div>
+      </Card>
     );
   }
 

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -31,19 +31,19 @@ import { useAppPerspective } from "~/lib/caregiver/scope";
 // reach household / invites through Settings → Care team, so it's
 // excluded here to avoid a confusing duplicate view.
 const PATIENT_ITEMS = [
-  { href: "/", key: "nav.dashboard", icon: LayoutDashboard },
-  { href: "/schedule", key: "nav.schedule", icon: CalendarDays },
-  { href: "/assessment", key: "nav.assessment", icon: Compass },
-  { href: "/treatment", key: "nav.treatment", icon: Syringe },
-  { href: "/labs", key: "nav.labs", icon: FlaskConical },
-  { href: "/nutrition", key: "nav.nutrition", icon: Salad },
-  { href: "/practices", key: "nav.practices", icon: Sparkles },
-  { href: "/carers", key: "nav.carers", icon: UserPlus },
-  { href: "/bridge", key: "nav.bridge", icon: Route },
-  { href: "/history", key: "nav.history", icon: HistoryIcon },
-  { href: "/ingest", key: "nav.ingest", icon: ScanLine },
-  { href: "/reports", key: "nav.reports", icon: FileText },
-  { href: "/settings", key: "nav.settings", icon: SettingsIcon },
+  { href: "/", key: "nav.dashboard", icon: LayoutDashboard, descKey: "nav.desc.dashboard" },
+  { href: "/schedule", key: "nav.schedule", icon: CalendarDays, descKey: "nav.desc.schedule" },
+  { href: "/assessment", key: "nav.assessment", icon: Compass, descKey: "nav.desc.assessment" },
+  { href: "/treatment", key: "nav.treatment", icon: Syringe, descKey: "nav.desc.treatment" },
+  { href: "/labs", key: "nav.labs", icon: FlaskConical, descKey: "nav.desc.labs" },
+  { href: "/nutrition", key: "nav.nutrition", icon: Salad, descKey: "nav.desc.nutrition" },
+  { href: "/practices", key: "nav.practices", icon: Sparkles, descKey: "nav.desc.practices" },
+  { href: "/carers", key: "nav.carers", icon: UserPlus, descKey: "nav.desc.carers" },
+  { href: "/bridge", key: "nav.bridge", icon: Route, descKey: "nav.desc.bridge" },
+  { href: "/history", key: "nav.history", icon: HistoryIcon, descKey: "nav.desc.history" },
+  { href: "/ingest", key: "nav.ingest", icon: ScanLine, descKey: "nav.desc.ingest" },
+  { href: "/reports", key: "nav.reports", icon: FileText, descKey: "nav.desc.reports" },
+  { href: "/settings", key: "nav.settings", icon: SettingsIcon, descKey: "nav.desc.settings" },
 ] as const;
 
 // Caregiver nav: the things a supporting family member actually uses
@@ -52,13 +52,13 @@ const PATIENT_ITEMS = [
 // wizard, weekly/fortnightly, treatment cycle, assessment, bridge,
 // reports) are hidden.
 const CAREGIVER_ITEMS = [
-  { href: "/family", key: "nav.family", icon: Users },
-  { href: "/schedule", key: "nav.schedule", icon: CalendarDays },
-  { href: "/carers", key: "nav.carers", icon: UserPlus },
-  { href: "/nutrition", key: "nav.nutrition", icon: Salad },
-  { href: "/log", key: "nav.log", icon: Sparkles },
-  { href: "/history", key: "nav.history", icon: HistoryIcon },
-  { href: "/settings", key: "nav.settings", icon: SettingsIcon },
+  { href: "/family", key: "nav.family", icon: Users, descKey: "nav.desc.family" },
+  { href: "/schedule", key: "nav.schedule", icon: CalendarDays, descKey: "nav.desc.schedule" },
+  { href: "/carers", key: "nav.carers", icon: UserPlus, descKey: "nav.desc.carers" },
+  { href: "/nutrition", key: "nav.nutrition", icon: Salad, descKey: "nav.desc.nutrition" },
+  { href: "/log", key: "nav.log", icon: Sparkles, descKey: "nav.desc.log" },
+  { href: "/history", key: "nav.history", icon: HistoryIcon, descKey: "nav.desc.history" },
+  { href: "/settings", key: "nav.settings", icon: SettingsIcon, descKey: "nav.desc.settings" },
 ] as const;
 
 type NavItem = (typeof PATIENT_ITEMS)[number] | (typeof CAREGIVER_ITEMS)[number];
@@ -88,12 +88,13 @@ export function DesktopSidebar() {
         {items.map((item) => {
           const Icon = item.icon;
           const active = pathname === item.href;
+          const desc = "descKey" in item ? t(item.descKey) : "";
           return (
             <Link
               key={item.href}
               href={item.href}
               className={cn(
-                "flex items-center gap-3 rounded-md px-3 py-2 text-[13px] transition-colors",
+                "flex items-start gap-3 rounded-md px-3 py-2 transition-colors",
                 active
                   ? "bg-ink-100/80 text-ink-900"
                   : "text-ink-500 hover:bg-ink-100/40 hover:text-ink-700",
@@ -101,12 +102,22 @@ export function DesktopSidebar() {
             >
               <Icon
                 className={cn(
-                  "h-4 w-4",
+                  "mt-0.5 h-4 w-4 shrink-0",
                   active ? "text-[var(--tide-2)]" : "",
                 )}
                 aria-hidden
               />
-              <span>{t(item.key)}</span>
+              <div className="min-w-0 flex-1">
+                <div className="text-[13px]">{t(item.key)}</div>
+                {desc && desc !== item.descKey && (
+                  <div className={cn(
+                    "text-[10.5px] leading-tight",
+                    active ? "text-ink-500" : "text-ink-400",
+                  )}>
+                    {desc}
+                  </div>
+                )}
+              </div>
             </Link>
           );
         })}


### PR DESCRIPTION
## Summary

Comprehensive user story audit across all core flows. Tested 7 user stories from the perspective of a first-time user: onboarding, daily check-in, full daily wizard, fortnightly assessment, bridge strategy, caregiver joining, and navigation. Found and fixed 7 concrete issues.

## Fixes

**1. Remove admin SQL migration message from user-facing UI**
The caregiver onboarding `PickPatientStep` was showing `"Server admin: apply migration 2026_04_24_slice_p_caregiver_onboarding_reload.sql in Supabase…"` to all users when the picker was unavailable. Replaced with a plain instruction to paste the invite link.

**2. Make "Finish setup later" discoverable**
The skip link was rendered as a 12px underlined text element — invisible under cognitive load on tired days. Promoted to a ghost `Button` component so it has proper size and tap target.

**3. ECOG plain-language explainer on Bridge page**
The Bridge page referenced "ECOG 0–1" throughout with no definition. A patient without clinical background has no way to interpret this. Added a visual card explaining grades 0/1/2/3–4 in plain English and 中文, colour-coded green → red.

**4. Rename "Ingest" → "Upload" (English nav)**
"Ingest" is clinical/developer jargon. Chinese already used "导入" (Import). English nav now matches with "Upload". Both locales now use accessible, patient-facing terminology.

**5. Nav item descriptions in desktop sidebar**
Every sidebar item now shows a one-line description below its label (e.g. "Bridge → Strategy & trial eligibility", "Assessment → Functional tests & scores"). New users no longer need to open a section to understand what it does. Both EN and ZH locales updated.

**6. Daily wizard pick screen — interaction model made explicit**
The original subtitle said "pick what applies" but didn't explain the tap-then-Start mechanic. A first-time user would stare at a disabled "Start (0)" button without knowing why. Rewritten subtitle explains tap-then-Start. Disabled button now reads "Select cards above" instead of "Start (0)".

**7. TodayFeed empty state — first-run context**
The generic `"Nothing urgent for today. Don't forget to log your daily check-in."` string gave no orientation to a new user seeing an empty feed. Replaced with a two-line card explaining the feed populates after the first check-in, with a pointer to the QuickCheckinCard above it.

## Test plan

- [ ] Onboarding: complete as patient, skip to done at each skippable step — "Finish setup later" is visible as a ghost button
- [ ] Onboarding: complete as caregiver with picker unavailable — no SQL migration string visible, only invite-link paste box
- [ ] Bridge page: ECOG explainer card renders with 4 grade rows, all colour-coded
- [ ] Nav sidebar (desktop): every item shows a description line below its label
- [ ] Nav: "Upload" appears for the ingest item (English); "导入" unchanged (Chinese)
- [ ] Daily wizard: subtitle explains tap-to-select; button reads "Select cards above" when 0 selected; reads "Start (N selected)" after tapping
- [ ] TodayFeed with no data: shows the Sparkles icon + two-line orientation card, not a plain text string

https://claude.ai/code/session_01JMq5qDcMJoe81qaXZ6AmCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMq5qDcMJoe81qaXZ6AmCb)_