### PR TITLE
design: collapse hand-rolled alerts/chips/section heads onto primitives

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -88,37 +88,19 @@ export default function DailyPage() {
                     </span>
                   )}
                 </div>
-                <div className="flex gap-1.5 text-xs">
+                <div className="flex flex-wrap gap-1.5">
                   {e.fever && (
-                    <span
-                      className="rounded-full px-2 py-0.5 text-[11px]"
-                      style={{
-                        background: "var(--warn-soft)",
-                        color: "var(--warn)",
-                      }}
-                    >
+                    <span className="a-chip warn">
                       {locale === "zh" ? "发热" : "fever"}
                     </span>
                   )}
                   {(e.neuropathy_feet || e.neuropathy_hands) && (
-                    <span
-                      className="rounded-full px-2 py-0.5 text-[11px]"
-                      style={{
-                        background: "var(--sand)",
-                        color: "oklch(45% 0.06 70)",
-                      }}
-                    >
+                    <span className="a-chip sand">
                       {locale === "zh" ? "神经病变" : "neuropathy"}
                     </span>
                   )}
                   {e.new_bruising && (
-                    <span
-                      className="rounded-full px-2 py-0.5 text-[11px]"
-                      style={{
-                        background: "var(--sand)",
-                        color: "oklch(45% 0.06 70)",
-                      }}
-                    >
+                    <span className="a-chip sand">
                       {locale === "zh" ? "瘀斑" : "bruising"}
                     </span>
                   )}

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -16,6 +16,7 @@ import { LOG_TAGS, type AgentId, type LogTag } from "~/types/agent";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
 import { Field, Textarea } from "~/components/ui/field";
+import { Alert } from "~/components/ui/alert";
 import { PageHeader } from "~/components/ui/page-header";
 import { cn } from "~/lib/utils/cn";
 import { Send, Sparkles, Check, Loader2, ArrowLeft, Mic, MicOff } from "lucide-react";
@@ -302,45 +303,37 @@ export default function LogPage() {
         </div>
 
         {run.kind === "error" && (
-          <div
-            role="alert"
-            className="mt-4 rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-3 text-sm text-[var(--warn)]"
-          >
+          <Alert variant="warn" role="alert" className="mt-4">
             {run.message}
-          </div>
+          </Alert>
         )}
 
         {(run.kind === "saving" || run.kind === "running") && (
-          <div
+          <Alert
+            variant="info"
             role="status"
-            className="mt-4 flex items-center gap-2 rounded-md border border-ink-200 bg-paper-2 p-3 text-sm text-ink-700"
+            icon={<Loader2 className="h-4 w-4 animate-spin" />}
+            className="mt-4"
           >
-            <Loader2 className="h-4 w-4 animate-spin" />
-            <span>
-              {run.kind === "saving"
-                ? locale === "zh"
-                  ? "保存中…"
-                  : "Saving…"
-                : locale === "zh"
-                  ? `${run.total} 个智能体在整理…`
-                  : `${run.total} agent${run.total === 1 ? "" : "s"} thinking…`}
-            </span>
-          </div>
+            {run.kind === "saving"
+              ? locale === "zh"
+                ? "保存中…"
+                : "Saving…"
+              : locale === "zh"
+                ? `${run.total} 个智能体在整理…`
+                : `${run.total} agent${run.total === 1 ? "" : "s"} thinking…`}
+          </Alert>
         )}
 
         {run.kind === "filed" && (
-          <div
+          <Alert
+            variant="ok"
             role="status"
-            className="mt-4 space-y-2 rounded-md border border-[var(--ok)]/40 bg-[var(--ok-soft)] p-3 text-sm"
+            title={locale === "zh" ? "已归档" : "Filed"}
+            className="mt-4"
           >
-            <div className="flex items-center gap-2 text-ink-900">
-              <Check className="h-4 w-4 text-[var(--ok)]" />
-              {locale === "zh" ? "已归档" : "Filed"}
-            </div>
-            <div className="text-[13px] text-ink-700">
-              {run.summary[locale]}
-            </div>
-            <div className="text-[11px] text-ink-500">
+            <div className="text-[13px]">{run.summary[locale]}</div>
+            <div className="mt-1 text-[11px] opacity-80">
               {locale === "zh"
                 ? run.target === "lab"
                   ? "已加入化验记录。智能体未参与解读。"
@@ -349,22 +342,20 @@ export default function LogPage() {
                   ? "Added to labs. Agents were not called."
                   : "Added to today's entry. Agents were not called."}
             </div>
-          </div>
+          </Alert>
         )}
 
         {run.kind === "done" && (
-          <div
+          <Alert
+            variant="ok"
             role="status"
-            className="mt-4 space-y-2 rounded-md border border-ink-200 bg-paper-2 p-3 text-sm"
+            title={locale === "zh" ? "已记录" : "Logged"}
+            className="mt-4"
           >
-            <div className="flex items-center gap-2 text-ink-900">
-              <Check className="h-4 w-4 text-[var(--ok)]" />
-              {locale === "zh" ? "已记录" : "Logged"}
-            </div>
-            <ul className="space-y-1 text-[12.5px] text-ink-600">
+            <ul className="space-y-1 text-[12.5px]">
               {run.ran.map((id) => (
                 <li key={id} className="flex items-center gap-1.5">
-                  <Sparkles className="h-3 w-3 text-[var(--tide-2)]" />
+                  <Sparkles className="h-3 w-3" />
                   {AGENT_LABELS[id][locale]}
                 </li>
               ))}
@@ -378,7 +369,7 @@ export default function LogPage() {
                 </li>
               ))}
             </ul>
-          </div>
+          </Alert>
         )}
 
         <div className="mt-5 flex items-center justify-between gap-3">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
 import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
+import { Alert } from "~/components/ui/alert";
 import { PageHeader } from "~/components/ui/page-header";
 import { useT } from "~/hooks/use-translate";
 
@@ -101,20 +102,14 @@ function LoginForm() {
         </Field>
 
         {error && (
-          <div
-            role="alert"
-            className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-3 text-sm text-[var(--warn)]"
-          >
+          <Alert variant="warn" role="alert">
             {error}
-          </div>
+          </Alert>
         )}
         {info && (
-          <div
-            role="status"
-            className="rounded-md border border-ink-200 bg-paper-2 p-3 text-sm text-ink-700"
-          >
+          <Alert variant="info" role="status">
             {info}
-          </div>
+          </Alert>
         )}
 
         <Button type="submit" size="lg" className="w-full" disabled={loading}>

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -10,6 +10,7 @@ import { useUIStore } from "~/stores/ui-store";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { Field, TextInput, Textarea } from "~/components/ui/field";
+import { Alert } from "~/components/ui/alert";
 import { PROTOCOL_LIBRARY, PROTOCOL_BY_ID } from "~/config/protocols";
 import type { ProtocolId } from "~/types/treatment";
 import type { Locale, Settings } from "~/types/clinical";
@@ -714,17 +715,13 @@ function PickPatientStep({
       </p>
 
       {joinedName && (
-        <div className="flex items-start gap-2 rounded-md border border-[var(--ok)]/40 bg-[var(--ok-soft)] p-3 text-[12.5px] text-ink-700">
-          <Check className="mt-0.5 h-4 w-4 shrink-0 text-[var(--ok)]" />
-          <div>
-            <div className="font-semibold text-ink-900">
-              {L("You're in.", "已加入。")}
-            </div>
-            <div className="text-ink-500">
-              {L(`Joined ${joinedName}'s care team.`, `已加入 ${joinedName} 的护理团队。`)}
-            </div>
-          </div>
-        </div>
+        <Alert
+          variant="ok"
+          title={L("You're in.", "已加入。")}
+          dense
+        >
+          {L(`Joined ${joinedName}'s care team.`, `已加入 ${joinedName} 的护理团队。`)}
+        </Alert>
       )}
 
       {loading && !joinedName && (
@@ -815,9 +812,9 @@ function PickPatientStep({
       )}
 
       {error && !joinedName && (
-        <div className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2.5 text-[12px] text-[var(--warn)]">
+        <Alert variant="warn" dense>
           {error}
-        </div>
+        </Alert>
       )}
 
       {!joinedName && (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -13,9 +13,9 @@ import { HouseholdSection } from "~/components/settings/household-section";
 import { NotificationsSection } from "~/components/settings/notifications-section";
 import { CareTeamSection } from "~/components/settings/care-team-section";
 import { TrackedSymptomsSection } from "~/components/settings/tracked-symptoms-section";
-import { PageHeader } from "~/components/ui/page-header";
+import { PageHeader, SectionHeader } from "~/components/ui/page-header";
 import { Button } from "~/components/ui/button";
-import { Field, TextInput, Textarea } from "~/components/ui/field";
+import { Field, Select, TextInput, Textarea } from "~/components/ui/field";
 
 export default function SettingsPage() {
   const t = useT();
@@ -114,7 +114,7 @@ export default function SettingsPage() {
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
         <section className="space-y-3">
-          <h2 className="eyebrow">{t("settings.profile")}</h2>
+          <SectionHeader title={t("settings.profile")} />
           <Field label={t("settings.profile_name")}>
             <TextInput {...register("profile_name")} />
           </Field>
@@ -125,10 +125,10 @@ export default function SettingsPage() {
             <TextInput type="date" {...register("diagnosis_date")} />
           </Field>
           <Field label={t("settings.locale")}>
-            <select className={selectCls} {...register("locale")}>
+            <Select {...register("locale")}>
               <option value="en">{t("settings.locale_en")}</option>
               <option value="zh">{t("settings.locale_zh")}</option>
-            </select>
+            </Select>
           </Field>
           <Field
             label={
@@ -142,14 +142,14 @@ export default function SettingsPage() {
         </section>
 
         <section className="space-y-3">
-          <h2 className="eyebrow">
-            {locale === "zh" ? "紧急情况" : "Emergency"}
-          </h2>
-          <p className="text-xs text-ink-500">
-            {locale === "zh"
-              ? "肿瘤科医生、医院、24 小时联系人请在「护理团队」中维护;此处仅记录何时直接前往急诊。"
-              : "Oncologist, hospital, and 24/7 contacts live in the Care team section above. Use this for the situation-specific guidance the patient should follow when something feels off."}
-          </p>
+          <SectionHeader
+            title={locale === "zh" ? "紧急情况" : "Emergency"}
+            description={
+              locale === "zh"
+                ? "肿瘤科医生、医院、24 小时联系人请在「护理团队」中维护;此处仅记录何时直接前往急诊。"
+                : "Oncologist, hospital, and 24/7 contacts live in the Care team section above. Use this for the situation-specific guidance the patient should follow when something feels off."
+            }
+          />
           <div className="grid gap-3 sm:grid-cols-2">
             <Field
               label={
@@ -182,12 +182,14 @@ export default function SettingsPage() {
         </section>
 
         <section className="space-y-3">
-          <h2 className="eyebrow">{locale === "zh" ? "AI 模型" : "AI model"}</h2>
-          <p className="text-xs text-ink-500">
-            {locale === "zh"
-              ? "Claude 调用通过 Anchor 服务器(在 Vercel 中配置的共享 ANTHROPIC_API_KEY)进行 —— 无需每台设备单独配置密钥。此字段用于覆盖默认模型。"
-              : "Claude calls run through Anchor’s server (the shared ANTHROPIC_API_KEY configured in Vercel) — no per-device key needed. This field lets you override the default model."}
-          </p>
+          <SectionHeader
+            title={locale === "zh" ? "AI 模型" : "AI model"}
+            description={
+              locale === "zh"
+                ? "Claude 调用通过 Anchor 服务器(在 Vercel 中配置的共享 ANTHROPIC_API_KEY)进行 —— 无需每台设备单独配置密钥。此字段用于覆盖默认模型。"
+                : "Claude calls run through Anchor’s server (the shared ANTHROPIC_API_KEY configured in Vercel) — no per-device key needed. This field lets you override the default model."
+            }
+          />
           <Field
             label={
               locale === "zh"
@@ -214,6 +216,3 @@ export default function SettingsPage() {
     </div>
   );
 }
-
-const selectCls =
-  "h-11 w-full rounded-md border border-ink-200 bg-paper px-3 text-sm text-ink-900 focus:border-ink-900 focus:outline-none focus:ring-2 focus:ring-ink-900/10";

--- a/src/app/treatment/new/page.tsx
+++ b/src/app/treatment/new/page.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
+import { Alert } from "~/components/ui/alert";
 import { cn } from "~/lib/utils/cn";
 import { PROTOCOL_LIBRARY, PROTOCOL_BY_ID } from "~/config/protocols";
 import { DRUGS_BY_ID } from "~/config/drug-registry";
@@ -265,12 +266,9 @@ export default function NewTreatmentCyclePage() {
       )}
 
       {error && (
-        <div
-          role="alert"
-          className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-3 text-[12.5px] text-[var(--warn)]"
-        >
+        <Alert variant="warn" role="alert" dense>
           {error}
-        </div>
+        </Alert>
       )}
 
       <div className="flex items-center justify-between gap-2 pt-2">

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -3,6 +3,7 @@ import type {
   InputHTMLAttributes,
   LabelHTMLAttributes,
   ReactNode,
+  SelectHTMLAttributes,
   TextareaHTMLAttributes,
 } from "react";
 import { forwardRef } from "react";
@@ -70,3 +71,16 @@ export function Textarea({
     />
   );
 }
+
+// Select shares the height, border, focus halo, and typography of TextInput so
+// dropdowns line up cleanly when mixed with text fields in the same form. Uses
+// the same INPUT_CLASSES baseline as TextInput.
+export const Select = forwardRef<
+  HTMLSelectElement,
+  SelectHTMLAttributes<HTMLSelectElement>
+>(({ className, children, ...props }, ref) => (
+  <select ref={ref} className={cn(INPUT_CLASSES, "pr-8", className)} {...props}>
+    {children}
+  </select>
+));
+Select.displayName = "Select";


### PR DESCRIPTION
## Summary
Design audit pass against `docs/UX_PRINCIPLES.md` and the design tokens in `src/styles/globals.css` / `tailwind.config.ts`. Surfaced four inconsistencies that each existed in two or more pages and quietly drifted the visual language away from the system primitives:

- Bespoke alert-styled divs (rounded border + warn/ok/tide tint + body copy) duplicated the existing `<Alert>` component eight times across `/log`, `/login`, `/onboarding`, and `/treatment/new`.
- The three status pills on `/daily` (fever / neuropathy / bruising) used inline `style={{}}` instead of the `a-chip` class — so they read as plain lowercase tags rather than the mono-uppercase pill the chip spec calls for.
- `/settings` had a duplicated `selectCls` constant matching `TextInput`, plus three `<h2 className="eyebrow">` blocks that should have been `<SectionHeader>`.
- No `Select` primitive in `field.tsx`, even though TextInput / Textarea / Field were already exported from there.

### Changes
- `Field` gains a `Select` primitive that mirrors `TextInput`'s height, border, and focus halo so dropdowns line up cleanly with text fields in the same form.
- `/settings` replaces the local `selectCls`, three `<h2 eyebrow>` blocks, and the AI-model description with `Select` + `SectionHeader`.
- `/daily` entry-row symptom pills drop inline styles for the `a-chip warn` / `a-chip sand` tone variants.
- `/log`, `/login`, `/onboarding` (caregiver picker), and `/treatment/new` collapse eight hand-rolled status / error / progress divs onto `<Alert>` with `warn` / `ok` / `info` variants.

Net: -110 / +86 lines across 7 files. No new top-level screens; only realignment onto existing primitives.

## Test plan
- [x] `pnpm typecheck` clean (with the existing `--ignoreDeprecations` workaround for the pre-existing `baseUrl` warning)
- [x] `pnpm test` — 692/692 passing
- [x] `pnpm lint` — only pre-existing warnings remain, none introduced
- [ ] Manual smoke on `/daily`, `/log`, `/login`, `/onboarding`, `/settings`, `/treatment/new` — verify chips/alerts render with the right tone and layout doesn't shift

https://claude.ai/code/session_01JdMdMQdJ5iF8saWryAQxsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdMdMQdJ5iF8saWryAQxsP)_