### PR TITLE
Voice-first /log, library/file photo uploads, Melbourne oncologist picker

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { db } from "~/lib/db/dexie";
 import { todayISO } from "~/lib/utils/date";
@@ -15,11 +15,20 @@ import { useUIStore } from "~/stores/ui-store";
 import { LOG_TAGS, type AgentId, type LogTag } from "~/types/agent";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
-import { Field, Textarea } from "~/components/ui/field";
+import { Textarea } from "~/components/ui/field";
 import { Alert } from "~/components/ui/alert";
 import { PageHeader } from "~/components/ui/page-header";
 import { cn } from "~/lib/utils/cn";
-import { Send, Sparkles, Check, Loader2, ArrowLeft, Mic, MicOff } from "lucide-react";
+import {
+  Send,
+  Sparkles,
+  Check,
+  Loader2,
+  ArrowLeft,
+  Mic,
+  MicOff,
+  Keyboard,
+} from "lucide-react";
 import { useSpeechRecognition } from "~/hooks/use-speech-recognition";
 
 const TAG_LABELS: Record<LogTag, { en: string; zh: string }> = {
@@ -74,6 +83,13 @@ export default function LogPage() {
   const [text, setText] = useState("");
   const [overrideTags, setOverrideTags] = useState<Set<LogTag> | null>(null);
   const [run, setRun] = useState<RunState>({ kind: "idle" });
+  // The page is voice-first by default. Patients who prefer typing flip
+  // this once and the surface stays in keyboard mode for the session.
+  const [editMode, setEditMode] = useState(false);
+  // Auto-start dictation on mount, but only on the first arrival. If the
+  // user stops listening or switches to typing we do not silently
+  // restart, because that would feel like the page is hijacking input.
+  const autoStartedRef = useRef(false);
 
   const enteredBy = useUIStore((s) => s.enteredBy);
 
@@ -81,11 +97,23 @@ export default function LogPage() {
   // patient can correct what was heard before submitting. Mandarin
   // uses zh-CN; everything else en-US. The hook returns null on
   // browsers that don't expose SpeechRecognition (older Firefox,
-  // some webviews) so the button is hidden cleanly when unsupported.
+  // some webviews) so we fall back to a plain textarea cleanly.
   const speech = useSpeechRecognition({
     lang: locale === "zh" ? "zh-CN" : "en-US",
     onFinal: (chunk) => setText((cur) => `${cur} ${chunk}`.trim()),
   });
+
+  useEffect(() => {
+    if (!speech) return;
+    if (autoStartedRef.current) return;
+    if (editMode) return;
+    autoStartedRef.current = true;
+    // Safari needs a user gesture for SpeechRecognition.start(). Tapping
+    // the FAB item to land here counts on most browsers; if it doesn't,
+    // the hook's start() swallows the error and the patient sees an
+    // idle mic button that they can tap manually.
+    speech.start();
+  }, [speech, editMode]);
 
   const autoTags = useMemo(() => new Set(tagInput(text)), [text]);
   const tags = overrideTags ?? autoTags;
@@ -188,6 +216,8 @@ export default function LogPage() {
     setText("");
     setOverrideTags(null);
     setRun({ kind: "idle" });
+    speech?.reset();
+    autoStartedRef.current = false;
   }
 
   // A direct-filed value bypasses the agent requirement.
@@ -208,50 +238,31 @@ export default function LogPage() {
       />
 
       <Card className="p-5">
-        <Field label={locale === "zh" ? "记录" : "Log"}>
-          <div className="relative">
-            <Textarea
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              rows={5}
-              disabled={run.kind === "saving" || run.kind === "running"}
-              placeholder={
-                locale === "zh"
-                  ? "例如：早餐吃了两个鸡蛋，约 16 克蛋白；右手指尖比昨天更麻"
-                  : "e.g. two eggs at breakfast, ~16 g protein; right fingertips more numb than yesterday"
-              }
-              className="min-h-[140px] pr-12 text-base"
-            />
-            {speech && (
-              <button
-                type="button"
-                onClick={speech.toggle}
-                disabled={run.kind === "saving" || run.kind === "running"}
-                className={cn(
-                  "absolute bottom-2 right-2 inline-flex h-9 w-9 items-center justify-center rounded-full transition-colors",
-                  speech.listening
-                    ? "bg-[var(--warn,#d97706)] text-white"
-                    : "bg-ink-100 text-ink-700 hover:bg-ink-200",
-                )}
-                aria-label={
-                  speech.listening
-                    ? locale === "zh"
-                      ? "停止录音"
-                      : "Stop dictation"
-                    : locale === "zh"
-                      ? "开始录音"
-                      : "Start dictation"
-                }
-              >
-                {speech.listening ? (
-                  <MicOff className="h-4 w-4" />
-                ) : (
-                  <Mic className="h-4 w-4" />
-                )}
-              </button>
-            )}
-          </div>
-        </Field>
+        {speech && !editMode ? (
+          <VoiceCapture
+            speech={speech}
+            text={text}
+            setText={setText}
+            disabled={run.kind === "saving" || run.kind === "running"}
+            locale={locale}
+            onSwitchToTyping={() => {
+              speech.stop();
+              setEditMode(true);
+            }}
+          />
+        ) : (
+          <TypingCapture
+            text={text}
+            setText={setText}
+            disabled={run.kind === "saving" || run.kind === "running"}
+            locale={locale}
+            canSwitchToVoice={Boolean(speech)}
+            onSwitchToVoice={() => {
+              setEditMode(false);
+              autoStartedRef.current = false;
+            }}
+          />
+        )}
 
         <div className="mt-4">
           <div className="eyebrow mb-1.5">
@@ -407,9 +418,171 @@ export default function LogPage() {
 
       <p className="text-center text-[11px] text-ink-400">
         {locale === "zh"
-          ? "也支持语音输入。需要拍照/上传文件请到「智能识别」。"
-          : "Voice dictation works. For photos or document uploads, use Smart Ingest."}
+          ? "默认语音输入，可随时切换打字。需要拍照/上传文件请到「智能识别」。"
+          : "Voice by default — switch to typing anytime. For photos or document uploads, use Smart Ingest."}
       </p>
+    </div>
+  );
+}
+
+function VoiceCapture({
+  speech,
+  text,
+  setText,
+  disabled,
+  locale,
+  onSwitchToTyping,
+}: {
+  speech: NonNullable<ReturnType<typeof useSpeechRecognition>>;
+  text: string;
+  setText: (v: string) => void;
+  disabled: boolean;
+  locale: "en" | "zh";
+  onSwitchToTyping: () => void;
+}) {
+  // While listening, the hook's `transcript` carries the in-flight
+  // interim words. Final chunks have already flowed into `text` via
+  // `onFinal`, so we strip the prefix overlap and append only the
+  // unsettled tail to avoid double-rendering.
+  const interimTail = useMemo(() => {
+    if (!speech.listening) return "";
+    const t = speech.transcript.trim();
+    if (!t) return "";
+    if (text && t.startsWith(text.trim())) return t.slice(text.trim().length).trim();
+    return t;
+  }, [speech.listening, speech.transcript, text]);
+
+  return (
+    <div>
+      <div className="flex flex-col items-center gap-3">
+        <button
+          type="button"
+          onClick={speech.toggle}
+          disabled={disabled}
+          aria-label={
+            speech.listening
+              ? locale === "zh" ? "停止录音" : "Stop recording"
+              : locale === "zh" ? "开始录音" : "Start recording"
+          }
+          aria-pressed={speech.listening}
+          className={cn(
+            "relative flex h-20 w-20 items-center justify-center rounded-full shadow-md transition-all",
+            speech.listening
+              ? "bg-[var(--warn,#d97706)] text-white"
+              : "bg-ink-900 text-paper hover:scale-105",
+            disabled && "opacity-50",
+          )}
+        >
+          {speech.listening && (
+            <span className="absolute inset-0 animate-ping rounded-full bg-[var(--warn,#d97706)]/40" />
+          )}
+          {speech.listening ? (
+            <MicOff className="relative h-7 w-7" />
+          ) : (
+            <Mic className="relative h-7 w-7" />
+          )}
+        </button>
+        <div className="text-[12px] text-ink-500" aria-live="polite">
+          {speech.listening
+            ? locale === "zh" ? "正在听…轻点停止" : "Listening — tap to stop"
+            : text.trim()
+              ? locale === "zh" ? "再次轻点继续录音" : "Tap to keep recording"
+              : locale === "zh" ? "轻点麦克风开始" : "Tap the mic to start"}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="eyebrow mb-1.5">
+          {locale === "zh" ? "听到的内容" : "Transcript"}
+        </div>
+        <Textarea
+          value={text + (interimTail ? (text ? " " : "") + interimTail : "")}
+          onChange={(e) => setText(e.target.value)}
+          rows={5}
+          disabled={disabled}
+          placeholder={
+            locale === "zh"
+              ? "例如：早餐吃了两个鸡蛋，约 16 克蛋白；右手指尖比昨天更麻"
+              : "e.g. two eggs at breakfast, ~16 g protein; right fingertips more numb than yesterday"
+          }
+          className="min-h-[120px] text-base"
+        />
+        <p className="mt-1.5 text-[11px] text-ink-400">
+          {locale === "zh"
+            ? "可以随时编辑听到的内容。"
+            : "You can edit the transcript anytime."}
+        </p>
+      </div>
+
+      {speech.error && (
+        <Alert variant="warn" role="alert" className="mt-3">
+          {locale === "zh"
+            ? `语音识别出错：${speech.error}`
+            : `Speech recognition error: ${speech.error}`}
+        </Alert>
+      )}
+
+      <div className="mt-3 flex justify-end">
+        <button
+          type="button"
+          onClick={onSwitchToTyping}
+          disabled={disabled}
+          className="inline-flex items-center gap-1.5 text-[12px] text-ink-500 hover:text-ink-900"
+        >
+          <Keyboard className="h-3.5 w-3.5" />
+          {locale === "zh" ? "改用打字" : "Type instead"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function TypingCapture({
+  text,
+  setText,
+  disabled,
+  locale,
+  canSwitchToVoice,
+  onSwitchToVoice,
+}: {
+  text: string;
+  setText: (v: string) => void;
+  disabled: boolean;
+  locale: "en" | "zh";
+  canSwitchToVoice: boolean;
+  onSwitchToVoice: () => void;
+}) {
+  return (
+    <div>
+      <div className="eyebrow mb-1.5">
+        {locale === "zh" ? "记录" : "Log"}
+      </div>
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={5}
+        disabled={disabled}
+        placeholder={
+          locale === "zh"
+            ? "例如：早餐吃了两个鸡蛋，约 16 克蛋白；右手指尖比昨天更麻"
+            : "e.g. two eggs at breakfast, ~16 g protein; right fingertips more numb than yesterday"
+        }
+        className="min-h-[140px] text-base"
+        autoFocus
+      />
+      {canSwitchToVoice && (
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            onClick={onSwitchToVoice}
+            disabled={disabled}
+            className="inline-flex items-center gap-1.5 text-[12px] text-ink-500 hover:text-ink-900"
+          >
+            <Mic className="h-3.5 w-3.5" />
+            {locale === "zh" ? "改用语音" : "Use voice"}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/nutrition/foods/page.tsx
+++ b/src/app/nutrition/foods/page.tsx
@@ -592,7 +592,6 @@ function PhotoField({
         ref={ref}
         type="file"
         accept="image/*"
-        capture="environment"
         hidden
         onChange={(e) => {
           const f = e.target.files?.[0];

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -9,9 +9,14 @@ import { useSettings } from "~/hooks/use-settings";
 import { useUIStore } from "~/stores/ui-store";
 import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
-import { Field, TextInput, Textarea } from "~/components/ui/field";
+import { Field, Select, TextInput, Textarea } from "~/components/ui/field";
 import { Alert } from "~/components/ui/alert";
 import { PROTOCOL_LIBRARY, PROTOCOL_BY_ID } from "~/config/protocols";
+import {
+  MELBOURNE_ONCOLOGISTS,
+  HOSPITAL_BY_ID,
+  ONCOLOGIST_BY_ID,
+} from "~/config/oncologists";
 import type { ProtocolId } from "~/types/treatment";
 import type { Locale, Settings } from "~/types/clinical";
 import {
@@ -977,6 +982,31 @@ function TeamStep({
   update: <K extends keyof FormState>(k: K, v: FormState[K]) => void;
   locale: Locale;
 }) {
+  // Match the typed name back to the seed list so re-entering this
+  // step shows the correct selection. Fall back to "" (custom).
+  const pickedId =
+    MELBOURNE_ONCOLOGISTS.find((o) => o.name.en === form.managing_oncologist)
+      ?.id ?? "";
+
+  function pickOncologist(id: string) {
+    if (!id) {
+      // "Other / type my own" — clear the seeded fields so the user
+      // can enter their own without overwriting any in-progress edit.
+      update("managing_oncologist", "");
+      return;
+    }
+    const onc = ONCOLOGIST_BY_ID[id];
+    if (!onc) return;
+    const hosp = HOSPITAL_BY_ID[onc.hospital_id];
+    update("managing_oncologist", onc.name[locale] ?? onc.name.en);
+    if (hosp) {
+      update("hospital_name", hosp.name[locale] ?? hosp.name.en);
+      update("hospital_phone", hosp.phone);
+      update("hospital_address", hosp.address);
+      if (hosp.oncall_phone) update("oncall_phone", hosp.oncall_phone);
+    }
+  }
+
   return (
     <Card className="p-6 space-y-4">
       <div>
@@ -989,6 +1019,41 @@ function TeamStep({
             : "These numbers appear on the emergency card when a red-zone alert fires."}
         </p>
       </div>
+      <Field
+        label={
+          locale === "zh"
+            ? "从墨尔本肿瘤科医师中选择（可选）"
+            : "Pick a Melbourne oncologist (optional)"
+        }
+        hint={
+          locale === "zh"
+            ? "选定后会自动填写医院信息，可再次修改。"
+            : "Selecting prefills the hospital details — you can edit any field after."
+        }
+      >
+        <Select
+          value={pickedId}
+          onChange={(e) => pickOncologist(e.target.value)}
+        >
+          <option value="">
+            {locale === "zh"
+              ? "其他 / 自行输入"
+              : "Other / type my own"}
+          </option>
+          {MELBOURNE_ONCOLOGISTS.map((o) => {
+            const hosp = HOSPITAL_BY_ID[o.hospital_id];
+            const where = hosp
+              ? (hosp.name[locale] ?? hosp.name.en)
+              : "";
+            return (
+              <option key={o.id} value={o.id}>
+                {(o.name[locale] ?? o.name.en) +
+                  (where ? ` — ${where}` : "")}
+              </option>
+            );
+          })}
+        </Select>
+      </Field>
       <div className="grid gap-3 sm:grid-cols-2">
         <Field label={locale === "zh" ? "主诊肿瘤科医师" : "Managing oncologist"}>
           <TextInput

--- a/src/app/schedule/new/page.tsx
+++ b/src/app/schedule/new/page.tsx
@@ -191,7 +191,6 @@ function SmartEntry({
           <input
             type="file"
             accept="image/*"
-            capture="environment"
             className="hidden"
             disabled={busy}
             onChange={(e) => {

--- a/src/components/ingest/camera-capture.tsx
+++ b/src/components/ingest/camera-capture.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useRef } from "react";
-import { Camera } from "lucide-react";
+import { ImagePlus } from "lucide-react";
 import { useLocale } from "~/hooks/use-translate";
 
+// On iOS/Android, omitting `capture` causes the native picker to offer
+// camera + photo library + files in one sheet. Forcing capture would
+// shut out gallery/file uploads entirely.
 export function CameraCapture({
   onPhoto,
   accept = "image/*",
@@ -21,13 +24,11 @@ export function CameraCapture({
         ref={inputRef}
         type="file"
         accept={accept}
-        capture="environment"
         className="hidden"
         onChange={(e) => {
           const f = e.target.files?.[0];
           if (f) {
             onPhoto(f);
-            // reset so the same photo can be selected again
             e.target.value = "";
           }
         }}
@@ -37,8 +38,8 @@ export function CameraCapture({
         onClick={() => inputRef.current?.click()}
         className="inline-flex items-center gap-2 rounded-md bg-ink-900 px-4 py-2 text-sm font-medium text-paper transition-colors hover:bg-ink-700"
       >
-        <Camera className="h-4 w-4" />
-        {label ?? (locale === "zh" ? "拍照" : "Take photo")}
+        <ImagePlus className="h-4 w-4" />
+        {label ?? (locale === "zh" ? "添加照片" : "Add photo")}
       </button>
     </>
   );

--- a/src/components/nutrition/meal-ingest.tsx
+++ b/src/components/nutrition/meal-ingest.tsx
@@ -113,7 +113,6 @@ export function MealIngest({
               ref={fileRef}
               type="file"
               accept="image/*"
-              capture="environment"
               hidden
               onChange={(e) => {
                 const f = e.target.files?.[0];

--- a/src/config/oncologists.ts
+++ b/src/config/oncologists.ts
@@ -1,0 +1,148 @@
+// Pre-fill data for the onboarding "Clinical team" step. Lets the
+// patient pick a known Melbourne medical oncologist (with GI / pancreas
+// involvement) and have the hospital, switchboard, and address
+// populated from a fixed table of public institutional numbers.
+//
+// Everything here is editable downstream — the picker only seeds the
+// fields. If a user picks "Other", the fields stay blank for them to
+// type. Direct office numbers are not seeded because they vary by
+// secretary; the user fills them in if they have them on hand.
+
+export interface MelbourneHospital {
+  id: string;
+  name: { en: string; zh: string };
+  phone: string;
+  address: string;
+  // 24/7 on-call number when the hospital publishes one distinct from
+  // the main switchboard (e.g. cancer helpline, ED direct).
+  oncall_phone?: string;
+}
+
+export interface MelbourneOncologist {
+  id: string;
+  name: { en: string; zh: string };
+  // Primary hospital affiliation used to pre-fill hospital fields. Some
+  // clinicians work across multiple sites; this is the dominant one for
+  // GI / pancreas care.
+  hospital_id: string;
+  // Optional secondary affiliation shown in the picker label.
+  also_at?: string;
+  specialty: { en: string; zh: string };
+}
+
+export const MELBOURNE_HOSPITALS: MelbourneHospital[] = [
+  {
+    id: "peter_mac",
+    name: { en: "Peter MacCallum Cancer Centre", zh: "彼得麦卡伦癌症中心" },
+    phone: "+61 3 8559 5000",
+    address: "305 Grattan St, Melbourne VIC 3000",
+  },
+  {
+    id: "austin_onj",
+    name: {
+      en: "Austin Health — Olivia Newton-John Cancer Centre",
+      zh: "Austin 医院 — ONJ 癌症中心",
+    },
+    phone: "+61 3 9496 5000",
+    address: "145 Studley Rd, Heidelberg VIC 3084",
+  },
+  {
+    id: "rmh",
+    name: { en: "Royal Melbourne Hospital", zh: "皇家墨尔本医院" },
+    phone: "+61 3 9342 7000",
+    address: "300 Grattan St, Parkville VIC 3050",
+  },
+  {
+    id: "western_sunshine",
+    name: {
+      en: "Western Health — Sunshine Hospital",
+      zh: "Western Health — Sunshine 医院",
+    },
+    phone: "+61 3 8345 1333",
+    address: "176 Furlong Rd, St Albans VIC 3021",
+  },
+  {
+    id: "eastern_box_hill",
+    name: {
+      en: "Eastern Health — Box Hill Hospital",
+      zh: "Eastern Health — Box Hill 医院",
+    },
+    phone: "+61 3 9095 2222",
+    address: "8 Arnold St, Box Hill VIC 3128",
+  },
+  {
+    id: "epworth_freemasons",
+    name: { en: "Epworth Freemasons", zh: "Epworth Freemasons" },
+    phone: "+61 3 9418 8188",
+    address: "320 Victoria Pde, East Melbourne VIC 3002",
+  },
+  {
+    id: "epworth_richmond",
+    name: { en: "Epworth Richmond", zh: "Epworth Richmond" },
+    phone: "+61 3 9426 6666",
+    address: "89 Bridge Rd, Richmond VIC 3121",
+  },
+  {
+    id: "northern",
+    name: { en: "Northern Hospital Epping", zh: "Northern 医院 Epping" },
+    phone: "+61 3 8405 8000",
+    address: "185 Cooper St, Epping VIC 3076",
+  },
+];
+
+export const MELBOURNE_ONCOLOGISTS: MelbourneOncologist[] = [
+  {
+    id: "ananda_s",
+    name: { en: "A/Prof Sumitra Ananda", zh: "Sumitra Ananda 副教授" },
+    hospital_id: "peter_mac",
+    also_at: "Epworth Freemasons",
+    specialty: { en: "GI / pancreas", zh: "消化道 / 胰腺" },
+  },
+  {
+    id: "tebbutt_n",
+    name: { en: "Prof Niall Tebbutt", zh: "Niall Tebbutt 教授" },
+    hospital_id: "austin_onj",
+    specialty: { en: "GI / pancreas", zh: "消化道 / 胰腺" },
+  },
+  {
+    id: "gibbs_p",
+    name: { en: "Prof Peter Gibbs", zh: "Peter Gibbs 教授" },
+    hospital_id: "western_sunshine",
+    also_at: "WEHI",
+    specialty: { en: "GI / colorectal / pancreas", zh: "消化道 / 结直肠 / 胰腺" },
+  },
+  {
+    id: "wong_r",
+    name: { en: "A/Prof Rachel Wong", zh: "Rachel Wong 副教授" },
+    hospital_id: "eastern_box_hill",
+    also_at: "Epworth Eastern",
+    specialty: { en: "GI / upper GI", zh: "消化道 / 上消化道" },
+  },
+  {
+    id: "lee_b",
+    name: { en: "Dr Belinda Lee", zh: "Belinda Lee 医生" },
+    hospital_id: "northern",
+    also_at: "Royal Melbourne Hospital",
+    specialty: { en: "GI / pancreas trials", zh: "消化道 / 胰腺临床试验" },
+  },
+  {
+    id: "wong_hl",
+    name: { en: "A/Prof Hui-Li Wong", zh: "Hui-Li Wong 副教授" },
+    hospital_id: "peter_mac",
+    specialty: { en: "GI / pancreas", zh: "消化道 / 胰腺" },
+  },
+  {
+    id: "michael_m",
+    name: { en: "Prof Michael Michael", zh: "Michael Michael 教授" },
+    hospital_id: "peter_mac",
+    specialty: { en: "GI / NET / pancreas", zh: "消化道 / 神经内分泌 / 胰腺" },
+  },
+];
+
+export const HOSPITAL_BY_ID: Record<string, MelbourneHospital> = Object.fromEntries(
+  MELBOURNE_HOSPITALS.map((h) => [h.id, h]),
+);
+
+export const ONCOLOGIST_BY_ID: Record<string, MelbourneOncologist> = Object.fromEntries(
+  MELBOURNE_ONCOLOGISTS.map((o) => [o.id, o]),
+);


### PR DESCRIPTION
## Summary

- **FAB "Say what's happening" defaults to voice + transcription.** `/log` opens with a large mic that auto-starts dictation, a live transcript pane the patient can edit, and a "Type instead" toggle for unsupported browsers / quiet environments. Tag inference, agent fan-out, and direct-file logic are unchanged — only the input surface flips.
- **Photo inputs accept library + file uploads.** Dropped `capture="environment"` from `CameraCapture`, `meal-ingest`, `schedule/new`, and `nutrition/foods`. The native iOS / Android picker now offers Take Photo / Photo Library / Choose Files in one tap. `UniversalDrop` already supported gallery uploads.
- **Onboarding pre-populates Melbourne oncologists.** New seed table (`src/config/oncologists.ts`) with seven GI / pancreas oncologists across Peter Mac, Austin (ONJ), RMH, Western, Eastern, Northern, and Epworth. Picking one prefills hospital name, switchboard, and address; "Other / type my own" leaves the fields blank.

## Test plan

- [ ] On a SpeechRecognition-capable browser (Chrome / Safari): tap FAB → "Say what's happening" → mic auto-starts, transcript fills as you speak, edits stick, submit fans out to agents.
- [ ] On a non-SR browser: page falls back to typing-first textarea; "Use voice" link is hidden.
- [ ] iOS Safari: tap a photo button (any of the four touched surfaces) and verify the action sheet shows Photo Library + Take Photo + Choose File.
- [ ] Onboarding → Clinical team step → pick "A/Prof Sumitra Ananda" → verify name + Peter Mac switchboard + address auto-fill; switching to "Other" lets you type a custom oncologist without losing in-progress hospital edits (it only clears the name field).
- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm test` — all clean (760/760).

https://claude.ai/code/session_01UUjU7ojaS5eGXn1h4rVgUW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUjU7ojaS5eGXn1h4rVgUW)_