### PR TITLE
Carers: fix permanent "Loading…" stuck state on /carers

### DIFF
--- a/src/app/carers/page.tsx
+++ b/src/app/carers/page.tsx
@@ -30,31 +30,22 @@ import {
   CalendarClock,
 } from "lucide-react";
 
-// /carers — the single source of truth for everyone involved in the
-// patient's care.
+// /carers — single source of truth for everyone involved in the
+// patient's care. See the README at the bottom of this file for the
+// design rationale.
 //
-// Replaces three previously-separate surfaces:
-//   - /household        (Anchor account members, just-built)
-//   - /settings#care-team (local contact registry)
-//   - /care-team        (clinical visit log — kept at its URL but
-//                        demoted from the primary nav)
-//
-// Mental model:
-//   "Carers" = PEOPLE involved in care
-//   "Add carer" = invite them to an Anchor account (the primary CTA)
-//
-// Two sections under the hood:
-//   1. On Anchor — household members + pending invites. These are
-//      people with their own logins who can actively participate
-//      (log check-ins, confirm attendance, edit appointments…).
-//   2. Local contacts — phone numbers and notes for clinicians /
-//      services that don't need Anchor accounts (oncologist's
-//      office, on-call line, GP, allied health). Most of the
-//      clinical care orbit lives here, not on Anchor.
-//
-// The clinical visit log (date / kind / notes per interaction) is
-// the bridge-strategy contact-cadence metric — it stays at /care-team
-// and is reachable from a footer link below.
+// Page layout (top → bottom):
+//   1. Top section — depends on auth/household state. Renders the
+//      "Add carer" CTA + Anchor membership list when signed in with
+//      a household; falls back to a "Sign in" or "Set up household"
+//      prompt otherwise. NEVER blocks the page on a global loading
+//      spinner — useHousehold has its own 4s safety timeout, and
+//      this page renders the local-contacts directory regardless.
+//   2. Local contacts — always rendered. It's pure Dexie / offline
+//      and has no dependency on Supabase, so if the cloud is
+//      unreachable the user can still read the oncologist's phone
+//      number and call.
+//   3. Footer link → /care-team (visit log).
 
 export default function CarersPage() {
   const locale = useLocale();
@@ -95,12 +86,55 @@ export default function CarersPage() {
     void reload();
   }, [reload]);
 
-  // OFFLINE-only Anchor build: the local-contacts directory still
-  // works (it's all Dexie), but Anchor account invites need Supabase.
-  // Render local-contacts on its own with a notice up top.
-  if (!isSupabaseConfigured()) {
-    return (
-      <Shell locale={locale}>
+  const activeInvites = invites.filter(
+    (i) => !i.accepted_at && !i.revoked_at && new Date(i.expires_at) > new Date(),
+  );
+
+  const supabaseConfigured = isSupabaseConfigured();
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
+      <PageHeader
+        eyebrow={L("CARERS", "护理人员")}
+        title={
+          household
+            ? L(
+                `${household.patient_display_name}'s care team`,
+                `${household.patient_display_name} 的护理团队`,
+              )
+            : L("Carers", "护理人员")
+        }
+        subtitle={
+          household && members.length > 0 ? (
+            <span className="text-[12px] text-ink-500">
+              {L(
+                `${members.length} ${members.length === 1 ? "carer" : "carers"} on Anchor`,
+                `${members.length} 位 Anchor 账号成员`,
+              )}
+              {activeInvites.length > 0 && (
+                <>
+                  {" · "}
+                  {L(
+                    `${activeInvites.length} pending`,
+                    `${activeInvites.length} 份待接受`,
+                  )}
+                </>
+              )}
+            </span>
+          ) : undefined
+        }
+      />
+
+      {/* TOP: Anchor-account section. Renders one of:
+          - "Add carer" CTA + members list (signed in + has household)
+          - read-only members hint (signed in but not primary_carer)
+          - "Sign in" prompt (signed out)
+          - "Set up household" prompt (signed in, no household)
+          - "Sync isn't configured" notice (offline-only build)
+          - Inline loading hint (still resolving)
+          The local contacts section below is unaffected by any of
+          these states. */}
+      {!supabaseConfigured ? (
         <Card>
           <CardContent className="space-y-2 pt-5 text-[13px] text-ink-500">
             <div className="flex items-center gap-2 text-ink-700">
@@ -117,30 +151,14 @@ export default function CarersPage() {
             </p>
           </CardContent>
         </Card>
-        <section className="space-y-2">
-          <SectionHeader title={L("Local contacts", "本地通讯录")} />
-          <LocalContactsSection />
-        </section>
-      </Shell>
-    );
-  }
-
-  if (loading) {
-    return (
-      <Shell locale={locale}>
+      ) : loading ? (
         <Card>
-          <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {L("Loading…", "加载中…")}
+          <CardContent className="flex items-center gap-2 pt-5 text-[12.5px] text-ink-500">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            {L("Checking your account…", "正在检查账号…")}
           </CardContent>
         </Card>
-      </Shell>
-    );
-  }
-
-  if (!profile) {
-    return (
-      <Shell locale={locale}>
+      ) : !profile ? (
         <Card>
           <CardContent className="space-y-3 pt-5 text-[13px] text-ink-500">
             <p>
@@ -154,15 +172,7 @@ export default function CarersPage() {
             </Link>
           </CardContent>
         </Card>
-      </Shell>
-    );
-  }
-
-  // Signed in but not part of any household yet — show local-contacts
-  // anyway (it doesn't depend on a household), and prompt for setup.
-  if (!membership || !householdId) {
-    return (
-      <Shell locale={locale}>
+      ) : !membership || !householdId ? (
         <Card>
           <CardContent className="space-y-3 pt-5 text-[13px] text-ink-500">
             <p>
@@ -171,110 +181,97 @@ export default function CarersPage() {
                 "您尚未加入家庭。请完成引导流程创建家庭，再从此页添加护理人员。",
               )}
             </p>
-            <div className="flex gap-2">
-              <Link href="/onboarding">
-                <Button size="md">
-                  {L("Set up household", "创建家庭")}
-                </Button>
-              </Link>
-            </div>
+            <Link href="/onboarding">
+              <Button size="md">
+                {L("Set up household", "创建家庭")}
+              </Button>
+            </Link>
           </CardContent>
         </Card>
-        <section className="space-y-2">
-          <SectionHeader title={L("Local contacts", "本地通讯录")} />
-          <LocalContactsSection />
-        </section>
-      </Shell>
-    );
-  }
-
-  const activeInvites = invites.filter(
-    (i) => !i.accepted_at && !i.revoked_at && new Date(i.expires_at) > new Date(),
-  );
-
-  return (
-    <Shell
-      locale={locale}
-      household={household}
-      memberCount={members.length}
-      pendingCount={activeInvites.length}
-    >
-      {/* Primary CTA — the answer to "no obvious way to add carers". */}
-      {isPrimary && !showInviteFlow && (
-        <Card className="border-[var(--tide-2)]/40 bg-[var(--tide-soft)]">
-          <CardContent className="flex items-center justify-between gap-3 pt-4">
-            <div className="flex min-w-0 items-center gap-3">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--tide-2)]/15 text-[var(--tide-2)]">
-                <UserPlus className="h-5 w-5" />
-              </div>
-              <div className="min-w-0">
-                <div className="text-[13.5px] font-semibold text-ink-900">
-                  {L("Add a carer", "添加护理人员")}
+      ) : (
+        <>
+          {/* Primary CTA — the answer to "no obvious way to add carers". */}
+          {isPrimary && !showInviteFlow && (
+            <Card className="border-[var(--tide-2)]/40 bg-[var(--tide-soft)]">
+              <CardContent className="flex items-center justify-between gap-3 pt-4">
+                <div className="flex min-w-0 items-center gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--tide-2)]/15 text-[var(--tide-2)]">
+                    <UserPlus className="h-5 w-5" />
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-[13.5px] font-semibold text-ink-900">
+                      {L("Add a carer", "添加护理人员")}
+                    </div>
+                    <p className="mt-0.5 text-[11.5px] text-ink-500">
+                      {L(
+                        "Send an invite link — family member, clinician, or observer.",
+                        "发送邀请链接 —— 家人、医师或观察者均可。",
+                      )}
+                    </p>
+                  </div>
                 </div>
-                <p className="mt-0.5 text-[11.5px] text-ink-500">
+                <Button onClick={() => setShowInviteFlow(true)} size="md">
+                  {L("Add carer", "添加")}
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+
+          {!isPrimary && (
+            <Card>
+              <CardContent className="flex items-start gap-2 pt-4 text-[12.5px] text-ink-500">
+                <Lock className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span>
                   {L(
-                    "Send an invite link — family member, clinician, or observer.",
-                    "发送邀请链接 —— 家人、医师或观察者均可。",
+                    "Only the primary carer can add or remove carers. Ask them if you'd like to bring someone in.",
+                    "仅主要照护者可添加或移除护理人员。如需新增，请联系主要照护者。",
                   )}
-                </p>
-              </div>
-            </div>
-            <Button onClick={() => setShowInviteFlow(true)} size="md">
-              {L("Add carer", "添加")}
-            </Button>
-          </CardContent>
-        </Card>
+                </span>
+              </CardContent>
+            </Card>
+          )}
+
+          {isPrimary && showInviteFlow && (
+            <InviteCarerFlow
+              householdId={householdId}
+              onClose={() => setShowInviteFlow(false)}
+              onIssued={() => void reload()}
+            />
+          )}
+
+          <section className="space-y-2">
+            <SectionHeader title={L("On Anchor", "Anchor 账号")} />
+            {loadingData && members.length === 0 ? (
+              <Card>
+                <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  {L("Loading members…", "加载成员中…")}
+                </CardContent>
+              </Card>
+            ) : (
+              <MembersList
+                members={members}
+                currentUserId={profile.id}
+                isPrimary={Boolean(isPrimary)}
+                householdId={householdId}
+                onChanged={reload}
+              />
+            )}
+          </section>
+
+          {isPrimary && invites.length > 0 && (
+            <section className="space-y-2">
+              <SectionHeader title={L("Invites", "邀请")} />
+              <PendingInvitesList invites={invites} onChanged={reload} />
+            </section>
+          )}
+        </>
       )}
 
-      {!isPrimary && (
-        <Card>
-          <CardContent className="flex items-start gap-2 pt-4 text-[12.5px] text-ink-500">
-            <Lock className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-            <span>
-              {L(
-                "Only the primary carer can add or remove carers. Ask them if you'd like to bring someone in.",
-                "仅主要照护者可添加或移除护理人员。如需新增，请联系主要照护者。",
-              )}
-            </span>
-          </CardContent>
-        </Card>
-      )}
-
-      {isPrimary && showInviteFlow && (
-        <InviteCarerFlow
-          householdId={householdId}
-          onClose={() => setShowInviteFlow(false)}
-          onIssued={() => void reload()}
-        />
-      )}
-
-      <section className="space-y-2">
-        <SectionHeader title={L("On Anchor", "Anchor 账号")} />
-        {loadingData && members.length === 0 ? (
-          <Card>
-            <CardContent className="flex items-center gap-2 pt-5 text-[13px] text-ink-500">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              {L("Loading members…", "加载成员中…")}
-            </CardContent>
-          </Card>
-        ) : (
-          <MembersList
-            members={members}
-            currentUserId={profile.id}
-            isPrimary={Boolean(isPrimary)}
-            householdId={householdId}
-            onChanged={reload}
-          />
-        )}
-      </section>
-
-      {isPrimary && invites.length > 0 && (
-        <section className="space-y-2">
-          <SectionHeader title={L("Invites", "邀请")} />
-          <PendingInvitesList invites={invites} onChanged={reload} />
-        </section>
-      )}
-
+      {/* Local contacts ALWAYS renders — pure offline / Dexie. The
+          phone book is the most important fallback when sync is
+          flaky: tired carer needs to call the oncologist, opens
+          /carers, gets the number. Don't gate it behind anything. */}
       <section className="space-y-2">
         <SectionHeader title={L("Local contacts", "本地通讯录")} />
         <LocalContactsSection />
@@ -290,60 +287,6 @@ export default function CarersPage() {
           <ChevronRight className="h-3 w-3" />
         </Link>
       </section>
-    </Shell>
-  );
-}
-
-// Page chrome shared by every state. Pulled out so the loading /
-// signed-out / no-household / fully-loaded branches don't each
-// re-implement the header.
-function Shell({
-  locale,
-  children,
-  household,
-  memberCount,
-  pendingCount,
-}: {
-  locale: "en" | "zh";
-  children: React.ReactNode;
-  household?: Household | null;
-  memberCount?: number;
-  pendingCount?: number;
-}) {
-  const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
-  return (
-    <div className="mx-auto max-w-2xl space-y-5 p-4 md:p-8">
-      <PageHeader
-        eyebrow={L("CARERS", "护理人员")}
-        title={
-          household
-            ? L(
-                `${household.patient_display_name}'s care team`,
-                `${household.patient_display_name} 的护理团队`,
-              )
-            : L("Carers", "护理人员")
-        }
-        subtitle={
-          household && memberCount !== undefined ? (
-            <span className="text-[12px] text-ink-500">
-              {L(
-                `${memberCount} ${memberCount === 1 ? "carer" : "carers"} on Anchor`,
-                `${memberCount} 位 Anchor 账号成员`,
-              )}
-              {pendingCount !== undefined && pendingCount > 0 && (
-                <>
-                  {" · "}
-                  {L(
-                    `${pendingCount} pending`,
-                    `${pendingCount} 份待接受`,
-                  )}
-                </>
-              )}
-            </span>
-          ) : undefined
-        }
-      />
-      {children}
     </div>
   );
 }

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -108,8 +108,12 @@ export default function InvitePage() {
         });
         return;
       }
-      const { data: auth } = await sb.auth.getUser();
-      if (!auth.user) {
+      // getSession() reads from local storage — no network call. The
+      // accept RPC below verifies auth server-side anyway, so we don't
+      // need the network round-trip from getUser() here, and skipping
+      // it prevents the page from hanging on flaky / Capacitor networks.
+      const { data: { session } } = await sb.auth.getSession();
+      if (!session?.user) {
         setPhase({ kind: "needs_signin", preview });
         return;
       }

--- a/src/hooks/use-household.ts
+++ b/src/hooks/use-household.ts
@@ -14,6 +14,15 @@ import type {
 // Live-loading current-user membership + profile. Returns undefined
 // while loading so components can fall back; null when the user is
 // signed out or Supabase isn't configured.
+//
+// Has a hard 4-second loading-resolve timeout: if the underlying
+// Supabase calls don't finish (poor network on Capacitor / iOS, a
+// hung WebView fetch, expired session that's mid-refresh), we flip
+// any still-undefined values to null instead of leaving the UI on a
+// permanent loading spinner. The next call to refresh() (e.g. after
+// auth state change) will retry. This is a UX safety net, not a
+// correctness boundary — the actual auth check is server-side RLS.
+const LOAD_TIMEOUT_MS = 4000;
 
 export function useHousehold(): {
   membership: HouseholdMembership | null | undefined;
@@ -36,12 +45,25 @@ export function useHousehold(): {
 
   useEffect(() => {
     void load();
+
+    // Safety net: never let the UI hang on the loading state.
+    const timeout = setTimeout(() => {
+      setMembership((m) => (m === undefined ? null : m));
+      setProfile((p) => (p === undefined ? null : p));
+    }, LOAD_TIMEOUT_MS);
+
     const sb = getSupabaseBrowser();
-    if (!sb) return;
+    if (!sb) {
+      clearTimeout(timeout);
+      return;
+    }
     const { data: sub } = sb.auth.onAuthStateChange(() => {
       void load();
     });
-    return () => sub?.subscription.unsubscribe();
+    return () => {
+      clearTimeout(timeout);
+      sub?.subscription.unsubscribe();
+    };
   }, []);
 
   return {

--- a/src/lib/supabase/households.ts
+++ b/src/lib/supabase/households.ts
@@ -15,12 +15,27 @@ import type {
 // household + profile + invite surface. Every function is a no-op
 // returning null/empty when Supabase isn't configured, so local-only
 // sessions keep working.
+//
+// All "current user" lookups go through `currentUserId` instead of
+// calling `sb.auth.getUser()` directly. `getUser()` makes a network
+// call to /auth/v1/user and can hang on poor / Capacitor / iOS
+// network conditions, leaving `useHousehold` permanently in the
+// loading state. `getSession()` reads from local storage and is
+// instant — RLS on the server is what actually authenticates the
+// query, so a stale session token here is harmless: a failed query
+// surfaces as an error from the RLS check, not a silent hang.
+
+async function currentUserId(): Promise<string | null> {
+  const sb = getSupabaseBrowser();
+  if (!sb) return null;
+  const { data } = await sb.auth.getSession();
+  return data.session?.user?.id ?? null;
+}
 
 export async function getCurrentMembership(): Promise<HouseholdMembership | null> {
   const sb = getSupabaseBrowser();
   if (!sb) return null;
-  const { data: user } = await sb.auth.getUser();
-  const uid = user.user?.id;
+  const uid = await currentUserId();
   if (!uid) return null;
   const { data, error } = await sb
     .from("household_memberships")
@@ -35,8 +50,7 @@ export async function getCurrentMembership(): Promise<HouseholdMembership | null
 export async function getCurrentProfile(): Promise<Profile | null> {
   const sb = getSupabaseBrowser();
   if (!sb) return null;
-  const { data: user } = await sb.auth.getUser();
-  const uid = user.user?.id;
+  const uid = await currentUserId();
   if (!uid) return null;
   const { data, error } = await sb
     .from("profiles")
@@ -62,8 +76,7 @@ export async function updateMyProfile(
 ): Promise<void> {
   const sb = getSupabaseBrowser();
   if (!sb) return;
-  const { data: user } = await sb.auth.getUser();
-  const uid = user.user?.id;
+  const uid = await currentUserId();
   if (!uid) return;
   const { error } = await sb.from("profiles").update(patch).eq("id", uid);
   if (error) throw error;
@@ -226,8 +239,7 @@ export async function createInvite(args: {
 }): Promise<HouseholdInvite> {
   const sb = getSupabaseBrowser();
   if (!sb) throw new Error("supabase_not_configured");
-  const { data: user } = await sb.auth.getUser();
-  const uid = user.user?.id;
+  const uid = await currentUserId();
   if (!uid) throw new Error("not_signed_in");
   const { data, error } = await sb
     .from("household_invites")
@@ -270,8 +282,7 @@ export async function revokeInvite(inviteId: string): Promise<void> {
 export async function leaveHousehold(householdId: string): Promise<void> {
   const sb = getSupabaseBrowser();
   if (!sb) return;
-  const { data: user } = await sb.auth.getUser();
-  const uid = user.user?.id;
+  const uid = await currentUserId();
   if (!uid) return;
   const { error } = await sb
     .from("household_memberships")


### PR DESCRIPTION
## Symptom

User reported `/carers` showed a permanent "Loading…" card on iOS — page never resolved to either signed-in or signed-out state. Screenshot showed the spinner sitting under the "Carers" header with no path forward.

## Root cause — three compounding bugs

1. **`useHousehold` made a network call to validate the JWT.** It used `sb.auth.getUser()`, which hits `/auth/v1/user`. On iOS Capacitor / poor networks this can hang indefinitely, so the hook's `loading` flag never flipped.
2. **No timeout safety in `useHousehold`.** If the network call never resolved, the hook stayed in loading forever.
3. **`/carers` gated the entire page on `useHousehold().loading`** — including the local contacts directory, which is pure offline / Dexie. A hung Supabase call meant the carer couldn't even look up the oncologist's phone number.

## Fixes

- **Switch to `getSession()` everywhere.** Replaced every "current user id" lookup in `households.ts` (and the `/invite/[token]` accept-flow) from `auth.getUser()` to `auth.getSession()`. `getSession()` reads from local storage — no network call. RLS on the server is what actually authenticates each query, so a stale session here is harmless: a failed query surfaces as an error, not a silent hang. Centralised in a `currentUserId()` helper.
- **4-second hard timeout in `useHousehold`.** Any field still `undefined` after 4s flips to `null`, so the UI always resolves to either "signed in" or "signed out" within bounded time. The next auth state change retries the load.
- **Restructure `/carers` so local contacts always render**, regardless of Supabase/auth state. Only the "On Anchor" top section is gated on loading. The phone book is the most important fallback when sync is flaky — opening `/carers` should never leave the user staring at a spinner with no way to call the oncologist.

## Tests

- 692 unit tests pass
- typecheck, lint, build green
- `/carers` route still 14.1 kB

## Test plan

- [ ] Open `/carers` on iOS / Capacitor — page renders within ~1s; never stuck on loading
- [ ] Toggle airplane mode → reload `/carers` — local contacts section still renders, "Sync isn't configured" or signed-out card up top
- [ ] Sign in → `/carers` → "Add carer" CTA appears as expected
- [ ] Accept an invite via `/invite/<token>` — flow still works (now using getSession)

https://claude.ai/code/session_0166RgD8Vg8nA1EvWSdsR4LA

---
_Generated by [Claude Code](https://claude.ai/code/session_0166RgD8Vg8nA1EvWSdsR4LA)_