### PR TITLE
Carers: don't bounce signed-in carers to patient onboarding

### DIFF
--- a/src/app/invite/welcome/page.tsx
+++ b/src/app/invite/welcome/page.tsx
@@ -9,6 +9,7 @@ import {
   updateMyProfile,
 } from "~/lib/supabase/households";
 import { useHousehold } from "~/hooks/use-household";
+import { db, now as nowISO } from "~/lib/db/dexie";
 import { useUIStore } from "~/stores/ui-store";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent } from "~/components/ui/card";
@@ -157,14 +158,56 @@ export default function InviteWelcomePage() {
     try {
       const finalRelationship =
         customRelationship.trim() || relationship.trim() || null;
+      const finalDisplayName = displayName.trim() || "Care team member";
       await updateMyProfile({
-        display_name: displayName.trim() || "Care team member",
+        display_name: finalDisplayName,
         relationship: finalRelationship,
         care_role_label: finalRelationship,
         locale,
         timezone: timezone || browserTimezone,
       });
       setUILocale(locale);
+
+      // Backfill a minimal Dexie settings row marked as caregiver /
+      // clinician + onboarded_at. Without this, the next time the user
+      // hits `/` the dashboard's onboarded_at gate fires and dumps
+      // them in the patient onboarding wizard — wrong audience. The
+      // dashboard now ALSO has a Supabase-membership-first redirect
+      // for safety, but writing the local row keeps the offline
+      // experience consistent and prevents flicker.
+      try {
+        const ts = nowISO();
+        const userType: "caregiver" | "clinician" =
+          membership?.role === "clinician" ? "clinician" : "caregiver";
+        const existing = await db.settings.toArray();
+        const existingRow = existing[0];
+        if (existingRow?.id) {
+          await db.settings.update(existingRow.id, {
+            user_type: userType,
+            profile_name:
+              existingRow.profile_name?.trim() || finalDisplayName,
+            locale,
+            home_timezone: timezone || browserTimezone || existingRow.home_timezone,
+            onboarded_at: existingRow.onboarded_at ?? ts,
+            updated_at: ts,
+          });
+        } else {
+          await db.settings.add({
+            user_type: userType,
+            profile_name: finalDisplayName,
+            locale,
+            home_timezone: timezone || browserTimezone,
+            onboarded_at: ts,
+            created_at: ts,
+            updated_at: ts,
+          });
+        }
+      } catch {
+        // Dexie write is a nice-to-have; failure here doesn't block the
+        // user from continuing to /family. The dashboard's Supabase-
+        // membership check covers the routing case either way.
+      }
+
       router.replace("/family");
     } catch {
       // Fail-open: even if the profile write errors we still drop them on

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,18 +38,30 @@ export default function DashboardPage() {
   // racing useEffects can't both call router.replace on the same
   // render. Order:
   //   1. Settings still loading (undefined) → wait.
-  //   2. No settings row OR no onboarded_at → /onboarding (everyone
-  //      finishes onboarding before any role-based routing).
-  //   3. Caregiver / clinician (per Dexie settings.user_type) →
+  //   2. Supabase household membership still resolving → wait. The
+  //      hook has a 4s timeout, so this branch can't deadlock.
+  //   3. Authenticated household member with a non-patient,
+  //      non-primary-carer role (per Supabase) → /family. Checked
+  //      BEFORE the Dexie onboarded_at gate because a freshly-
+  //      signed-in carer who came via /invite/<token> has no Dexie
+  //      settings row yet — sending them to /onboarding would dump
+  //      them in the patient wizard, which is the wrong audience.
+  //   4. No settings row OR no onboarded_at → /onboarding (the
+  //      patient / primary-carer onboarding wizard).
+  //   5. Caregiver / clinician (per Dexie settings.user_type) →
   //      /family. Set during onboarding before any sign-in.
-  //   4. Authenticated household member with a non-patient,
-  //      non-primary-carer role (per Supabase) → /family. We wait
-  //      for the household hook to resolve (membership === undefined)
-  //      before acting on this branch so we don't route a
-  //      yet-to-load primary_carer to the family view by accident.
-  //   5. Otherwise (patient / primary carer) → stay on dashboard.
+  //   6. Otherwise (patient / primary carer) → stay on dashboard.
   useEffect(() => {
-    if (settings === undefined) return; // still loading
+    if (settings === undefined) return; // dexie still loading
+    if (membership === undefined) return; // supabase still resolving
+    if (
+      membership !== null &&
+      membership.role !== "primary_carer" &&
+      membership.role !== "patient"
+    ) {
+      router.replace("/family");
+      return;
+    }
     if (!settings?.onboarded_at) {
       router.replace("/onboarding");
       return;
@@ -58,14 +70,7 @@ export default function DashboardPage() {
       router.replace("/family");
       return;
     }
-    if (membership === undefined) return; // hook still resolving
-    if (
-      membership !== null &&
-      membership.role !== "primary_carer" &&
-      membership.role !== "patient"
-    ) {
-      router.replace("/family");
-    }
+    // Otherwise stay on the dashboard (patient / primary carer).
   }, [membership, router, settings]);
 
   const { greeting, eyebrow } = useMemo(() => {
@@ -96,6 +101,14 @@ export default function DashboardPage() {
   // than flash the patient dashboard at a caregiver who's about to be
   // routed to /family. The app-level loading.tsx covers the visual.
   if (settings === undefined) return null;
+  if (membership === undefined) return null;
+  if (
+    membership !== null &&
+    membership.role !== "primary_carer" &&
+    membership.role !== "patient"
+  ) {
+    return null;
+  }
   if (!settings?.onboarded_at) return null;
   if (settings.user_type === "caregiver" || settings.user_type === "clinician") {
     return null;


### PR DESCRIPTION
## Symptom

User reported: a carer signing in lands on the **patient onboarding wizard** instead of `/family`. That wizard asks for DOB / diagnosis date / treatment protocol — the wrong audience entirely.

## Root cause

The dashboard's redirect ladder in `src/app/page.tsx` checked Dexie's `onboarded_at` **before** looking at the Supabase household membership. A freshly-signed-in carer who came in via `/invite/<token>`:

- ✅ Has Supabase membership + profile (the invite RPC creates them)
- ❌ Has no Dexie `settings` row (it was never written client-side for invite flows)

So the `!settings?.onboarded_at` gate fired immediately and bounced them to `/onboarding`.

## Fixes

**1. Reorder dashboard redirect ladder.** Check Supabase membership first. If the role is `family` / `clinician` / `observer`, route straight to `/family` — even without a Dexie settings row. The body-render early-returns are updated to match so we don't flash the patient dashboard at a soon-to-be-redirected carer.

**2. Backfill Dexie settings on `/invite/welcome` finish.** Belt-and-braces: write a minimal settings row when the carer completes the welcome wizard:
- `user_type = caregiver` or `clinician` (mirrored from the household role)
- `profile_name` from the welcome form
- `locale`, `home_timezone` from the form
- `onboarded_at = now`

The dashboard fix works without this, but writing the local row keeps offline / future-session behaviour consistent and prevents nav flicker between Dexie-only and Supabase-only states.

## Tests

- 692 unit tests pass
- typecheck, lint, build green

## Test plan

- [ ] As a fresh user, accept an invite via `/invite/<token>`, complete `/invite/welcome` — land on `/family`, NOT `/onboarding`
- [ ] Reload the app while signed in as a carer → still lands on `/family` (Dexie row now has `user_type=caregiver`)
- [ ] As primary carer, signing in still lands on `/` dashboard (unchanged)
- [ ] As patient, signing in still lands on `/` dashboard (unchanged)
- [ ] No Dexie settings row + signed in as carer → goes to `/family` even without backfill (Supabase-membership-first guard)

https://claude.ai/code/session_0166RgD8Vg8nA1EvWSdsR4LA

---
_Generated by [Claude Code](https://claude.ai/code/session_0166RgD8Vg8nA1EvWSdsR4LA)_