### PR TITLE
Fix voice-memo duplication and switch /log to click-to-record

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { db } from "~/lib/db/dexie";
 import { todayISO } from "~/lib/utils/date";
@@ -83,13 +83,10 @@ export default function LogPage() {
   const [text, setText] = useState("");
   const [overrideTags, setOverrideTags] = useState<Set<LogTag> | null>(null);
   const [run, setRun] = useState<RunState>({ kind: "idle" });
-  // The page is voice-first by default. Patients who prefer typing flip
-  // this once and the surface stays in keyboard mode for the session.
+  // The page offers voice and typing modes. Voice never auto-starts —
+  // the patient taps the mic to begin recording. Switching to typing
+  // hides the mic surface for the rest of the session.
   const [editMode, setEditMode] = useState(false);
-  // Auto-start dictation on mount, but only on the first arrival. If the
-  // user stops listening or switches to typing we do not silently
-  // restart, because that would feel like the page is hijacking input.
-  const autoStartedRef = useRef(false);
 
   const enteredBy = useUIStore((s) => s.enteredBy);
 
@@ -100,20 +97,8 @@ export default function LogPage() {
   // some webviews) so we fall back to a plain textarea cleanly.
   const speech = useSpeechRecognition({
     lang: locale === "zh" ? "zh-CN" : "en-US",
-    onFinal: (chunk) => setText((cur) => `${cur} ${chunk}`.trim()),
+    onFinal: (chunk) => setText((cur) => (cur ? `${cur} ${chunk}` : chunk)),
   });
-
-  useEffect(() => {
-    if (!speech) return;
-    if (autoStartedRef.current) return;
-    if (editMode) return;
-    autoStartedRef.current = true;
-    // Safari needs a user gesture for SpeechRecognition.start(). Tapping
-    // the FAB item to land here counts on most browsers; if it doesn't,
-    // the hook's start() swallows the error and the patient sees an
-    // idle mic button that they can tap manually.
-    speech.start();
-  }, [speech, editMode]);
 
   const autoTags = useMemo(() => new Set(tagInput(text)), [text]);
   const tags = overrideTags ?? autoTags;
@@ -217,7 +202,6 @@ export default function LogPage() {
     setOverrideTags(null);
     setRun({ kind: "idle" });
     speech?.reset();
-    autoStartedRef.current = false;
   }
 
   // A direct-filed value bypasses the agent requirement.
@@ -259,7 +243,6 @@ export default function LogPage() {
             canSwitchToVoice={Boolean(speech)}
             onSwitchToVoice={() => {
               setEditMode(false);
-              autoStartedRef.current = false;
             }}
           />
         )}
@@ -440,17 +423,10 @@ function VoiceCapture({
   locale: "en" | "zh";
   onSwitchToTyping: () => void;
 }) {
-  // While listening, the hook's `transcript` carries the in-flight
-  // interim words. Final chunks have already flowed into `text` via
-  // `onFinal`, so we strip the prefix overlap and append only the
-  // unsettled tail to avoid double-rendering.
-  const interimTail = useMemo(() => {
-    if (!speech.listening) return "";
-    const t = speech.transcript.trim();
-    if (!t) return "";
-    if (text && t.startsWith(text.trim())) return t.slice(text.trim().length).trim();
-    return t;
-  }, [speech.listening, speech.transcript, text]);
+  // Final chunks already flowed into `text` via the hook's `onFinal`
+  // callback. We only render the unsettled interim tail on top, so the
+  // patient sees mid-utterance words without any duplication.
+  const interimTail = speech.listening ? speech.interim : "";
 
   return (
     <div>

--- a/src/components/ingest/phone-note.tsx
+++ b/src/components/ingest/phone-note.tsx
@@ -76,6 +76,16 @@ export function PhoneCallNote({
   const [error, setError] = useState<string | null>(null);
   const [listening, setListening] = useState(false);
   const recRef = useRef<SpeechRecognition | null>(null);
+  // Canonical finalised transcript for the current dictation session.
+  // We rebuild this from `ev.results` on every event rather than
+  // appending a delta — Chrome and Safari both re-emit overlapping
+  // result indices, so an append-style accumulator double-counts and
+  // the patient sees their words repeat.
+  const finalRef = useRef("");
+  // The text already in the textarea when dictation starts. New
+  // dictated text gets appended after this baseline so we never
+  // overwrite typing from before dictation.
+  const baseTextRef = useRef("");
   const canSpeech = typeof getSpeechRecognitionCtor() === "function";
 
   useEffect(() => {
@@ -92,13 +102,19 @@ export function PhoneCallNote({
     rec.continuous = true;
     rec.interimResults = true;
     rec.lang = localeTag(locale);
+    finalRef.current = "";
+    baseTextRef.current = text;
     rec.onresult = (ev) => {
-      let delta = "";
-      for (let i = ev.resultIndex; i < ev.results.length; i += 1) {
+      let finalText = "";
+      for (let i = 0; i < ev.results.length; i += 1) {
         const res = ev.results[i];
-        if (res && res[0] && res.isFinal) delta += res[0].transcript;
+        if (res && res[0] && res.isFinal) finalText += res[0].transcript;
       }
-      if (delta) setText((prev) => (prev ? `${prev} ${delta}` : delta));
+      const trimmed = finalText.trim();
+      if (trimmed.length <= finalRef.current.length) return;
+      finalRef.current = trimmed;
+      const base = baseTextRef.current;
+      setText(base ? `${base} ${trimmed}` : trimmed);
     };
     rec.onerror = (e) => {
       setError(String((e as unknown as { error?: string }).error ?? "speech-error"));

--- a/src/hooks/use-speech-recognition.ts
+++ b/src/hooks/use-speech-recognition.ts
@@ -50,7 +50,10 @@ declare global {
 
 export interface UseSpeechRecognitionResult {
   listening: boolean;
+  /** Full display string: finalised text plus the in-flight interim tail. */
   transcript: string;
+  /** In-flight interim words only (empty when nothing pending). */
+  interim: string;
   error: string | null;
   start: () => void;
   stop: () => void;
@@ -65,8 +68,16 @@ export function useSpeechRecognition(
   const [supported, setSupported] = useState(false);
   const [listening, setListening] = useState(false);
   const [transcript, setTranscript] = useState("");
+  const [interim, setInterim] = useState("");
   const [error, setError] = useState<string | null>(null);
   const recRef = useRef<SpeechRecognitionLike | null>(null);
+  // Canonical finalised transcript for the current session. We rebuild
+  // this from `e.results` on every event rather than appending deltas:
+  // browsers (notably Chrome on Android and Safari) re-emit the same
+  // final indices across events, and an interim that becomes final
+  // shares its index with the prior interim — so any append-style
+  // accumulator double-counts and the patient sees their words repeat.
+  const finalRef = useRef("");
   // Capture the latest `onFinal` so we don't have to recreate the
   // recogniser when the parent re-renders with a new closure.
   const onFinalRef = useRef(onFinal);
@@ -85,19 +96,36 @@ export function useSpeechRecognition(
     rec.onresult = (e) => {
       let finalText = "";
       let interimText = "";
-      for (let i = e.resultIndex; i < e.results.length; i++) {
+      // Walk the entire results list each time and recompute. This is
+      // O(n) per event but n stays small for any realistic utterance,
+      // and it's the only way to get a duplication-free transcript.
+      for (let i = 0; i < e.results.length; i++) {
         const r = e.results[i];
         if (r.isFinal) finalText += r[0].transcript;
         else interimText += r[0].transcript;
       }
-      setTranscript((cur) => {
-        const next = (cur + finalText).trim();
-        if (interimText) return `${next} ${interimText.trim()}`.trim();
-        return next;
-      });
-      if (finalText.trim() && onFinalRef.current) {
-        onFinalRef.current(finalText.trim());
+      const trimmedFinal = finalText.trim();
+      const prevFinal = finalRef.current;
+      // Detect the genuinely-new final delta by length comparison
+      // against the last canonical final text. We only call onFinal
+      // for that delta so callers appending to their own state never
+      // see a repeat.
+      if (trimmedFinal.length > prevFinal.length) {
+        const delta = trimmedFinal.slice(prevFinal.length).trim();
+        finalRef.current = trimmedFinal;
+        if (delta && onFinalRef.current) onFinalRef.current(delta);
+      } else if (trimmedFinal.length < prevFinal.length) {
+        // New session started under us (e.g. browser auto-restart);
+        // accept the shorter canonical text as the new baseline.
+        finalRef.current = trimmedFinal;
       }
+      const trimmedInterim = interimText.trim();
+      setInterim(trimmedInterim);
+      setTranscript(
+        trimmedInterim
+          ? `${finalRef.current} ${trimmedInterim}`.trim()
+          : finalRef.current,
+      );
     };
     rec.onerror = (e) => {
       setError(e.error);
@@ -115,6 +143,8 @@ export function useSpeechRecognition(
     if (!recRef.current) return;
     setError(null);
     setTranscript("");
+    setInterim("");
+    finalRef.current = "";
     try {
       recRef.current.start();
       setListening(true);
@@ -133,8 +163,12 @@ export function useSpeechRecognition(
     else start();
   }, [listening, start, stop]);
 
-  const reset = useCallback(() => setTranscript(""), []);
+  const reset = useCallback(() => {
+    setTranscript("");
+    setInterim("");
+    finalRef.current = "";
+  }, []);
 
   if (!supported) return null;
-  return { listening, transcript, error, start, stop, toggle, reset };
+  return { listening, transcript, interim, error, start, stop, toggle, reset };
 }


### PR DESCRIPTION
## Summary

Two bugs reported in voice-memo capture:

1. **Words and whole messages repeat as the patient dictates.** The `useSpeechRecognition` hook (and the duplicate handler in `phone-note.tsx`) accumulated finals via `setTranscript((cur) => cur + finalText)`. The Web Speech API re-emits overlapping result indices across `onresult` events — Chrome on Android and Safari both fire a final result whose index was the prior interim, and `cur` already contained that interim text. The append path therefore double-counted on every utterance boundary.

2. **Voice transcription auto-started on `/log`.** A `useEffect` on mount called `speech.start()` the first time the page rendered. The user wants click-to-record only.

## Changes

- **`src/hooks/use-speech-recognition.ts`** — rebuild the canonical final transcript from scratch on every `onresult` (iterate from index 0) and track the last canonical final text in a ref. `onFinal` fires only on a genuine length-delta. Expose `interim` separately so consumers can render in-flight words without prefix-stripping. Reset state cleanly on `start()` and `reset()`.
- **`src/app/log/page.tsx`** — drop the mount-time `speech.start()` and the `autoStartedRef` plumbing. Voice now begins only when the patient taps the mic. Replace the brittle `interimTail` prefix-strip with `speech.interim` directly.
- **`src/components/ingest/phone-note.tsx`** — same recompute-from-scratch pattern. Capture the existing textarea text as a baseline at start so dictated words are appended after any pre-existing typing without overwriting.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 760/760 unit tests pass
- [ ] Manual: open `/log`, confirm mic does not auto-start; tap mic and dictate a sentence — words appear once, no repeats
- [ ] Manual: dictate, pause, dictate again — second utterance does not duplicate the first
- [ ] Manual: phone-call note dictation — same no-duplication behaviour
- [ ] Manual: dictate in `zh-CN` locale — Mandarin transcript also free of repeats

https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU

---
_Generated by [Claude Code](https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU)_