### PR TITLE
Slice 2: AI parses voice memos into daily-form fields automatically

### DIFF
--- a/src/app/api/ai/parse-voice-memo/route.ts
+++ b/src/app/api/ai/parse-voice-memo/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { jsonOutputFormat } from "~/lib/anthropic/json-output";
+import {
+  DEFAULT_AI_MODEL,
+  getAnthropicClient,
+  readJsonBody,
+  withAnthropicErrorBoundary,
+} from "~/lib/anthropic/route-helpers";
+import { requireSession } from "~/lib/auth/require-session";
+import { loadHouseholdProfile } from "~/lib/household/profile";
+import { wrapUserInput } from "~/lib/anthropic/wrap-user-input";
+import {
+  VoiceMemoParseSchema,
+  buildVoiceMemoParseSystem,
+} from "~/lib/voice-memo/parse-schema";
+
+// Structured-fields extractor for a voice-memo transcript. Whisper
+// already produced the text; this route asks Claude which daily-form
+// fields the memo verbalises (energy, sleep, pain, neuropathy, etc.)
+// and returns them in a Zod-validated shape. The client merges them
+// into the day's `daily_entries` row as a safe fill — never an
+// overwrite — so the diary turns voice memos into structured tracking
+// without the patient having to open the daily form.
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+interface ParseBody {
+  transcript: string;
+  locale?: "en" | "zh";
+  recorded_at?: string;
+  model?: string;
+}
+
+export async function POST(req: Request) {
+  const auth = await requireSession();
+  if (!auth.ok) return auth.error;
+
+  const gate = getAnthropicClient();
+  if (gate.error) return gate.error;
+
+  const parsed = await readJsonBody<ParseBody>(req);
+  if (parsed.error) return parsed.error;
+  const body = parsed.body;
+
+  if (!body?.transcript?.trim()) {
+    return NextResponse.json({ error: "transcript required" }, { status: 400 });
+  }
+
+  const profile = await loadHouseholdProfile(auth.session.household_id);
+  const localeNote =
+    body.locale === "zh"
+      ? "The transcript is Mandarin. Translate before extracting."
+      : "";
+  const recordedHint = body.recorded_at
+    ? `The memo was recorded at ${body.recorded_at}.`
+    : "";
+
+  const result = await withAnthropicErrorBoundary(() =>
+    gate.client.messages.parse({
+      model: body.model ?? DEFAULT_AI_MODEL,
+      max_tokens: 800,
+      system: [
+        {
+          type: "text",
+          text: [buildVoiceMemoParseSystem(profile), localeNote, recordedHint]
+            .filter(Boolean)
+            .join("\n\n"),
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      output_config: { format: jsonOutputFormat(VoiceMemoParseSchema) },
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: wrapUserInput(
+                "Extract structured daily-tracking fields from the voice-memo transcript.",
+                body.transcript,
+              ),
+            },
+          ],
+        },
+      ],
+    }),
+  );
+  if (result.error) return result.error;
+
+  if (!result.value.parsed_output) {
+    return NextResponse.json(
+      { error: "No parse returned" },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ parsed: result.value.parsed_output });
+}

--- a/src/components/diary/voice-memo-card.tsx
+++ b/src/components/diary/voice-memo-card.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Mic, Pause, Play, CloudUpload, CloudOff } from "lucide-react";
-import type { VoiceMemo } from "~/types/voice-memo";
+import type { VoiceMemo, VoiceMemoParsedFields } from "~/types/voice-memo";
 import { resolveVoiceMemoAudioUrl } from "~/lib/voice-memo/cloud";
 import { Card } from "~/components/ui/card";
 import { cn } from "~/lib/utils/cn";
@@ -130,6 +130,12 @@ export function VoiceMemoCard({ memo, locale }: VoiceMemoCardProps) {
               </span>
             )}
           </p>
+          {memo.parsed_fields && (
+            <ParsedFieldsRow
+              parsed={memo.parsed_fields}
+              locale={locale}
+            />
+          )}
           {error && (
             <p className="mt-1.5 text-[11px] text-[var(--warn)]">{error}</p>
           )}
@@ -158,6 +164,128 @@ function formatDuration(ms: number): string {
   const mins = Math.floor(total / 60);
   const secs = total % 60;
   return `${mins}:${String(secs).padStart(2, "0")}`;
+}
+
+function ParsedFieldsRow({
+  parsed,
+  locale,
+}: {
+  parsed: VoiceMemoParsedFields;
+  locale: "en" | "zh";
+}) {
+  const chips = collectChips(parsed, locale);
+  const showLowConfidenceHint =
+    parsed.confidence !== "high" && (chips.length > 0 || parsed.notes);
+
+  if (chips.length === 0 && !parsed.notes) {
+    if (parsed.confidence === "low") {
+      return (
+        <p className="mt-1.5 text-[10.5px] italic text-ink-400">
+          {locale === "zh"
+            ? "（信息不足，未提取结构化字段）"
+            : "(not enough detail to extract structured fields)"}
+        </p>
+      );
+    }
+    return null;
+  }
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      {chips.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {chips.map((c) => (
+            <span
+              key={c.label}
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10.5px] font-medium",
+                parsed.confidence === "high"
+                  ? "bg-[var(--tide-2)]/12 text-[var(--tide-2)]"
+                  : "bg-ink-100 text-ink-500",
+              )}
+            >
+              {c.label}
+              <span className="font-normal opacity-70">{c.value}</span>
+            </span>
+          ))}
+        </div>
+      )}
+      {parsed.notes && (
+        <p className="text-[11.5px] italic text-ink-500">
+          {locale === "zh" ? "笔记：" : "Notes: "}
+          {parsed.notes}
+        </p>
+      )}
+      {showLowConfidenceHint && (
+        <p className="text-[10.5px] text-ink-400">
+          {locale === "zh"
+            ? `识别可信度：${confidenceLabel(parsed.confidence, "zh")}（高可信度才会自动写入日常表）`
+            : `Confidence: ${confidenceLabel(parsed.confidence, "en")} — only high-confidence fields auto-fill the daily form.`}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function collectChips(
+  parsed: VoiceMemoParsedFields,
+  locale: "en" | "zh",
+): { label: string; value: string }[] {
+  const chips: { label: string; value: string }[] = [];
+  function num(label: { en: string; zh: string }, val: number | undefined, suffix = "/10") {
+    if (typeof val !== "number") return;
+    chips.push({
+      label: locale === "zh" ? label.zh : label.en,
+      value: `${val}${suffix}`,
+    });
+  }
+  function bool(label: { en: string; zh: string }, val: boolean | undefined) {
+    if (val !== true) return;
+    chips.push({
+      label: locale === "zh" ? label.zh : label.en,
+      value: locale === "zh" ? "是" : "yes",
+    });
+  }
+  num({ en: "energy", zh: "精力" }, parsed.energy);
+  num({ en: "sleep", zh: "睡眠" }, parsed.sleep_quality);
+  num({ en: "appetite", zh: "胃口" }, parsed.appetite);
+  num({ en: "pain", zh: "疼痛" }, parsed.pain_current);
+  num({ en: "pain (worst)", zh: "最痛" }, parsed.pain_worst);
+  num({ en: "mood", zh: "心情" }, parsed.mood_clarity);
+  num({ en: "nausea", zh: "恶心" }, parsed.nausea);
+  num({ en: "fatigue", zh: "疲倦" }, parsed.fatigue);
+  num({ en: "anorexia", zh: "厌食" }, parsed.anorexia);
+  num({ en: "abdo pain", zh: "腹痛" }, parsed.abdominal_pain);
+  num({ en: "neuro hands", zh: "手麻" }, parsed.neuropathy_hands, "/4");
+  num({ en: "neuro feet", zh: "脚麻" }, parsed.neuropathy_feet, "/4");
+  if (typeof parsed.weight_kg === "number") {
+    chips.push({
+      label: locale === "zh" ? "体重" : "weight",
+      value: `${parsed.weight_kg.toFixed(1)} kg`,
+    });
+  }
+  if (typeof parsed.diarrhoea_count === "number") {
+    chips.push({
+      label: locale === "zh" ? "腹泻" : "diarrhoea",
+      value: `${parsed.diarrhoea_count}×`,
+    });
+  }
+  bool({ en: "cold dysaesthesia", zh: "冷敏感" }, parsed.cold_dysaesthesia);
+  bool({ en: "mouth sores", zh: "口腔溃疡" }, parsed.mouth_sores);
+  bool({ en: "fever", zh: "发烧" }, parsed.fever);
+  return chips;
+}
+
+function confidenceLabel(
+  c: VoiceMemoParsedFields["confidence"],
+  locale: "en" | "zh",
+): string {
+  if (locale === "zh") {
+    if (c === "high") return "高";
+    if (c === "medium") return "中";
+    return "低";
+  }
+  return c;
 }
 
 function sourceLabel(

--- a/src/hooks/use-voice-transcription.ts
+++ b/src/hooks/use-voice-transcription.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { persistVoiceMemo } from "~/lib/voice-memo/persist";
 import { uploadVoiceMemoAudio } from "~/lib/voice-memo/cloud";
+import { parseAndApplyVoiceMemo } from "~/lib/voice-memo/parse";
 import type { VoiceMemo } from "~/types/voice-memo";
 import type { EnteredBy } from "~/types/clinical";
 
@@ -75,6 +76,15 @@ export interface UseVoiceTranscriptionOptions {
    * `log_event_id` onto the memo.
    */
   onPersisted?: (memo: { memo_id: number; transcript: string }) => void;
+  /**
+   * Run the Slice-2 Claude parser after persistence so the memo's
+   * structured fields land on the row and are safe-filled into
+   * `daily_entries`. Defaults to true for diary, log, and any other
+   * source — voice memos as foundational data means structured
+   * extraction is on by default. Pass false for one-off transient
+   * captures (test fixtures, fully-typed flows that bypass diary).
+   */
+  parseAfterPersist?: boolean;
 }
 
 export function useVoiceTranscription(
@@ -88,6 +98,7 @@ export function useVoiceTranscription(
     source = "diary",
     enteredBy = "hulin",
     onPersisted,
+    parseAfterPersist = true,
   } = opts;
 
   const [supported, setSupported] = useState(false);
@@ -116,6 +127,8 @@ export function useVoiceTranscription(
   sourceRef.current = source;
   const enteredByRef = useRef(enteredBy);
   enteredByRef.current = enteredBy;
+  const parseAfterPersistRef = useRef(parseAfterPersist);
+  parseAfterPersistRef.current = parseAfterPersist;
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -220,6 +233,12 @@ export function useVoiceTranscription(
                   // eslint-disable-next-line no-console
                   console.warn("[voice-memo] cloud upload failed", err);
                 });
+                if (parseAfterPersistRef.current) {
+                  void parseAndApplyVoiceMemo(memo_id).catch((err) => {
+                    // eslint-disable-next-line no-console
+                    console.warn("[voice-memo] parse failed", err);
+                  });
+                }
               } catch (err) {
                 // eslint-disable-next-line no-console
                 console.warn("[voice-memo] persist failed", err);

--- a/src/lib/voice-memo/parse-schema.ts
+++ b/src/lib/voice-memo/parse-schema.ts
@@ -1,0 +1,122 @@
+import { z } from "zod/v4";
+import {
+  FALLBACK_HOUSEHOLD_PROFILE,
+  type HouseholdProfile,
+} from "~/types/household-profile";
+
+// Schema for the daily-form fields Claude extracts from a patient
+// voice memo. Every field is optional — Claude only sets values it
+// can defend from the transcript. Anything ambiguous goes into
+// `notes` instead so the patient can confirm without losing context.
+//
+// Fields mirror `DailyEntry` so the safe-merge step can copy them
+// straight across. Confidence drives whether daily_entries gets
+// written — low/medium results stay on the memo card only.
+
+const ZeroToTen = z
+  .number()
+  .min(0)
+  .max(10);
+
+const NeuropathyGrade = z
+  .number()
+  .int()
+  .min(0)
+  .max(4)
+  .describe(
+    "CTCAE 0–4. 0=none, 1=tingling/cold dysaesthesia only, 2=interferes with fine motor (buttons, keys), 3=limits ADLs, 4=disabling.",
+  );
+
+export const VoiceMemoParseSchema = z.object({
+  energy: ZeroToTen
+    .nullable()
+    .optional()
+    .describe(
+      "0–10 self-rated energy. Set only when verbalised: a number, a clear word like 'exhausted'→2, 'sluggish'→4, 'normal'→6, 'good'→7.",
+    ),
+  sleep_quality: ZeroToTen
+    .nullable()
+    .optional()
+    .describe("0–10. 'awful sleep'→2, 'broken'→4, 'okay'→6, 'great'→8."),
+  appetite: ZeroToTen
+    .nullable()
+    .optional()
+    .describe("0–10. 'no appetite'→1, 'forced myself to eat'→3, 'normal'→6."),
+  pain_current: ZeroToTen
+    .nullable()
+    .optional()
+    .describe("Pain 0–10 right now."),
+  pain_worst: ZeroToTen
+    .nullable()
+    .optional()
+    .describe("Worst pain today, 0–10."),
+  mood_clarity: ZeroToTen
+    .nullable()
+    .optional()
+    .describe("0–10. 'foggy'→3, 'clear-headed'→8."),
+  nausea: ZeroToTen.nullable().optional().describe("0–10 nausea severity."),
+  fatigue: ZeroToTen.nullable().optional(),
+  anorexia: ZeroToTen
+    .nullable()
+    .optional()
+    .describe("0–10 loss-of-desire-to-eat severity."),
+  abdominal_pain: ZeroToTen.nullable().optional(),
+  neuropathy_hands: NeuropathyGrade.nullable().optional(),
+  neuropathy_feet: NeuropathyGrade.nullable().optional(),
+  weight_kg: z
+    .number()
+    .min(20)
+    .max(200)
+    .nullable()
+    .optional()
+    .describe("Only when the patient states a weight. Reject implausible values."),
+  diarrhoea_count: z
+    .number()
+    .int()
+    .min(0)
+    .max(20)
+    .nullable()
+    .optional()
+    .describe("Number of loose stools today, when stated."),
+  cold_dysaesthesia: z
+    .boolean()
+    .nullable()
+    .optional()
+    .describe(
+      "True when the patient describes cold-triggered tingling or pain (e.g. 'fridge feels electric'). Never set false on a memo that doesn't mention it.",
+    ),
+  mouth_sores: z.boolean().nullable().optional(),
+  fever: z.boolean().nullable().optional(),
+  notes: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Anything noteworthy that doesn't fit a structured field — taste changes, food eaten, conversations, observations. Keep concise: 1–3 short sentences.",
+    ),
+  confidence: z
+    .enum(["low", "medium", "high"])
+    .describe(
+      "high: explicit numerics or unambiguous descriptions. medium: clear qualitative anchors. low: only vague mentions, transcript noise, or speech-recognition garbage.",
+    ),
+});
+
+export type VoiceMemoParseResult = z.infer<typeof VoiceMemoParseSchema>;
+
+export function buildVoiceMemoParseSystem(
+  profile: HouseholdProfile = FALLBACK_HOUSEHOLD_PROFILE,
+): string {
+  return `You read short voice-memo transcripts from ${profile.patient_initials}, a patient with ${profile.diagnosis_full} on first-line gemcitabine + nab-paclitaxel, and extract structured daily-tracking fields.
+
+The memo is a self-report — the patient is telling their diary how the day went. Extract only fields the patient actually verbalises. Never infer from absence: a memo that doesn't mention pain doesn't mean pain=0. Leave the field unset.
+
+Output rules:
+1. Every field is optional. Set a value only if the transcript supports it.
+2. Numeric scales are 0–10 unless noted. Map clear qualitative anchors when an explicit number isn't given (see field descriptions). Reject anything you'd guess.
+3. Neuropathy is CTCAE 0–4. Be conservative: vague tingling is grade 1, only set ≥2 if the patient describes interference with hand or foot function.
+4. Booleans only flip true. Never set a boolean false on the strength of silence.
+5. Anything noteworthy that doesn't map to a structured field belongs in \`notes\` (taste changes, foods eaten, conversations, mood detail). Keep notes brief and faithful — don't add analysis.
+6. Set \`confidence\` honestly. low when transcripts are short, garbled, or only mention vague feelings. high only when the patient gives clear numbers or unambiguous descriptions.
+7. Never invent specific numbers, weights, dates, or medications. If the transcript is too vague, return \`{"confidence": "low"}\` with no other fields.
+8. Translate Mandarin or mixed Mandarin/English memos before extracting — the structured fields are language-neutral, but \`notes\` should follow the memo's language.`;
+}

--- a/src/lib/voice-memo/parse.ts
+++ b/src/lib/voice-memo/parse.ts
@@ -1,0 +1,171 @@
+import { db, now } from "~/lib/db/dexie";
+import { localDayISO } from "~/lib/utils/date";
+import { postJson } from "~/lib/utils/http";
+import type { DailyEntry, EnteredBy } from "~/types/clinical";
+import type { VoiceMemo, VoiceMemoParsedFields } from "~/types/voice-memo";
+
+// Slice 2: Claude-powered structured extraction. After Whisper hands
+// us a transcript, we ask Claude to pull out daily-tracking fields
+// (energy, sleep, pain, neuropathy, etc.) and merge them into the
+// day's `daily_entries` row as a safe fill — never an overwrite.
+//
+// Why "safe fill"? The daily form is the source of truth when the
+// patient (or carer) explicitly fills it. Voice memos are a
+// supplementary stream; if the patient already wrote energy=7 on the
+// form, a memo saying "felt sluggish" shouldn't silently rewrite that
+// to a 4. Empty fields get filled; populated fields are preserved.
+//
+// `parsed_fields` always lands on the memo regardless of confidence
+// so the diary card can show what Claude heard. Only `high`-
+// confidence numeric fields ever flow into `daily_entries`.
+
+interface ParseResponse {
+  parsed: VoiceMemoParsedFields;
+}
+
+// Run the full parse-and-apply pipeline for one memo. Errors don't
+// throw into the UI — they're logged and the memo stays unparsed,
+// which the diary surfaces as a re-parse affordance later.
+export async function parseAndApplyVoiceMemo(memoId: number): Promise<void> {
+  const memo = await db.voice_memos.get(memoId);
+  if (!memo) return;
+  if (memo.parsed_fields) return; // already parsed
+  if (!memo.transcript.trim()) return;
+
+  let parsed: VoiceMemoParsedFields;
+  try {
+    const res = await postJson<ParseResponse>("/api/ai/parse-voice-memo", {
+      transcript: memo.transcript,
+      locale: memo.locale,
+      recorded_at: memo.recorded_at,
+    });
+    parsed = res.parsed;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn("[voice-memo] parse failed", memoId, err);
+    return;
+  }
+
+  await db.voice_memos.update(memoId, {
+    parsed_fields: parsed,
+    updated_at: now(),
+  });
+
+  if (parsed.confidence === "high") {
+    await applyParsedFieldsToDaily(memo, parsed);
+  }
+}
+
+// Merge a parsed memo into its day's daily_entries row using
+// fill-empty-only semantics. Booleans only flip true; numerics only
+// fill when the daily field is undefined; `notes` accumulates so
+// multiple memos in a day don't clobber each other.
+export async function applyParsedFieldsToDaily(
+  memo: VoiceMemo,
+  parsed: VoiceMemoParsedFields,
+): Promise<void> {
+  const day = memo.day || localDayISO(memo.recorded_at);
+  const existing = await db.daily_entries
+    .where("date")
+    .equals(day)
+    .first();
+  const ts = now();
+
+  if (existing?.id) {
+    const patch = buildSafeFillPatch(existing, parsed);
+    if (Object.keys(patch).length === 0) return;
+    await db.daily_entries.update(existing.id, {
+      ...patch,
+      updated_at: ts,
+    });
+    return;
+  }
+
+  // No daily row yet — create a stub with whatever the memo provided.
+  const stub = buildSafeFillPatch({} as Partial<DailyEntry>, parsed);
+  if (Object.keys(stub).length === 0) return;
+  const enteredBy: EnteredBy = memo.entered_by;
+  await db.daily_entries.add({
+    ...stub,
+    date: day,
+    entered_at: ts,
+    entered_by: enteredBy,
+    created_at: ts,
+    updated_at: ts,
+  } as DailyEntry);
+}
+
+// Decide which keys move from the parsed result into the daily row
+// without trampling existing data. Exported for unit testing — the
+// merge rules are the part most worth pinning down.
+export function buildSafeFillPatch(
+  existing: Partial<DailyEntry>,
+  parsed: VoiceMemoParsedFields,
+): Partial<DailyEntry> {
+  const out: Partial<DailyEntry> = {};
+
+  // Numeric scales — only set when the daily row hasn't recorded one.
+  fillNumber(out, existing, parsed, "energy");
+  fillNumber(out, existing, parsed, "sleep_quality");
+  fillNumber(out, existing, parsed, "appetite");
+  fillNumber(out, existing, parsed, "pain_current");
+  fillNumber(out, existing, parsed, "pain_worst");
+  fillNumber(out, existing, parsed, "mood_clarity");
+  fillNumber(out, existing, parsed, "nausea");
+  fillNumber(out, existing, parsed, "fatigue");
+  fillNumber(out, existing, parsed, "anorexia");
+  fillNumber(out, existing, parsed, "abdominal_pain");
+  fillNumber(out, existing, parsed, "neuropathy_hands");
+  fillNumber(out, existing, parsed, "neuropathy_feet");
+  fillNumber(out, existing, parsed, "weight_kg");
+  fillNumber(out, existing, parsed, "diarrhoea_count");
+
+  // Booleans — only flip undefined → true. Never invert true → false
+  // and never write false from a memo (silence isn't denial).
+  flipTrue(out, existing, parsed, "cold_dysaesthesia");
+  flipTrue(out, existing, parsed, "mouth_sores");
+  flipTrue(out, existing, parsed, "fever");
+
+  return out;
+}
+
+function fillNumber<K extends NumericFillKey>(
+  out: Partial<DailyEntry>,
+  existing: Partial<DailyEntry>,
+  parsed: VoiceMemoParsedFields,
+  key: K,
+): void {
+  const incoming = parsed[key];
+  if (typeof incoming !== "number") return;
+  if (typeof existing[key] === "number") return;
+  out[key] = incoming;
+}
+
+function flipTrue<K extends BoolFillKey>(
+  out: Partial<DailyEntry>,
+  existing: Partial<DailyEntry>,
+  parsed: VoiceMemoParsedFields,
+  key: K,
+): void {
+  if (parsed[key] !== true) return;
+  if (existing[key] === true) return;
+  out[key] = true;
+}
+
+type NumericFillKey =
+  | "energy"
+  | "sleep_quality"
+  | "appetite"
+  | "pain_current"
+  | "pain_worst"
+  | "mood_clarity"
+  | "nausea"
+  | "fatigue"
+  | "anorexia"
+  | "abdominal_pain"
+  | "neuropathy_hands"
+  | "neuropathy_feet"
+  | "weight_kg"
+  | "diarrhoea_count";
+
+type BoolFillKey = "cold_dysaesthesia" | "mouth_sores" | "fever";

--- a/src/types/voice-memo.ts
+++ b/src/types/voice-memo.ts
@@ -43,10 +43,38 @@ export interface VoiceMemo {
 }
 
 export interface VoiceMemoParsedFields {
+  // Subjective 0–10 scales matching DailyEntry. Only set when the
+  // patient verbalises a number or a clear qualitative anchor we can
+  // map (e.g. "no pain at all" → 0, "really tired" → ~3 energy).
   energy?: number;
-  sleep_hours?: number;
-  pain?: number;
-  mood?: number;
-  symptoms?: string[];
+  sleep_quality?: number;
+  appetite?: number;
+  pain_current?: number;
+  pain_worst?: number;
+  mood_clarity?: number;
+  nausea?: number;
+  fatigue?: number;
+  anorexia?: number;
+  abdominal_pain?: number;
+  // CTCAE 0–4 neuropathy. Inferred from descriptions like "tingling
+  // when I touch cold things" → 1, "interferes with buttoning shirt"
+  // → 2.
+  neuropathy_hands?: number;
+  neuropathy_feet?: number;
+  // Concrete objective values when the patient states them.
+  weight_kg?: number;
+  diarrhoea_count?: number;
+  // Booleans only flip true when the patient clearly reports the
+  // symptom. We never invert a previously-true daily-entry boolean
+  // back to false from a memo that's silent on it.
+  cold_dysaesthesia?: boolean;
+  mouth_sores?: boolean;
+  fever?: boolean;
+  // Free-form catch-all for things that don't map to a daily field
+  // (taste changes, food eaten, conversations had, mood notes).
   notes?: string;
+  // Confidence the parser had in the extraction. Low/medium results
+  // do not write to daily_entries even when fields are present —
+  // they only show on the memo card so the patient can confirm.
+  confidence: "low" | "medium" | "high";
 }

--- a/tests/unit/voice-memo-parse.test.ts
+++ b/tests/unit/voice-memo-parse.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { db } from "~/lib/db/dexie";
+import {
+  applyParsedFieldsToDaily,
+  buildSafeFillPatch,
+} from "~/lib/voice-memo/parse";
+import { persistVoiceMemo } from "~/lib/voice-memo/persist";
+import type { DailyEntry } from "~/types/clinical";
+import type { VoiceMemoParsedFields } from "~/types/voice-memo";
+
+beforeEach(async () => {
+  await db.delete();
+  await db.open();
+});
+
+describe("buildSafeFillPatch", () => {
+  it("fills empty numeric fields and leaves populated ones alone", () => {
+    const existing: Partial<DailyEntry> = { energy: 7, pain_current: 0 };
+    const parsed: VoiceMemoParsedFields = {
+      energy: 4,
+      pain_current: 5,
+      sleep_quality: 6,
+      confidence: "high",
+    };
+    const patch = buildSafeFillPatch(existing, parsed);
+    // sleep_quality wasn't on the daily row → fills.
+    expect(patch.sleep_quality).toBe(6);
+    // energy and pain_current are already set → preserved.
+    expect("energy" in patch).toBe(false);
+    expect("pain_current" in patch).toBe(false);
+  });
+
+  it("flips booleans only undefined → true, never true → false", () => {
+    const parsedFlipsOn: VoiceMemoParsedFields = {
+      cold_dysaesthesia: true,
+      mouth_sores: false,
+      confidence: "high",
+    };
+    const patch1 = buildSafeFillPatch({}, parsedFlipsOn);
+    expect(patch1.cold_dysaesthesia).toBe(true);
+    // false from a memo never lands — silence is not denial.
+    expect("mouth_sores" in patch1).toBe(false);
+
+    const parsedTriesToInvert: VoiceMemoParsedFields = {
+      cold_dysaesthesia: false,
+      confidence: "high",
+    };
+    const patch2 = buildSafeFillPatch(
+      { cold_dysaesthesia: true },
+      parsedTriesToInvert,
+    );
+    expect("cold_dysaesthesia" in patch2).toBe(false);
+  });
+
+  it("ignores absent fields", () => {
+    const patch = buildSafeFillPatch({}, { confidence: "high" });
+    expect(Object.keys(patch)).toHaveLength(0);
+  });
+
+  it("handles neuropathy CTCAE grades 0–4 the same as other numerics", () => {
+    const patch = buildSafeFillPatch(
+      { neuropathy_hands: 1 },
+      { neuropathy_hands: 3, neuropathy_feet: 2, confidence: "high" },
+    );
+    expect(patch.neuropathy_feet).toBe(2);
+    expect("neuropathy_hands" in patch).toBe(false);
+  });
+});
+
+describe("applyParsedFieldsToDaily", () => {
+  it("creates a new daily_entries row when none exists for the day", async () => {
+    const { memo_id } = await persistVoiceMemo({
+      blob: new Blob([new Uint8Array(8)], { type: "audio/webm" }),
+      mime: "audio/webm",
+      duration_ms: 4000,
+      transcript: "energy 6, slept ok",
+      locale: "en",
+      entered_by: "hulin",
+      source_screen: "diary",
+      recorded_at: "2026-04-29T08:00:00",
+    });
+    const memo = await db.voice_memos.get(memo_id);
+    if (!memo) throw new Error("memo missing");
+
+    await applyParsedFieldsToDaily(memo, {
+      energy: 6,
+      sleep_quality: 6,
+      confidence: "high",
+    });
+
+    const row = await db.daily_entries.where("date").equals("2026-04-29").first();
+    expect(row?.energy).toBe(6);
+    expect(row?.sleep_quality).toBe(6);
+    expect(row?.entered_by).toBe("hulin");
+    expect(row?.date).toBe("2026-04-29");
+  });
+
+  it("merges into the existing daily_entries row without overwriting", async () => {
+    const ts = "2026-04-29T07:00:00";
+    await db.daily_entries.add({
+      date: "2026-04-29",
+      entered_at: ts,
+      entered_by: "hulin",
+      energy: 8, // user said 8 in the form earlier
+      created_at: ts,
+      updated_at: ts,
+    });
+    const { memo_id } = await persistVoiceMemo({
+      blob: new Blob([new Uint8Array(8)], { type: "audio/webm" }),
+      mime: "audio/webm",
+      duration_ms: 4000,
+      transcript: "felt sluggish, sleep was patchy",
+      locale: "en",
+      entered_by: "hulin",
+      source_screen: "diary",
+      recorded_at: "2026-04-29T20:00:00",
+    });
+    const memo = await db.voice_memos.get(memo_id);
+    if (!memo) throw new Error("memo missing");
+
+    await applyParsedFieldsToDaily(memo, {
+      energy: 4, // memo disagrees, but user form wins
+      sleep_quality: 4, // form had no value → fills
+      confidence: "high",
+    });
+
+    const row = await db.daily_entries.where("date").equals("2026-04-29").first();
+    expect(row?.energy).toBe(8);
+    expect(row?.sleep_quality).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2 of the "voice memos as foundational data" plan. Voice memos already land as durable rows in the diary (Slice 1, PR #136); this PR closes the loop so the structured signal Whisper picks up actually flows into daily tracking.

After a memo persists, `useVoiceTranscription` kicks off a Claude extraction that pulls **energy / sleep / pain (current + worst) / neuropathy (hands + feet) / mood / appetite / nausea / fatigue / anorexia / abdominal pain / weight / diarrhoea count / cold dysaesthesia / mouth sores / fever** plus a free-form `notes` string out of the transcript. The result is stamped onto `voice_memos.parsed_fields` and safe-filled into the day's `daily_entries` row.

## Safe-fill semantics

These are non-negotiable for trust — covered by 4 new unit tests:

- **Numerics fill only when the daily field is `undefined`.** Explicit form values are never overwritten by a memo. If the patient wrote energy=8 in the form and a later memo says "felt sluggish", the form wins.
- **Booleans only flip `undefined → true`.** Silence is not denial; a memo never writes `false`, and never inverts a previously-true field.
- **Only `confidence: "high"` results write to `daily_entries`.** Medium / low parses still appear on the diary card so the patient can confirm, but never silently rewrite tracking. The threshold pushes "guessy" extractions into UI rather than data.

## Pieces

- `POST /api/ai/parse-voice-memo` — Claude JSON extractor. Prompt cached (ephemeral), household profile interpolated, max_tokens=800.
- `src/lib/voice-memo/parse-schema.ts` — Zod schema (mirrors `DailyEntry`) + system prompt with explicit "never infer from absence" rules and `low/medium/high` confidence anchors.
- `src/lib/voice-memo/parse.ts` — `parseAndApplyVoiceMemo` orchestrator + pure `buildSafeFillPatch` for the merge logic.
- `useVoiceTranscription` gains `parseAfterPersist` (default `true`). Every screen that records — `/diary`, `/log`, meal-ingest, phone-note — now produces parsed fields automatically.
- `VoiceMemoCard` shows extracted fields as chips, a notes line, and a confidence hint when medium / low.
- `VoiceMemoParsedFields` (types/voice-memo.ts) extended to cover the `DailyEntry` surface.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 88 files / **769 tests** pass
- [ ] Manual `/diary`: record "energy maybe 7, hands tingling at fingertips, slept ok". After ~2s, chips appear: `energy 7/10 · neuro hands 1/4 · sleep 6/10`. Open `/daily` — fields filled.
- [ ] Manual: pre-fill `energy=8` on `/daily`, then record a memo saying "felt sluggish, like a 4". Memo card shows `energy 4/10` chip but `/daily` still shows 8.
- [ ] Manual zh-CN: 录一段"今天精力大概六分，胃口一般" — chips show 精力 6/10 · 胃口 5/10, `notes` empty (numbers covered the structured extraction).
- [ ] Manual: short noisy memo ("uh, hi") returns `confidence: low` — chips empty, low-confidence hint shown, no daily-entries write.
- [ ] Vercel preview env has `OPENAI_API_KEY` (Whisper, from Slice 1) **and** `ANTHROPIC_API_KEY` (the parse route).

## Out of scope

- Re-parse button on existing memos (today, parsing only triggers on fresh capture). Easy to add later.
- Cross-memo reconciliation (a later memo conflicts with an earlier one). Current rule: first-wins per field per day. Sufficient for daily diary semantics; revisit if patients use it heavily.
- Surfacing parsed fields in the agent fan-out — the agents still see the transcript via `log_events`, not the structured fields.

https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU

---
_Generated by [Claude Code](https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU)_