### PR TITLE
Refactor: dedupe API route boilerplate + centralise bilingual type

### DIFF
--- a/src/app/api/ai/assessment-summary/route.ts
+++ b/src/app/api/ai/assessment-summary/route.ts
@@ -3,12 +3,10 @@ import { z } from "zod/v4";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import {
   DEFAULT_AI_MODEL,
-  getAnthropicClient,
-  readJsonBody,
+  createClaudeRoute,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
 import { buildSummarySystem } from "~/lib/ai/coach";
-import { requireSession } from "~/lib/auth/require-session";
 import { loadHouseholdProfile } from "~/lib/household/profile";
 import { wrapUserInputBlock } from "~/lib/anthropic/wrap-user-input";
 
@@ -26,17 +24,7 @@ interface RequestBody {
   prior_assessment?: Record<string, unknown> | null;
 }
 
-export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
-  const gate = getAnthropicClient();
-  if (gate.error) return gate.error;
-
-  const parsed = await readJsonBody<RequestBody>(req);
-  if (parsed.error) return parsed.error;
-  const body = parsed.body;
-
+export const POST = createClaudeRoute<RequestBody>(async ({ body, client, session }) => {
   if (!body?.assessment) {
     return NextResponse.json(
       { error: "assessment required" },
@@ -44,10 +32,10 @@ export async function POST(req: Request) {
     );
   }
 
-  const profile = await loadHouseholdProfile(auth.session.household_id);
+  const profile = await loadHouseholdProfile(session.household_id);
 
   const result = await withAnthropicErrorBoundary(() =>
-    gate.client.messages.parse({
+    client.messages.parse({
       model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 800,
       system: [
@@ -85,4 +73,4 @@ export async function POST(req: Request) {
     );
   }
   return NextResponse.json({ result: result.value.parsed_output });
-}
+});

--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -6,11 +6,9 @@ import {
 } from "~/lib/ai/coach";
 import {
   DEFAULT_AI_MODEL,
-  getAnthropicClient,
-  readJsonBody,
+  createClaudeRoute,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
-import { requireSession } from "~/lib/auth/require-session";
 import { loadHouseholdProfile } from "~/lib/household/profile";
 import { wrapUserInputBlock } from "~/lib/anthropic/wrap-user-input";
 import type { Locale } from "~/types/clinical";
@@ -25,17 +23,7 @@ interface RequestBody {
   locale?: Locale;
 }
 
-export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
-  const gate = getAnthropicClient();
-  if (gate.error) return gate.error;
-
-  const parsed = await readJsonBody<RequestBody>(req);
-  if (parsed.error) return parsed.error;
-  const body = parsed.body;
-
+export const POST = createClaudeRoute<RequestBody>(async ({ body, client, session }) => {
   if (!body?.context || !Array.isArray(body?.history)) {
     return NextResponse.json(
       { error: "context and history[] required" },
@@ -44,11 +32,11 @@ export async function POST(req: Request) {
   }
 
   const { model = DEFAULT_AI_MODEL, context, history, locale = "en" } = body;
-  const profile = await loadHouseholdProfile(auth.session.household_id);
+  const profile = await loadHouseholdProfile(session.household_id);
   const contextBlock = `Current step: ${context.stepTitle}\nKey: ${context.stepKey}\nInstructions shown to the user:\n${context.stepInstructions}\n\nRespond in ${locale === "zh" ? "Simplified Chinese (简体中文)" : "English"}.`;
 
   const result = await withAnthropicErrorBoundary(() =>
-    gate.client.messages.create({
+    client.messages.create({
       model,
       max_tokens: 600,
       system: [
@@ -77,4 +65,4 @@ export async function POST(req: Request) {
     );
   }
   return NextResponse.json({ reply: block.text });
-}
+});

--- a/src/app/api/ai/feed-narrative/route.ts
+++ b/src/app/api/ai/feed-narrative/route.ts
@@ -2,11 +2,9 @@ import { NextResponse } from "next/server";
 import { buildNarrativeSystem } from "~/lib/nudges/ai-narrative";
 import {
   DEFAULT_AI_MODEL,
-  getAnthropicClient,
-  readJsonBody,
+  createClaudeRoute,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
-import { requireSession } from "~/lib/auth/require-session";
 import { loadHouseholdProfile } from "~/lib/household/profile";
 import { wrapUserInputBlock } from "~/lib/anthropic/wrap-user-input";
 import type { FeedItem } from "~/types/feed";
@@ -21,23 +19,13 @@ interface RequestBody {
   model?: string;
 }
 
-export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
-  const gate = getAnthropicClient();
-  if (gate.error) return gate.error;
-
-  const parsed = await readJsonBody<RequestBody>(req);
-  if (parsed.error) return parsed.error;
-  const body = parsed.body;
-
+export const POST = createClaudeRoute<RequestBody>(async ({ body, client, session }) => {
   if (!Array.isArray(body?.items)) {
     return NextResponse.json({ error: "items[] required" }, { status: 400 });
   }
 
   const { locale = "en", items, model = DEFAULT_AI_MODEL } = body;
-  const profile = await loadHouseholdProfile(auth.session.household_id);
+  const profile = await loadHouseholdProfile(session.household_id);
   const signals = items
     .slice(0, 8)
     .map((item, i) => {
@@ -48,7 +36,7 @@ export async function POST(req: Request) {
     .join("\n");
 
   const result = await withAnthropicErrorBoundary(() =>
-    gate.client.messages.create({
+    client.messages.create({
       model,
       max_tokens: 300,
       system: [
@@ -81,4 +69,4 @@ export async function POST(req: Request) {
     );
   }
   return NextResponse.json({ narrative: block.text.trim() });
-}
+});

--- a/src/app/api/ai/ingest-meal/route.ts
+++ b/src/app/api/ai/ingest-meal/route.ts
@@ -2,12 +2,10 @@ import { NextResponse } from "next/server";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import {
   DEFAULT_AI_MODEL,
-  getAnthropicClient,
-  readJsonBody,
+  createClaudeRoute,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
 import { MealSchema, buildMealSystem } from "~/lib/ingest/meal-vision";
-import { requireSession } from "~/lib/auth/require-session";
 import { loadHouseholdProfile } from "~/lib/household/profile";
 import type { PreparedImage } from "~/lib/ingest/image";
 
@@ -19,25 +17,15 @@ interface RequestBody {
   model?: string;
 }
 
-export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
-  const gate = getAnthropicClient();
-  if (gate.error) return gate.error;
-
-  const parsed = await readJsonBody<RequestBody>(req);
-  if (parsed.error) return parsed.error;
-  const body = parsed.body;
-
+export const POST = createClaudeRoute<RequestBody>(async ({ body, client, session }) => {
   if (!body?.image?.base64 || !body.image.mediaType) {
     return NextResponse.json({ error: "image required" }, { status: 400 });
   }
 
-  const profile = await loadHouseholdProfile(auth.session.household_id);
+  const profile = await loadHouseholdProfile(session.household_id);
 
   const result = await withAnthropicErrorBoundary(() =>
-    gate.client.messages.parse({
+    client.messages.parse({
       model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 1024,
       system: [
@@ -78,4 +66,4 @@ export async function POST(req: Request) {
     );
   }
   return NextResponse.json({ result: result.value.parsed_output });
-}
+});

--- a/src/app/api/ai/ingest-notes/route.ts
+++ b/src/app/api/ai/ingest-notes/route.ts
@@ -2,15 +2,13 @@ import { NextResponse } from "next/server";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import {
   DEFAULT_AI_MODEL,
-  getAnthropicClient,
-  readJsonBody,
+  createClaudeRoute,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
 import {
   NotesStructureSchema,
   buildNotesSystem,
 } from "~/lib/ingest/notes-vision";
-import { requireSession } from "~/lib/auth/require-session";
 import { loadHouseholdProfile } from "~/lib/household/profile";
 import type { PreparedImage } from "~/lib/ingest/image";
 
@@ -22,25 +20,15 @@ interface RequestBody {
   model?: string;
 }
 
-export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
-  const gate = getAnthropicClient();
-  if (gate.error) return gate.error;
-
-  const parsed = await readJsonBody<RequestBody>(req);
-  if (parsed.error) return parsed.error;
-  const body = parsed.body;
-
+export const POST = createClaudeRoute<RequestBody>(async ({ body, client, session }) => {
   if (!body?.image?.base64 || !body.image.mediaType) {
     return NextResponse.json({ error: "image required" }, { status: 400 });
   }
 
-  const profile = await loadHouseholdProfile(auth.session.household_id);
+  const profile = await loadHouseholdProfile(session.household_id);
 
   const result = await withAnthropicErrorBoundary(() =>
-    gate.client.messages.parse({
+    client.messages.parse({
       model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 1500,
       system: [
@@ -81,4 +69,4 @@ export async function POST(req: Request) {
     );
   }
   return NextResponse.json({ result: result.value.parsed_output });
-}
+});

--- a/src/app/api/ai/ingest-report/route.ts
+++ b/src/app/api/ai/ingest-report/route.ts
@@ -2,15 +2,13 @@ import { NextResponse } from "next/server";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import {
   DEFAULT_AI_MODEL,
-  getAnthropicClient,
-  readJsonBody,
+  createClaudeRoute,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
 import {
   ExtractionSchema,
   EXTRACTION_SYSTEM,
 } from "~/lib/ingest/claude-parser";
-import { requireSession } from "~/lib/auth/require-session";
 import { wrapUserInputBlock } from "~/lib/anthropic/wrap-user-input";
 import type { PreparedImage } from "~/lib/ingest/image";
 
@@ -24,17 +22,7 @@ interface RequestBody {
   model?: string;
 }
 
-export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
-  const gate = getAnthropicClient();
-  if (gate.error) return gate.error;
-
-  const parsed = await readJsonBody<RequestBody>(req);
-  if (parsed.error) return parsed.error;
-  const body = parsed.body;
-
+export const POST = createClaudeRoute<RequestBody>(async ({ body, client }) => {
   if (!body?.text && !body?.image) {
     return NextResponse.json(
       { error: "text or image required" },
@@ -79,7 +67,7 @@ export async function POST(req: Request) {
   }
 
   const result = await withAnthropicErrorBoundary(() =>
-    gate.client.messages.parse({
+    client.messages.parse({
       model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 2048,
       system: [
@@ -102,4 +90,4 @@ export async function POST(req: Request) {
     );
   }
   return NextResponse.json({ result: result.value.parsed_output });
-}
+});

--- a/src/app/api/ai/ingest-universal/route.ts
+++ b/src/app/api/ai/ingest-universal/route.ts
@@ -2,15 +2,13 @@ import { NextResponse } from "next/server";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import {
   DEFAULT_AI_MODEL,
-  getAnthropicClient,
-  readJsonBody,
+  createClaudeRoute,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
 import {
   buildIngestSystem,
   ingestDraftSchema,
 } from "~/lib/ingest/draft-schema";
-import { requireSession } from "~/lib/auth/require-session";
 import { loadHouseholdProfile } from "~/lib/household/profile";
 import { wrapUserInputBlock } from "~/lib/anthropic/wrap-user-input";
 import type { PreparedImage } from "~/lib/ingest/image";
@@ -35,17 +33,7 @@ interface RequestBody {
   model?: string;
 }
 
-export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
-  const gate = getAnthropicClient();
-  if (gate.error) return gate.error;
-
-  const parsed = await readJsonBody<RequestBody>(req);
-  if (parsed.error) return parsed.error;
-  const body = parsed.body;
-
+export const POST = createClaudeRoute<RequestBody>(async ({ body, client, session }) => {
   if (!body?.text && !body?.image) {
     return NextResponse.json(
       { error: "text or image required" },
@@ -58,7 +46,7 @@ export async function POST(req: Request) {
 
   const today = body.today ?? todayISO();
   const locale = body.locale ?? "en";
-  const profile = await loadHouseholdProfile(auth.session.household_id);
+  const profile = await loadHouseholdProfile(session.household_id);
 
   const content: Array<
     | { type: "text"; text: string }
@@ -98,7 +86,7 @@ export async function POST(req: Request) {
   }
 
   const result = await withAnthropicErrorBoundary(() =>
-    gate.client.messages.parse({
+    client.messages.parse({
       model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 4096,
       system: [
@@ -125,4 +113,4 @@ export async function POST(req: Request) {
     ...result.value.parsed_output,
   };
   return NextResponse.json({ draft });
-}
+});

--- a/src/app/api/ai/parse-meal/route.ts
+++ b/src/app/api/ai/parse-meal/route.ts
@@ -2,15 +2,13 @@ import { NextResponse } from "next/server";
 import { jsonOutputFormat } from "~/lib/anthropic/json-output";
 import {
   DEFAULT_AI_MODEL,
-  getAnthropicClient,
-  readJsonBody,
+  createClaudeRoute,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
 import {
   ParsedMealSchema,
   buildNutritionSystem,
 } from "~/lib/nutrition/parser-schema";
-import { requireSession } from "~/lib/auth/require-session";
 import { loadHouseholdProfile } from "~/lib/household/profile";
 import { wrapUserInput } from "~/lib/anthropic/wrap-user-input";
 import type { PreparedImage } from "~/lib/ingest/image";
@@ -32,17 +30,7 @@ interface TextBody {
 }
 type RequestBody = PhotoBody | TextBody;
 
-export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
-  const gate = getAnthropicClient();
-  if (gate.error) return gate.error;
-
-  const parsed = await readJsonBody<RequestBody>(req);
-  if (parsed.error) return parsed.error;
-  const body = parsed.body;
-
+export const POST = createClaudeRoute<RequestBody>(async ({ body, client, session }) => {
   if (!body || (body.kind !== "photo" && body.kind !== "text")) {
     return NextResponse.json(
       { error: "kind must be 'photo' or 'text'" },
@@ -56,14 +44,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "text required" }, { status: 400 });
   }
 
-  const profile = await loadHouseholdProfile(auth.session.household_id);
+  const profile = await loadHouseholdProfile(session.household_id);
   const localeNote =
     body.locale === "zh"
       ? "Reply in English keys, but populate name_zh for every item."
       : "name_zh is optional; only populate when obvious (e.g. Chinese dish).";
 
   const result = await withAnthropicErrorBoundary(() =>
-    gate.client.messages.parse({
+    client.messages.parse({
       model: body.model ?? DEFAULT_AI_MODEL,
       max_tokens: 1500,
       system: [
@@ -120,4 +108,4 @@ export async function POST(req: Request) {
     );
   }
   return NextResponse.json({ result: result.value.parsed_output });
-}
+});

--- a/src/app/api/parse-appointment/route.ts
+++ b/src/app/api/parse-appointment/route.ts
@@ -3,10 +3,8 @@ import { z } from "zod";
 import { parsedAppointmentSchema } from "~/lib/appointments/schema";
 import {
   DEFAULT_AI_MODEL,
-  getAnthropicClient,
-  readJsonBody,
+  createClaudeRoute,
 } from "~/lib/anthropic/route-helpers";
-import { requireSession } from "~/lib/auth/require-session";
 import { wrapUserInputBlock } from "~/lib/anthropic/wrap-user-input";
 
 // Server-side vision/text parser for appointment letters, cards, and
@@ -61,14 +59,8 @@ Fields:
 
 Return nothing for fields you can't see. Never fabricate. If the input clearly isn't an appointment, still return an object but with confidence "low" and title="Unable to parse".`;
 
-export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
-  const json = await readJsonBody<unknown>(req);
-  if (json.error) return json.error;
-
-  const parsed = RequestSchema.safeParse(json.body);
+export const POST = createClaudeRoute<unknown>(async ({ body, client }) => {
+  const parsed = RequestSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
       { error: "Invalid request", detail: parsed.error.flatten() },
@@ -82,9 +74,6 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
-
-  const gate = getAnthropicClient();
-  if (gate.error) return gate.error;
 
   const { jsonOutputFormat } = await import("~/lib/anthropic/json-output");
 
@@ -123,7 +112,7 @@ export async function POST(req: Request) {
   });
 
   try {
-    const response = await gate.client.messages.parse({
+    const response = await client.messages.parse({
       model: process.env.ANTHROPIC_LOG_MODEL || DEFAULT_AI_MODEL,
       max_tokens: 800,
       system: [
@@ -150,7 +139,7 @@ export async function POST(req: Request) {
       { status: 502 },
     );
   }
-}
+});
 
 function stripDataUrlPrefix(b64: string): string {
   const marker = "base64,";

--- a/src/app/api/push/send-test/route.ts
+++ b/src/app/api/push/send-test/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getSupabaseServer } from "~/lib/supabase/server";
+import { requireSupabaseUser } from "~/lib/auth/require-supabase-user";
 import { getServiceRoleClient, sendPushToUser } from "~/lib/push/server";
 
 // Dev helper: sends a test push to every subscription belonging to the
@@ -20,17 +20,10 @@ export async function POST() {
       { status: 403 },
     );
   }
-  const sb = getSupabaseServer();
-  if (!sb) {
-    return NextResponse.json(
-      { error: "Supabase is not configured." },
-      { status: 503 },
-    );
-  }
-  const { data: auth } = await sb.auth.getUser();
-  if (!auth.user) {
-    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
-  }
+  const auth = await requireSupabaseUser();
+  if (!auth.ok) return auth.error;
+  const { user } = auth.data;
+
   const service = getServiceRoleClient();
   if (!service) {
     return NextResponse.json(
@@ -39,7 +32,7 @@ export async function POST() {
     );
   }
 
-  const result = await sendPushToUser(service, auth.user.id, {
+  const result = await sendPushToUser(service, user.id, {
     title: "Anchor test",
     body: "Push is wired up.",
     url: "/",

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getSupabaseServer } from "~/lib/supabase/server";
+import { requireSupabaseUser } from "~/lib/auth/require-supabase-user";
 
 // POST: upsert a PushSubscription for the current user + device.
 // The body shape mirrors what PushSubscription.toJSON() produces on
@@ -16,17 +16,9 @@ interface RequestBody {
 }
 
 export async function POST(req: Request) {
-  const sb = getSupabaseServer();
-  if (!sb) {
-    return NextResponse.json(
-      { error: "Supabase is not configured." },
-      { status: 503 },
-    );
-  }
-  const { data: auth } = await sb.auth.getUser();
-  if (!auth.user) {
-    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
-  }
+  const auth = await requireSupabaseUser();
+  if (!auth.ok) return auth.error;
+  const { user, sb } = auth.data;
 
   let body: RequestBody;
   try {
@@ -45,7 +37,7 @@ export async function POST(req: Request) {
     .from("push_subscriptions")
     .upsert(
       {
-        user_id: auth.user.id,
+        user_id: user.id,
         endpoint: body.endpoint,
         p256dh: body.keys.p256dh,
         auth: body.keys.auth,

--- a/src/app/api/push/unsubscribe/route.ts
+++ b/src/app/api/push/unsubscribe/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getSupabaseServer } from "~/lib/supabase/server";
+import { requireSupabaseUser } from "~/lib/auth/require-supabase-user";
 
 // POST: delete the subscription row matching { user_id, endpoint }.
 // The client calls this after PushSubscription.unsubscribe() so the
@@ -12,17 +12,9 @@ interface RequestBody {
 }
 
 export async function POST(req: Request) {
-  const sb = getSupabaseServer();
-  if (!sb) {
-    return NextResponse.json(
-      { error: "Supabase is not configured." },
-      { status: 503 },
-    );
-  }
-  const { data: auth } = await sb.auth.getUser();
-  if (!auth.user) {
-    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
-  }
+  const auth = await requireSupabaseUser();
+  if (!auth.ok) return auth.error;
+  const { user, sb } = auth.data;
 
   let body: RequestBody;
   try {
@@ -37,7 +29,7 @@ export async function POST(req: Request) {
   const { error } = await sb
     .from("push_subscriptions")
     .delete()
-    .eq("user_id", auth.user.id)
+    .eq("user_id", user.id)
     .eq("endpoint", body.endpoint);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/care-team/page.tsx
+++ b/src/app/care-team/page.tsx
@@ -14,8 +14,9 @@ import type {
 import { differenceInCalendarDays, format, parseISO } from "date-fns";
 import { cn } from "~/lib/utils/cn";
 import { todayISO } from "~/lib/utils/date";
+import type { LocalizedText } from "~/types/localized";
 
-const KIND_LABELS: Record<CareTeamContactKind, { en: string; zh: string }> = {
+const KIND_LABELS: Record<CareTeamContactKind, LocalizedText> = {
   clinic_visit: { en: "Clinic visit", zh: "门诊" },
   clinician_call: { en: "Phone / telehealth", zh: "电话 / 远程医疗" },
   specialist_visit: { en: "Specialist visit", zh: "专科门诊" },

--- a/src/app/diary/page.tsx
+++ b/src/app/diary/page.tsx
@@ -34,6 +34,7 @@ import { VoiceMemoCard } from "~/components/diary/voice-memo-card";
 import { cn } from "~/lib/utils/cn";
 import type { AgentRunRow } from "~/types/agent";
 import type { AppliedPatch, VoiceMemo } from "~/types/voice-memo";
+import type { LocalizedText } from "~/types/localized";
 
 // /diary — the patient's daily timeline. One section per day, newest
 // first, combining:
@@ -433,7 +434,7 @@ function buildDailySummary(
   locale: "en" | "zh",
 ): string {
   const parts: string[] = [];
-  function push(label: { en: string; zh: string }, value: string) {
+  function push(label: LocalizedText, value: string) {
     parts.push(`${locale === "zh" ? label.zh : label.en} ${value}`);
   }
   if (typeof entry.energy === "number") {

--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "~/lib/ingest/meal-vision";
 import { todayISO } from "~/lib/utils/date";
 import { Sparkles, Check, Loader2 } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 export default function MealIngestPage() {
   const locale = useLocale();
@@ -250,7 +251,7 @@ function MealResult({
   onDiscard: () => void;
   saving: boolean;
 }) {
-  const confidenceLabel: Record<MealEstimate["confidence"], { en: string; zh: string }> = {
+  const confidenceLabel: Record<MealEstimate["confidence"], LocalizedText> = {
     low: { en: "low confidence", zh: "置信度低" },
     medium: { en: "medium confidence", zh: "置信度中" },
     high: { en: "high confidence", zh: "置信度高" },

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -30,8 +30,9 @@ import {
   Keyboard,
 } from "lucide-react";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
+import type { LocalizedText } from "~/types/localized";
 
-const TAG_LABELS: Record<LogTag, { en: string; zh: string }> = {
+const TAG_LABELS: Record<LogTag, LocalizedText> = {
   diet: { en: "diet", zh: "饮食" },
   toxicity: { en: "toxicity", zh: "毒性反应" },
   physical: { en: "physical", zh: "活动" },
@@ -51,7 +52,7 @@ const TAG_LABELS: Record<LogTag, { en: string; zh: string }> = {
   legacy_session: { en: "legacy session", zh: "传承" },
 };
 
-const AGENT_LABELS: Record<AgentId, { en: string; zh: string }> = {
+const AGENT_LABELS: Record<AgentId, LocalizedText> = {
   nutrition: { en: "nutrition", zh: "营养" },
   toxicity: { en: "toxicity", zh: "毒性反应" },
   clinical: { en: "clinical", zh: "临床" },
@@ -67,7 +68,7 @@ type RunState =
   | { kind: "done"; ran: AgentId[]; failed: AgentId[] }
   | {
       kind: "filed";
-      summary: { en: string; zh: string };
+      summary: LocalizedText;
       target: "lab" | "daily";
       rowId: number;
       filed: DirectFileResult;

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -8,8 +8,9 @@ import { Card, CardContent } from "~/components/ui/card";
 import { DRUG_REGISTRY } from "~/config/drug-registry";
 import { ChevronRight } from "lucide-react";
 import type { MedicationCategory, DrugInfo } from "~/types/medication";
+import type { LocalizedText } from "~/types/localized";
 
-const CATEGORY_LABELS: Record<MedicationCategory, { en: string; zh: string }> = {
+const CATEGORY_LABELS: Record<MedicationCategory, LocalizedText> = {
   chemo: { en: "Chemotherapy", zh: "化疗" },
   targeted: { en: "Targeted / Investigational", zh: "靶向 / 试验性" },
   immunotherapy: { en: "Immunotherapy", zh: "免疫治疗" },

--- a/src/app/nutrition/foods/page.tsx
+++ b/src/app/nutrition/foods/page.tsx
@@ -16,8 +16,9 @@ import { Button } from "~/components/ui/button";
 import { TextInput, Field, Textarea } from "~/components/ui/field";
 import { cn } from "~/lib/utils/cn";
 import type { FoodCategory, FoodItem } from "~/types/nutrition";
+import type { LocalizedText } from "~/types/localized";
 
-const CATEGORY_LABEL: Record<FoodCategory, { en: string; zh: string }> = {
+const CATEGORY_LABEL: Record<FoodCategory, LocalizedText> = {
   protein: { en: "Protein", zh: "蛋白" },
   dairy: { en: "Dairy", zh: "奶制品" },
   fat_oil: { en: "Fats & oils", zh: "脂肪/油" },

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -27,6 +27,7 @@ import {
   Check,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
 
 // Order is load-bearing: welcome + profile + preferences is the "core" path
 // that gets every user onto the dashboard quickly. Team / treatment are
@@ -611,8 +612,8 @@ function UserTypeStep({
 }) {
   const options: Array<{
     id: "patient" | "caregiver" | "clinician";
-    title: { en: string; zh: string };
-    body: { en: string; zh: string };
+    title: LocalizedText;
+    body: LocalizedText;
   }> = [
     {
       id: "patient",

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { format, parseISO } from "date-fns";
+import type { LocalizedText } from "~/types/localized";
 
 type Filter = "all" | "open" | "resolved";
 
@@ -291,7 +292,7 @@ function SignalHistoryRow({
 
 function StatusBadge({ status }: { status: ChangeSignalRow["status"] }) {
   const locale = useLocale();
-  const labels: Record<ChangeSignalRow["status"], { en: string; zh: string }> = {
+  const labels: Record<ChangeSignalRow["status"], LocalizedText> = {
     open: { en: "OPEN", zh: "未结" },
     acknowledged: { en: "ACK", zh: "已知" },
     dismissed: { en: "DISMISSED", zh: "关闭" },
@@ -317,7 +318,7 @@ function StatusBadge({ status }: { status: ChangeSignalRow["status"] }) {
 
 const EVENT_KIND_LABEL: Record<
   SignalEventKind,
-  { en: string; zh: string }
+  LocalizedText
 > = {
   emitted: { en: "signal emitted", zh: "信号触发" },
   acknowledged: { en: "acknowledged", zh: "已知" },

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -15,6 +15,7 @@ import {
   useTaskInstances,
 } from "~/hooks/use-task-instances";
 import { Plus, Sparkles, ListTodo } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 export default function TasksPage() {
   const t = useT();
@@ -39,7 +40,7 @@ export default function TasksPage() {
 
   const sectionOrder: [
     string,
-    { en: string; zh: string },
+    LocalizedText,
   ][] = [
     ["overdue", { en: "Overdue", zh: "已超期" }],
     ["due_today", { en: "Due today", zh: "今日到期" }],

--- a/src/app/treatment/new/page.tsx
+++ b/src/app/treatment/new/page.tsx
@@ -27,6 +27,7 @@ import type {
 } from "~/types/medication";
 import type { Appointment } from "~/types/appointment";
 import { ChevronLeft, ChevronRight, Check } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 // Three-step wizard for setting up a chemo cycle. Replaces the previous
 // one-shot CycleForm so the patient (or carer) can preview every linked
@@ -302,7 +303,7 @@ export default function NewTreatmentCyclePage() {
 }
 
 function Stepper({ step, locale }: { step: Step; locale: "en" | "zh" }) {
-  const labels: Array<{ en: string; zh: string }> = [
+  const labels: Array<LocalizedText> = [
     { en: "Protocol", zh: "方案" },
     { en: "Schedule", zh: "细节" },
     { en: "Review", zh: "检查" },

--- a/src/app/treatment/page.tsx
+++ b/src/app/treatment/page.tsx
@@ -12,8 +12,9 @@ import { formatDate } from "~/lib/utils/date";
 import { cn } from "~/lib/utils/cn";
 import type { CycleStatus } from "~/types/treatment";
 import { BookOpen, ChevronRight, ClipboardList, Pencil, Syringe } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
-const STATUS_STYLES: Record<CycleStatus, { label: { en: string; zh: string }; cls: string }> = {
+const STATUS_STYLES: Record<CycleStatus, { label: LocalizedText; cls: string }> = {
   planned: {
     label: { en: "Planned", zh: "已计划" },
     cls: "bg-ink-100 text-ink-600",

--- a/src/components/assessment/test-list-builder.tsx
+++ b/src/components/assessment/test-list-builder.tsx
@@ -24,10 +24,11 @@ import {
   Minus,
   Clock,
 } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 const CATEGORY_META: Record<
   TestCategory,
-  { icon: React.ComponentType<{ className?: string }>; label: { en: string; zh: string } }
+  { icon: React.ComponentType<{ className?: string }>; label: LocalizedText }
 > = {
   physical: { icon: HeartPulse, label: { en: "Physical", zh: "身体" } },
   symptoms: { icon: AlertCircle, label: { en: "Symptoms", zh: "症状" } },

--- a/src/components/daily/daily-wizard.tsx
+++ b/src/components/daily/daily-wizard.tsx
@@ -16,6 +16,7 @@ import { Toggle } from "./toggle";
 import { SymptomStep } from "./symptom-step";
 import { isInChemoWindow } from "~/lib/daily/symptom-catalog";
 import type { DailyEntry } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 import {
   Activity,
   Bed,
@@ -35,17 +36,16 @@ import {
 import { cn } from "~/lib/utils/cn";
 
 type Draft = Partial<DailyEntry>;
-type Bilingual = { en: string; zh: string };
 
 const CATS = [
   {
     id: "feelings",
     icon: Activity,
-    title: { en: "How you feel", zh: "整体感受" } as Bilingual,
+    title: { en: "How you feel", zh: "整体感受" } as LocalizedText,
     hint: {
       en: "Energy, pain, mood, appetite",
       zh: "精力、疼痛、情绪、食欲",
-    } as Bilingual,
+    } as LocalizedText,
     fields: [
       "energy",
       "pain_current",
@@ -57,22 +57,22 @@ const CATS = [
   {
     id: "sleep",
     icon: Bed,
-    title: { en: "Sleep", zh: "睡眠" } as Bilingual,
-    hint: { en: "Last night's sleep", zh: "昨晚的睡眠" } as Bilingual,
+    title: { en: "Sleep", zh: "睡眠" } as LocalizedText,
+    hint: { en: "Last night's sleep", zh: "昨晚的睡眠" } as LocalizedText,
     fields: ["sleep_quality"],
   },
   {
     id: "weight",
     icon: Scale,
-    title: { en: "Weight", zh: "体重" } as Bilingual,
-    hint: { en: "Only if you weighed in", zh: "若今天称重了再填" } as Bilingual,
+    title: { en: "Weight", zh: "体重" } as LocalizedText,
+    hint: { en: "Only if you weighed in", zh: "若今天称重了再填" } as LocalizedText,
     fields: ["weight_kg"],
   },
   {
     id: "practice",
     icon: Sparkles,
-    title: { en: "Practice", zh: "修习" } as Bilingual,
-    hint: { en: "Qigong, meditation", zh: "气功、冥想" } as Bilingual,
+    title: { en: "Practice", zh: "修习" } as LocalizedText,
+    hint: { en: "Qigong, meditation", zh: "气功、冥想" } as LocalizedText,
     fields: [
       "practice_morning_completed",
       "practice_morning_quality",
@@ -83,18 +83,18 @@ const CATS = [
   {
     id: "food",
     icon: Utensils,
-    title: { en: "Food", zh: "饮食" } as Bilingual,
-    hint: { en: "Protein, meals, fluids", zh: "蛋白质、正餐、饮水" } as Bilingual,
+    title: { en: "Food", zh: "饮食" } as LocalizedText,
+    hint: { en: "Protein, meals, fluids", zh: "蛋白质、正餐、饮水" } as LocalizedText,
     fields: ["protein_grams", "meals_count", "snacks_count", "fluids_ml"],
   },
   {
     id: "movement",
     icon: Footprints,
-    title: { en: "Movement", zh: "活动" } as Bilingual,
+    title: { en: "Movement", zh: "活动" } as LocalizedText,
     hint: {
       en: "Walking, resistance, steps",
       zh: "步行、阻力训练、步数",
-    } as Bilingual,
+    } as LocalizedText,
     fields: [
       "walking_minutes",
       "resistance_training",
@@ -105,11 +105,11 @@ const CATS = [
   {
     id: "symptoms",
     icon: AlertTriangle,
-    title: { en: "Symptoms", zh: "症状" } as Bilingual,
+    title: { en: "Symptoms", zh: "症状" } as LocalizedText,
     hint: {
       en: "Only record what's actually present",
       zh: "只记今日出现的",
-    } as Bilingual,
+    } as LocalizedText,
     fields: [
       "nausea",
       "fever",
@@ -126,8 +126,8 @@ const CATS = [
   {
     id: "reflection",
     icon: PenLine,
-    title: { en: "Reflection", zh: "反思" } as Bilingual,
-    hint: { en: "Anything worth noting", zh: "想记下的一点" } as Bilingual,
+    title: { en: "Reflection", zh: "反思" } as LocalizedText,
+    hint: { en: "Anything worth noting", zh: "想记下的一点" } as LocalizedText,
     fields: ["reflection"],
   },
 ] as const;

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -10,6 +10,7 @@ import { useDefaultAiModel } from "~/hooks/use-settings";
 import { generateNarrative } from "~/lib/nudges/ai-narrative";
 import { Card } from "~/components/ui/card";
 import { localize, type FeedItem } from "~/types/feed";
+import type { LocalizedText } from "~/types/localized";
 import { AgentFeedbackControls } from "./agent-feedback-controls";
 import type { AgentId } from "~/types/agent";
 import { cn } from "~/lib/utils/cn";
@@ -318,7 +319,7 @@ function categoryLabel(
   c: FeedItem["category"],
   locale: "en" | "zh",
 ): string {
-  const labels: Record<FeedItem["category"], { en: string; zh: string }> = {
+  const labels: Record<FeedItem["category"], LocalizedText> = {
     safety: { en: "Safety", zh: "安全" },
     checkin: { en: "Check-in", zh: "记录" },
     treatment: { en: "Treatment", zh: "治疗" },

--- a/src/components/diary/voice-memo-card.tsx
+++ b/src/components/diary/voice-memo-card.tsx
@@ -12,6 +12,7 @@ import {
   CheckCircle2,
 } from "lucide-react";
 import type { VoiceMemo, VoiceMemoParsedFields } from "~/types/voice-memo";
+import type { LocalizedText } from "~/types/localized";
 import { resolveVoiceMemoAudioUrl } from "~/lib/voice-memo/cloud";
 import { Card } from "~/components/ui/card";
 import { cn } from "~/lib/utils/cn";
@@ -284,14 +285,14 @@ function collectChips(
   locale: "en" | "zh",
 ): { label: string; value: string }[] {
   const chips: { label: string; value: string }[] = [];
-  function num(label: { en: string; zh: string }, val: number | undefined, suffix = "/10") {
+  function num(label: LocalizedText, val: number | undefined, suffix = "/10") {
     if (typeof val !== "number") return;
     chips.push({
       label: locale === "zh" ? label.zh : label.en,
       value: `${val}${suffix}`,
     });
   }
-  function bool(label: { en: string; zh: string }, val: boolean | undefined) {
+  function bool(label: LocalizedText, val: boolean | undefined) {
     if (val !== true) return;
     chips.push({
       label: locale === "zh" ? label.zh : label.en,

--- a/src/components/family/call-list.tsx
+++ b/src/components/family/call-list.tsx
@@ -6,6 +6,7 @@ import { db } from "~/lib/db/dexie";
 import { useLocale, useL } from "~/hooks/use-translate";
 import type { CareTeamMember, CareTeamRole } from "~/types/care-team";
 import { Phone, Mail, Star } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 // Tap-to-call directory, grouped by role. Reads the care-team
 // registry; no opinions, no fallbacks — if it's empty, we point the
@@ -22,7 +23,7 @@ const ROLE_ORDER: CareTeamRole[] = [
   "other",
 ];
 
-const ROLE_LABEL: Record<CareTeamRole, { en: string; zh: string }> = {
+const ROLE_LABEL: Record<CareTeamRole, LocalizedText> = {
   oncologist: { en: "Oncology", zh: "肿瘤科" },
   surgeon: { en: "Surgery", zh: "外科" },
   nurse: { en: "Nursing", zh: "护理" },

--- a/src/components/family/zone-banner.tsx
+++ b/src/components/family/zone-banner.tsx
@@ -6,20 +6,21 @@ import { highestZone } from "~/lib/rules/engine";
 import { useLocale } from "~/hooks/use-translate";
 import type { Zone } from "~/types/clinical";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
 
 // A calm, one-line status banner for the family surface. Reads all open
 // zone_alerts, picks the highest, and renders a measured sentence — no
 // stacked alerts, no rule ids, no agent output. Family members just need
 // to know "is dad OK right now".
 
-const LABEL: Record<Zone, { en: string; zh: string }> = {
+const LABEL: Record<Zone, LocalizedText> = {
   green: { en: "Stable", zh: "稳定" },
   yellow: { en: "Review needed", zh: "需要复核" },
   orange: { en: "Urgent review", zh: "紧急复核" },
   red: { en: "Immediate action", zh: "立即处理" },
 };
 
-const DETAIL: Record<Zone, { en: string; zh: string }> = {
+const DETAIL: Record<Zone, LocalizedText> = {
   green: {
     en: "Nothing urgent right now.",
     zh: "目前没有紧急情况。",

--- a/src/components/ingest/bulk-queue.tsx
+++ b/src/components/ingest/bulk-queue.tsx
@@ -15,10 +15,11 @@ import {
   ScanText,
   Eye,
 } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 const STATUS_META: Record<
   BulkItem["status"],
-  { label: { en: string; zh: string }; tone: string; icon: React.ComponentType<{ className?: string }> }
+  { label: LocalizedText; tone: string; icon: React.ComponentType<{ className?: string }> }
 > = {
   queued: {
     label: { en: "Queued", zh: "排队" },

--- a/src/components/ingest/preview-diff.tsx
+++ b/src/components/ingest/preview-diff.tsx
@@ -33,6 +33,7 @@ import {
   PencilLine,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
 
 const OP_ICON: Record<IngestOpKind, React.ComponentType<{ className?: string }>> = {
   add_appointment: CalendarPlus,
@@ -51,7 +52,7 @@ const OP_ICON: Record<IngestOpKind, React.ComponentType<{ className?: string }>>
   update_settings: SettingsIcon,
 };
 
-const OP_LABEL: Record<IngestOpKind, { en: string; zh: string }> = {
+const OP_LABEL: Record<IngestOpKind, LocalizedText> = {
   add_appointment: { en: "New appointment", zh: "新增预约" },
   update_appointment: { en: "Update appointment", zh: "更新预约" },
   add_lab_result: { en: "New lab result", zh: "新增化验结果" },

--- a/src/components/invite/local-contacts-section.tsx
+++ b/src/components/invite/local-contacts-section.tsx
@@ -31,6 +31,7 @@ import {
   CircleAlert,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
 
 // Local contacts directory — phone numbers, specialties, and notes for
 // people in the patient's external care orbit (oncologist, surgeon, GP,
@@ -59,7 +60,7 @@ const ROLES: CareTeamRole[] = [
   "other",
 ];
 
-const ROLE_LABELS: Record<CareTeamRole, { en: string; zh: string }> = {
+const ROLE_LABELS: Record<CareTeamRole, LocalizedText> = {
   family: { en: "Family", zh: "家人" },
   oncologist: { en: "Oncologist", zh: "肿瘤科" },
   surgeon: { en: "Surgeon", zh: "外科" },

--- a/src/components/schedule/attendance-controls.tsx
+++ b/src/components/schedule/attendance-controls.tsx
@@ -12,6 +12,7 @@ import { useLocale, useL } from "~/hooks/use-translate";
 import type { Appointment } from "~/types/appointment";
 import { Check, Clock, X, CircleDashed } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
 
 // Per-member attendance chip row on the appointment detail page.
 // Each household member gets one button that cycles through the
@@ -19,7 +20,7 @@ import { cn } from "~/lib/utils/cn";
 // appointment.attendees) render as passive pending chips — they
 // can't claim themselves from this device.
 
-const STATUS_LABEL: Record<PendingOrStatus, { en: string; zh: string }> = {
+const STATUS_LABEL: Record<PendingOrStatus, LocalizedText> = {
   pending: { en: "Tap to confirm", zh: "点击确认" },
   confirmed: { en: "Going", zh: "参加" },
   tentative: { en: "Maybe", zh: "可能" },

--- a/src/components/schedule/linked-records.tsx
+++ b/src/components/schedule/linked-records.tsx
@@ -21,6 +21,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
 
 // Shows every cross-module record an appointment is linked to. A
 // chemo appointment → its treatment cycle; a blood-test appointment
@@ -47,7 +48,7 @@ const KIND_ICON: Record<
 
 const KIND_LABEL: Record<
   AppointmentLinkedRecordKind,
-  { en: string; zh: string }
+  LocalizedText
 > = {
   treatment_cycle: { en: "Cycle", zh: "疗程" },
   lab_result: { en: "Lab", zh: "化验" },

--- a/src/components/schedule/prep-editor.tsx
+++ b/src/components/schedule/prep-editor.tsx
@@ -12,6 +12,7 @@ import type {
 import { Field, TextInput } from "~/components/ui/field";
 import { Button } from "~/components/ui/button";
 import { Plus, Trash2 } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 // Reusable prep-item editor — used in the appointment form (on
 // create / edit) and surfaced on the detail page when the patient
@@ -40,7 +41,7 @@ const SOURCE_OPTIONS: AppointmentPrepSource[] = [
   "other",
 ];
 
-const SOURCE_LABEL: Record<AppointmentPrepSource, { en: string; zh: string }> = {
+const SOURCE_LABEL: Record<AppointmentPrepSource, LocalizedText> = {
   phone: { en: "Phone", zh: "电话" },
   email: { en: "Email", zh: "邮件" },
   letter: { en: "Letter", zh: "信函" },

--- a/src/components/settings/tracked-symptoms-section.tsx
+++ b/src/components/settings/tracked-symptoms-section.tsx
@@ -12,6 +12,7 @@ import { cn } from "~/lib/utils/cn";
 import { localeTag } from "~/lib/utils/date";
 import { Card, CardContent } from "~/components/ui/card";
 import { Stethoscope, RotateCcw } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 const TAG_STYLE: Record<SymptomTag, string> = {
   pdac: "bg-[var(--tide-soft)] text-[var(--tide-2)]",
@@ -21,7 +22,7 @@ const TAG_STYLE: Record<SymptomTag, string> = {
   safety: "bg-[var(--warn-soft)] text-[var(--warn)]",
 };
 
-const TAG_LABEL: Record<SymptomTag, { en: string; zh: string }> = {
+const TAG_LABEL: Record<SymptomTag, LocalizedText> = {
   pdac: { en: "PDAC", zh: "胰腺癌" },
   chemo: { en: "Chemo", zh: "化疗" },
   gnp: { en: "GnP", zh: "GnP" },

--- a/src/components/shared/add-fab.tsx
+++ b/src/components/shared/add-fab.tsx
@@ -18,14 +18,15 @@ import {
 } from "lucide-react";
 import { useIngestModal } from "~/components/ingest/ingest-modal";
 import { useAppPerspective } from "~/lib/caregiver/scope";
+import type { LocalizedText } from "~/types/localized";
 
 interface FabItem {
   href?: string;
   // When set, the item is rendered as a button that runs `action`
   // instead of navigating. Used for the smart-ingest opener.
   action?: "ingest";
-  label: { en: string; zh: string };
-  hint: { en: string; zh: string };
+  label: LocalizedText;
+  hint: LocalizedText;
   icon: React.ComponentType<{ className?: string }>;
   tone?: "tide" | "sand";
 }

--- a/src/components/shared/attribution.tsx
+++ b/src/components/shared/attribution.tsx
@@ -4,6 +4,7 @@ import { useHouseholdProfiles } from "~/hooks/use-household-profiles";
 import { useLocale } from "~/hooks/use-translate";
 import { cn } from "~/lib/utils/cn";
 import { localeTag } from "~/lib/utils/date";
+import type { LocalizedText } from "~/types/localized";
 
 // Small inline chip: "Thomas · 2h ago" when a profile exists for the
 // given auth uid; falls back to the legacy `entered_by` label for rows
@@ -14,7 +15,7 @@ import { localeTag } from "~/lib/utils/date";
 // household profile / per-user profile lookup — these are only used
 // when a row was saved by a legacy `entered_by` string and we don't
 // have an auth uid to resolve to a profile row.
-const STRING_LABELS: Record<string, { en: string; zh: string }> = {
+const STRING_LABELS: Record<string, LocalizedText> = {
   patient: { en: "Patient", zh: "患者" },
   carer: { en: "Carer", zh: "照护者" },
   clinician: { en: "Clinician", zh: "医师" },

--- a/src/components/tasks/task-row.tsx
+++ b/src/components/tasks/task-row.tsx
@@ -6,12 +6,13 @@ import { cn } from "~/lib/utils/cn";
 import { useLocale } from "~/hooks/use-translate";
 import type { TaskBucket, TaskInstance } from "~/types/task";
 import { localizedTitle } from "~/types/task";
+import type { LocalizedText } from "~/types/localized";
 import { Button } from "~/components/ui/button";
 import { Check, Clock, AlertTriangle, CalendarClock, MoonStar } from "lucide-react";
 
 const BUCKET_META: Record<
   TaskBucket,
-  { tone: string; icon: React.ComponentType<{ className?: string }>; label: { en: string; zh: string } }
+  { tone: string; icon: React.ComponentType<{ className?: string }>; label: LocalizedText }
 > = {
   overdue: {
     tone: "border-[var(--warn)]/50 bg-[var(--warn-soft)] text-[var(--warn)]",

--- a/src/components/treatment/cycle-calendar.tsx
+++ b/src/components/treatment/cycle-calendar.tsx
@@ -11,11 +11,12 @@ import {
 } from "~/types/treatment";
 import { cycleDayFor, currentPhase } from "~/lib/treatment/engine";
 import { FlaskConical } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 type Swatch = {
   bg: string;
   color: string;
-  label: { en: string; zh: string };
+  label: LocalizedText;
 };
 
 const SWATCHES: Record<string, Swatch> = {

--- a/src/components/treatment/cycle-form.tsx
+++ b/src/components/treatment/cycle-form.tsx
@@ -9,6 +9,7 @@ import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
 import { cn } from "~/lib/utils/cn";
 import type { CycleStatus, ProtocolId, TreatmentCycle } from "~/types/treatment";
+import type { LocalizedText } from "~/types/localized";
 
 export interface CycleFormValues {
   protocol_id: ProtocolId;
@@ -28,7 +29,7 @@ const STATUSES: CycleStatus[] = [
   "cancelled",
 ];
 
-const STATUS_LABEL: Record<CycleStatus, { en: string; zh: string }> = {
+const STATUS_LABEL: Record<CycleStatus, LocalizedText> = {
   planned: { en: "Planned", zh: "已计划" },
   active: { en: "Active", zh: "进行中" },
   completed: { en: "Completed", zh: "已完成" },
@@ -43,7 +44,7 @@ export function CycleForm({
   onCancel,
 }: {
   initial?: TreatmentCycle;
-  submitLabel: { en: string; zh: string };
+  submitLabel: LocalizedText;
   onSubmit: (values: CycleFormValues) => Promise<void>;
   onCancel?: () => void;
 }) {

--- a/src/components/treatment/nudge-card.tsx
+++ b/src/components/treatment/nudge-card.tsx
@@ -16,6 +16,7 @@ import {
   Info,
   X,
 } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 const CATEGORY_ICON: Record<
   NudgeCategory,
@@ -32,7 +33,7 @@ const CATEGORY_ICON: Record<
   intimacy: Heart,
 };
 
-const CATEGORY_LABEL: Record<NudgeCategory, { en: string; zh: string }> = {
+const CATEGORY_LABEL: Record<NudgeCategory, LocalizedText> = {
   diet: { en: "Diet", zh: "饮食" },
   hygiene: { en: "Hygiene", zh: "卫生" },
   exercise: { en: "Exercise", zh: "运动" },

--- a/src/config/lab-reference-ranges.ts
+++ b/src/config/lab-reference-ranges.ts
@@ -7,6 +7,7 @@
 // remain with Dr Lee.
 
 import type { LabResult } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 
 export type AnalyteKey = Exclude<
   keyof LabResult,
@@ -25,7 +26,7 @@ export type AnalyteGroup =
 
 export interface AnalyteDef {
   key: AnalyteKey;
-  label: { en: string; zh: string };
+  label: LocalizedText;
   short: string; // short label for pills / calendar dots
   unit: string;
   /** Reference range [low, high]. `null` means no standard range (e.g. CA19-9 uses upper-bound only). */
@@ -39,7 +40,7 @@ export interface AnalyteDef {
   /** How many decimal places to display in tables. */
   decimals?: number;
   /** Short 1-line clinical note shown in TestView. */
-  note?: { en: string; zh: string };
+  note?: LocalizedText;
 }
 
 export const ANALYTES: AnalyteDef[] = [
@@ -423,7 +424,7 @@ export const ANALYTE_BY_KEY: Record<AnalyteKey, AnalyteDef> = Object.fromEntries
   ANALYTES.map((a) => [a.key, a]),
 ) as Record<AnalyteKey, AnalyteDef>;
 
-export const GROUP_LABEL: Record<AnalyteGroup, { en: string; zh: string }> = {
+export const GROUP_LABEL: Record<AnalyteGroup, LocalizedText> = {
   tumour_marker: { en: "Tumour markers", zh: "肿瘤标志物" },
   nutrition: { en: "Nutrition & inflammation", zh: "营养与炎症" },
   haematology: { en: "Blood count", zh: "血常规" },

--- a/src/config/oncologists.ts
+++ b/src/config/oncologists.ts
@@ -8,9 +8,11 @@
 // type. Direct office numbers are not seeded because they vary by
 // secretary; the user fills them in if they have them on hand.
 
+import type { LocalizedText } from "~/types/localized";
+
 export interface MelbourneHospital {
   id: string;
-  name: { en: string; zh: string };
+  name: LocalizedText;
   phone: string;
   address: string;
   // 24/7 on-call number when the hospital publishes one distinct from
@@ -20,14 +22,14 @@ export interface MelbourneHospital {
 
 export interface MelbourneOncologist {
   id: string;
-  name: { en: string; zh: string };
+  name: LocalizedText;
   // Primary hospital affiliation used to pre-fill hospital fields. Some
   // clinicians work across multiple sites; this is the dominant one for
   // GI / pancreas care.
   hospital_id: string;
   // Optional secondary affiliation shown in the picker label.
   also_at?: string;
-  specialty: { en: string; zh: string };
+  specialty: LocalizedText;
 }
 
 export const MELBOURNE_HOSPITALS: MelbourneHospital[] = [

--- a/src/lib/anthropic/route-helpers.ts
+++ b/src/lib/anthropic/route-helpers.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
+import {
+  requireSession,
+  type RequireSessionResult,
+} from "~/lib/auth/require-session";
 
 export { DEFAULT_AI_MODEL } from "./model";
 
@@ -60,4 +64,38 @@ export async function withAnthropicErrorBoundary<T>(
       error: NextResponse.json({ error: message }, { status: 502 }),
     };
   }
+}
+
+export interface ClaudeRouteContext<TBody> {
+  body: TBody;
+  client: Anthropic;
+  session: RequireSessionResult;
+  req: Request;
+}
+
+// Composes the three gates every Claude-backed route runs: requireSession()
+// (401 / 503), getAnthropicClient() (503), readJsonBody() (400). The handler
+// receives the parsed body, an authenticated client, and the session — no
+// try/catch, no early-return ladder. Validation of body shape stays inside
+// the handler since each route has different requirements.
+export function createClaudeRoute<TBody>(
+  handler: (ctx: ClaudeRouteContext<TBody>) => Promise<Response>,
+): (req: Request) => Promise<Response> {
+  return async (req) => {
+    const auth = await requireSession();
+    if (!auth.ok) return auth.error;
+
+    const gate = getAnthropicClient();
+    if (gate.error) return gate.error;
+
+    const parsed = await readJsonBody<TBody>(req);
+    if (parsed.error) return parsed.error;
+
+    return handler({
+      body: parsed.body,
+      client: gate.client,
+      session: auth.session,
+      req,
+    });
+  };
 }

--- a/src/lib/appointments/prep.ts
+++ b/src/lib/appointments/prep.ts
@@ -4,6 +4,7 @@ import type {
   AppointmentPrepKind,
 } from "~/types/appointment";
 import type { PatientTask } from "~/types/task";
+import type { LocalizedText } from "~/types/localized";
 
 // Slice I helpers. Pure functions around AppointmentPrep so the UI
 // can answer three questions without duplicating clock logic:
@@ -149,7 +150,7 @@ export function deriveAwaitingPrepTasks(args: {
 // Small label helpers for the UI.
 export const PREP_KIND_LABEL: Record<
   AppointmentPrepKind,
-  { en: string; zh: string }
+  LocalizedText
 > = {
   fast: { en: "Fast", zh: "禁食" },
   medication_hold: { en: "Hold medication", zh: "停药" },

--- a/src/lib/assessment/catalog.ts
+++ b/src/lib/assessment/catalog.ts
@@ -1,3 +1,5 @@
+import type { LocalizedText } from "~/types/localized";
+
 export type TestCategory =
   | "physical"
   | "symptoms"
@@ -36,10 +38,10 @@ export type TestId =
 export interface TestDef {
   id: TestId;
   category: TestCategory;
-  title: { en: string; zh: string };
-  description: { en: string; zh: string };
+  title: LocalizedText;
+  description: LocalizedText;
   est_minutes: number;
-  equipment?: { en: string; zh: string };
+  equipment?: LocalizedText;
   default_on: boolean;
 }
 
@@ -347,7 +349,7 @@ export type PresetId = "comprehensive" | "quick" | "function" | "custom";
 
 export const PRESETS: Record<
   PresetId,
-  { title: { en: string; zh: string }; description: { en: string; zh: string }; tests: TestId[] }
+  { title: LocalizedText; description: LocalizedText; tests: TestId[] }
 > = {
   comprehensive: {
     title: { en: "Comprehensive baseline", zh: "完整基线" },

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -1,5 +1,6 @@
 import type { HouseholdRole } from "~/types/household";
 import type { SyncedTable } from "~/lib/sync/tables";
+import type { LocalizedText } from "~/types/localized";
 
 // Authoritative permission matrix. This file is the single source of
 // truth — the client-side gates read from `PERMISSIONS`, and the
@@ -92,7 +93,7 @@ export function actionsFor(role: HouseholdRole): PermissionAction[] {
 // post-invite welcome screen and any "permission denied" toast.
 export const ACTION_LABEL: Record<
   PermissionAction,
-  { en: string; zh: string }
+  LocalizedText
 > = {
   invite_members: { en: "Invite new members", zh: "邀请新成员" },
   remove_members: { en: "Remove members", zh: "移除成员" },
@@ -117,7 +118,7 @@ export const ACTION_LABEL: Record<
 };
 
 // Roles expanded with their user-facing label, sorted for display.
-export const ROLE_LABEL: Record<HouseholdRole, { en: string; zh: string }> = {
+export const ROLE_LABEL: Record<HouseholdRole, LocalizedText> = {
   primary_carer: { en: "Primary carer", zh: "主要照护者" },
   patient: { en: "Patient", zh: "患者" },
   family: { en: "Family", zh: "家人" },
@@ -170,7 +171,7 @@ export const TABLE_WRITE_ACTION: Partial<Record<SyncedTable, PermissionAction>> 
 // on the welcome screen after acceptance.
 export const ROLE_DESCRIPTION: Record<
   HouseholdRole,
-  { en: string; zh: string }
+  LocalizedText
 > = {
   primary_carer: {
     en: "Runs the household — can invite, remove, and edit the treatment plan.",

--- a/src/lib/auth/require-supabase-user.ts
+++ b/src/lib/auth/require-supabase-user.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getSupabaseServer } from "~/lib/supabase/server";
+
+// Lightweight Supabase-only auth gate for routes that need a signed-in
+// user but don't care about household membership (push subscription
+// management, etc.). Distinct from requireSession() — that helper also
+// resolves household_id, returns lowercase error codes, and is used by
+// AI/agent routes where the household profile drives prompts.
+//
+// Returns either the user + the Supabase client (so the caller doesn't
+// re-instantiate it), or a NextResponse the caller can return directly.
+
+export interface RequireSupabaseUserResult {
+  user: { id: string; email: string | null };
+  sb: SupabaseClient;
+}
+
+export type RequireSupabaseUserOutcome =
+  | { ok: true; data: RequireSupabaseUserResult; error?: undefined }
+  | { ok: false; error: NextResponse; data?: undefined };
+
+export async function requireSupabaseUser(): Promise<RequireSupabaseUserOutcome> {
+  const sb = getSupabaseServer();
+  if (!sb) {
+    return {
+      ok: false,
+      error: NextResponse.json(
+        { error: "Supabase is not configured." },
+        { status: 503 },
+      ),
+    };
+  }
+  const { data: auth } = await sb.auth.getUser();
+  if (!auth.user) {
+    return {
+      ok: false,
+      error: NextResponse.json({ error: "Not signed in." }, { status: 401 }),
+    };
+  }
+  return {
+    ok: true,
+    data: {
+      user: { id: auth.user.id, email: auth.user.email ?? null },
+      sb,
+    },
+  };
+}

--- a/src/lib/cron/digest.ts
+++ b/src/lib/cron/digest.ts
@@ -1,6 +1,7 @@
 import type { Zone } from "~/types/clinical";
 import { highestZone } from "~/lib/rules/engine";
 import { localeTag } from "~/lib/utils/date";
+import type { LocalizedText } from "~/types/localized";
 
 // Pure digest builder: given a household's context (appointments,
 // open zone alerts, follow-up tasks) + a user's locale, produces the
@@ -53,7 +54,7 @@ function startOfDay(d: Date): Date {
 }
 
 function zoneLabel(z: Zone, locale: "en" | "zh"): string {
-  const labels: Record<Zone, { en: string; zh: string }> = {
+  const labels: Record<Zone, LocalizedText> = {
     green: { en: "Stable", zh: "稳定" },
     yellow: { en: "Review needed", zh: "需复核" },
     orange: { en: "Urgent review", zh: "紧急复核" },

--- a/src/lib/daily/symptom-catalog.ts
+++ b/src/lib/daily/symptom-catalog.ts
@@ -1,4 +1,5 @@
 import type { DailyEntry } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 
 // The curated mPDAC/ GnP symptom catalog. Each entry is one checkable
 // item on the daily-wizard "Symptoms" step. The catalog is the single
@@ -37,8 +38,8 @@ export type SymptomTag =
 
 export interface SymptomDefinition {
   id: string;
-  label: { en: string; zh: string };
-  hint?: { en: string; zh: string };
+  label: LocalizedText;
+  hint?: LocalizedText;
   scale: SymptomScale;
   tags: readonly SymptomTag[];
   defaultTracked: boolean;

--- a/src/lib/legacy/orchestrator.ts
+++ b/src/lib/legacy/orchestrator.ts
@@ -2,6 +2,7 @@ import type { FeedItem } from "~/types/feed";
 import type { Zone } from "~/types/clinical";
 import type { BiographicalOutline } from "~/types/legacy";
 import type { TreatmentCycle } from "~/types/treatment";
+import type { LocalizedText } from "~/types/localized";
 
 // Orchestrator — deterministic event-suggestion layer.
 //
@@ -32,8 +33,8 @@ export interface OrchestratorInputs {
 export interface EventSuggestion {
   id: string;
   theme: "lightness" | "seasonal" | "chapter_gap" | "recovery";
-  title: { en: string; zh: string };
-  body: { en: string; zh: string };
+  title: LocalizedText;
+  body: LocalizedText;
   chapter_hint?: string;
 }
 

--- a/src/lib/log/direct-file.ts
+++ b/src/lib/log/direct-file.ts
@@ -19,26 +19,27 @@
 
 import { todayISO } from "~/lib/utils/date";
 import type { DailyEntry, LabResult } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 
 export type DirectFileResult =
   | {
       kind: "lab";
       date: string;
       patch: Partial<LabResult> & { date: string; source: "patient_self_report" };
-      summary: { en: string; zh: string };
+      summary: LocalizedText;
       icon: "lab";
     }
   | {
       kind: "daily";
       date: string;
       patch: Partial<DailyEntry>;
-      summary: { en: string; zh: string };
+      summary: LocalizedText;
       icon: "daily";
     };
 
 const DAY_PART_RE = /\b(this morning|morning|am|afternoon|pm|evening|tonight|today|now)\b/i;
 
-function timeOfDay(text: string): { en: string; zh: string } {
+function timeOfDay(text: string): LocalizedText {
   const m = DAY_PART_RE.exec(text);
   const hit = m?.[1]?.toLowerCase();
   if (!hit) return { en: "today", zh: "今日" };

--- a/src/lib/log/follow-ups.ts
+++ b/src/lib/log/follow-ups.ts
@@ -13,14 +13,15 @@ import type { DirectFileResult } from "./direct-file";
 import type { AppointmentDiscussionItem } from "~/types/appointment";
 import type { Appointment } from "~/types/appointment";
 import type { CareTeamMember } from "~/types/care-team";
+import type { LocalizedText } from "~/types/localized";
 
 export type FollowUpSeverity = "routine" | "watch" | "urgent";
 
 export interface FollowUpItem {
   id: string;
   severity: FollowUpSeverity;
-  title: { en: string; zh: string };
-  body: { en: string; zh: string };
+  title: LocalizedText;
+  body: LocalizedText;
   actions: FollowUpAction[];
 }
 
@@ -29,7 +30,7 @@ export type FollowUpAction =
       kind: "add_to_clinic";
       appointment_id: number;
       text: string;
-      label: { en: string; zh: string };
+      label: LocalizedText;
     }
   | {
       kind: "message_care_team";
@@ -37,13 +38,13 @@ export type FollowUpAction =
       channel: "phone" | "sms" | "email";
       target: string;          // tel:+…, sms:+…, mailto:…
       draft?: string;
-      label: { en: string; zh: string };
+      label: LocalizedText;
     }
   | {
       kind: "engage_agent";
       agent_id: "nutrition" | "toxicity" | "clinical" | "psychology" | "rehabilitation" | "treatment";
       prompt: string;
-      label: { en: string; zh: string };
+      label: LocalizedText;
     };
 
 function slug(s: string): string {

--- a/src/lib/medication/prompts.ts
+++ b/src/lib/medication/prompts.ts
@@ -11,12 +11,12 @@
 import type {
   DrugInfo,
   DrugReference,
-  LocalizedText,
   Medication,
   MedicationPromptEvent,
   ReferenceSource,
 } from "~/types/medication";
 import type { ProtocolId, TreatmentCycle } from "~/types/treatment";
+import type { LocalizedText } from "~/types/localized";
 
 export interface PromptCitation {
   label: string;

--- a/src/lib/nudges/weather-nudges.ts
+++ b/src/lib/nudges/weather-nudges.ts
@@ -2,6 +2,7 @@ import type { FeedItem } from "~/types/feed";
 import type { CurrentWeather } from "~/lib/weather/open-meteo";
 import { weatherCondition } from "~/lib/weather/open-meteo";
 import type { CycleContext } from "~/types/treatment";
+import type { LocalizedText } from "~/types/localized";
 
 export interface WeatherNudgeInputs {
   weather: CurrentWeather | null;
@@ -187,7 +188,7 @@ function conditionLabel(
   c: ReturnType<typeof weatherCondition>,
   locale: "en" | "zh",
 ): string {
-  const labels: Record<typeof c, { en: string; zh: string }> = {
+  const labels: Record<typeof c, LocalizedText> = {
     clear: { en: "Clear", zh: "晴天" },
     cloud: { en: "Cloudy", zh: "多云" },
     rain: { en: "Rain", zh: "有雨" },

--- a/src/lib/nutrition/pert-engine.ts
+++ b/src/lib/nutrition/pert-engine.ts
@@ -1,5 +1,6 @@
 import type { MealType } from "~/types/nutrition";
 import type { Citation } from "./sources";
+import type { LocalizedText } from "~/types/localized";
 
 // JPCC PERT decision rules (Jreissati Family Pancreatic Centre at
 // Epworth, 2021, p. 19).
@@ -53,7 +54,7 @@ export interface PertEvaluationInput {
 export interface PertEvaluation {
   required: boolean;
   recommendation: PertDoseRecommendation;
-  reason: { en: string; zh: string };
+  reason: LocalizedText;
   citations: Citation[];
 }
 

--- a/src/lib/nutrition/policy.ts
+++ b/src/lib/nutrition/policy.ts
@@ -1,5 +1,6 @@
 import type { DailyEntry, Settings } from "~/types/clinical";
 import type { Citation } from "./sources";
+import type { LocalizedText } from "~/types/localized";
 
 // Carb-policy state machine. The /nutrition/guide page in Anchor
 // historically advocated relaxed-keto (≤ 50 g net carbs/day) per the
@@ -24,14 +25,14 @@ export type PolicyTriggerKind =
 
 export interface PolicyTrigger {
   kind: PolicyTriggerKind;
-  detail: { en: string; zh: string };
+  detail: LocalizedText;
   citations: Citation[];
 }
 
 export interface NutritionPolicyState {
   mode: NutritionMode;
   triggers: PolicyTrigger[];
-  rationale: { en: string; zh: string };
+  rationale: LocalizedText;
 }
 
 export interface PolicyInputs {

--- a/src/lib/nutrition/symptom-context.ts
+++ b/src/lib/nutrition/symptom-context.ts
@@ -1,6 +1,7 @@
 import { db } from "~/lib/db/dexie";
 import { todayISO } from "~/lib/utils/date";
 import type { DailyEntry } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 
 // Symptom-aware context for the food picker and JPCC playbooks.
 // Reads today's DailyEntry (and yesterday's as a fallback so a
@@ -97,7 +98,7 @@ function daysAgo(iso: string, n: number): string {
 
 export const SYMPTOM_LABEL: Record<
   SymptomFlag,
-  { en: string; zh: string }
+  LocalizedText
 > = {
   nausea: { en: "nausea", zh: "恶心" },
   mucositis: { en: "mouth sores", zh: "口腔溃疡" },

--- a/src/lib/nutrition/taste-tweaks.ts
+++ b/src/lib/nutrition/taste-tweaks.ts
@@ -1,4 +1,5 @@
 import type { Citation } from "./sources";
+import type { LocalizedText } from "~/types/localized";
 
 // JPCC nutrition guide p. 16: four taste-issue quadrants and a
 // remedy list for each. Common during chemotherapy (especially
@@ -27,13 +28,13 @@ export const TASTE_ISSUES: TasteIssue[] = [
 
 export interface TasteTweak {
   issue: TasteIssue;
-  suggestions: { en: string; zh: string }[];
+  suggestions: LocalizedText[];
   citations: Citation[];
 }
 
 const JPCC_TASTE_CITE: Citation = { source_id: "jpcc_2021", page: 16 };
 
-const TWEAKS: Record<TasteIssue, { en: string; zh: string }[]> = {
+const TWEAKS: Record<TasteIssue, LocalizedText[]> = {
   too_sweet: [
     {
       en: "Eat the food cool — lower temperatures reduce sweetness.",

--- a/src/lib/state/history.ts
+++ b/src/lib/state/history.ts
@@ -15,6 +15,7 @@ import type {
 } from "~/types/clinical";
 import type { TreatmentCycle } from "~/types/treatment";
 import type { Medication, MedicationEvent } from "~/types/medication";
+import type { LocalizedText } from "~/types/localized";
 
 export type HistoryCategory =
   | "signal"
@@ -29,11 +30,6 @@ export type HistoryCategory =
   | "life_event";
 
 export type HistoryTone = "info" | "positive" | "caution" | "warning";
-
-export interface LocalizedText {
-  en: string;
-  zh: string;
-}
 
 export interface HistoryEntry {
   // Stable identifier composed from source table + id + variant, so the

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,4 +1,5 @@
 import type { Locale } from "./clinical";
+import type { LocalizedText } from "./localized";
 import type { PhaseKey } from "./treatment";
 
 export type TaskCategory =
@@ -88,9 +89,9 @@ export interface TaskInstance {
 
 export interface TaskPreset {
   id: string;
-  title: { en: string; zh: string };
+  title: LocalizedText;
   category: TaskCategory;
-  notes?: { en: string; zh: string };
+  notes?: LocalizedText;
   schedule_kind: TaskScheduleKind;
   recurrence_interval_days?: number;
   cycle_day?: number;
@@ -98,7 +99,7 @@ export interface TaskPreset {
   lead_time_days: number;
   priority: TaskPriority;
   default_due_offset_days?: number; // for one-off, set due N days from now
-  rationale: { en: string; zh: string };
+  rationale: LocalizedText;
 }
 
 export function localizedTitle(task: PatientTask, locale: Locale): string {


### PR DESCRIPTION
## Summary

Three focused DRY cleanups, no behaviour changes.

### 1. `createClaudeRoute` wrapper — `src/lib/anthropic/route-helpers.ts`
Composes the `requireSession` → `getAnthropicClient` → `readJsonBody` gate every Claude-backed route was open-coding. Migrates 9 routes (8 under `/api/ai` + `parse-appointment`) so each handler now starts with body validation instead of three identical guard blocks.

### 2. `requireSupabaseUser` helper — `src/lib/auth/require-supabase-user.ts`
Distinct from `requireSession` (no household lookup, different error shape) for routes that only need a signed-in user. Migrates the three `/api/push/*` routes — 27 lines of duplicated supabase null check + `getUser()` + 401 boilerplate collapse to one call each.

### 3. `LocalizedText` replaces inline `{ en: string; zh: string }`
The canonical shape lives in `src/types/localized.ts`; **73 inline declarations across 44 files** now reference the alias. Also drops a private `type Bilingual` in `daily-wizard` and a duplicate `LocalizedText` interface in `lib/state/history.ts`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 763 / 763 pass (auth gate behaviour preserved by existing `api-auth.test.ts` against the migrated routes)
- [x] `pnpm build` — production build succeeds
- [ ] Spot-check `/api/ai/coach` and `/api/push/subscribe` in dev to confirm runtime parity

https://claude.ai/code/session_01VS3SmpL4wqpey6J6siyhPD

---
_Generated by [Claude Code](https://claude.ai/code/session_01VS3SmpL4wqpey6J6siyhPD)_