### PR TITLE
refactor: unify LocalizedText type + adopt postJson for remaining inline POSTs

### DIFF
--- a/src/lib/ingest/meal-vision.ts
+++ b/src/lib/ingest/meal-vision.ts
@@ -5,6 +5,7 @@ import {
   FALLBACK_HOUSEHOLD_PROFILE,
   type HouseholdProfile,
 } from "~/types/household-profile";
+import { postJson } from "~/lib/utils/http";
 
 export const MealSchema = z.object({
   description: z
@@ -60,14 +61,9 @@ export async function estimateMeal({
   model?: string;
   image: PreparedImage;
 }): Promise<MealEstimate> {
-  const res = await fetch("/api/ai/ingest-meal", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ image, model }),
-  });
-  if (!res.ok) {
-    throw new Error(await res.text());
-  }
-  const data = (await res.json()) as { result: MealEstimate };
+  const data = await postJson<{ result: MealEstimate }>(
+    "/api/ai/ingest-meal",
+    { image, model },
+  );
   return data.result;
 }

--- a/src/lib/legacy/ethical-will.ts
+++ b/src/lib/legacy/ethical-will.ts
@@ -1,4 +1,4 @@
-import type { LocalizedString } from "~/types/feed";
+import type { LocalizedText } from "~/types/localized";
 
 // Ethical will — guided composition scaffold.
 //
@@ -15,9 +15,9 @@ import type { LocalizedString } from "~/types/feed";
 
 export interface EthicalWillSection {
   key: string;
-  title: LocalizedString;
-  prompt: LocalizedString;
-  example?: LocalizedString;
+  title: LocalizedText;
+  prompt: LocalizedText;
+  example?: LocalizedText;
   optional?: boolean;
 }
 
@@ -72,7 +72,7 @@ export const ETHICAL_WILL_SECTIONS: EthicalWillSection[] = [
       en: "What I wish I had done differently",
       zh: "我希望当初另作选择的事",
       zh_fallback: "我希望当初另作选择的事",
-    } as LocalizedString,
+    } as LocalizedText,
     prompt: {
       en: "Are there apologies you'd like to offer, or things you'd wish to have done differently? Write only what you want to.",
       zh: "有哪些您想表达的歉意,或者希望当初另作选择的事?只写您愿意写的。",

--- a/src/lib/legacy/prompts-seed.ts
+++ b/src/lib/legacy/prompts-seed.ts
@@ -1,5 +1,5 @@
 import type { ProfilePrompt, PromptSource } from "~/types/legacy";
-import type { LocalizedString } from "~/types/feed";
+import type { LocalizedText } from "~/types/localized";
 
 // Seeded bilingual prompt library. ~120 prompts across seven evidence-
 // based frameworks plus a deliberate lightness band.
@@ -36,7 +36,7 @@ function p(
   source: PromptSource,
   sensitivity: ProfilePrompt["sensitivity"],
   cadence_weight: number,
-  question: LocalizedString,
+  question: LocalizedText,
   pair_id?: string,
 ): PromptSeed {
   return {

--- a/src/lib/log/run-agents.ts
+++ b/src/lib/log/run-agents.ts
@@ -9,6 +9,7 @@ import type {
 } from "~/types/agent";
 import type { Locale } from "~/types/clinical";
 import { agentsForTags } from "~/agents/routing";
+import { HttpError, postJson } from "~/lib/utils/http";
 
 // Client-side orchestration for running one specialist agent.
 // 1. Read state.md + recent feedback for this agent from Dexie
@@ -64,29 +65,24 @@ export async function runAgentClient(
     );
   }
 
-  const res = await fetch(`/api/agent/${args.agentId}/run`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
+  let body: { agent_id: AgentId; ran_at: string; output: AgentOutput };
+  try {
+    body = await postJson(`/api/agent/${args.agentId}/run`, {
       referrals,
       state_md: stateMd,
       recent_feedback: feedback,
       locale: args.locale,
       date: args.date,
       trigger: args.trigger,
-    }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`agent ${args.agentId} run failed: ${res.status} ${text}`);
+    });
+  } catch (err) {
+    if (err instanceof HttpError) {
+      throw new Error(
+        `agent ${args.agentId} run failed: ${err.status} ${err.body}`,
+      );
+    }
+    throw err;
   }
-
-  const body = (await res.json()) as {
-    agent_id: AgentId;
-    ran_at: string;
-    output: AgentOutput;
-  };
 
   const referralIds = referrals
     .map((r) => r.id)

--- a/src/lib/push/client.ts
+++ b/src/lib/push/client.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { HttpError, postJson } from "~/lib/utils/http";
+
 // Client-side push subscribe / unsubscribe / status. Wraps the
 // ServiceWorker + PushManager dance and the server round-trips so the
 // Settings UI stays tiny.
@@ -107,25 +109,23 @@ export async function enablePush(args: {
   }
 
   const json = sub.toJSON();
-  const body = {
-    endpoint: json.endpoint,
-    keys: json.keys,
-    user_agent: navigator.userAgent,
-    locale: args.locale,
-  };
-  const res = await fetch("/api/push/subscribe", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
+  try {
+    await postJson("/api/push/subscribe", {
+      endpoint: json.endpoint,
+      keys: json.keys,
+      user_agent: navigator.userAgent,
+      locale: args.locale,
+    });
+  } catch (err) {
     // Roll back the browser-side subscription if the server rejected.
     try {
       await sub.unsubscribe();
     } catch {
       // ignore
     }
-    return { ok: false, reason: (await res.text()) || "server-rejected" };
+    const reason =
+      err instanceof HttpError ? err.body || "server-rejected" : "server-rejected";
+    return { ok: false, reason };
   }
   return { ok: true, endpoint: json.endpoint ?? "" };
 }
@@ -139,12 +139,11 @@ export async function disablePush(): Promise<{ ok: true } | { ok: false; reason:
   } catch {
     // continue — server cleanup is still worth doing
   }
-  const res = await fetch("/api/push/unsubscribe", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ endpoint }),
-  });
-  if (!res.ok) return { ok: false, reason: "server-error" };
+  try {
+    await postJson("/api/push/unsubscribe", { endpoint });
+  } catch {
+    return { ok: false, reason: "server-error" };
+  }
   return { ok: true };
 }
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,4 +1,5 @@
-import type { FeedItem, LocalizedString } from "./feed";
+import type { FeedItem } from "./feed";
+import type { LocalizedText } from "./localized";
 import type { Locale } from "./clinical";
 
 // IDs of specialist agents. No triage agent — routing is deterministic
@@ -94,14 +95,14 @@ export interface DexiePatch {
 
 export interface SafetyFlag {
   level: "red" | "orange" | "yellow";
-  title: LocalizedString;
-  detail: LocalizedString;
+  title: LocalizedText;
+  detail: LocalizedText;
   rule_id?: string; // optional zone-rule id if mapped to the engine
 }
 
 export interface FollowUpQuestion {
   id: string; // stable id so the feed can dedup
-  prompt: LocalizedString;
+  prompt: LocalizedText;
   kind: "numeric" | "yesno" | "text" | "scale_0_10";
 }
 
@@ -112,7 +113,7 @@ export interface FollowUpQuestion {
 export interface AgentOutput {
   // Patient-facing morning brief for this batch — markdown narrative the
   // feed renders as the agent's daily report card.
-  daily_report: LocalizedString;
+  daily_report: LocalizedText;
   safety_flags: SafetyFlag[];
   filings: DexiePatch[];
   questions: FollowUpQuestion[];

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -1,4 +1,7 @@
-import type { Locale } from "./clinical";
+import type { LocalizedText } from "./localized";
+
+export { localize } from "./localized";
+export type { LocalizedText } from "./localized";
 
 export type FeedCategory =
   | "safety"
@@ -21,19 +24,14 @@ export type FeedCategory =
 
 export type FeedTone = "info" | "caution" | "warning" | "positive";
 
-export interface LocalizedString {
-  en: string;
-  zh: string;
-}
-
 export interface FeedItem {
   id: string;
   priority: number;
   category: FeedCategory;
   tone: FeedTone;
-  title: LocalizedString;
-  body: LocalizedString;
-  cta?: { href: string; label: LocalizedString };
+  title: LocalizedText;
+  body: LocalizedText;
+  cta?: { href: string; label: LocalizedText };
   icon?: string;
   source?: string;
   // Optional structured meta for sources that need to thread state back
@@ -47,7 +45,3 @@ export type AgentRunMeta = {
   agent_id: string;
   run_id: number;
 };
-
-export function localize(s: LocalizedString, locale: Locale): string {
-  return s[locale] ?? s.en;
-}

--- a/src/types/legacy.ts
+++ b/src/types/legacy.ts
@@ -6,7 +6,7 @@
 // and the singleton consent record that bounds future AI use.
 
 import type { EnteredBy, Locale } from "./clinical";
-import type { LocalizedString } from "./feed";
+import type { LocalizedText } from "./localized";
 
 export type ProfileEntryKind =
   | "voice_memo"
@@ -97,7 +97,7 @@ export interface ProfilePrompt {
   category: string;
   depth: PromptDepth;
   audience: PromptAudience;
-  question: LocalizedString;
+  question: LocalizedText;
   source: PromptSource;
   sensitivity: PromptSensitivity;
   /** 0..1. Higher = surfaces more often under the cadence engine. */

--- a/src/types/localized.ts
+++ b/src/types/localized.ts
@@ -1,0 +1,15 @@
+import type { Locale } from "./clinical";
+
+// Single source of truth for the bilingual text shape used across feed,
+// treatment, agent outputs, legacy, and medication metadata. Previously
+// duplicated as `LocalizedString` (feed.ts) and `LocalizedText`
+// (treatment.ts) with identical `{ en; zh }` bodies.
+
+export interface LocalizedText {
+  en: string;
+  zh: string;
+}
+
+export function localize(text: LocalizedText, locale: Locale): string {
+  return text[locale] ?? text.en;
+}

--- a/src/types/medication.ts
+++ b/src/types/medication.ts
@@ -1,4 +1,4 @@
-import type { LocalizedText } from "./treatment";
+import type { LocalizedText } from "./localized";
 import type { SourceSystem } from "./clinical";
 
 // Re-export so the medication module is self-contained for consumers.

--- a/src/types/treatment.ts
+++ b/src/types/treatment.ts
@@ -1,4 +1,7 @@
-import type { Locale, SourceSystem } from "./clinical";
+import type { SourceSystem } from "./clinical";
+import type { LocalizedText } from "./localized";
+
+export type { LocalizedText };
 
 export type ProtocolId =
   | "gnp_weekly"
@@ -30,11 +33,6 @@ export type PhaseKey =
   | "recovery_late"
   | "rest"
   | "pre_dose";
-
-export interface LocalizedText {
-  en: string;
-  zh: string;
-}
 
 export interface ProtocolAgent {
   id: string;
@@ -155,6 +153,3 @@ export function resolveProtocol(
   return library?.find((p) => p.id === id);
 }
 
-export function localized(text: LocalizedText, locale: Locale): string {
-  return text[locale] ?? text.en;
-}


### PR DESCRIPTION
## Summary

Two narrowly-scoped DRY wins surfaced by a code-debt audit. Skipped the larger candidates (1k-LoC component split, AI-route factory) per the project's "don't refactor for hypothetical futures" rule — those would have been speculative and high-regression-risk for marginal gain.

### 1. Unify the bilingual-text type

`LocalizedText` (treatment.ts) and `LocalizedString` (feed.ts) were two parallel definitions of the same `{ en: string; zh: string }` shape. They cross-cut feed, treatment, agent outputs, legacy, and medication metadata.

- New canonical `src/types/localized.ts` exporting `LocalizedText` + `localize()`
- Removed the duplicate definitions in `feed.ts` and `treatment.ts`
- Removed the dead `localized()` helper from `treatment.ts` (defined, never imported)
- Migrated the four `LocalizedString` callers (`agent.ts`, `legacy.ts`, `ethical-will.ts`, `prompts-seed.ts`) to the canonical name; dropped the `LocalizedString` alias entirely

`nutrition.ts` keeps its own `LocalizedString` — it has different semantics (`zh?` optional). Touching it would change behaviour, so out of scope.

### 2. Route remaining inline POSTs through `postJson()`

The `postJson` helper in `src/lib/utils/http.ts` was already widely adopted (~15 call sites) but four spots still hand-rolled the `method/headers/JSON.stringify/!res.ok/throw` boilerplate:

- `src/lib/log/run-agents.ts` — agent run dispatch
- `src/lib/ingest/meal-vision.ts` — meal vision endpoint
- `src/lib/push/client.ts` — subscribe + unsubscribe (preserved subscribe's rollback-on-failure semantics by catching `HttpError`)

Every client-side POST now shares the same `HttpError` shape. `sendTestPush` stays inline — it has no body and doesn't read the response, so `postJson` doesn't fit.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 754 tests pass (85 files)
- [x] `pnpm lint` clean
- [ ] Manual smoke of push subscribe/unsubscribe + agent run dispatch in dev (recommended before merging)

https://claude.ai/code/session_01WxJG5tNebJXjHErpu3dS2z

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxJG5tNebJXjHErpu3dS2z)_