### PR TITLE
Fix silent save failures and placeholder pollution in capture flows

### DIFF
--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -5,9 +5,11 @@ import { format } from "date-fns";
 import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
 import { useDefaultAiModel } from "~/hooks/use-settings";
+import { useUIStore } from "~/stores/ui-store";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
+import { Alert } from "~/components/ui/alert";
 import { CameraCapture } from "~/components/ingest/camera-capture";
 import {
   prepareImageForVision,
@@ -23,6 +25,7 @@ import { Sparkles, Check, Loader2 } from "lucide-react";
 export default function MealIngestPage() {
   const locale = useLocale();
   const model = useDefaultAiModel();
+  const enteredBy = useUIStore((s) => s.enteredBy);
 
   const [prepared, setPrepared] = useState<PreparedImage | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
@@ -31,6 +34,7 @@ export default function MealIngestPage() {
     null,
   );
   const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<{ proteinAdd: number } | null>(null);
 
   async function onPhoto(file: File) {
     reset();
@@ -64,6 +68,7 @@ export default function MealIngestPage() {
   async function saveToToday() {
     if (!estimate) return;
     setBusy("save");
+    setError(null);
     try {
       const today = todayISO();
       const existing = await db.daily_entries
@@ -79,39 +84,25 @@ export default function MealIngestPage() {
           updated_at: ts,
         });
       } else {
+        // Per DailyEntry's "every clinical field is optional" contract,
+        // only write what the patient actually provided. Stamping placeholder
+        // 5s for energy / mood / pain etc. would lie to the rule engine.
         await db.daily_entries.add({
           date: today,
           entered_at: ts,
-          entered_by: "hulin",
-          energy: 5,
-          sleep_quality: 5,
-          appetite: 5,
-          pain_worst: 0,
-          pain_current: 0,
-          mood_clarity: 5,
-          nausea: 0,
-          practice_morning_completed: false,
-          practice_evening_completed: false,
-          cold_dysaesthesia: false,
-          neuropathy_hands: 0,
-          neuropathy_feet: 0,
-          mouth_sores: false,
-          diarrhoea_count: 0,
-          new_bruising: false,
-          dyspnoea: false,
-          fever: false,
+          entered_by: enteredBy,
           protein_grams: proteinAdd,
           meals_count: 1,
           created_at: ts,
           updated_at: ts,
         });
       }
-      reset();
-      alert(
-        locale === "zh"
-          ? `已加入 ${proteinAdd} g 蛋白到今日记录`
-          : `Added ${proteinAdd} g protein to today's log`,
-      );
+      setPrepared(null);
+      setPreview(null);
+      setEstimate(null);
+      setSaved({ proteinAdd });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setBusy(null);
     }
@@ -122,6 +113,7 @@ export default function MealIngestPage() {
     setPreview(null);
     setEstimate(null);
     setError(null);
+    setSaved(null);
   }
 
   return (
@@ -138,7 +130,26 @@ export default function MealIngestPage() {
 
       <Card>
         <CardContent className="space-y-4 pt-5">
-          {!prepared && (
+          {saved && (
+            <Alert
+              variant="ok"
+              role="status"
+              title={locale === "zh" ? "已加入今日" : "Added to today"}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[13px]">
+                  {locale === "zh"
+                    ? `+ ${saved.proteinAdd} g 蛋白`
+                    : `+ ${saved.proteinAdd} g protein`}
+                </span>
+                <Button variant="ghost" onClick={reset}>
+                  {locale === "zh" ? "再拍一张" : "Snap another"}
+                </Button>
+              </div>
+            </Alert>
+          )}
+
+          {!prepared && !saved && (
             <div className="space-y-3">
               <CameraCapture
                 onPhoto={onPhoto}

--- a/src/app/ingest/notes/page.tsx
+++ b/src/app/ingest/notes/page.tsx
@@ -4,9 +4,11 @@ import { useState } from "react";
 import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
 import { useDefaultAiModel } from "~/hooks/use-settings";
+import { useUIStore } from "~/stores/ui-store";
 import { PageHeader } from "~/components/ui/page-header";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
+import { Alert } from "~/components/ui/alert";
 import { CameraCapture } from "~/components/ingest/camera-capture";
 import {
   prepareImageForVision,
@@ -24,6 +26,7 @@ type DailyPatch = NonNullable<NotesStructure["daily_patch"]>;
 export default function NotesIngestPage() {
   const locale = useLocale();
   const model = useDefaultAiModel();
+  const enteredBy = useUIStore((s) => s.enteredBy);
 
   const [prepared, setPrepared] = useState<PreparedImage | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
@@ -32,6 +35,7 @@ export default function NotesIngestPage() {
     null,
   );
   const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<{ fields: number } | null>(null);
 
   async function onPhoto(file: File) {
     reset();
@@ -65,9 +69,11 @@ export default function NotesIngestPage() {
   async function applyToToday() {
     if (!structured) return;
     setBusy("save");
+    setError(null);
     try {
       const today = todayISO();
       const patch = strip(structured.daily_patch);
+      const fieldCount = Object.keys(patch).length;
       const existing = await db.daily_entries
         .where("date")
         .equals(today)
@@ -79,38 +85,25 @@ export default function NotesIngestPage() {
           updated_at: ts,
         });
       } else {
+        // Per DailyEntry's "every clinical field is optional" contract,
+        // only write the fields the note actually contained. Stamping
+        // placeholder 5s for energy / mood / pain etc. would lie to the
+        // rule engine.
         await db.daily_entries.add({
           date: today,
           entered_at: ts,
-          entered_by: "hulin",
-          energy: 5,
-          sleep_quality: 5,
-          appetite: 5,
-          pain_worst: 0,
-          pain_current: 0,
-          mood_clarity: 5,
-          nausea: 0,
-          practice_morning_completed: false,
-          practice_evening_completed: false,
-          cold_dysaesthesia: false,
-          neuropathy_hands: 0,
-          neuropathy_feet: 0,
-          mouth_sores: false,
-          diarrhoea_count: 0,
-          new_bruising: false,
-          dyspnoea: false,
-          fever: false,
+          entered_by: enteredBy,
           ...patch,
           created_at: ts,
           updated_at: ts,
         });
       }
-      reset();
-      alert(
-        locale === "zh"
-          ? "已合并到今日记录"
-          : "Merged into today's daily entry",
-      );
+      setPrepared(null);
+      setPreview(null);
+      setStructured(null);
+      setSaved({ fields: fieldCount });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setBusy(null);
     }
@@ -121,6 +114,7 @@ export default function NotesIngestPage() {
     setPreview(null);
     setStructured(null);
     setError(null);
+    setSaved(null);
   }
 
   return (
@@ -139,7 +133,30 @@ export default function NotesIngestPage() {
 
       <Card>
         <CardContent className="space-y-4 pt-5">
-          {!prepared && (
+          {saved && (
+            <Alert
+              variant="ok"
+              role="status"
+              title={locale === "zh" ? "已合并到今日" : "Merged into today"}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[13px]">
+                  {saved.fields === 0
+                    ? locale === "zh"
+                      ? "未识别到结构化字段"
+                      : "No structured fields detected"
+                    : locale === "zh"
+                      ? `已映射 ${saved.fields} 个字段`
+                      : `${saved.fields} field${saved.fields === 1 ? "" : "s"} mapped`}
+                </span>
+                <Button variant="ghost" onClick={reset}>
+                  {locale === "zh" ? "再拍一张" : "Snap another"}
+                </Button>
+              </div>
+            </Alert>
+          )}
+
+          {!prepared && !saved && (
             <div className="space-y-3">
               <CameraCapture
                 onPhoto={onPhoto}

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -373,7 +373,7 @@ export default function LogPage() {
         )}
 
         <div className="mt-5 flex items-center justify-between gap-3">
-          {run.kind === "done" ? (
+          {run.kind === "done" || run.kind === "filed" ? (
             <>
               <Button variant="ghost" onClick={() => router.push("/")}>
                 <ArrowLeft className="h-4 w-4" />

--- a/src/app/nutrition/log/page.tsx
+++ b/src/app/nutrition/log/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { ArrowLeft, Check, Sparkles, Clock, Loader2 } from "lucide-react";
 import { todayISO } from "~/lib/utils/date";
 import { useLocale } from "~/hooks/use-translate";
+import { useUIStore } from "~/stores/ui-store";
 import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/field";
@@ -32,6 +33,7 @@ interface PendingItem {
 export default function LogMealPage() {
   const router = useRouter();
   const locale = useLocale();
+  const enteredBy = useUIStore((s) => s.enteredBy);
   const [parsed, setParsed] = useState<ParsedMealResult | null>(null);
   const [photoUrl, setPhotoUrl] = useState<string | undefined>(undefined);
   const [parsedSource, setParsedSource] = useState<"photo" | "text">("text");
@@ -81,7 +83,7 @@ export default function LogMealPage() {
         source: "photo",
         confidence: result.confidence,
         pert_taken: false,
-        entered_by: "hulin",
+        entered_by: enteredBy,
         // Parser emits per-eaten-serving macros; createMeal expects
         // per-100 g. Bridge through parsedItemToInline so the values
         // round-trip into meal_items at the right magnitude.
@@ -112,7 +114,7 @@ export default function LogMealPage() {
         source: parsedSource,
         confidence: data.confidence,
         pert_taken: data.pert_taken,
-        entered_by: "hulin",
+        entered_by: enteredBy,
         items: data.items.map((it) => {
           if (it.food_id && it.food_match) {
             return {
@@ -154,7 +156,7 @@ export default function LogMealPage() {
         logged_at: assembleLoggedAt(todayISO(), mealTime),
         notes: manualNotes || undefined,
         source: "manual",
-        entered_by: "hulin",
+        entered_by: enteredBy,
         items: manualItems.map((p) => ({
           kind: "food" as const,
           food: p.food,

--- a/src/components/daily/daily-wizard.tsx
+++ b/src/components/daily/daily-wizard.tsx
@@ -213,6 +213,10 @@ export function DailyWizard({ entryId, date }: Props) {
   );
   const [cursor, setCursor] = useState(0);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  // After a successful add we capture the new row id so a retry (e.g. user
+  // hits Save again after an engine warning) updates instead of duplicating.
+  const [savedId, setSavedId] = useState<number | undefined>(undefined);
 
   useEffect(() => {
     if (existing) {
@@ -298,6 +302,7 @@ export function DailyWizard({ entryId, date }: Props) {
 
   async function save() {
     setSaving(true);
+    setSaveError(null);
     try {
       const { getCachedUserId } = await import("~/lib/supabase/current-user");
       const uid = getCachedUserId();
@@ -309,13 +314,17 @@ export function DailyWizard({ entryId, date }: Props) {
         entered_at: existing?.entered_at ?? now(),
         updated_at: now(),
       };
-      if (entryId) {
-        await db.daily_entries.update(entryId, base);
+      // Persist the entry first. If this throws the user can retry without
+      // a duplicate row being created.
+      const targetId = entryId ?? savedId;
+      if (targetId) {
+        await db.daily_entries.update(targetId, base);
       } else {
-        await db.daily_entries.add({
+        const newId = await db.daily_entries.add({
           ...(base as DailyEntry),
           created_at: now(),
         });
+        setSavedId(newId);
       }
 
       // Stamp the symptom baseline the first time a check-in writes to
@@ -341,8 +350,23 @@ export function DailyWizard({ entryId, date }: Props) {
         }
       }
 
-      await runEngineAndPersist();
+      // Engine evaluation is best-effort — entry is already saved, so a
+      // failure here must not abort navigation or re-throw to React.
+      try {
+        await runEngineAndPersist();
+      } catch (engineErr) {
+        // eslint-disable-next-line no-console
+        console.warn("[daily-wizard] engine evaluation failed", engineErr);
+      }
       router.push("/daily");
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[daily-wizard] save failed", err);
+      setSaveError(
+        locale === "zh"
+          ? "保存失败，请再试一次。"
+          : "Couldn't save — please try again.",
+      );
     } finally {
       setSaving(false);
     }
@@ -385,6 +409,7 @@ export function DailyWizard({ entryId, date }: Props) {
       picked={picked}
       draft={draft}
       saving={saving}
+      saveError={saveError}
       onResume={(id) => {
         const idx = picked.indexOf(id);
         if (idx >= 0) {
@@ -1073,6 +1098,7 @@ function ReviewScreen({
   picked,
   draft,
   saving,
+  saveError,
   onResume,
   onAddMore,
   onSave,
@@ -1081,6 +1107,7 @@ function ReviewScreen({
   picked: CatId[];
   draft: Draft;
   saving: boolean;
+  saveError: string | null;
   onResume: (id: CatId) => void;
   onAddMore: () => void;
   onSave: () => void;
@@ -1155,6 +1182,15 @@ function ReviewScreen({
           )}
         </CardContent>
       </Card>
+
+      {saveError && (
+        <div
+          role="alert"
+          className="rounded-md border border-[var(--warn)]/40 bg-[var(--warn-soft)] p-2.5 text-xs text-[var(--warn)]"
+        >
+          {saveError}
+        </div>
+      )}
 
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <Button variant="ghost" onClick={onAddMore}>

--- a/src/components/nutrition/hydration-card.tsx
+++ b/src/components/nutrition/hydration-card.tsx
@@ -15,6 +15,7 @@ import {
 import { Card, CardContent } from "~/components/ui/card";
 import { TargetBar } from "./macro-bar";
 import { useLocale, useL } from "~/hooks/use-translate";
+import { useUIStore } from "~/stores/ui-store";
 import { cn } from "~/lib/utils/cn";
 import type { FluidKind } from "~/types/nutrition";
 
@@ -23,6 +24,7 @@ import type { FluidKind } from "~/types/nutrition";
 // target, and a collapsible list of today's swallow events.
 export function HydrationCard({ date }: { date: string }) {
   const locale = useLocale();
+  const enteredBy = useUIStore((s) => s.enteredBy);
   const fluidsRaw = useLiveQuery(
     async () => listFluidsForDate(date),
     [date],
@@ -67,7 +69,7 @@ export function HydrationCard({ date }: { date: string }) {
                   date,
                   kind: preset.kind,
                   volume_ml: preset.volume_ml,
-                  entered_by: "hulin",
+                  entered_by: enteredBy,
                 })
               }
               className="inline-flex items-center gap-1.5 rounded-full border border-ink-200 bg-paper px-2.5 py-1 text-[11px] text-ink-700 hover:border-ink-300 hover:bg-paper-2/60"
@@ -124,7 +126,7 @@ export function HydrationCard({ date }: { date: string }) {
                   date,
                   kind: customKind,
                   volume_ml: customMl,
-                  entered_by: "hulin",
+                  entered_by: enteredBy,
                 });
                 setOpen(false);
               }}

--- a/src/components/nutrition/meal-list.tsx
+++ b/src/components/nutrition/meal-list.tsx
@@ -15,6 +15,7 @@ import { todayISO } from "~/lib/utils/date";
 import { Card } from "~/components/ui/card";
 import { cn } from "~/lib/utils/cn";
 import { useLocale } from "~/hooks/use-translate";
+import { useUIStore } from "~/stores/ui-store";
 import type { MealType } from "~/types/nutrition";
 
 const ORDER: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
@@ -60,6 +61,7 @@ export function MealList({ date }: { date: string }) {
 
 function MealCard({ mealId }: { mealId: number }) {
   const locale = useLocale();
+  const enteredBy = useUIStore((s) => s.enteredBy);
   const [open, setOpen] = useState(false);
   const items =
     useLiveQuery(async () => listItemsForMeal(mealId), [mealId]) ?? [];
@@ -166,7 +168,7 @@ function MealCard({ mealId }: { mealId: number }) {
                 await relogMeal({
                   source_meal_id: mealId,
                   date: todayISO(),
-                  entered_by: "hulin",
+                  entered_by: enteredBy,
                 });
               }}
               className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-ink-500 hover:bg-ink-100 hover:text-ink-900"

--- a/src/components/nutrition/templates-picker.tsx
+++ b/src/components/nutrition/templates-picker.tsx
@@ -9,6 +9,7 @@ import {
   logTemplate,
 } from "~/lib/nutrition/templates";
 import { useLocale, pickL } from "~/hooks/use-translate";
+import { useUIStore } from "~/stores/ui-store";
 import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils/cn";
@@ -27,6 +28,7 @@ export function TemplatesPicker({
   onLogged: (meal_id: number) => void;
 }) {
   const locale = useLocale();
+  const enteredBy = useUIStore((s) => s.enteredBy);
   const [order, setOrder] = useState<"recent" | "favourites">("recent");
   const templates =
     useLiveQuery(
@@ -82,7 +84,7 @@ export function TemplatesPicker({
                   template_id: t.id!,
                   date,
                   meal_type,
-                  entered_by: "hulin",
+                  entered_by: enteredBy,
                 });
                 onLogged(id);
               }}


### PR DESCRIPTION
## Summary

UX pass over the capture surfaces. The patient-facing flows had a few places where errors disappeared into `finally` blocks, success states left forms primed for accidental re-submission, and the meal / notes ingest paths quietly lied to the rule engine by stamping placeholder `5`s for energy / mood / pain when seeding a new daily entry.

## What changed

- **Daily wizard** (`src/components/daily/daily-wizard.tsx`): the `save()` path was a single try/finally that re-threw on failure — engine errors stranded the patient on the review screen with no message and no navigation, and a retry could create a duplicate `daily_entries` row. Now: save errors surface as an inline alert; engine evaluation is best-effort and never aborts navigation; the new row id is captured locally so retries become updates.
- **/log page** (`src/app/log/page.tsx`): after a `filed` direct-file save (e.g. "blood sugar 7.9"), the form previously kept the text + tags and showed the original Cancel / Log buttons, inviting a duplicate submission. It now mirrors the agent-run `done` state with Back to home / Log another.
- **Ingest meal + notes** (`src/app/ingest/{meal,notes}/page.tsx`):
  - Replaced the `alert()` popup with an inline `Alert` success card.
  - Plumbed `enteredBy` from the UI store instead of the hardcoded `"hulin"` literal.
  - Stopped stamping placeholder defaults (`energy: 5`, `pain: 0`, etc.) when seeding a new `daily_entries` row. Per the schema's "every clinical field is optional" contract, undefined means "not entered today" — those fake 5s polluted the rule engine for any patient whose first capture of the day was a meal photo or a notes scan.
- **Nutrition logging** (`hydration-card.tsx`, `meal-list.tsx`, `templates-picker.tsx`, `app/nutrition/log/page.tsx`): same `entered_by: "hulin"` literal removed in favour of the store value, so caregiver-mode logs are now attributed to the caregiver.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 754 / 754 passing
- [x] `pnpm build` clean
- [ ] Manual: open daily wizard with picked categories, kill the engine import, confirm the inline error appears and a retry doesn't duplicate the row
- [ ] Manual: log a direct-file value via /log ("weight 64 kg"), confirm the form clears to the Back-to-home / Log-another state
- [ ] Manual: snap a meal photo before any check-in exists for today, confirm the new daily_entries row only carries `protein_grams` / `meals_count` (no fake 5s)

https://claude.ai/code/session_015iDazsA8PdQPd4e5AFr1uh

---
_Generated by [Claude Code](https://claude.ai/code/session_015iDazsA8PdQPd4e5AFr1uh)_