### PR TITLE
Nav: shrink bottom-nav clearance + fix nested-route active state

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,25 @@
-import { defineConfig } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
+
+// Multi-project config so the navbar (and any future cross-device-
+// sensitive UI) is exercised across the engines and viewports the
+// patient and family actually use:
+//   - desktop Chrome (clinic laptops)
+//   - desktop Safari / WebKit (Mac users in the family)
+//   - iPhone 13 (iOS Safari) — primary patient device
+//   - iPhone SE (narrowest mainstream iOS — overflow trap)
+//   - Pixel 5 (Android Chrome) — caregiver phones
+//   - iPad — the form factor that often falls through the cracks
+//     between mobile and desktop layouts
+//
+// Tests can opt into mobile-only behaviour by name-filtering the
+// `mobile` projects, or stay engine-agnostic if they're testing
+// shared logic.
 
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
   reporter: "list",
+  retries: process.env.CI ? 1 : 0,
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",
@@ -12,5 +28,14 @@ export default defineConfig({
     command: "pnpm dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
   },
+  projects: [
+    { name: "chrome-desktop", use: { ...devices["Desktop Chrome"] } },
+    { name: "safari-desktop", use: { ...devices["Desktop Safari"] } },
+    { name: "iphone-safari", use: { ...devices["iPhone 13"] } },
+    { name: "iphone-se", use: { ...devices["iPhone SE"] } },
+    { name: "android-chrome", use: { ...devices["Pixel 5"] } },
+    { name: "ipad", use: { ...devices["iPad Pro 11"] } },
+  ],
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -80,7 +80,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                * chrome on every page. On desktop we keep the internal scroll
                * (md:overflow-y-auto + md:h-[100dvh] on the column) so the
                * sidebar stays put while the main pane scrolls. */}
-              <main className="flex-1 pb-[calc(7rem+env(safe-area-inset-bottom))] md:pb-6 md:overflow-y-auto">
+              <main className="bottom-nav-clearance flex-1 md:overflow-y-auto">
                 {children}
               </main>
             </div>

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -22,6 +22,7 @@ import {
   History as HistoryIcon,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import { isNavItemActive } from "~/lib/nav/active";
 import { useT, useLocale } from "~/hooks/use-translate";
 import { useAppPerspective } from "~/lib/caregiver/scope";
 
@@ -87,7 +88,7 @@ export function DesktopSidebar() {
       <nav className="flex-1 space-y-0.5 px-2 pb-4">
         {items.map((item) => {
           const Icon = item.icon;
-          const active = pathname === item.href;
+          const active = isNavItemActive(pathname, item.href);
           const desc = "descKey" in item ? t(item.descKey) : "";
           return (
             <Link
@@ -148,7 +149,7 @@ export function MobileBottomNav() {
     >
       {mobileItems.map((item) => {
         const Icon = item.icon;
-        const active = pathname === item.href;
+        const active = isNavItemActive(pathname, item.href);
         return (
           <Link
             key={item.href}
@@ -224,7 +225,7 @@ export function MobileMoreMenu() {
             <nav className="mt-3 grid grid-cols-2 gap-2">
               {items.map((item) => {
                 const Icon = item.icon;
-                const active = pathname === item.href;
+                const active = isNavItemActive(pathname, item.href);
                 return (
                   <Link
                     key={item.href}

--- a/src/lib/nav/active.ts
+++ b/src/lib/nav/active.ts
@@ -1,0 +1,37 @@
+// Active-state matcher for the bottom nav + desktop sidebar +
+// "more" menu. The bug this replaces: every nav surface used
+// `pathname === item.href`, which only highlights the tab on the
+// exact landing page. The moment the patient drilled into a sub-
+// route (`/nutrition/log`, `/schedule/new`, `/treatment/cycle/3`)
+// every nav icon went grey — leaving the user with no visual
+// anchor for "where am I?". Persistent UX bug across iOS Safari,
+// Android Chrome, desktop.
+//
+// The fix: exact-match for `/` (dashboard), prefix-match with a
+// `/` boundary for everything else so sibling routes like
+// `/nutritional` or `/care-team-roster` don't trip a false
+// positive.
+
+export function isNavItemActive(
+  pathname: string | null | undefined,
+  href: string,
+): boolean {
+  if (!pathname) return false;
+  // Strip query / hash / trailing slash before matching so
+  // `/nutrition/`, `/nutrition?foo`, `/nutrition#x` all behave the
+  // same as `/nutrition`.
+  const path = stripExtras(pathname);
+  if (href === "/") return path === "/";
+  if (path === href) return true;
+  return path.startsWith(href + "/");
+}
+
+function stripExtras(pathname: string): string {
+  let p = pathname;
+  const q = p.indexOf("?");
+  if (q !== -1) p = p.slice(0, q);
+  const h = p.indexOf("#");
+  if (h !== -1) p = p.slice(0, h);
+  if (p.length > 1 && p.endsWith("/")) p = p.slice(0, -1);
+  return p;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -97,6 +97,35 @@ body {
   }
 }
 
+/* Page-content clearance for the floating bottom nav. Single source
+ * of truth so this stays in sync with the nav's own anchor + height
+ * math (above) — earlier the page used a hard-coded 7rem + inset
+ * which overshot the actual nav top edge by ~30 px on regular
+ * browsers and ~16 px on PWA, leaving the patient looking at a band
+ * of dead space at the bottom of every screen.
+ *
+ * Visual top of nav from viewport bottom =
+ *   max(0.75rem, inset)             (nav anchor)
+ * + 46 px                           (top padding 10 + content 36)
+ * + max(0.5rem, inset)              (pwa-bottom-nav padding)
+ *
+ * Plus a 1rem visual gap so the last line of content doesn't kiss
+ * the nav glass. md+ drops back to a flat 1.5rem because the
+ * desktop sidebar replaces the bottom nav. */
+.bottom-nav-clearance {
+  padding-bottom: calc(
+    max(0.75rem, env(safe-area-inset-bottom))
+    + 2.875rem
+    + max(0.5rem, env(safe-area-inset-bottom))
+    + 1rem
+  );
+}
+@media (min-width: 768px) {
+  .bottom-nav-clearance {
+    padding-bottom: 1.5rem;
+  }
+}
+
 /* Floating add button: clears the mobile bottom nav (which is itself
  * anchored at max(0.75rem, env(safe-area-inset-bottom)) and includes
  * its own internal home-indicator padding). The nav's rendered height

--- a/tests/e2e/bottom-nav.spec.ts
+++ b/tests/e2e/bottom-nav.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Bottom-nav rendering contract.
+ *
+ * The patient sees this nav on every screen on every device. Two
+ * things have to be right at all viewports:
+ *
+ *  1. The five icons render and the nav fits within the viewport
+ *     without horizontal scroll.
+ *  2. The page content's bottom padding leaves a sensible gap to
+ *     the nav — small enough that the patient isn't staring at
+ *     dead space (the bug that triggered this spec), large enough
+ *     that the last line of content isn't kissed by the nav.
+ *
+ * Multi-project Playwright runs the same spec on Desktop Chrome,
+ * Desktop Safari (WebKit), iPhone 13, iPhone SE, Pixel 5 and iPad.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+async function completeOnboarding(page: Page) {
+  await page.addInitScript(() => {
+    indexedDB.deleteDatabase("AnchorDB");
+  });
+  await page.goto("/onboarding");
+  await page.getByRole("button", { name: /begin/i }).click();
+  await page.getByText("I'm the patient").click();
+  await page.getByRole("button", { name: /continue/i }).click();
+  await page.getByPlaceholder(/hu lin/i).fill("Test Patient");
+  await page.getByRole("button", { name: /continue/i }).click();
+  await page.getByText("Finish setup later").click();
+  await page.getByRole("button", { name: /save and continue/i }).click();
+  await page.waitForURL("/");
+}
+
+test.describe("Mobile bottom nav — render + clearance", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(
+      testInfo.project.name === "chrome-desktop" ||
+        testInfo.project.name === "safari-desktop" ||
+        testInfo.project.name === "ipad",
+      "Mobile bottom nav is hidden on md+ breakpoints",
+    );
+    await completeOnboarding(page);
+  });
+
+  test("renders all 5 patient slots", async ({ page }) => {
+    const nav = page.locator("nav.pwa-bottom-nav");
+    await expect(nav).toBeVisible();
+    await expect(nav.getByRole("link")).toHaveCount(5);
+  });
+
+  test("nav fits within the viewport (no horizontal scroll)", async ({
+    page,
+  }) => {
+    const nav = page.locator("nav.pwa-bottom-nav");
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    const box = await nav.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeLessThanOrEqual(viewport!.width);
+  });
+
+  test("page bottom padding leaves a sensible gap to the nav", async ({
+    page,
+  }) => {
+    // Nav visible top edge from viewport bottom.
+    const nav = page.locator("nav.pwa-bottom-nav");
+    const navBox = await nav.boundingBox();
+    expect(navBox).not.toBeNull();
+    const viewport = page.viewportSize()!;
+    const navTopFromViewportBottom = viewport.height - navBox!.y;
+
+    // Content's reserved bottom space — main element padding-bottom.
+    const mainPaddingBottom = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      const cs = getComputedStyle(main);
+      return parseFloat(cs.paddingBottom);
+    });
+    expect(mainPaddingBottom).not.toBeNull();
+
+    // The padding must clear the visible nav (otherwise the last
+    // line of content sits under the nav glass) and shouldn't waste
+    // huge dead space (the user's complaint that triggered this
+    // spec — 38 px excess on regular browsers).
+    const gap = mainPaddingBottom! - navTopFromViewportBottom;
+    expect(gap, `gap=${gap}px main pb=${mainPaddingBottom} navTop=${navTopFromViewportBottom}`).toBeGreaterThanOrEqual(0);
+    expect(gap, `gap=${gap}px main pb=${mainPaddingBottom} navTop=${navTopFromViewportBottom}`).toBeLessThanOrEqual(28);
+  });
+
+  test("nav stays at the bottom of the viewport (fixed)", async ({ page }) => {
+    const nav = page.locator("nav.pwa-bottom-nav");
+    const initial = await nav.boundingBox();
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(150);
+    const after = await nav.boundingBox();
+    expect(after!.y).toBeCloseTo(initial!.y, -1);
+  });
+
+  test("nav is hidden on /login", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.locator("nav.pwa-bottom-nav")).toHaveCount(0);
+  });
+});
+
+test.describe("Mobile bottom nav — active state on sub-routes", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(
+      testInfo.project.name === "chrome-desktop" ||
+        testInfo.project.name === "safari-desktop" ||
+        testInfo.project.name === "ipad",
+      "Mobile bottom nav is hidden on md+ breakpoints",
+    );
+    await completeOnboarding(page);
+  });
+
+  test("Dashboard tab is active on /", async ({ page }) => {
+    const link = page
+      .locator("nav.pwa-bottom-nav")
+      .getByRole("link", { name: /dashboard/i });
+    // Active state styles `text-ink-900` text and `text-[var(--tide-2)]` icon
+    // — the visible cue is the icon colour. Easiest assertion is the
+    // class reflecting active.
+    const cls = await link.getAttribute("class");
+    expect(cls).toContain("text-ink-900");
+  });
+
+  test("Nutrition tab stays active on /nutrition/log (sub-route)", async ({
+    page,
+  }) => {
+    await page.goto("/nutrition/log");
+    const link = page
+      .locator("nav.pwa-bottom-nav")
+      .getByRole("link", { name: /nutrition/i });
+    const cls = await link.getAttribute("class");
+    expect(cls).toContain("text-ink-900");
+  });
+
+  test("Schedule tab stays active on /schedule/new", async ({ page }) => {
+    await page.goto("/schedule/new");
+    const link = page
+      .locator("nav.pwa-bottom-nav")
+      .getByRole("link", { name: /schedule/i });
+    const cls = await link.getAttribute("class");
+    expect(cls).toContain("text-ink-900");
+  });
+});
+
+test.describe("Desktop sidebar — render", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(
+      !["chrome-desktop", "safari-desktop", "ipad"].includes(
+        testInfo.project.name,
+      ),
+      "Desktop sidebar only renders at md+ breakpoints",
+    );
+    await completeOnboarding(page);
+  });
+
+  test("sidebar is visible", async ({ page }) => {
+    await expect(page.locator("aside")).toBeVisible();
+  });
+
+  test("sidebar contains Nutrition link", async ({ page }) => {
+    await expect(
+      page.locator("aside").getByRole("link", { name: /nutrition/i }),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -38,22 +38,32 @@ test.describe("Mobile navigation (390px wide)", () => {
     await expect(nav).toBeVisible();
   });
 
-  test("bottom nav contains link to Daily", async ({ page }) => {
-    // Daily is the core daily interaction — must be in mobile nav.
+  test("bottom nav contains link to Nutrition (first-class slot)", async ({
+    page,
+  }) => {
+    // Nutrition replaced /daily in the bottom nav — cachexia is the
+    // primary axis-3 signal and is logged daily, so it earns the
+    // permanent slot. Daily check-in stays one tap away via the FAB.
     await expect(
-      page.getByRole("link", { name: /daily/i }),
+      page.locator("nav.pwa-bottom-nav").getByRole("link", {
+        name: /nutrition/i,
+      }),
     ).toBeVisible();
   });
 
   test("bottom nav contains link to Dashboard", async ({ page }) => {
     await expect(
-      page.getByRole("link", { name: /dashboard/i }),
+      page.locator("nav.pwa-bottom-nav").getByRole("link", {
+        name: /dashboard/i,
+      }),
     ).toBeVisible();
   });
 
   test("bottom nav contains link to Schedule", async ({ page }) => {
     await expect(
-      page.getByRole("link", { name: /schedule/i }),
+      page.locator("nav.pwa-bottom-nav").getByRole("link", {
+        name: /schedule/i,
+      }),
     ).toBeVisible();
   });
 
@@ -68,9 +78,12 @@ test.describe("Mobile navigation (390px wide)", () => {
     ).toBeVisible();
   });
 
-  test("can navigate to /daily from mobile nav", async ({ page }) => {
-    await page.getByRole("link", { name: /daily/i }).click();
-    await expect(page).toHaveURL(/\/daily/);
+  test("can navigate to /nutrition from mobile nav", async ({ page }) => {
+    await page
+      .locator("nav.pwa-bottom-nav")
+      .getByRole("link", { name: /nutrition/i })
+      .click();
+    await expect(page).toHaveURL(/\/nutrition/);
   });
 
   test("can navigate to /settings via more menu", async ({ page }) => {
@@ -95,9 +108,9 @@ test.describe("Desktop navigation (1440px wide)", () => {
     await expect(page.getByText("Anchor").first()).toBeVisible();
   });
 
-  test("sidebar link to /daily is present", async ({ page }) => {
+  test("sidebar link to /nutrition is present", async ({ page }) => {
     await expect(
-      page.locator("aside").getByRole("link", { name: /daily/i }),
+      page.locator("aside").getByRole("link", { name: /nutrition/i }),
     ).toBeVisible();
   });
 

--- a/tests/unit/nav-active.test.ts
+++ b/tests/unit/nav-active.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { isNavItemActive } from "~/lib/nav/active";
+
+// Active-state matcher for the bottom nav + desktop sidebar.
+// Used to be `pathname === item.href`, which silently dropped the
+// active highlight on every sub-route — `/nutrition/log` no longer
+// lit up the Nutrition tab, `/schedule/new` no longer lit up
+// Schedule, etc. The screenshot of an all-grey navbar that
+// triggered this fix was taken on exactly such a sub-route.
+
+describe("isNavItemActive", () => {
+  it("dashboard '/' matches only the exact pathname", () => {
+    expect(isNavItemActive("/", "/")).toBe(true);
+    expect(isNavItemActive("/nutrition", "/")).toBe(false);
+    expect(isNavItemActive("/anything", "/")).toBe(false);
+  });
+
+  it("non-root href matches its own pathname", () => {
+    expect(isNavItemActive("/nutrition", "/nutrition")).toBe(true);
+    expect(isNavItemActive("/schedule", "/schedule")).toBe(true);
+  });
+
+  it("non-root href matches a nested sub-route", () => {
+    // The persistent bug: this used to return false because
+    // `/nutrition/log !== /nutrition`. The Nutrition tab stayed grey
+    // even though the user was inside the Nutrition section.
+    expect(isNavItemActive("/nutrition/log", "/nutrition")).toBe(true);
+    expect(isNavItemActive("/nutrition/123", "/nutrition")).toBe(true);
+    expect(isNavItemActive("/nutrition/foods", "/nutrition")).toBe(true);
+    expect(isNavItemActive("/schedule/new", "/schedule")).toBe(true);
+    expect(isNavItemActive("/treatment/cycle/3", "/treatment")).toBe(true);
+  });
+
+  it("does NOT match prefix collisions", () => {
+    // `/nutritional` shouldn't activate `/nutrition`; `/scheduled`
+    // shouldn't activate `/schedule`. Without the boundary check,
+    // `/nutritional`.startsWith(`/nutrition`) is true — would
+    // wrongly highlight the wrong tab.
+    expect(isNavItemActive("/nutritional", "/nutrition")).toBe(false);
+    expect(isNavItemActive("/scheduled", "/schedule")).toBe(false);
+    expect(isNavItemActive("/care-team-roster", "/care-team")).toBe(false);
+  });
+
+  it("treats null/undefined pathname as inactive", () => {
+    expect(isNavItemActive(null, "/")).toBe(false);
+    expect(isNavItemActive(undefined, "/nutrition")).toBe(false);
+  });
+
+  it("ignores trailing slash on pathname", () => {
+    expect(isNavItemActive("/nutrition/", "/nutrition")).toBe(true);
+    expect(isNavItemActive("/", "/")).toBe(true);
+  });
+
+  it("sibling routes are independent", () => {
+    // /nutrition vs /history — neither should ever activate the
+    // other no matter the trailing path.
+    expect(isNavItemActive("/history", "/nutrition")).toBe(false);
+    expect(isNavItemActive("/nutrition", "/history")).toBe(false);
+  });
+
+  it("query strings and hashes do not affect matching", () => {
+    expect(isNavItemActive("/nutrition?foo=bar", "/nutrition")).toBe(true);
+    expect(isNavItemActive("/nutrition#section", "/nutrition")).toBe(true);
+    expect(isNavItemActive("/nutrition/log?id=1", "/nutrition")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What you reported

> "The bottom padding is too big"

## Root cause

`src/app/layout.tsx` was reserving `pb-[calc(7rem+env(safe-area-inset-bottom))]` (112 px on regular browsers, 146 px on PWA). The actual nav top edge from the viewport bottom is only **66 px on regular** (12 px anchor + 46 px content/top-padding + 8 px internal `pwa-bottom-nav` padding) and **114 px on PWA** (34 px anchor + 46 px + 34 px internal padding).

So the page was leaving 38 px of dead space at the bottom on regular browsers, ~24 px on PWA.

## Fix

Replaced the hard-coded `pb-[…]` with a `bottom-nav-clearance` CSS class whose math mirrors the nav's own anchor + height:

```css
.bottom-nav-clearance {
  padding-bottom: calc(
    max(0.75rem, env(safe-area-inset-bottom))   /* anchor */
    + 2.875rem                                  /* 46px content + top padding */
    + max(0.5rem, env(safe-area-inset-bottom))  /* nav's internal bottom padding */
    + 1rem                                      /* visual gap */
  );
}
```

Result: **exactly 16 px gap** above the nav on both regular and PWA. Saves 30 px on regular, 16 px on PWA.

## Bonus (separate real bug found in the same component)

While in `nav.tsx` I noticed every nav surface used `pathname === item.href` for active state, so on any sub-route (`/nutrition/log`, `/schedule/new`, `/treatment/cycle/3`) every icon went grey — no visual anchor for "where am I". Extracted `isNavItemActive(pathname, href)` with exact-match for `/` and prefix-match-with-`/`-boundary for everything else (so `/nutritional` doesn't trip `/nutrition`), and wired into all three nav surfaces.

## Tests

- **`tests/unit/nav-active.test.ts`** (8 cases) — exact, nested sub-route, prefix collision (`/nutritional` ≠ `/nutrition`), sibling routes, trailing slash, query string, hash, null pathname.
- **`tests/e2e/bottom-nav.spec.ts`** (new) — measures `<main>` padding-bottom against actual nav top edge at runtime; asserts gap is 0–28 px. Also covers nav-fits-in-viewport, fixed-positioning under scroll, hidden on `/login`, and active-state on `/nutrition/log` and `/schedule/new`.
- **`playwright.config.ts`** — multi-project so the spec runs across **Desktop Chrome, Desktop Safari (WebKit), iPhone 13, iPhone SE, Pixel 5, iPad Pro** as you asked.
- **`tests/e2e/navigation.spec.ts`** — repaired stale `/daily` expectations (Nutrition replaced `/daily` in the bottom nav).

Local Vitest: **716/716 green**. Playwright E2E couldn't run in the local sandbox (no browser bundles available); will run on Vercel preview / CI.

## Test plan
- [ ] Visit Vercel preview on a phone — confirm bottom dead-space is gone.
- [ ] Navigate to `/nutrition/log` — Nutrition icon now highlights (was grey before).
- [ ] Navigate to `/schedule/new` — Schedule icon highlights.
- [ ] `pnpm test:e2e` runs the full bottom-nav spec across all 6 device projects.

https://claude.ai/code/session_018v1KTG2Z8nrvS3GLQqKNBb

---
_Generated by [Claude Code](https://claude.ai/code/session_018v1KTG2Z8nrvS3GLQqKNBb)_