### PR TITLE
APK workflow: pre-write Bubblewrap config so init is non-interactive

### DIFF
--- a/.github/workflows/apk-build.yml
+++ b/.github/workflows/apk-build.yml
@@ -123,6 +123,19 @@ jobs:
 
       - name: Bubblewrap init
         run: |
+          # Bubblewrap reads ~/.bubblewrap/config.json on startup and only
+          # prompts for JDK / SDK locations if the config is missing. The
+          # CI runner already has both installed (setup-java + setup-android
+          # steps above export JAVA_HOME and ANDROID_HOME); pre-write the
+          # config so init runs non-interactively. Without this it hangs on
+          # "Do you want Bubblewrap to install the JDK?" and dies (exit 130).
+          mkdir -p "$HOME/.bubblewrap"
+          cat > "$HOME/.bubblewrap/config.json" <<EOF
+          {
+            "jdkPath": "${JAVA_HOME}",
+            "androidSdkPath": "${ANDROID_HOME}"
+          }
+          EOF
           # --skipPwaValidation lets init run without hitting the live PWA
           # (CI shouldn't depend on production being reachable). The
           # generated android/ tree is overwritten by the keystore step


### PR DESCRIPTION
## Summary

Stops the APK build workflow from hanging on Bubblewrap's first-run JDK install prompt. Pre-writes `~/.bubblewrap/config.json` pointing at the runner's existing `JAVA_HOME` and `ANDROID_HOME` so init runs non-interactive.

## Failure mode this fixes

```
? Do you want Bubblewrap to install the JDK (recommended)?
  (Enter "No" to use your own JDK 17 installation) (Y/n)
Error: Process completed with exit code 130.
```

CI has no TTY, so the prompt never gets answered and the process is terminated with exit 130 (Ctrl+C equivalent). The new step writes `{"jdkPath": "...", "androidSdkPath": "..."}` to `~/.bubblewrap/config.json` before `bubblewrap init`, which is the canonical way to skip the prompt — Bubblewrap reads the config on startup and only asks for paths if the file is missing.

The `actions/setup-java@v4` and `android-actions/setup-android@v3` steps that already run earlier in the job export `JAVA_HOME` and `ANDROID_HOME`, so the config picks up the right paths.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses without error
- [ ] Re-run **APK build** — Bubblewrap init should now produce the android/ scaffold without hanging on a prompt

https://claude.ai/code/session_016zkTNnLPU4Ws74dkP2y6TD

---
_Generated by [Claude Code](https://claude.ai/code/session_016zkTNnLPU4Ws74dkP2y6TD)_