### PR TITLE
Voice routes honour local-first: drop session gate on transcribe + parse

### DIFF
--- a/src/app/api/ai/parse-voice-memo/route.ts
+++ b/src/app/api/ai/parse-voice-memo/route.ts
@@ -6,7 +6,7 @@ import {
   readJsonBody,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
-import { requireSession } from "~/lib/auth/require-session";
+import { getSupabaseServer } from "~/lib/supabase/server";
 import { loadHouseholdProfile } from "~/lib/household/profile";
 import { wrapUserInput } from "~/lib/anthropic/wrap-user-input";
 import {
@@ -21,6 +21,13 @@ import {
 // into the day's `daily_entries` row as a safe fill — never an
 // overwrite — so the diary turns voice memos into structured tracking
 // without the patient having to open the daily form.
+//
+// Auth: not required. Voice memos are foundational and the project is
+// local-first (per middleware.ts and CLAUDE.md). When a Supabase
+// session is present we use it to fetch the household profile so the
+// system prompt is interpolated against the right patient identity;
+// when it's not, we fall back to FALLBACK_HOUSEHOLD_PROFILE which is
+// generic but still produces a useful parse.
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -33,9 +40,6 @@ interface ParseBody {
 }
 
 export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
   const gate = getAnthropicClient();
   if (gate.error) return gate.error;
 
@@ -47,7 +51,27 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "transcript required" }, { status: 400 });
   }
 
-  const profile = await loadHouseholdProfile(auth.session.household_id);
+  // Best-effort household lookup — load the patient identity envelope
+  // when a Supabase session happens to be present, fall back to the
+  // generic profile when it isn't. Never block the parse on this.
+  let householdId: string | null = null;
+  try {
+    const sb = getSupabaseServer();
+    if (sb) {
+      const { data } = await sb.auth.getUser();
+      if (data?.user) {
+        const { data: membership } = await sb
+          .from("household_memberships")
+          .select("household_id")
+          .eq("user_id", data.user.id)
+          .maybeSingle();
+        householdId = (membership?.household_id as string | undefined) ?? null;
+      }
+    }
+  } catch {
+    // unauthenticated or schema mismatch — use the fallback profile
+  }
+  const profile = await loadHouseholdProfile(householdId);
   const localeNote =
     body.locale === "zh"
       ? "The transcript is Mandarin. Translate before extracting."

--- a/src/app/api/ai/transcribe/route.ts
+++ b/src/app/api/ai/transcribe/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { requireSession } from "~/lib/auth/require-session";
 
 // Voice-memo transcription. Browser records via MediaRecorder, posts
 // the resulting audio blob here as multipart/form-data; we hand it
@@ -17,6 +16,14 @@ import { requireSession } from "~/lib/auth/require-session";
 //
 // Anthropic's API doesn't accept audio at all, so OpenAI is the only
 // surface for the actual speech-to-text step.
+//
+// Auth: this route does NOT require a signed-in Supabase session.
+// Voice memos are foundational for dad's diary, and the project is
+// local-first (per middleware.ts and CLAUDE.md): the app must work
+// before the patient ever signs in. The OpenAI key is bounded by
+// the standard per-account rate limits, and the app is single-
+// household by design — IP-level rate limiting would be the right
+// hardening if this ever sits behind a public URL.
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -29,9 +36,6 @@ const STREAMING_MODELS = new Set([
 ]);
 
 export async function POST(req: Request) {
-  const auth = await requireSession();
-  if (!auth.ok) return auth.error;
-
   const apiKeyResult = readApiKey();
   if (apiKeyResult.error) return apiKeyResult.error;
   const apiKey = apiKeyResult.key;

--- a/src/hooks/use-voice-transcription.ts
+++ b/src/hooks/use-voice-transcription.ts
@@ -191,7 +191,7 @@ export function useVoiceTranscription(
     });
     if (!res.ok) {
       const detail = await res.text().catch(() => "");
-      throw new Error(detail || `transcribe failed (${res.status})`);
+      throw new Error(humaniseTranscribeError(detail, res.status));
     }
     const isStream =
       res.headers.get("x-anchor-stream") === "1" ||
@@ -409,4 +409,37 @@ function extFor(mime: string): string {
     default:
       return "webm";
   }
+}
+
+// Translate raw transcribe-route error responses into a sentence the
+// patient can act on. Avoids dumping JSON envelopes into the alert.
+function humaniseTranscribeError(detail: string, status: number): string {
+  const trimmed = detail.trim();
+  // Try to unwrap `{"error":"..."}` so common server errors surface as
+  // plain prose. Falls back to the raw body when it isn't JSON.
+  let inner = trimmed;
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as { error?: string };
+      if (typeof parsed.error === "string") inner = parsed.error;
+    } catch {
+      // not JSON — keep raw
+    }
+  }
+  if (status === 401 || /unauthenticated/i.test(inner)) {
+    return "Sign in not required, but the transcribe endpoint is mis-gated. Refresh the page; if the error persists, redeploy.";
+  }
+  if (status === 503 && /OPENAI_API_KEY/.test(inner)) {
+    return inner;
+  }
+  if (status === 503) {
+    return "Transcription is offline (server config). Try again in a moment.";
+  }
+  if (status === 413) {
+    return "Recording is too long for one transcription. Keep memos under ~25 minutes.";
+  }
+  if (status === 502 || status === 504) {
+    return "The transcription service didn't respond. Try again in a moment.";
+  }
+  return inner || `transcribe failed (${status})`;
 }


### PR DESCRIPTION
## Summary

`Voice error: {"error":"unauthenticated"}` — the transcribe + parse-voice-memo routes were `requireSession()`-gated, but `src/middleware.ts` is explicit:

> The app is local-first (per CLAUDE.md). Anyone can use it without an account; sign-in is offered post-first-entry so data can sync across devices.

So dad recording memos before/without signing in was hitting a 401 with a raw JSON envelope. Voice memos are foundational data — gating them on Supabase breaks the local-first promise the rest of the app keeps.

## Changes

- **`/api/ai/transcribe`** — drop `requireSession()`. The OpenAI key is bounded by per-account rate limits; IP-level throttling is the right hardening if this surface ever gets a public URL.
- **`/api/ai/parse-voice-memo`** — make auth optional. When a session exists we still resolve `household_id` so the system prompt interpolates the right patient identity; when it doesn't, `loadHouseholdProfile(null)` returns `FALLBACK_HOUSEHOLD_PROFILE` and the parse runs anyway.
- **`useVoiceTranscription`** — humanise non-OK responses. Unwraps `{"error":"…"}` envelopes, maps 401/503/413/502/504 to one-sentence messages a patient can act on. No more raw JSON in the alert banner.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 89 files / 782 tests pass
- [ ] Manual signed-out: open `/diary` in incognito (no Supabase session), record a memo. Transcript streams in via SSE; memo lands in `/memos`; Claude parse populates the preview form on the detail page.
- [ ] Manual signed-in: same flow still works, household profile resolves and the system prompt names the right patient.
- [ ] Manual error path: temporarily mis-set `OPENAI_API_KEY` → recorder shows the position-aware ASCII guard message instead of a generic alert.

https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU

---
_Generated by [Claude Code](https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU)_