### PR TITLE
Trim dead dashboard UI + anchor labs in time

### DIFF
--- a/src/app/diary/page.tsx
+++ b/src/app/diary/page.tsx
@@ -58,21 +58,41 @@ export default function DiaryPage() {
   const [windowDays, setWindowDays] = useState(WINDOW_DAYS_DEFAULT);
   const [days, setDays] = useState<DiaryDay[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setLoadError(null);
     const to = todayISO();
     const fromDate = new Date(to);
     fromDate.setDate(fromDate.getDate() - windowDays);
     const from = fromDate.toISOString().slice(0, 10);
-    void buildDiaryDays({ from, to, includeEmpty: true }).then((rows) => {
+    // Hard timeout so a hung Dexie query (corrupt index, OPFS lock,
+    // huge backlog) can't trap the user on an infinite spinner. 10s
+    // is well past any healthy aggregation; past that, surface an
+    // error and let the user retry / open a different page.
+    const timeout = setTimeout(() => {
       if (cancelled) return;
-      setDays(rows);
+      setLoadError("timeout");
       setLoading(false);
-    });
+    }, 10000);
+    void buildDiaryDays({ from, to, includeEmpty: true })
+      .then((rows) => {
+        if (cancelled) return;
+        clearTimeout(timeout);
+        setDays(rows);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        clearTimeout(timeout);
+        setLoadError(err instanceof Error ? err.message : "unknown");
+        setLoading(false);
+      });
     return () => {
       cancelled = true;
+      clearTimeout(timeout);
     };
     // Re-run whenever any underlying table changes row count or the
     // window expands. Cheap because the aggregator reads each table
@@ -126,7 +146,13 @@ export default function DiaryPage() {
         </Button>
       </div>
 
-      {loading && days.length === 0 ? (
+      {loadError ? (
+        <Alert variant="warn" role="alert">
+          {locale === "zh"
+            ? "日记加载失败，请刷新页面重试。"
+            : "Diary failed to load. Try refreshing the page."}
+        </Alert>
+      ) : loading && days.length === 0 ? (
         <Card className="p-5">
           <div className="flex items-center gap-2 text-[12px] text-ink-500">
             <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/app/practices/page.tsx
+++ b/src/app/practices/page.tsx
@@ -159,7 +159,14 @@ function PracticeRow({
               <button
                 type="button"
                 onClick={() => {
-                  if (med.id && confirm("Delete this practice and its logs?"))
+                  if (
+                    med.id &&
+                    confirm(
+                      locale === "zh"
+                        ? "删除此修习及其全部记录？"
+                        : "Delete this practice and its logs?",
+                    )
+                  )
                     void deleteCustomPractice(med.id);
                 }}
                 className="text-[11px] text-ink-400 hover:text-[var(--warn)]"

--- a/src/components/dashboard/pillar-tiles.tsx
+++ b/src/components/dashboard/pillar-tiles.tsx
@@ -122,13 +122,29 @@ export function PillarTiles() {
   }, [recentCycle, locale]);
 
   // -- CA 19-9 ----------------------------------------------------------
-  const ca199Series = (labs ?? [])
-    .slice()
-    .reverse()
-    .map((l) => l.ca199)
-    .filter((v): v is number => typeof v === "number");
+  // Carry the date alongside the value so the tile can show *when* the
+  // latest result was drawn. Without this, "↓20% since start" reads
+  // identically whether the latest CA 19-9 was today or three months
+  // ago, which is clinically misleading.
+  const ca199Points = useMemo(
+    () =>
+      (labs ?? [])
+        .slice()
+        .reverse()
+        .map((l) => ({ value: l.ca199, date: l.date }))
+        .filter(
+          (p): p is { value: number; date: string } =>
+            typeof p.value === "number",
+        ),
+    [labs],
+  );
+  const ca199Series = useMemo(
+    () => ca199Points.map((p) => p.value),
+    [ca199Points],
+  );
   const ca199Latest = ca199Series[ca199Series.length - 1];
   const ca199First = ca199Series[0];
+  const ca199LatestDate = ca199Points[ca199Points.length - 1]?.date ?? null;
   const ca199Delta =
     ca199Latest && ca199First && ca199First > 0
       ? Math.round(((ca199Latest - ca199First) / ca199First) * 100)
@@ -156,7 +172,11 @@ export function PillarTiles() {
       });
     }
     if (flags.length === 0) return null;
-    return { date: latestLab.date, flags };
+    const ageDays = differenceInCalendarDays(
+      new Date(),
+      parseISO(latestLab.date),
+    );
+    return { date: latestLab.date, ageDays, flags };
   }, [latestLab, locale]);
 
   // -- Practice today --------------------------------------------------
@@ -313,6 +333,14 @@ export function PillarTiles() {
           <div className="mono mt-auto text-[10px] uppercase tracking-wider text-ink-500">
             {locale === "zh" ? "最近化验：" : "Latest labs "}
             {lftFlag.date}
+            {lftFlag.ageDays >= 1 && (
+              <span className="ml-1 text-ink-400">
+                ·{" "}
+                {locale === "zh"
+                  ? `${lftFlag.ageDays} 天前`
+                  : `${lftFlag.ageDays}d ago`}
+              </span>
+            )}
           </div>
         </Link>
       ),
@@ -359,6 +387,12 @@ export function PillarTiles() {
                 ? "第一次结果"
                 : "first result"}
           </div>
+          {ca199LatestDate && (
+            <div className="mono text-[10px] uppercase tracking-wider text-ink-400">
+              {locale === "zh" ? "最近：" : "Latest "}
+              {ca199LatestDate}
+            </div>
+          )}
           <div className="mt-auto">
             {ca199Series.length > 1 && (
               <Sparkline

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -9,7 +9,6 @@ import { useLocale, useT } from "~/hooks/use-translate";
 import { useDefaultAiModel } from "~/hooks/use-settings";
 import { generateNarrative } from "~/lib/nudges/ai-narrative";
 import { Card } from "~/components/ui/card";
-import { Button } from "~/components/ui/button";
 import { localize, type FeedItem } from "~/types/feed";
 import { AgentFeedbackControls } from "./agent-feedback-controls";
 import type { AgentId } from "~/types/agent";
@@ -33,6 +32,10 @@ import {
   Circle,
   CheckCircle2,
 } from "lucide-react";
+
+// Bumped when the narrative prompt or shape changes so that stale
+// payloads in localStorage are ignored without forcing a manual clear.
+const NARRATIVE_CACHE_VERSION = "v2";
 
 const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   thermo: Thermometer,
@@ -111,9 +114,19 @@ export function TodayFeed({
   // Narrative fetch — cached daily per locale. Uses the server-side
   // ANTHROPIC_API_KEY via /api/ai/feed-narrative; no per-user key needed.
   useEffect(() => {
-    if (feed.length === 0) return;
+    if (feed.length === 0) {
+      // Clear any stale narrative left over from a previous render
+      // when the feed has emptied out (e.g. user removed an item that
+      // was the last remaining feed entry).
+      setNarrative(null);
+      setNarrativeLoading(false);
+      return;
+    }
     const today = todayISO();
-    const cacheTag = `${today}_${locale}`;
+    // Cache key includes locale + version so that switching language
+    // mid-day, or shipping a new prompt, fetches a fresh narrative
+    // instead of showing the old one in the wrong language.
+    const cacheTag = `${today}_${locale}_${NARRATIVE_CACHE_VERSION}`;
     try {
       const raw = localStorage.getItem(CACHE_KEY);
       if (raw) {
@@ -126,6 +139,10 @@ export function TodayFeed({
     } catch {
       // ignore
     }
+    // Cache miss: drop any prior locale's narrative immediately so we
+    // don't display English text under a Chinese eyebrow while the
+    // new fetch is in flight.
+    setNarrative(null);
     setNarrativeLoading(true);
     void (async () => {
       try {
@@ -158,30 +175,11 @@ export function TodayFeed({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model, locale, feedSignature]);
 
-  if (feed.length === 0) {
-    return (
-      <Card className="p-5">
-        <div className="flex items-start gap-3">
-          <div
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
-            style={{ background: "var(--tide-soft)", color: "var(--tide-2)" }}
-          >
-            <Sparkles className="h-4 w-4" />
-          </div>
-          <div className="space-y-1">
-            <div className="text-[13px] font-semibold text-ink-900">
-              {locale === "zh" ? "今天的动态会显示在这里" : "Your feed will appear here"}
-            </div>
-            <p className="text-[12.5px] text-ink-500 leading-relaxed">
-              {locale === "zh"
-                ? "完成今日记录后，这里会显示摘要、提醒和趋势。先从上方的快速记录开始。"
-                : "After you log today's check-in, this feed will show your summary, alerts, and trends. Start with the quick check-in above."}
-            </p>
-          </div>
-        </div>
-      </Card>
-    );
-  }
+  // Empty feed: render nothing. The dashboard already shows a
+  // QuickCheckinCard / capture surface above; a "your feed will
+  // appear here" placeholder is dead UI on day one and pushes real
+  // content (invites, baseline nudges) further down for no payoff.
+  if (feed.length === 0) return null;
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
## Summary

UX pass focused on dead UI, locale bugs, and clinical time-anchoring. All changes are small and contained — no refactors.

- **TodayFeed empty state** — return `null` on empty days. The "Your feed will appear here" placeholder was clutter on day one and pushed real content (invites, baseline nudge) below the fold while a `QuickCheckinCard` was already the primary capture surface above it.
- **TodayFeed locale switch** — narrative cache key now includes a version tag, and we clear `narrative` state on cache miss / empty feed. Previously, switching to Chinese mid-day flashed the prior English narrative under the new eyebrow until the next fetch landed.
- **PillarTiles time-anchoring** — surface the latest CA 19-9 date alongside the % delta (a 20% drop reads identically whether the latest draw was today or three months ago) and tag the LFT flag tile with "Nd ago" when labs are ≥1 day old so a stale liver flag isn't visually identical to a fresh one.
- **Diary spinner** — added a 10s timeout + error path around `buildDiaryDays` so a hung Dexie aggregation can't trap the user on an infinite "Loading diary…" state. On timeout / error the page renders an inline alert instead of a perpetual spinner.
- **Practices delete confirm** — bilingualised. The Chinese-mode user was getting a hardcoded English browser confirm dialog.

Items audited but **not** changed because they're already correct: pick-patient is in `CAN_SKIP_FROM` (escape hatch exists); back button is correctly hidden only on the welcome step; `/carers?action=add-carer` deep link is wired.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 763/763 passing
- [ ] Manual: open dashboard with no feed items, confirm `TodayFeed` does not render
- [ ] Manual: switch language while a narrative is on screen, confirm no English-under-Chinese flash
- [ ] Manual: open `/diary` with empty Dexie, confirm spinner resolves to empty-state (not infinite)
- [ ] Manual: in Chinese mode, tap delete on a custom practice, confirm Chinese prompt

https://claude.ai/code/session_01W1G6oRvka49VDwbzZexvkE

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1G6oRvka49VDwbzZexvkE)_