### PR TITLE
Repair family-onboarding flow across settings, /family, caregiver onboarding

### DIFF
--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -4,6 +4,7 @@ import { useLocale } from "~/hooks/use-translate";
 import { PageHeader } from "~/components/ui/page-header";
 import { EmergencyCard } from "~/components/dashboard/emergency-card";
 import { HouseholdHeader } from "~/components/family/household-header";
+import { NoHouseholdBanner } from "~/components/family/no-household-banner";
 import { ProfileCompletionBanner } from "~/components/family/profile-completion-banner";
 import { PresenceStack } from "~/components/shared/presence-stack";
 import { ZoneBanner } from "~/components/family/zone-banner";
@@ -28,6 +29,8 @@ export default function FamilyPage() {
       />
 
       <HouseholdHeader />
+
+      <NoHouseholdBanner />
 
       <ProfileCompletionBanner />
 

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { Field, Select, TextInput, Textarea } from "~/components/ui/field";
 import { Alert } from "~/components/ui/alert";
+import { InlineSignIn } from "~/components/auth/inline-sign-in";
 import { PROTOCOL_LIBRARY, PROTOCOL_BY_ID } from "~/config/protocols";
 import {
   MELBOURNE_ONCOLOGISTS,
@@ -157,13 +158,59 @@ export default function OnboardingPage() {
   const setEnteredBy = useUIStore((s) => s.setEnteredBy);
   const existingSettings = useSettings();
 
+  // Re-entry escape hatch. A caregiver who completed onboarding on
+  // device but never picked a patient (cancelled mid-flow, or the join
+  // RPC errored) was previously trapped: /onboarding bounced to / and
+  // / bounced back to /family, which had no recovery surface. The
+  // NoHouseholdBanner on /family now links here with `?step=pick_patient`
+  // so we can skip the "already onboarded" bounce and drop them
+  // straight into the PickPatientStep.
+  const [rejoinTarget, setRejoinTarget] = useState<StepKey | null>(null);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const target = params.get("step");
+    if (target === "pick_patient" || target === "user_type") {
+      setRejoinTarget(target as StepKey);
+    }
+  }, []);
+
   const [form, setForm] = useState<FormState>({ ...EMPTY, locale });
   const [step, setStep] = useState<StepKey>("welcome");
   const [saving, setSaving] = useState(false);
 
-  // If already onboarded, bounce back to dashboard.
+  // If already onboarded, bounce back to dashboard — UNLESS the user
+  // is explicitly re-entering via `?step=…` (caregiver-finds-patient
+  // recovery flow). In that case we drop them on the requested step
+  // and prefill EVERY field from existing settings so finish() (which
+  // does a full `db.settings.put`) doesn't blow away other fields.
   useEffect(() => {
     const s = existingSettings;
+    if (s?.onboarded_at && rejoinTarget) {
+      setForm((f) => ({
+        ...f,
+        user_type:
+          rejoinTarget === "pick_patient"
+            ? "caregiver"
+            : s.user_type ?? f.user_type,
+        profile_name: s.profile_name ?? "",
+        dob: s.dob ?? "",
+        diagnosis_date: s.diagnosis_date ?? "",
+        managing_oncologist: s.managing_oncologist ?? "",
+        managing_oncologist_phone: s.managing_oncologist_phone ?? "",
+        hospital_name: s.hospital_name ?? "",
+        hospital_phone: s.hospital_phone ?? "",
+        hospital_address: s.hospital_address ?? "",
+        oncall_phone: s.oncall_phone ?? "",
+        emergency_instructions: s.emergency_instructions ?? "",
+        height_cm: s.height_cm ? String(s.height_cm) : "",
+        weight_kg: s.baseline_weight_kg ? String(s.baseline_weight_kg) : "",
+        locale: s.locale ?? f.locale,
+        home_city: s.home_city ?? "",
+      }));
+      setStep(rejoinTarget);
+      return;
+    }
     if (s?.onboarded_at) {
       router.replace("/");
     } else if (s) {
@@ -187,7 +234,7 @@ export default function OnboardingPage() {
         home_city: s.home_city ?? "",
       }));
     }
-  }, [existingSettings, router]);
+  }, [existingSettings, rejoinTarget, router]);
 
   function update<K extends keyof FormState>(k: K, v: FormState[K]) {
     setForm((f) => ({ ...f, [k]: v }));
@@ -679,6 +726,9 @@ function PickPatientStep({
   locale: Locale;
 }) {
   const L = useL();
+  const [authState, setAuthState] = useState<
+    "unknown" | "signed_out" | "signed_in"
+  >("unknown");
   const [rows, setRows] = useState<
     Array<{
       id: string;
@@ -688,26 +738,77 @@ function PickPatientStep({
       member_count: number;
     }>
   >([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [joining, setJoining] = useState<string | null>(null);
   const [joinedName, setJoinedName] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   // When the discovery RPC isn't installed (typically because the carer-
-  // onboarding migration hasn't been applied), we fall back to an
-  // invite-token paste box so the user can still complete onboarding.
+  // onboarding migration hasn't been applied), the picker becomes
+  // pure-paste — used to gate copy that says "or paste a link" vs the
+  // standalone fallback. The paste-invite block itself is now ALWAYS
+  // visible (a legitimate alternative even when discovery works), so
+  // a caregiver who only has a token is never gated behind a flag.
   const [pickerUnavailable, setPickerUnavailable] = useState(false);
   const [inviteInput, setInviteInput] = useState("");
   const [acceptingInvite, setAcceptingInvite] = useState(false);
 
+  // Resolve auth state up-front. The household-discovery RPC is granted
+  // only to `authenticated`; calling it as anon hits a raw permission-
+  // denied error that surfaces as untranslated PostgreSQL text. We
+  // gate the picker behind sign-in and render <InlineSignIn> when
+  // the caregiver hasn't authenticated yet.
   useEffect(() => {
     let cancelled = false;
+    let unsub: (() => void) | null = null;
+    void (async () => {
+      const { getSupabaseBrowser, isSupabaseConfigured } = await import(
+        "~/lib/supabase/client"
+      );
+      if (!isSupabaseConfigured()) {
+        if (!cancelled) setAuthState("signed_out");
+        return;
+      }
+      const sb = getSupabaseBrowser();
+      if (!sb) {
+        if (!cancelled) setAuthState("signed_out");
+        return;
+      }
+      const { data } = await sb.auth.getSession();
+      if (cancelled) return;
+      setAuthState(data.session?.user ? "signed_in" : "signed_out");
+      const { data: sub } = sb.auth.onAuthStateChange((_e, session) => {
+        if (cancelled) return;
+        setAuthState(session?.user ? "signed_in" : "signed_out");
+      });
+      unsub = () => sub.subscription.unsubscribe();
+      // If the component unmounted between the await and here, fire
+      // the cleanup we just registered. Otherwise the outer cleanup
+      // closure will pick it up.
+      if (cancelled) unsub();
+    })();
+    return () => {
+      cancelled = true;
+      unsub?.();
+    };
+  }, []);
+
+  // Once signed in, fetch the household list. Re-runs after sign-in
+  // because authState transitions from `signed_out` → `signed_in`.
+  useEffect(() => {
+    if (authState !== "signed_in") return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
     void (async () => {
       try {
         const { listAllHouseholds } = await import(
           "~/lib/supabase/households"
         );
         const all = await listAllHouseholds();
-        if (!cancelled) setRows(all);
+        if (!cancelled) {
+          setRows(all);
+          setPickerUnavailable(false);
+        }
       } catch (err) {
         if (cancelled) return;
         if (
@@ -726,7 +827,7 @@ function PickPatientStep({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [authState]);
 
   async function join(id: string, displayName: string) {
     setJoining(id);
@@ -781,8 +882,8 @@ function PickPatientStep({
       </div>
       <p className="text-[13px] text-ink-500">
         {L(
-          "Pick the patient already using Anchor. You'll join their care team — no baselines or clinical setup on your end.",
-          "选择已在使用 Anchor 的患者。您将加入其护理团队 —— 无需输入基线或临床信息。",
+          "Pick the patient already using Anchor — or paste an invite link they sent you. You'll join their care team; no clinical setup on your end.",
+          "选择已在使用 Anchor 的患者，或粘贴对方发来的邀请链接。您将加入其护理团队 —— 无需输入临床信息。",
         )}
       </p>
 
@@ -796,65 +897,96 @@ function PickPatientStep({
         </Alert>
       )}
 
-      {loading && !joinedName && (
+      {/* Auth gate. The picker RPC requires `authenticated`, so we
+          inline a sign-in/sign-up panel rather than punting the user
+          out to /login mid-onboarding (which loses every other field
+          they entered). After auth the household-list effect re-runs
+          automatically. */}
+      {!joinedName && authState === "signed_out" && (
+        <div className="rounded-md border border-ink-200 bg-paper-2 p-4">
+          <InlineSignIn
+            title={L(
+              "Sign in to find the patient",
+              "登录后查找患者",
+            )}
+            subtitle={L(
+              "We need to know who you are before we can list the patients on Anchor or accept an invite link on your behalf.",
+              "查看患者列表或代您接受邀请链接前，需先确认您的身份。",
+            )}
+          />
+        </div>
+      )}
+
+      {!joinedName && authState === "signed_in" && loading && (
         <div className="rounded-md border border-ink-200 bg-paper-2 p-3 text-[12.5px] text-ink-500">
           {L("Loading patients…", "加载中…")}
         </div>
       )}
 
-      {!loading && !joinedName && !pickerUnavailable && !error && rows.length === 0 && (
-        <div className="rounded-md border border-dashed border-ink-300 bg-paper p-4 text-[12.5px] text-ink-600">
-          {L(
-            "No patients have set up Anchor yet. Ask the person you're supporting to create their profile first, or set up a fresh patient yourself.",
-            "尚无患者设置 Anchor。请先请患者本人创建资料,或由您自己开始新患者流程。",
-          )}
-        </div>
-      )}
-
-      {!loading && !joinedName && rows.length > 0 && (
-        <ul className="space-y-2">
-          {rows.map((h) => {
-            const display = h.patient_display_name || h.name;
-            return (
-              <li key={h.id}>
-                <button
-                  type="button"
-                  onClick={() => void join(h.id, display)}
-                  disabled={joining !== null}
-                  className={cn(
-                    "flex w-full items-center justify-between gap-3 rounded-xl border p-4 text-left transition-colors",
-                    joining === h.id
-                      ? "border-[var(--tide-2)] bg-[var(--tide-soft)]"
-                      : "border-ink-200 bg-paper-2 hover:border-ink-400",
-                  )}
-                >
-                  <div className="min-w-0 flex-1">
-                    <div className="text-[14.5px] font-semibold text-ink-900">
-                      {display}
+      {!joinedName &&
+        authState === "signed_in" &&
+        !loading &&
+        rows.length > 0 && (
+          <ul className="space-y-2">
+            {rows.map((h) => {
+              const display = h.patient_display_name || h.name;
+              return (
+                <li key={h.id}>
+                  <button
+                    type="button"
+                    onClick={() => void join(h.id, display)}
+                    disabled={joining !== null}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-3 rounded-xl border p-4 text-left transition-colors",
+                      joining === h.id
+                        ? "border-[var(--tide-2)] bg-[var(--tide-soft)]"
+                        : "border-ink-200 bg-paper-2 hover:border-ink-400",
+                    )}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[14.5px] font-semibold text-ink-900">
+                        {display}
+                      </div>
+                      <div className="mt-0.5 text-[11.5px] text-ink-500">
+                        {h.member_count}{" "}
+                        {h.member_count === 1
+                          ? L("member", "位成员")
+                          : L("members", "位成员")}
+                      </div>
                     </div>
-                    <div className="mt-0.5 text-[11.5px] text-ink-500">
-                      {h.member_count}{" "}
-                      {h.member_count === 1
-                        ? L("member", "位成员")
-                        : L("members", "位成员")}
-                    </div>
-                  </div>
-                  <span className="mono text-[10px] uppercase tracking-[0.12em] text-ink-400">
-                    {joining === h.id ? L("Joining…", "加入中…") : L("Join", "加入")}
-                  </span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      )}
+                    <span className="mono text-[10px] uppercase tracking-[0.12em] text-ink-400">
+                      {joining === h.id ? L("Joining…", "加入中…") : L("Join", "加入")}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
 
-      {!loading && !joinedName && pickerUnavailable && (
-        <div className="space-y-3 rounded-md border border-ink-200 bg-paper-2 p-4">
+      {!joinedName &&
+        authState === "signed_in" &&
+        !loading &&
+        rows.length === 0 &&
+        !pickerUnavailable && (
+          <div className="rounded-md border border-dashed border-ink-300 bg-paper p-4 text-[12.5px] text-ink-600">
+            {L(
+              "No patients have set up Anchor yet. Paste an invite link below if you've been sent one, or tap \"I'm setting up a new patient instead\" to start the patient flow yourself.",
+              "尚无患者设置 Anchor。如已收到邀请链接，请在下方粘贴；或点击下方“我要新建一位患者”自行开始患者流程。",
+            )}
+          </div>
+        )}
+
+      {/* Paste-invite block — ALWAYS visible once signed in. The
+          previous version hid it behind `pickerUnavailable` so a
+          caregiver with a token but a working RPC had no way to use
+          their token. */}
+      {!joinedName && authState === "signed_in" && (
+        <div className="space-y-2 rounded-md border border-ink-200 bg-paper-2 p-4">
           <div className="text-[12.5px] text-ink-700">
             {L(
-              "Paste the invite link the patient sent you to join their care team.",
-              "请粘贴患者发来的邀请链接加入其护理团队。",
+              "Have an invite link from the patient? Paste it here.",
+              "已收到患者发来的邀请链接？请在此粘贴。",
             )}
           </div>
           <div className="flex gap-2">

--- a/src/components/auth/inline-sign-in.tsx
+++ b/src/components/auth/inline-sign-in.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
+import { useL } from "~/hooks/use-translate";
+import { Button } from "~/components/ui/button";
+import { Field, TextInput } from "~/components/ui/field";
+import { Alert } from "~/components/ui/alert";
+import { Loader2 } from "lucide-react";
+
+// Embeddable sign-in / sign-up panel. Same behaviour as
+// /login and the welcome modal, but rendered inline so an onboarding
+// or settings flow doesn't have to redirect away. After auth the
+// caller's `onAuthed` fires; the surrounding UI is responsible for
+// what happens next (refresh hooks, advance step, etc.).
+//
+// Why pull this out of WelcomeAuthModal? Caregiver onboarding's
+// PickPatientStep was hitting a raw `permission denied for function
+// list_all_households` error because it called the auth-only RPC
+// without checking auth state first. Same UX problem will recur
+// anywhere we need an auth boundary mid-flow — a reusable panel
+// keeps every surface lit consistently.
+
+export interface InlineSignInProps {
+  // Fired when sign-in or sign-up succeeds and a session is active.
+  // Sign-up with email-confirmation enabled never fires this — the
+  // panel surfaces the "check your inbox" hint and waits.
+  onAuthed?: () => void | Promise<void>;
+  // Eyebrow + title above the form. Defaults to a generic "Sign in"
+  // header; surfaces with their own framing (e.g. caregiver
+  // onboarding) can pass tailored copy.
+  title?: string;
+  subtitle?: string;
+}
+
+export function InlineSignIn({
+  onAuthed,
+  title,
+  subtitle,
+}: InlineSignInProps) {
+  const L = useL();
+  const [mode, setMode] = useState<"signin" | "signup">("signin");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+
+  if (!isSupabaseConfigured()) {
+    return (
+      <Alert variant="warn" dense>
+        {L(
+          "Cloud sync isn't configured on this build. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY before signing in.",
+          "本版本未配置云同步。请先设置 NEXT_PUBLIC_SUPABASE_URL 与 NEXT_PUBLIC_SUPABASE_ANON_KEY 后再登录。",
+        )}
+      </Alert>
+    );
+  }
+
+  const heading =
+    title ??
+    (mode === "signin"
+      ? L("Sign in to Anchor", "登录 Anchor")
+      : L("Create an Anchor account", "创建 Anchor 账号"));
+  const tagline =
+    subtitle ??
+    L(
+      "Your account is yours — you can use it across devices.",
+      "账号属于您本人，可在多设备使用。",
+    );
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const supabase = getSupabaseBrowser();
+    if (!supabase) return;
+    setLoading(true);
+    setError(null);
+    setInfo(null);
+    try {
+      if (mode === "signin") {
+        const { error } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
+        if (error) throw error;
+        await onAuthed?.();
+        return;
+      }
+      const { data, error } = await supabase.auth.signUp({ email, password });
+      if (error) throw error;
+      if (data.session) {
+        await onAuthed?.();
+        return;
+      }
+      // Email confirmation is on; user has to click the link before
+      // we can proceed. Bounce them to sign-in mode and tell them
+      // what's happening.
+      setInfo(
+        L(
+          "Account created — check your email to confirm, then sign in.",
+          "账号已创建 —— 请查收邮件确认后再登录。",
+        ),
+      );
+      setMode("signin");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="space-y-1">
+        <div className="text-[14px] font-semibold text-ink-900">{heading}</div>
+        <p className="text-[12px] text-ink-500">{tagline}</p>
+      </div>
+      <Field label={L("Email", "邮箱")}>
+        <TextInput
+          type="email"
+          autoComplete="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          placeholder="you@example.com"
+        />
+      </Field>
+      <Field label={L("Password", "密码")}>
+        <TextInput
+          type="password"
+          autoComplete={mode === "signin" ? "current-password" : "new-password"}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={6}
+          placeholder="••••••••"
+        />
+      </Field>
+      {error && (
+        <Alert variant="warn" dense>
+          {error}
+        </Alert>
+      )}
+      {info && (
+        <Alert variant="info" dense>
+          {info}
+        </Alert>
+      )}
+      <Button type="submit" size="md" className="w-full" disabled={loading}>
+        {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {loading
+          ? L("Please wait…", "请稍候…")
+          : mode === "signin"
+            ? L("Sign in", "登录")
+            : L("Create account", "创建账号")}
+      </Button>
+      <button
+        type="button"
+        className="w-full text-[12px] text-ink-500 hover:text-ink-900"
+        onClick={() => {
+          setMode(mode === "signin" ? "signup" : "signin");
+          setError(null);
+          setInfo(null);
+        }}
+      >
+        {mode === "signin"
+          ? L("New here? Create an account", "首次使用？创建账号")
+          : L("Already have an account? Sign in", "已有账号？登录")}
+      </button>
+    </form>
+  );
+}

--- a/src/components/family/no-household-banner.tsx
+++ b/src/components/family/no-household-banner.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { useHousehold } from "~/hooks/use-household";
+import { isSupabaseConfigured } from "~/lib/supabase/client";
+import { useL } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { Loader2, UserPlus } from "lucide-react";
+
+// Shown at the top of /family when the user landed there without a
+// household membership. The page itself is built for caregivers who
+// HAVE joined a household; without one, every other card short-
+// circuits on `!membership` and the user sees a half-empty shell with
+// no way out. This banner gives them a deterministic next action:
+// finish caregiver onboarding (where they'll pick a patient or paste
+// an invite link). Never renders for fully-joined members.
+export function NoHouseholdBanner() {
+  const L = useL();
+  const { membership, profile, loading } = useHousehold();
+
+  if (!isSupabaseConfigured()) return null;
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center gap-2 pt-4 text-[12.5px] text-ink-500">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {L("Checking your account…", "正在检查账号…")}
+        </CardContent>
+      </Card>
+    );
+  }
+  if (membership) return null;
+
+  // Two distinct states get the same recovery destination
+  // (/onboarding) but different copy so the user understands which
+  // gap they're in.
+  const signedOut = !profile;
+
+  return (
+    <Card className="border-[var(--tide-2)]/40 bg-[var(--tide-soft)]">
+      <CardContent className="space-y-3 pt-4 text-[13px]">
+        <div className="flex items-center gap-2 text-ink-900">
+          <UserPlus className="h-4 w-4 text-[var(--tide-2)]" />
+          <span className="font-semibold">
+            {signedOut
+              ? L(
+                  "Sign in to find your patient",
+                  "登录后查找您要支持的患者",
+                )
+              : L("You're not on a care team yet", "您尚未加入护理团队")}
+          </span>
+        </div>
+        <p className="text-ink-700">
+          {signedOut
+            ? L(
+                "Anchor doesn't know who you're caring for yet. Sign in and pick the patient — or open the invite link they sent you.",
+                "Anchor 尚不知道您要支持的患者。请登录并选择患者，或打开对方发来的邀请链接。",
+              )
+            : L(
+                "We've signed you in but you haven't joined anyone's care team. Pick the patient you're supporting, or paste an invite link if you have one.",
+                "您已登录，但尚未加入任何护理团队。请选择您要支持的患者，或粘贴邀请链接。",
+              )}
+        </p>
+        <Link
+          href={
+            signedOut
+              ? "/login?next=%2Ffamily"
+              : "/onboarding?step=pick_patient"
+          }
+        >
+          <Button size="md">
+            {signedOut
+              ? L("Sign in", "登录")
+              : L("Find a patient", "查找患者")}
+          </Button>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/settings/household-section.tsx
+++ b/src/components/settings/household-section.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useHousehold } from "~/hooks/use-household";
+import { useL } from "~/hooks/use-translate";
+import { isSupabaseConfigured } from "~/lib/supabase/client";
 import {
   getHousehold,
   leaveHousehold,
@@ -11,13 +14,28 @@ import type { Household } from "~/types/household";
 import { Field, TextInput } from "~/components/ui/field";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
-import { Users, LogOut } from "lucide-react";
+import { Loader2, Lock, LogOut, UserPlus, Users } from "lucide-react";
 
-// Slim "My household" card — covers the personal slice of the original
-// HouseholdSection (your display name + role label + leave button) and
-// leaves member / invite management to the unified CareTeamSection.
+// Slim "My household" card. Renders a different state for each of the
+// five real situations a user can be in:
+//
+//   - Supabase isn't configured → offline-only build, no point in
+//     pretending invites are an option here. (No CTA.)
+//   - useHousehold still resolving → loading hint.
+//   - Signed out → "Sign in to share Anchor with carers." → /login.
+//   - Signed in but no household → "Set up your care team in one tap." →
+//     /carers?action=add-carer. The /carers page handles the bootstrap
+//     + invite flow. We do NOT route to /onboarding (it dead-ends on
+//     `settings.onboarded_at`).
+//   - Signed in + member → personal display-name + role-label form,
+//     plus a leave button for everyone except the primary carer.
+//
+// Earlier versions collapsed the first three states into a single
+// "you aren't part of a family yet" nag that fired regardless of
+// auth state and pointed users at a non-existent dashboard widget.
 
 export function HouseholdSection() {
+  const L = useL();
   const { membership, profile, loading, refresh } = useHousehold();
   const [household, setHousehold] = useState<Household | null>(null);
   const householdId = membership?.household_id ?? null;
@@ -31,64 +49,172 @@ export function HouseholdSection() {
     void getHousehold(householdId).then(setHousehold);
   }, [householdId]);
 
-  if (loading) {
+  return (
+    <section className="space-y-3">
+      <Heading L={L} />
+      <Body
+        L={L}
+        configured={isSupabaseConfigured()}
+        loading={loading}
+        signedIn={!!profile}
+        membership={membership}
+        household={household}
+        householdId={householdId}
+        isPrimary={!!isPrimary}
+        profileName={profile?.display_name ?? ""}
+        careLabel={profile?.care_role_label ?? ""}
+        refresh={refresh}
+      />
+    </section>
+  );
+}
+
+function Heading({ L }: { L: (en: string, zh: string) => string }) {
+  return (
+    <h2 className="eyebrow">
+      <Users className="mr-1.5 inline h-3.5 w-3.5" />
+      {L("Household", "家庭")}
+    </h2>
+  );
+}
+
+interface BodyProps {
+  L: (en: string, zh: string) => string;
+  configured: boolean;
+  loading: boolean;
+  signedIn: boolean;
+  membership: ReturnType<typeof useHousehold>["membership"];
+  household: Household | null;
+  householdId: string | null;
+  isPrimary: boolean;
+  profileName: string;
+  careLabel: string;
+  refresh: () => Promise<void>;
+}
+
+function Body({
+  L,
+  configured,
+  loading,
+  signedIn,
+  membership,
+  household,
+  householdId,
+  isPrimary,
+  profileName,
+  careLabel,
+  refresh,
+}: BodyProps) {
+  // Order matters. "Not configured" wins over every other state because
+  // there's literally no cloud to sign into.
+  if (!configured) {
     return (
-      <section className="space-y-3">
-        <h2 className="eyebrow">
-          <Users className="mr-1.5 inline h-3.5 w-3.5" />
-          Household
-        </h2>
-        <p className="text-[12px] text-ink-500">Loading&hellip;</p>
-      </section>
+      <Card>
+        <CardContent className="space-y-2 pt-4 text-[12.5px] text-ink-500">
+          <div className="flex items-center gap-2 text-ink-700">
+            <Lock className="h-3.5 w-3.5" />
+            <span className="font-medium">
+              {L("Sync isn't on for this build", "本版本未启用同步")}
+            </span>
+          </div>
+          <p>
+            {L(
+              "Anchor account features (sharing with carers, accepting invite links) need cloud sync. Local check-ins keep working without it.",
+              "邀请家人、接受邀请链接等账号功能需启用云同步。本地记录仍可离线使用。",
+            )}
+          </p>
+        </CardContent>
+      </Card>
     );
   }
 
-  if (!membership) {
+  if (loading) {
     return (
-      <section className="space-y-3">
-        <h2 className="eyebrow">
-          <Users className="mr-1.5 inline h-3.5 w-3.5" />
-          Household
-        </h2>
-        <Card>
-          <CardContent className="py-4 text-[12.5px] text-ink-500">
-            You aren&rsquo;t part of a family yet. Sign in and either
-            create one from the dashboard or accept an invite link.
-          </CardContent>
-        </Card>
-      </section>
+      <Card>
+        <CardContent className="flex items-center gap-2 pt-4 text-[12.5px] text-ink-500">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {L("Checking your account…", "正在检查账号…")}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!signedIn) {
+    return (
+      <Card className="border-[var(--tide-2)]/40 bg-[var(--tide-soft)]">
+        <CardContent className="space-y-3 pt-4 text-[13px]">
+          <div className="flex items-center gap-2 text-ink-900">
+            <UserPlus className="h-4 w-4 text-[var(--tide-2)]" />
+            <span className="font-semibold">
+              {L("Sign in to share Anchor with carers", "登录后即可与家人共享 Anchor")}
+            </span>
+          </div>
+          <p className="text-ink-700">
+            {L(
+              "An account lets you create your care team and invite family. The data on this device stays where it is until you sign in.",
+              "登录后即可创建护理团队并邀请家人。本设备数据在您登录前会保留在本地。",
+            )}
+          </p>
+          <Link href="/login?next=%2Fsettings">
+            <Button size="md">{L("Sign in", "登录")}</Button>
+          </Link>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!membership || !householdId) {
+    return (
+      <Card className="border-[var(--tide-2)]/40 bg-[var(--tide-soft)]">
+        <CardContent className="space-y-3 pt-4 text-[13px]">
+          <div className="flex items-center gap-2 text-ink-900">
+            <UserPlus className="h-4 w-4 text-[var(--tide-2)]" />
+            <span className="font-semibold">
+              {L("Set up your care team", "创建您的护理团队")}
+            </span>
+          </div>
+          <p className="text-ink-700">
+            {L(
+              "One tap creates your care team and lets you start sharing it with carers. If someone has invited you, open their invite link instead.",
+              "轻触一下即可创建护理团队并开始邀请家人。如已收到邀请链接，请直接打开链接。",
+            )}
+          </p>
+          <Link href="/carers?action=add-carer">
+            <Button size="md">
+              {L("Set up & invite a carer", "创建并邀请护理人员")}
+            </Button>
+          </Link>
+        </CardContent>
+      </Card>
     );
   }
 
   return (
-    <section className="space-y-3">
-      <div>
-        <h2 className="eyebrow">
-          <Users className="mr-1.5 inline h-3.5 w-3.5" />
-          Household
-        </h2>
-        {household && (
-          <p className="mt-1 text-xs text-ink-500">
-            {household.name} &middot; caring for{" "}
-            <span className="text-ink-700">
-              {household.patient_display_name}
-            </span>
-          </p>
-        )}
-      </div>
-
+    <>
+      {household && (
+        <p className="-mt-1 text-xs text-ink-500">
+          {L(
+            `${household.name} · caring for ${household.patient_display_name}`,
+            `${household.name} · 照护 ${household.patient_display_name}`,
+          )}
+        </p>
+      )}
       <MyProfileCard
-        profileName={profile?.display_name ?? ""}
-        careLabel={profile?.care_role_label ?? ""}
+        profileName={profileName}
+        careLabel={careLabel}
         onSaved={refresh}
+        L={L}
       />
-
-      {!isPrimary && householdId && (
+      {!isPrimary && (
         <LeaveButton
+          L={L}
           onLeave={async () => {
             if (
               !window.confirm(
-                "Leave this family? You'll stop seeing their data.",
+                L(
+                  "Leave this family? You'll stop seeing their data.",
+                  "确定要离开此家庭？将无法继续查看其数据。",
+                ),
               )
             )
               return;
@@ -97,7 +223,7 @@ export function HouseholdSection() {
           }}
         />
       )}
-    </section>
+    </>
   );
 }
 
@@ -105,10 +231,12 @@ function MyProfileCard({
   profileName,
   careLabel,
   onSaved,
+  L,
 }: {
   profileName: string;
   careLabel: string;
   onSaved: () => Promise<void>;
+  L: (en: string, zh: string) => string;
 }) {
   const [name, setName] = useState(profileName);
   const [label, setLabel] = useState(careLabel);
@@ -138,23 +266,26 @@ function MyProfileCard({
     <Card>
       <CardContent className="space-y-3 pt-4">
         <div className="text-[11px] font-medium uppercase tracking-[0.1em] text-ink-400">
-          Your profile
+          {L("Your profile", "您的资料")}
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
-          <Field label="Display name">
+          <Field label={L("Display name", "显示名称")}>
             <TextInput value={name} onChange={(e) => setName(e.target.value)} />
           </Field>
-          <Field label="Role label (optional)">
+          <Field label={L("Role label (optional)", "角色标签（可选）")}>
             <TextInput
               value={label}
               onChange={(e) => setLabel(e.target.value)}
-              placeholder="e.g. Son, Wife, Palliative RN"
+              placeholder={L(
+                "e.g. Son, Wife, Palliative RN",
+                "例如：儿子、妻子、姑息护理护士",
+              )}
             />
           </Field>
         </div>
         <div className="flex justify-end">
           <Button onClick={save} disabled={!dirty || saving} size="md">
-            {saving ? "Saving…" : "Save"}
+            {saving ? L("Saving…", "保存中…") : L("Save", "保存")}
           </Button>
         </div>
       </CardContent>
@@ -162,7 +293,13 @@ function MyProfileCard({
   );
 }
 
-function LeaveButton({ onLeave }: { onLeave: () => Promise<void> }) {
+function LeaveButton({
+  L,
+  onLeave,
+}: {
+  L: (en: string, zh: string) => string;
+  onLeave: () => Promise<void>;
+}) {
   return (
     <div className="flex justify-end">
       <button
@@ -171,7 +308,7 @@ function LeaveButton({ onLeave }: { onLeave: () => Promise<void> }) {
         className="inline-flex items-center gap-1.5 rounded-md border border-ink-200 px-3 py-2 text-[12px] text-ink-600 hover:border-[var(--warn)] hover:text-[var(--warn)]"
       >
         <LogOut className="h-3.5 w-3.5" />
-        Leave family
+        {L("Leave family", "离开家庭")}
       </button>
     </div>
   );


### PR DESCRIPTION
## What this fixes

The previous PR #132 repaired `/carers` for self-onboarding patients, but tracing the rest of the carer module turned up matching dead-ends. The explicit user complaint: Settings → Household showed

> "You aren't part of a family yet. Sign in and either create one from the dashboard or accept an invite link."

regardless of whether the user was signed in, signed out, or even configured for cloud at all. That branch fired for four distinct states with one piece of stale, monolingual copy.

The deeper audit also found:

1. **Caregiver onboarding's PickPatientStep** calls `list_all_households` on mount. That RPC is `GRANT EXECUTE TO authenticated`. An unauthenticated caregiver gets a raw `permission denied for function list_all_households` error and no path to sign in.
2. **The paste-invite fallback** was hidden behind a `pickerUnavailable` flag that only fires when the RPC is missing entirely. Caregivers with a working RPC but only a token (no patient on the list yet) had no path.
3. **/family for memberless caregivers** rendered a half-empty shell — every card short-circuits on `!membership` and there was no recovery surface.
4. **/onboarding bounces to /** when `settings.onboarded_at` is set, so a caregiver who completed onboarding once but never joined a household was trapped: /onboarding → / → /family → no path back.

## What changed

- **Settings → Household card** is now a 5-state machine (not-configured / loading / signed-out / signed-in-no-household / member). Each branch has accurate bilingual copy and the right CTA. Stale "from the dashboard" advice is gone.
- **`<InlineSignIn>`** — new shared component, extracted from `WelcomeAuthModal` logic. Lets onboarding/settings prompt for auth inline instead of redirecting away mid-flow.
- **PickPatientStep** detects auth state up-front. Unauthenticated callers see `<InlineSignIn>` instead of the raw permission-denied. After auth, the household-list effect re-runs automatically. Paste-invite block is **always visible** once signed in (a legitimate alternative even when discovery works). Empty-list copy points at the visible paste-invite block.
- **`<NoHouseholdBanner>`** on /family. Caregivers without a membership get a one-tap path: `/login` (if signed out) or `/onboarding?step=pick_patient` (if signed in but unjoined).
- **`?step=…` re-entry escape hatch** on /onboarding. Drops the user straight onto the requested step and pre-loads ALL existing settings so the full-replace `db.settings.put` in `finish()` doesn't wipe other fields.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 760 / 760 passing
- [x] `pnpm lint` — clean
- [ ] Manual: open Settings while signed-out → see "Sign in to share Anchor with carers" CTA → tap → /login → return to settings → see "Set up your care team" → tap → land on /carers with invite flow open
- [ ] Manual: open Settings on offline-only build → see "Sync isn't on for this build" notice (no broken CTA)
- [ ] Manual: caregiver onboarding on fresh device — pick "I'm family" → see InlineSignIn before the picker → sign up → patient list loads → join successfully
- [ ] Manual: caregiver onboarding when no patients exist — paste-invite block visible → paste link → join
- [ ] Manual: signed-in caregiver navigates to /family without a membership → sees NoHouseholdBanner → tap "Find a patient" → /onboarding?step=pick_patient drops directly on picker → join → /family fills in
- [ ] Manual: signed-out user navigates to /family → sees "Sign in to find your patient" → /login

## Related

Builds on PR #132 (already merged). Re-uses the same `claude/patient-carer-invitations-3dcka` branch per the development-branch instructions in CLAUDE.md.

https://claude.ai/code/session_013SCw3PXuWPmVHiJDfLHNKH

---
_Generated by [Claude Code](https://claude.ai/code/session_013SCw3PXuWPmVHiJDfLHNKH)_