### PR TITLE
Polish design consistency across pages and lists

### DIFF
--- a/src/app/assessment/page.tsx
+++ b/src/app/assessment/page.tsx
@@ -81,7 +81,7 @@ export default function AssessmentListPage() {
           <li key={a.id}>
             <Link
               href={a.status === "draft" ? `/assessment/run/${a.id}` : `/assessment/${a.id}`}
-              className="group flex items-center gap-4 rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300"
+              className="a-row group gap-4"
             >
               {typeof a.anchor_index === "number" ? (
                 <PillarRing score={a.anchor_index} size={56} />

--- a/src/app/bridge/page.tsx
+++ b/src/app/bridge/page.tsx
@@ -86,7 +86,7 @@ export default function BridgePage() {
   ];
 
   return (
-    <div className="max-w-4xl mx-auto p-4 md:p-8 space-y-8">
+    <div className="mx-auto max-w-4xl space-y-6 p-4 md:p-8">
       <PageHeader
         title={t("nav.bridge")}
         subtitle={
@@ -98,7 +98,7 @@ export default function BridgePage() {
       />
 
       {/* ECOG plain-language explainer */}
-      <div className="rounded-[var(--r-lg)] border border-ink-100 bg-paper-2 p-5 space-y-3">
+      <Card className="space-y-3 p-5">
         <div className="flex items-baseline gap-2">
           <div className="text-[13px] font-semibold text-ink-900">
             {L("What is ECOG?", "什么是 ECOG？")}
@@ -117,11 +117,11 @@ export default function BridgePage() {
           {ecogLevels.map((level) => (
             <div
               key={level.grade}
-              className="flex items-start gap-3 rounded-[var(--r-md)] p-3"
+              className="flex items-start gap-3 rounded-md p-3"
               style={{ background: level.soft }}
             >
               <div
-                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[12px] font-bold text-paper"
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[12px] font-semibold text-paper"
                 style={{ background: level.color }}
               >
                 {level.grade}
@@ -137,7 +137,7 @@ export default function BridgePage() {
             </div>
           ))}
         </div>
-      </div>
+      </Card>
 
       {/* Always-visible strategy explainer */}
       <div className="grid gap-4 md:grid-cols-3">

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -54,7 +54,7 @@ export default function DailyPage() {
           <li key={e.id}>
             <Link
               href={`/daily/${e.id}`}
-              className="group flex items-center justify-between rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300"
+              className="a-row group justify-between"
             >
               <div className="space-y-1">
                 <div className="flex items-center gap-2">

--- a/src/app/fortnightly/page.tsx
+++ b/src/app/fortnightly/page.tsx
@@ -57,7 +57,7 @@ export default function FortnightlyListPage() {
           <li key={a.id}>
             <Link
               href={`/fortnightly/${a.id}`}
-              className="group flex items-center justify-between rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300"
+              className="a-row group justify-between"
             >
               <div className="space-y-1">
                 <div className="text-sm font-medium text-ink-900">

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -338,9 +338,7 @@ function DateGroup({
       : format(d, "EEEE · d MMM yyyy");
   return (
     <section>
-      <div className="mono mb-2 text-[10px] uppercase tracking-[0.14em] text-ink-400">
-        {label}
-      </div>
+      <div className="eyebrow mb-2">{label}</div>
       <ul className="space-y-1.5">
         {entries.map((e) => (
           <li key={e.id}>

--- a/src/app/ingest/pending/page.tsx
+++ b/src/app/ingest/pending/page.tsx
@@ -142,7 +142,7 @@ export default function PendingResultsPage() {
       </Card>
 
       <section className="space-y-3">
-        <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
+        <h2 className="eyebrow">
           {locale === "zh" ? "未收到" : "Open"} ({open.length})
         </h2>
         {open.length === 0 && (
@@ -212,7 +212,7 @@ export default function PendingResultsPage() {
 
       {done.length > 0 && (
         <section className="space-y-3">
-          <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
+          <h2 className="eyebrow">
             {locale === "zh" ? "已收到" : "Received"} ({done.length})
           </h2>
           <ul className="space-y-2">

--- a/src/app/labs/[analyte]/page.tsx
+++ b/src/app/labs/[analyte]/page.tsx
@@ -290,7 +290,7 @@ export default function AnalyteDetailPage() {
       {/* Clinical note */}
       {def.note && (
         <div
-          className="flex items-start gap-2.5 rounded-[10px] p-3"
+          className="flex items-start gap-2.5 rounded-md p-3"
           style={{ background: "var(--tide-soft)" }}
         >
           <Sparkles

--- a/src/app/labs/page.tsx
+++ b/src/app/labs/page.tsx
@@ -7,6 +7,7 @@ import { format, parseISO } from "date-fns";
 import { latestLabs } from "~/lib/db/queries";
 import { useLocale } from "~/hooks/use-translate";
 import { PageHeader } from "~/components/ui/page-header";
+import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
 import { EmptyState } from "~/components/ui/empty-state";
 import { MetricChart, type MetricPoint } from "~/components/labs/metric-chart";
@@ -237,7 +238,7 @@ export default function LabsPage() {
 
         {def.note && (
           <div
-            className="mt-3.5 flex items-start gap-2.5 rounded-[10px] p-2.5"
+            className="mt-3.5 flex items-start gap-2.5 rounded-md p-2.5"
             style={{ background: "var(--tide-soft)" }}
           >
             <Sparkles className="h-3.5 w-3.5 shrink-0" style={{ color: "var(--tide-2)" }} />
@@ -266,17 +267,15 @@ export default function LabsPage() {
           }
           actions={
             <>
-              <Link
-                href="/ingest"
-                className="rounded-md bg-ink-900 px-4 py-2 text-sm font-medium text-paper hover:brightness-110"
-              >
-                {locale === "zh" ? "上传报告" : "Upload report"}
+              <Link href="/ingest">
+                <Button>
+                  {locale === "zh" ? "上传报告" : "Upload report"}
+                </Button>
               </Link>
-              <Link
-                href="/labs/ca199"
-                className="rounded-md border border-ink-200 bg-paper-2 px-4 py-2 text-sm font-medium text-ink-700 hover:border-ink-300"
-              >
-                {locale === "zh" ? "手动添加" : "Add manually"}
+              <Link href="/labs/ca199">
+                <Button variant="secondary">
+                  {locale === "zh" ? "手动添加" : "Add manually"}
+                </Button>
               </Link>
             </>
           }

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -254,7 +254,7 @@ export default function LogPage() {
         </Field>
 
         <div className="mt-4">
-          <div className="mono mb-1.5 text-[10px] uppercase tracking-[0.14em] text-ink-400">
+          <div className="eyebrow mb-1.5">
             {locale === "zh" ? "分类" : "Tags"}
           </div>
           <div className="flex flex-wrap gap-2">

--- a/src/app/nutrition/page.tsx
+++ b/src/app/nutrition/page.tsx
@@ -19,7 +19,7 @@ export default function NutritionPage() {
   const date = todayISO();
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-8">
       <PageHeader
         eyebrow={locale === "zh" ? "营养" : "NUTRITION"}
         title={
@@ -58,29 +58,23 @@ export default function NutritionPage() {
       <WeeklySummary />
 
       <section className="grid gap-2 sm:grid-cols-2">
-        <Link
-          href="/nutrition/foods"
-          className="flex items-center justify-between rounded-md border border-ink-100 bg-paper-2/40 px-4 py-3 text-sm transition-colors hover:border-ink-300"
-        >
-          <span className="flex items-center gap-3">
+        <Link href="/nutrition/foods" className="a-row dense group justify-between">
+          <span className="flex items-center gap-3 text-sm">
             <Apple className="h-4 w-4 text-[var(--tide-2)]" />
             <span className="text-ink-900">
               {locale === "zh" ? "食物库" : "Foods database"}
             </span>
           </span>
-          <ChevronRight className="h-4 w-4 text-ink-400" />
+          <ChevronRight className="h-4 w-4 text-ink-400 group-hover:text-ink-700" />
         </Link>
-        <Link
-          href="/nutrition/guide"
-          className="flex items-center justify-between rounded-md border border-ink-100 bg-paper-2/40 px-4 py-3 text-sm transition-colors hover:border-ink-300"
-        >
-          <span className="flex items-center gap-3">
+        <Link href="/nutrition/guide" className="a-row dense group justify-between">
+          <span className="flex items-center gap-3 text-sm">
             <BookOpen className="h-4 w-4 text-[var(--tide-2)]" />
             <span className="text-ink-900">
               {locale === "zh" ? "饮食策略" : "Diet strategy"}
             </span>
           </span>
-          <ChevronRight className="h-4 w-4 text-ink-400" />
+          <ChevronRight className="h-4 w-4 text-ink-400 group-hover:text-ink-700" />
         </Link>
       </section>
     </div>

--- a/src/app/prescriptions/page.tsx
+++ b/src/app/prescriptions/page.tsx
@@ -342,7 +342,7 @@ function PrescriptionRow({
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
             <div className="text-[14px] font-semibold text-ink-900">{name}</div>
-            <div className="mono text-[10.5px] uppercase tracking-[0.12em] text-ink-400">
+            <div className="eyebrow">
               {med.category}
               {med.source === "user_added" ? " · self-added" : ""}
             </div>

--- a/src/app/safety/chemo-at-home/page.tsx
+++ b/src/app/safety/chemo-at-home/page.tsx
@@ -17,7 +17,7 @@ import { getSource } from "~/lib/nutrition/sources";
 export default function ChemoAtHomePage() {
   const locale = useLocale();
   return (
-    <div className="mx-auto max-w-2xl space-y-5 px-4 py-6 sm:px-6">
+    <div className="mx-auto max-w-2xl space-y-6 p-4 md:p-8">
       <Link
         href="/safety"
         className="inline-flex items-center gap-1.5 text-[12px] text-ink-500 hover:text-ink-900"

--- a/src/app/safety/neutropenia/page.tsx
+++ b/src/app/safety/neutropenia/page.tsx
@@ -17,7 +17,7 @@ import { getSource } from "~/lib/nutrition/sources";
 export default function NeutropeniaPage() {
   const locale = useLocale();
   return (
-    <div className="mx-auto max-w-2xl space-y-5 px-4 py-6 sm:px-6">
+    <div className="mx-auto max-w-2xl space-y-6 p-4 md:p-8">
       <Link
         href="/safety"
         className="inline-flex items-center gap-1.5 text-[12px] text-ink-500 hover:text-ink-900"

--- a/src/app/safety/page.tsx
+++ b/src/app/safety/page.tsx
@@ -19,7 +19,7 @@ export default function SafetyIndex() {
   const locale = useLocale();
   const L = (en: string, zh: string) => (locale === "zh" ? zh : en);
   return (
-    <div className="mx-auto max-w-2xl space-y-5 px-4 py-6 sm:px-6">
+    <div className="mx-auto max-w-2xl space-y-6 p-4 md:p-8">
       <PageHeader
         eyebrow={L("SAFETY", "安全指引")}
         title={L("Safety at home", "居家安全")}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -97,7 +97,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto p-4 md:p-8 space-y-6">
+    <div className="mx-auto max-w-2xl space-y-6 p-4 md:p-8">
       <PageHeader title={t("settings.title")} />
 
       <AccountButton />

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -127,7 +127,7 @@ export default function TasksPage() {
         if (items.length === 0) return null;
         return (
           <section key={key} className="space-y-2">
-            <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
+            <h2 className="eyebrow">
               {label[locale]} · {items.length}
             </h2>
             <ul className="space-y-2">

--- a/src/app/treatment/[id]/page.tsx
+++ b/src/app/treatment/[id]/page.tsx
@@ -216,34 +216,32 @@ export default function CycleDetailPage() {
       )}
 
       <div className="grid gap-2 sm:grid-cols-2">
-        <Link
-          href="/safety/chemo-at-home"
-          className="rounded-md border border-ink-100 bg-paper-2/40 px-4 py-3 text-[12px] text-ink-700 hover:border-ink-300"
-        >
-          <div className="font-medium text-ink-900">
-            {locale === "zh"
-              ? "居家化疗安全"
-              : "Chemo safety at home"}
-          </div>
-          <div className="mt-0.5 text-[11px] text-ink-500">
-            {locale === "zh"
-              ? "用药后 48 小时体液防护"
-              : "Body-fluid precautions for 48 h after each dose"}
+        <Link href="/safety/chemo-at-home" className="a-row dense group">
+          <div className="min-w-0 flex-1">
+            <div className="text-[13px] font-semibold text-ink-900">
+              {locale === "zh"
+                ? "居家化疗安全"
+                : "Chemo safety at home"}
+            </div>
+            <div className="mt-0.5 text-[11.5px] text-ink-500">
+              {locale === "zh"
+                ? "用药后 48 小时体液防护"
+                : "Body-fluid precautions for 48 h after each dose"}
+            </div>
           </div>
         </Link>
-        <Link
-          href="/safety/neutropenia"
-          className="rounded-md border border-ink-100 bg-paper-2/40 px-4 py-3 text-[12px] text-ink-700 hover:border-ink-300"
-        >
-          <div className="font-medium text-ink-900">
-            {locale === "zh"
-              ? "中性粒细胞 & 感染防护"
-              : "Neutropenia & infection prevention"}
-          </div>
-          <div className="mt-0.5 text-[11px] text-ink-500">
-            {locale === "zh"
-              ? "用药后 7–14 天风险最高"
-              : "Risk peaks days 7–14 after each dose"}
+        <Link href="/safety/neutropenia" className="a-row dense group">
+          <div className="min-w-0 flex-1">
+            <div className="text-[13px] font-semibold text-ink-900">
+              {locale === "zh"
+                ? "中性粒细胞 & 感染防护"
+                : "Neutropenia & infection prevention"}
+            </div>
+            <div className="mt-0.5 text-[11.5px] text-ink-500">
+              {locale === "zh"
+                ? "用药后 7–14 天风险最高"
+                : "Risk peaks days 7–14 after each dose"}
+            </div>
           </div>
         </Link>
       </div>
@@ -316,9 +314,7 @@ export default function CycleDetailPage() {
             if (!items || items.length === 0) return null;
             return (
               <div key={cat}>
-                <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-500">
-                  {cat}
-                </div>
+                <div className="eyebrow mb-1.5">{cat}</div>
                 <div className="space-y-1.5">
                   {items.map((n) => (
                     <NudgeCard key={n.id} nudge={n} onSnooze={snooze} />
@@ -336,7 +332,7 @@ export default function CycleDetailPage() {
           )}
           {(cycle.snoozed_nudge_ids?.length ?? 0) > 0 && (
             <div className="pt-2">
-              <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-500">
+              <div className="eyebrow mb-1.5">
                 {locale === "zh" ? "已暂隐" : "Snoozed"}
               </div>
               <div className="flex flex-wrap gap-1.5 text-xs">
@@ -391,11 +387,11 @@ export default function CycleDetailPage() {
               >
                 {locale === "zh" ? "取消" : "Cancel"}
               </Button>
-              <button
-                type="button"
+              <Button
+                variant="danger"
+                size="sm"
                 onClick={deleteCycle}
                 disabled={deleting}
-                className="rounded-md bg-[var(--warn)] px-3 py-1.5 text-xs font-semibold text-white hover:brightness-95 disabled:opacity-60"
               >
                 {deleting
                   ? locale === "zh"
@@ -404,7 +400,7 @@ export default function CycleDetailPage() {
                   : locale === "zh"
                     ? "确认删除"
                     : "Confirm delete"}
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/src/app/treatment/new/page.tsx
+++ b/src/app/treatment/new/page.tsx
@@ -223,7 +223,7 @@ export default function NewTreatmentCyclePage() {
   if (!protocol) return null;
 
   return (
-    <div className="mx-auto max-w-3xl space-y-5 p-4 md:p-8">
+    <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-8">
       <PageHeader
         title={L("Start new cycle", "开始新周期")}
         subtitle={L(

--- a/src/app/treatment/page.tsx
+++ b/src/app/treatment/page.tsx
@@ -63,7 +63,7 @@ export default function TreatmentListPage() {
       <div className="grid gap-2 sm:grid-cols-2">
         <Link
           href="/prescriptions"
-          className="group flex items-center gap-3 rounded-xl border border-ink-100/70 bg-paper-2 p-3 transition-colors hover:border-ink-300"
+          className="a-row dense group"
         >
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--tide-soft)] text-[var(--tide-2)]">
             <ClipboardList className="h-4 w-4" />
@@ -82,7 +82,7 @@ export default function TreatmentListPage() {
         </Link>
         <Link
           href="/medications"
-          className="group flex items-center gap-3 rounded-xl border border-ink-100/70 bg-paper-2 p-3 transition-colors hover:border-ink-300"
+          className="a-row dense group"
         >
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--sand)] text-ink-900">
             <BookOpen className="h-4 w-4" />
@@ -124,7 +124,7 @@ export default function TreatmentListPage() {
           const style = STATUS_STYLES[c.status];
           return (
             <li key={c.id}>
-              <div className="group flex items-center justify-between rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300">
+              <div className="a-row group justify-between">
                 <Link
                   href={`/treatment/${c.id}`}
                   className="flex min-w-0 flex-1 items-center gap-3"

--- a/src/app/weekly/page.tsx
+++ b/src/app/weekly/page.tsx
@@ -57,7 +57,7 @@ export default function WeeklyListPage() {
           <li key={a.id}>
             <Link
               href={`/weekly/${a.id}`}
-              className="group flex items-center justify-between rounded-xl border border-ink-100/70 bg-paper-2 p-4 transition-colors hover:border-ink-300"
+              className="a-row group justify-between"
             >
               <div className="space-y-1">
                 <div className="text-sm font-medium text-ink-900">

--- a/src/components/shared/nav.tsx
+++ b/src/components/shared/nav.tsx
@@ -156,7 +156,7 @@ export function MobileBottomNav() {
       // The pill background extending into that zone is fine — iOS
       // draws the home indicator overlay on top, and our icons sit
       // well above it (~80 px from viewport bottom on PWA).
-      className="a-glass pwa-bottom-nav fixed inset-x-3 bottom-0 z-40 flex justify-around rounded-[22px] px-2 py-2.5 shadow-lg md:hidden"
+      className="a-glass pwa-bottom-nav fixed inset-x-3 bottom-0 z-40 flex justify-around rounded-lg px-2 py-2.5 shadow-lg md:hidden"
     >
       {mobileItems.map((item) => {
         const Icon = item.icon;
@@ -219,7 +219,7 @@ export function MobileMoreMenu() {
             className="absolute inset-0 bg-ink-900/30"
             onClick={() => setOpen(false)}
           />
-          <div className="absolute inset-x-3 top-3 rounded-[22px] bg-paper-2 p-4 shadow-xl">
+          <div className="absolute inset-x-3 top-3 rounded-lg bg-paper-2 p-4 shadow-xl">
             <div className="flex items-center justify-between">
               <div className="serif text-[17px] tracking-tight text-ink-900">
                 {locale === "zh" ? "导航" : "Navigate"}

--- a/src/components/treatment/cycle-calendar.tsx
+++ b/src/components/treatment/cycle-calendar.tsx
@@ -177,7 +177,7 @@ export function CycleCalendar({
                 aria-pressed={isSelected}
                 aria-label={tooltip}
                 title={tooltip}
-                className="relative flex aspect-square flex-col items-center justify-center rounded-[10px] transition-transform hover:scale-[1.03] focus:outline-none"
+                className="relative flex aspect-square flex-col items-center justify-center rounded-md transition-transform hover:scale-[1.03] focus:outline-none"
                 style={style}
               >
                 {content}
@@ -187,7 +187,7 @@ export function CycleCalendar({
           return (
             <div
               key={n}
-              className="relative flex aspect-square flex-col items-center justify-center rounded-[10px]"
+              className="relative flex aspect-square flex-col items-center justify-center rounded-md"
               style={style}
               title={tooltip}
             >

--- a/src/components/treatment/cycle-medications-card.tsx
+++ b/src/components/treatment/cycle-medications-card.tsx
@@ -112,13 +112,13 @@ function MedSection({
 }) {
   return (
     <section className="space-y-1.5">
-      <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-500">
+      <div className="eyebrow flex items-center gap-1.5">
         <Icon className="h-3 w-3" />
         {title}
-        <span className="mono text-[10px] text-ink-400">· {meds.length}</span>
+        <span className="text-ink-400">· {meds.length}</span>
       </div>
       {meds.length === 0 ? (
-        <div className="rounded-[var(--r-md)] border border-dashed border-ink-200 bg-paper px-3 py-2 text-[11.5px] text-ink-500">
+        <div className="rounded-md border border-dashed border-ink-200 bg-paper px-3 py-2 text-[11.5px] text-ink-500">
           {emptyLabel}
         </div>
       ) : (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -258,6 +258,30 @@ body {
   border: 0.5px solid rgba(20, 25, 40, 0.05);
 }
 
+/* a-row — the list-row card. Used for clickable list items that
+ * stand in for cards but stack densely (daily entries, treatment
+ * cycles, weekly/fortnightly assessments, etc.). Lighter than .a-card
+ * — single-pixel border, no shadow — so a stack of them reads as a
+ * list rather than a column of cards. The `group` modifier is
+ * applied at the call site so chevrons and other affordances can
+ * react on hover. */
+.a-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: var(--r-md);
+  border: 1px solid color-mix(in oklch, var(--ink-100), transparent 30%);
+  background: var(--paper-2);
+  padding: 1rem;
+  transition: border-color 120ms ease, background-color 120ms ease;
+}
+.a-row:hover {
+  border-color: var(--ink-300);
+}
+.a-row.dense {
+  padding: 0.75rem;
+}
+
 /* Horizon — subtle gradient line for section dividers */
 .a-horizon {
   height: 1px;


### PR DESCRIPTION
## Summary

A design audit + polish pass to align the app with `docs/UX_PRINCIPLES.md` and the existing token system in `src/styles/globals.css` / `tailwind.config.ts`. No behavioural changes — only visual consistency and reuse.

### What changed

- **New `.a-row` utility class** in `globals.css` for the repeated list-row pattern (`rounded-xl border border-ink-100/70 bg-paper-2 p-4 hover:...`). Replaces five+ near-duplicate implementations across daily / weekly / fortnightly / treatment / assessment / nutrition / safety pages, and standardises their corner radius onto the `--r-md` design token.
- **Eyebrow normalisation.** Inline `mono text-[10px] uppercase tracking-...` blocks replaced with the existing `.eyebrow` utility in history, log, tasks, prescriptions, ingest/pending, treatment/[id], and the cycle-medications card.
- **Buttons.** Ad-hoc danger and secondary-link styling on `treatment/[id]/page.tsx` and `labs/page.tsx` replaced with the shared `Button` component.
- **Border radii.** Off-token values (`rounded-[10px]`, `rounded-[22px]`) normalised to `rounded-md` / `rounded-lg` design tokens — affects the cycle calendar grid, mobile bottom nav pill, and lab clinical-note panels.
- **Page wrappers.** Standardised on `mx-auto max-w-* space-y-6 p-4 md:p-8` across settings, bridge, nutrition, safety pages, and treatment/new — class-order and padding now read identically.
- **Bridge ECOG explainer.** Custom `<div>` upgraded to `<Card>`; `font-bold` dropped from the grade indicator (per UX_PRINCIPLES "no celebratory typography").

### Files touched

24 files (22 page/component files + `globals.css` + the bridge Card refactor). +102 / −91.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 754 / 754 pass
- [ ] Visual smoke on `/`, `/daily`, `/weekly`, `/fortnightly`, `/treatment`, `/treatment/[id]`, `/assessment`, `/labs`, `/nutrition`, `/bridge`, `/safety`, `/safety/neutropenia`, `/safety/chemo-at-home`, `/settings`, `/log`, `/history`, `/tasks`, `/prescriptions`, `/ingest/pending`
- [ ] Confirm the mobile bottom-nav glass pill still has its rounded corners after the `rounded-[22px]` → `rounded-lg` change
- [ ] Confirm the cycle-day grid cells render correctly with `rounded-md`

https://claude.ai/code/session_01HxqbSuuF3wZ66HyAuzb6u6

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxqbSuuF3wZ66HyAuzb6u6)_