### PR TITLE
Memos: capture imaging + labs, add follow-up dialogue, simpler labels

### DIFF
--- a/src/app/diary/page.tsx
+++ b/src/app/diary/page.tsx
@@ -288,6 +288,16 @@ function RecorderCard({
           </div>
         </div>
       </div>
+      {!recording && !transcribing && (
+        <div className="mt-3 rounded-md border border-ink-100 bg-paper-2/40 px-3 py-2 text-[11.5px] leading-relaxed text-ink-500">
+          <span className="text-ink-700 font-medium">
+            {locale === "zh" ? "可以聊：" : "Try mentioning: "}
+          </span>
+          {locale === "zh"
+            ? "睡眠、精力、症状、饮食、活动、家人、化验或扫描结果。"
+            : "sleep, energy, symptoms, food, activity, family, scan or lab results."}
+        </div>
+      )}
       {transcribing && voice.liveText && (
         <div className="mt-3 rounded-md bg-paper-2/60 px-3 py-2 text-[13px] leading-relaxed text-ink-900">
           <span className="text-ink-500 text-[10.5px] uppercase tracking-wider">
@@ -513,8 +523,8 @@ function RecentMemoCard({
         className="inline-flex items-center gap-1 text-[12.5px] font-medium text-[var(--tide-2)] hover:underline"
       >
         {locale === "zh"
-          ? `识别可信度：${parsed.confidence === "medium" ? "中" : "低"} — 审核并登入`
-          : `Confidence: ${parsed.confidence} — review and log`}
+          ? `识别可信度：${parsed.confidence === "medium" ? "中" : "低"} — 审核并保存`
+          : `Confidence: ${parsed.confidence} — review and save`}
         <ChevronRight className="h-3.5 w-3.5" aria-hidden />
       </Link>
     );
@@ -527,6 +537,8 @@ function RecentMemoCard({
       </span>
     );
   }
+
+  const followUps = (parsed?.follow_up_questions ?? []).slice(0, 2);
 
   return (
     <Card className="p-4">
@@ -546,6 +558,28 @@ function RecentMemoCard({
           <X className="h-3.5 w-3.5" aria-hidden />
         </button>
       </div>
+      {followUps.length > 0 && (
+        <div className="mt-3 border-t border-ink-100 pt-3">
+          <div className="text-[10.5px] font-medium uppercase tracking-wider text-[var(--tide-2)]">
+            {locale === "zh" ? "AI 想问" : "From your AI nurse"}
+          </div>
+          <ul className="mt-1.5 space-y-1">
+            {followUps.map((q, i) => (
+              <li
+                key={i}
+                className="text-[12.5px] italic text-ink-700"
+              >
+                {q}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-1 text-[10.5px] text-ink-400">
+            {locale === "zh"
+              ? "想回答的话，再录一段就行。"
+              : "Want to answer? Just record again — Claude will read it."}
+          </p>
+        </div>
+      )}
     </Card>
   );
 }
@@ -575,8 +609,8 @@ function AppliedSummary({
       <div className="inline-flex items-center gap-1.5 text-[12px] font-medium text-emerald-700">
         <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
         {locale === "zh"
-          ? `已登入 ${patches.length} 项`
-          : `Logged ${patches.length} item${patches.length === 1 ? "" : "s"}`}
+          ? `已保存 ${patches.length} 项`
+          : `Saved ${patches.length} item${patches.length === 1 ? "" : "s"}`}
       </div>
       <ul className="space-y-1.5">
         {patches.map((p, i) => (

--- a/src/app/memos/[id]/page.tsx
+++ b/src/app/memos/[id]/page.tsx
@@ -150,6 +150,13 @@ function MemoDetail({
 
       {parsed?.personal && <PersonalCard personal={parsed.personal} locale={locale} />}
 
+      {(parsed?.follow_up_questions?.length ?? 0) > 0 && (
+        <FollowUpsCard
+          questions={parsed!.follow_up_questions!}
+          locale={locale}
+        />
+      )}
+
       {applied.length > 0 && (
         <AuditCard memoId={memo.id!} patches={applied} locale={locale} />
       )}
@@ -217,7 +224,7 @@ function ParsePendingCard({
           </Alert>
           <Button size="sm" variant="secondary" onClick={attempt}>
             <RefreshCw className="h-3.5 w-3.5" />
-            {locale === "zh" ? "重试" : "Try again"}
+            {locale === "zh" ? "重试" : "Retry"}
           </Button>
         </div>
       ) : (
@@ -476,22 +483,23 @@ function PreviewForm({
           <div className="text-[12px] text-ink-500">
             {locale === "zh"
               ? "勾选要写入表单的内容，可以先调整数值。"
-              : "Pick what to log. Adjust values first if anything's off."}
+              : "Pick what to save. Adjust first if anything's off."}
           </div>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
+        <button
+          type="button"
           onClick={onReparse}
           disabled={reparsing || busy}
+          aria-label={locale === "zh" ? "重新识别" : "Re-parse"}
+          title={locale === "zh" ? "重新识别" : "Re-parse"}
+          className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-full text-ink-500 hover:bg-ink-100 hover:text-ink-900 disabled:opacity-50"
         >
           {reparsing ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
-            <RefreshCw className="h-3.5 w-3.5" />
+            <RefreshCw className="h-4 w-4" />
           )}
-          {locale === "zh" ? "重新识别" : "Re-parse"}
-        </Button>
+        </button>
       </div>
 
       {parsed.confidence !== "high" && (
@@ -499,7 +507,7 @@ function PreviewForm({
           {locale === "zh"
             ? "AI 信心：" + (parsed.confidence === "medium" ? "中" : "低")
               + "。建议你确认每一项再登入。"
-            : `Confidence: ${parsed.confidence}. Double-check each value before logging.`}
+            : `Confidence: ${parsed.confidence}. Double-check each value before saving.`}
         </Alert>
       )}
 
@@ -533,6 +541,17 @@ function PreviewForm({
 
       {meds.length > 0 && <MedsSection locale={locale} meds={meds} />}
 
+      {(parsed.imaging_results?.length ?? 0) > 0 && (
+        <ImagingSection
+          locale={locale}
+          results={parsed.imaging_results!}
+        />
+      )}
+
+      {(parsed.lab_results?.length ?? 0) > 0 && (
+        <LabsSection locale={locale} results={parsed.lab_results!} />
+      )}
+
       {parsed.notes && (
         <div>
           <div className="eyebrow mb-1">
@@ -542,7 +561,7 @@ function PreviewForm({
         </div>
       )}
 
-      {!hasDaily && !visit?.summary && appts.length === 0 && meds.length === 0 && (
+      {!hasDaily && !visit?.summary && appts.length === 0 && meds.length === 0 && (parsed.imaging_results?.length ?? 0) === 0 && (parsed.lab_results?.length ?? 0) === 0 && (
         <Alert variant="info" role="status">
           {locale === "zh"
             ? "AI 没有从这段录音里抽出任何临床数据。可以重新识别，或者就把它当作个人日记保存。"
@@ -579,7 +598,7 @@ function PreviewForm({
           ) : (
             <Send className="h-4 w-4" />
           )}
-          {locale === "zh" ? "登入到表单" : "Log to forms"}
+          {locale === "zh" ? "保存" : "Save"}
         </Button>
       </div>
     </Card>
@@ -844,6 +863,167 @@ function MedsSection({
           : "Captured for reference. Adherence rows aren't auto-created from memos."}
       </p>
     </div>
+  );
+}
+
+function ImagingSection({
+  locale,
+  results,
+}: {
+  locale: "en" | "zh";
+  results: NonNullable<VoiceMemoParsedFields["imaging_results"]>;
+}) {
+  return (
+    <div>
+      <div className="eyebrow mb-1">
+        {locale === "zh" ? "影像" : "Imaging"}
+      </div>
+      <ul className="space-y-1.5 text-[13px]">
+        {results.map((r, i) => (
+          <li key={i} className="flex items-start gap-2">
+            <span
+              className={cn(
+                "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase",
+                r.status === "clear" || r.status === "improvement"
+                  ? "bg-emerald-50 text-emerald-700"
+                  : r.status === "stable"
+                    ? "bg-ink-100 text-ink-700"
+                    : r.status === "progression"
+                      ? "bg-[var(--warn,#d97706)]/12 text-[var(--warn,#d97706)]"
+                      : "bg-ink-100 text-ink-500",
+              )}
+            >
+              {r.modality}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-ink-900">{r.finding_summary}</div>
+              <div className="text-[10.5px] text-ink-500">
+                {imagingStatusLabel(r.status, locale)}
+                {r.date ? ` · ${r.date}` : ""}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-1 text-[11px] text-ink-400">
+        {locale === "zh"
+          ? "记录在录音上，不会自动写入「化验/影像」表。"
+          : "Captured on the memo. Not auto-filed into /imaging."}
+      </p>
+    </div>
+  );
+}
+
+function LabsSection({
+  locale,
+  results,
+}: {
+  locale: "en" | "zh";
+  results: NonNullable<VoiceMemoParsedFields["lab_results"]>;
+}) {
+  return (
+    <div>
+      <div className="eyebrow mb-1">
+        {locale === "zh" ? "化验" : "Labs"}
+      </div>
+      <ul className="space-y-1 text-[13px]">
+        {results.map((r, i) => (
+          <li key={i} className="flex items-baseline gap-2">
+            <span className="font-medium text-ink-900">{r.name}</span>
+            {r.value && <span className="text-ink-700">{r.value}</span>}
+            <span
+              className={cn(
+                "rounded-full px-1.5 py-0 text-[10px] font-medium",
+                r.status === "normal"
+                  ? "bg-emerald-50 text-emerald-700"
+                  : r.status === "raised" || r.status === "abnormal"
+                    ? "bg-[var(--warn,#d97706)]/12 text-[var(--warn,#d97706)]"
+                    : r.status === "low"
+                      ? "bg-amber-50 text-amber-700"
+                      : "bg-ink-100 text-ink-500",
+              )}
+            >
+              {labStatusLabel(r.status, locale)}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-1 text-[11px] text-ink-400">
+        {locale === "zh"
+          ? "记录在录音上，不会自动写入「化验」表。"
+          : "Captured on the memo. Not auto-filed into /labs."}
+      </p>
+    </div>
+  );
+}
+
+function imagingStatusLabel(
+  s: NonNullable<VoiceMemoParsedFields["imaging_results"]>[number]["status"],
+  locale: "en" | "zh",
+): string {
+  if (locale === "zh") {
+    return {
+      clear: "干净",
+      stable: "稳定",
+      improvement: "好转",
+      progression: "进展",
+      unclear: "不确定",
+    }[s];
+  }
+  return s;
+}
+
+function labStatusLabel(
+  s: NonNullable<VoiceMemoParsedFields["lab_results"]>[number]["status"],
+  locale: "en" | "zh",
+): string {
+  if (locale === "zh") {
+    return {
+      normal: "正常",
+      raised: "偏高",
+      low: "偏低",
+      abnormal: "异常",
+      unstated: "未说",
+    }[s];
+  }
+  return s;
+}
+
+function FollowUpsCard({
+  questions,
+  locale,
+}: {
+  questions: string[];
+  locale: "en" | "zh";
+}) {
+  return (
+    <Card className="p-4">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-[var(--tide-2)]">
+        {locale === "zh" ? "AI 的随访问题" : "From your AI nurse"}
+      </div>
+      <ul className="mt-2 space-y-2">
+        {questions.slice(0, 2).map((q, i) => (
+          <li
+            key={i}
+            className="flex items-start justify-between gap-3 rounded-md border border-ink-100 px-3 py-2"
+          >
+            <span className="text-[13.5px] italic text-ink-900">{q}</span>
+            <Link
+              href="/diary"
+              className="shrink-0 inline-flex items-center gap-1 text-[11.5px] font-medium text-[var(--tide-2)] hover:underline"
+            >
+              <Mic className="h-3 w-3" aria-hidden />
+              {locale === "zh" ? "录音回答" : "Record answer"}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-1 text-[11px] text-ink-400">
+        {locale === "zh"
+          ? "回答会保存为新的录音，AI 自动整理。"
+          : "Your answer becomes a new memo — Claude reads it the same way."}
+      </p>
+    </Card>
   );
 }
 

--- a/src/app/memos/[id]/page.tsx
+++ b/src/app/memos/[id]/page.tsx
@@ -429,6 +429,20 @@ function PreviewForm({
   const [includeAppts, setIncludeAppts] = useState(
     Boolean(parsed.clinical?.appointments_mentioned?.some((a) => a.confidence === "high")),
   );
+  // Slice 5: per-row "Add new scan/test" / "Add to /labs" toggles.
+  // Default OFF — linking to an existing appointment runs silently;
+  // creating a new clinical row needs an explicit tap.
+  const [imagingCreate, setImagingCreate] = useState<boolean[]>(
+    () => (parsed.imaging_results ?? []).map(() => false),
+  );
+  const [labCreate, setLabCreate] = useState<boolean[]>(
+    () => (parsed.lab_results ?? []).map(() => false),
+  );
+  useEffect(() => {
+    setImagingCreate((parsed.imaging_results ?? []).map(() => false));
+    setLabCreate((parsed.lab_results ?? []).map(() => false));
+  }, [parsed.imaging_results, parsed.lab_results]);
+
   const [busy, setBusy] = useState(false);
   const [reparsing, setReparsing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -439,11 +453,15 @@ function PreviewForm({
   const visit = parsed.clinical?.clinic_visit;
   const appts = parsed.clinical?.appointments_mentioned ?? [];
   const meds = parsed.clinical?.medications_mentioned ?? [];
+  const imagingResults = parsed.imaging_results ?? [];
+  const labResults = parsed.lab_results ?? [];
 
   const nothingToApply =
     (!includeDaily || !hasDaily) &&
     (!includeVisit || !visit?.summary) &&
-    (!includeAppts || appts.every((a) => a.confidence !== "high"));
+    (!includeAppts || appts.every((a) => a.confidence !== "high")) &&
+    imagingResults.length === 0 &&
+    labResults.length === 0;
 
   async function onApply() {
     if (!memo.id) return;
@@ -455,6 +473,8 @@ function PreviewForm({
         apply_clinic_visit: includeVisit,
         apply_appointments: includeAppts,
         daily_overrides: edits,
+        imaging_create: imagingCreate,
+        lab_create: labCreate,
       });
       setAppliedRecently(true);
     } catch (e) {
@@ -541,15 +561,22 @@ function PreviewForm({
 
       {meds.length > 0 && <MedsSection locale={locale} meds={meds} />}
 
-      {(parsed.imaging_results?.length ?? 0) > 0 && (
+      {imagingResults.length > 0 && (
         <ImagingSection
           locale={locale}
-          results={parsed.imaging_results!}
+          results={imagingResults}
+          create={imagingCreate}
+          setCreate={setImagingCreate}
         />
       )}
 
-      {(parsed.lab_results?.length ?? 0) > 0 && (
-        <LabsSection locale={locale} results={parsed.lab_results!} />
+      {labResults.length > 0 && (
+        <LabsSection
+          locale={locale}
+          results={labResults}
+          create={labCreate}
+          setCreate={setLabCreate}
+        />
       )}
 
       {parsed.notes && (
@@ -869,18 +896,30 @@ function MedsSection({
 function ImagingSection({
   locale,
   results,
+  create,
+  setCreate,
 }: {
   locale: "en" | "zh";
   results: NonNullable<VoiceMemoParsedFields["imaging_results"]>;
+  create: boolean[];
+  setCreate: (v: boolean[]) => void;
 }) {
+  function toggle(i: number) {
+    const next = create.slice();
+    next[i] = !next[i];
+    setCreate(next);
+  }
   return (
     <div>
       <div className="eyebrow mb-1">
         {locale === "zh" ? "影像" : "Imaging"}
       </div>
-      <ul className="space-y-1.5 text-[13px]">
+      <ul className="space-y-2 text-[13px]">
         {results.map((r, i) => (
-          <li key={i} className="flex items-start gap-2">
+          <li
+            key={i}
+            className="flex items-start gap-2 rounded-md border border-ink-100 px-2.5 py-2"
+          >
             <span
               className={cn(
                 "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase",
@@ -901,14 +940,25 @@ function ImagingSection({
                 {imagingStatusLabel(r.status, locale)}
                 {r.date ? ` · ${r.date}` : ""}
               </div>
+              <label className="mt-1.5 inline-flex items-center gap-1.5 cursor-pointer text-[11.5px] text-ink-700">
+                <input
+                  type="checkbox"
+                  checked={create[i] ?? false}
+                  onChange={() => toggle(i)}
+                  className="h-3.5 w-3.5"
+                />
+                {locale === "zh"
+                  ? "新增到「影像」记录"
+                  : "Add new scan/test entry"}
+              </label>
             </div>
           </li>
         ))}
       </ul>
       <p className="mt-1 text-[11px] text-ink-400">
         {locale === "zh"
-          ? "记录在录音上，不会自动写入「化验/影像」表。"
-          : "Captured on the memo. Not auto-filed into /imaging."}
+          ? "已有的预约会自动标为「已完成」并附上你说的内容。仅勾选时才新建影像条目。"
+          : "Matching appointment is auto-marked attended with your interpretation appended. New imaging row only when ticked."}
       </p>
     </div>
   );
@@ -917,41 +967,77 @@ function ImagingSection({
 function LabsSection({
   locale,
   results,
+  create,
+  setCreate,
 }: {
   locale: "en" | "zh";
   results: NonNullable<VoiceMemoParsedFields["lab_results"]>;
+  create: boolean[];
+  setCreate: (v: boolean[]) => void;
 }) {
+  function toggle(i: number) {
+    const next = create.slice();
+    next[i] = !next[i];
+    setCreate(next);
+  }
   return (
     <div>
       <div className="eyebrow mb-1">
         {locale === "zh" ? "化验" : "Labs"}
       </div>
-      <ul className="space-y-1 text-[13px]">
-        {results.map((r, i) => (
-          <li key={i} className="flex items-baseline gap-2">
-            <span className="font-medium text-ink-900">{r.name}</span>
-            {r.value && <span className="text-ink-700">{r.value}</span>}
-            <span
-              className={cn(
-                "rounded-full px-1.5 py-0 text-[10px] font-medium",
-                r.status === "normal"
-                  ? "bg-emerald-50 text-emerald-700"
-                  : r.status === "raised" || r.status === "abnormal"
-                    ? "bg-[var(--warn,#d97706)]/12 text-[var(--warn,#d97706)]"
-                    : r.status === "low"
-                      ? "bg-amber-50 text-amber-700"
-                      : "bg-ink-100 text-ink-500",
-              )}
+      <ul className="space-y-2 text-[13px]">
+        {results.map((r, i) => {
+          const numeric = /\d/.test(r.value ?? "");
+          return (
+            <li
+              key={i}
+              className="rounded-md border border-ink-100 px-2.5 py-2"
             >
-              {labStatusLabel(r.status, locale)}
-            </span>
-          </li>
-        ))}
+              <div className="flex items-baseline gap-2">
+                <span className="font-medium text-ink-900">{r.name}</span>
+                {r.value && <span className="text-ink-700">{r.value}</span>}
+                <span
+                  className={cn(
+                    "rounded-full px-1.5 py-0 text-[10px] font-medium",
+                    r.status === "normal"
+                      ? "bg-emerald-50 text-emerald-700"
+                      : r.status === "raised" || r.status === "abnormal"
+                        ? "bg-[var(--warn,#d97706)]/12 text-[var(--warn,#d97706)]"
+                        : r.status === "low"
+                          ? "bg-amber-50 text-amber-700"
+                          : "bg-ink-100 text-ink-500",
+                  )}
+                >
+                  {labStatusLabel(r.status, locale)}
+                </span>
+              </div>
+              {numeric ? (
+                <label className="mt-1.5 inline-flex items-center gap-1.5 cursor-pointer text-[11.5px] text-ink-700">
+                  <input
+                    type="checkbox"
+                    checked={create[i] ?? false}
+                    onChange={() => toggle(i)}
+                    className="h-3.5 w-3.5"
+                  />
+                  {locale === "zh"
+                    ? "新增到「化验」记录"
+                    : "Add to /labs"}
+                </label>
+              ) : (
+                <p className="mt-1 text-[10.5px] italic text-ink-400">
+                  {locale === "zh"
+                    ? "无具体数值，会附在已匹配的预约里。"
+                    : "No numeric value — appended to the linked appointment instead."}
+                </p>
+              )}
+            </li>
+          );
+        })}
       </ul>
       <p className="mt-1 text-[11px] text-ink-400">
         {locale === "zh"
-          ? "记录在录音上，不会自动写入「化验」表。"
-          : "Captured on the memo. Not auto-filed into /labs."}
+          ? "已有的抽血预约会自动标为「已完成」。仅勾选有数值的项才新建化验条目。"
+          : "Matching bloods appointment is auto-marked attended. Only numeric values can be saved as new lab entries."}
       </p>
     </div>
   );
@@ -1231,6 +1317,10 @@ function tableLabel(
         return "时间线事件";
       case "appointments":
         return "预约";
+      case "imaging":
+        return "影像";
+      case "labs":
+        return "化验";
     }
   }
   switch (table) {
@@ -1240,6 +1330,10 @@ function tableLabel(
       return "Life event";
     case "appointments":
       return "Appointment";
+    case "imaging":
+      return "Imaging";
+    case "labs":
+      return "Lab result";
   }
 }
 
@@ -1251,6 +1345,10 @@ function hrefForPatch(patch: AppliedPatch): string {
       return "/diary";
     case "life_events":
       return "/family/timeline";
+    case "imaging":
+      return "/labs";
+    case "labs":
+      return "/labs";
   }
 }
 

--- a/src/components/diary/voice-memo-card.tsx
+++ b/src/components/diary/voice-memo-card.tsx
@@ -196,8 +196,8 @@ function ReviewLink({
   } else if (applied.length > 0) {
     label =
       locale === "zh"
-        ? `已登入 ${applied.length} 项 · 查看`
-        : `Logged ${applied.length} item${applied.length === 1 ? "" : "s"} · view`;
+        ? `已保存 ${applied.length} 项 · 查看`
+        : `Saved ${applied.length} item${applied.length === 1 ? "" : "s"} · view`;
     icon = CheckCircle2;
     className = "text-emerald-700";
   } else {

--- a/src/lib/voice-memo/apply.ts
+++ b/src/lib/voice-memo/apply.ts
@@ -1,5 +1,5 @@
 import { db, now } from "~/lib/db/dexie";
-import type { DailyEntry, EnteredBy, LifeEvent } from "~/types/clinical";
+import type { DailyEntry, EnteredBy, Imaging, LabResult, LifeEvent } from "~/types/clinical";
 import type { Appointment } from "~/types/appointment";
 import type {
   AppliedPatch,
@@ -7,6 +7,14 @@ import type {
   VoiceMemoParsedFields,
 } from "~/types/voice-memo";
 import { localDayISO } from "~/lib/utils/date";
+import {
+  extractNumericValue,
+  findAppointmentForImaging,
+  findAppointmentForLab,
+  findExistingLabRow,
+  mapLabName,
+  mapModality,
+} from "./match";
 
 // Slice 3: turn a memo's parsed_fields into actual rows in the
 // appropriate tables — only when the patient has reviewed and
@@ -25,13 +33,22 @@ import { localDayISO } from "~/lib/utils/date";
 export interface ApplyOptions {
   // What the patient confirmed in the preview form. Each toggle lets
   // them include or exclude one section of the parse from the apply.
-  // Defaults: all true when the patient just hits "Log to forms".
+  // Defaults: all true when the patient just hits "Save".
   apply_daily?: boolean;
   apply_clinic_visit?: boolean;
   apply_appointments?: boolean;
   // Subset of the parsed daily values the patient may have edited
   // before applying. Falls back to memo.parsed_fields when omitted.
   daily_overrides?: DailyOverridePatch;
+  // Slice 5: per-result toggles for imaging + lab creates. The
+  // linking step (mark a matched appointment attended, append the
+  // memo's interpretation to its notes) is silent and always runs;
+  // creating a NEW imaging or labs row when no appointment matched
+  // requires an explicit tap. Index in the array maps 1:1 to the
+  // memo's `parsed_fields.imaging_results[]` / `lab_results[]`.
+  // When omitted, no new clinical rows are created.
+  imaging_create?: boolean[];
+  lab_create?: boolean[];
 }
 
 export type DailyOverridePatch = Partial<
@@ -90,6 +107,30 @@ export async function applyMemoPatches(
       if (appt.confidence !== "high") continue;
       const apptPatch = await applyAppointment(memo, appt);
       if (apptPatch) patches.push(apptPatch);
+    }
+  }
+
+  // Slice 5: imaging results. Always try to link to a matching
+  // appointment (auto). Only create a new imaging row when the caller
+  // opted in via `imaging_create[i]`.
+  if (parsed.imaging_results?.length) {
+    for (let i = 0; i < parsed.imaging_results.length; i++) {
+      const result = parsed.imaging_results[i]!;
+      const create = opts.imaging_create?.[i] ?? false;
+      const imagingPatches = await applyImagingResult(memo, result, create);
+      patches.push(...imagingPatches);
+    }
+  }
+
+  // Slice 5: lab results. Same rule — link silently to a matched
+  // appointment, only create a labs row when there's a numeric value
+  // AND the caller opted in.
+  if (parsed.lab_results?.length) {
+    for (let i = 0; i < parsed.lab_results.length; i++) {
+      const result = parsed.lab_results[i]!;
+      const create = opts.lab_create?.[i] ?? false;
+      const labPatches = await applyLabResult(memo, result, create);
+      patches.push(...labPatches);
     }
   }
 
@@ -258,6 +299,184 @@ async function applyAppointment(
     op: "create",
     applied_at: ts,
   };
+}
+
+// Slice 5: link a memo to an existing appointment. Auto-applied
+// silently when a fuzzy match is found. Flips status `scheduled` →
+// `attended`, appends a one-line attribution to notes (preserving
+// any existing notes), and stamps `source_memo_id` for provenance.
+// `prior_fields` records the pre-link state so undo can restore.
+async function linkAppointment(
+  memo: VoiceMemo,
+  appt: Appointment,
+  attribution: string,
+): Promise<AppliedPatch | null> {
+  if (!appt.id) return null;
+  const ts = now();
+  const priorStatus = appt.status;
+  const priorNotes = appt.notes ?? "";
+  const newNotes = priorNotes
+    ? `${priorNotes}\n\n${attribution}`
+    : attribution;
+
+  const flipStatus =
+    priorStatus === "scheduled" ? ("attended" as const) : priorStatus;
+
+  await db.appointments.update(appt.id, {
+    status: flipStatus,
+    notes: newNotes,
+    source_memo_id: memo.id,
+    updated_at: ts,
+  });
+
+  const fields: Record<string, string | number> = {
+    status: flipStatus,
+    notes_appended: attribution,
+  };
+  return {
+    table: "appointments",
+    row_id: appt.id,
+    fields,
+    prior_fields: {
+      status: priorStatus,
+      notes: priorNotes,
+    },
+    op: "update",
+    applied_at: ts,
+  };
+}
+
+// Slice 5: apply an imaging result from a memo. Two-step:
+//   1. Try to link to a recent matching appointment (always silent
+//      auto-link). Only fires when the apply step finds a match in
+//      the 14-day-back / 7-day-forward window.
+//   2. When `createNew` is true, also create an imaging row tied to
+//      the matched appointment (when present) and the memo. Driven
+//      by the patient tapping "Add new scan/test" in the preview.
+async function applyImagingResult(
+  memo: VoiceMemo,
+  result: NonNullable<VoiceMemoParsedFields["imaging_results"]>[number],
+  createNew: boolean,
+): Promise<AppliedPatch[]> {
+  const patches: AppliedPatch[] = [];
+  const day = result.date ?? memo.day ?? localDayISO(memo.recorded_at);
+
+  const matched = await findAppointmentForImaging(result.modality, day);
+  if (matched?.id) {
+    const linkPatch = await linkAppointment(
+      memo,
+      matched,
+      `From voice memo: ${result.modality.toUpperCase()} — ${result.finding_summary} (${result.status}).`,
+    );
+    if (linkPatch) patches.push(linkPatch);
+  }
+
+  if (createNew) {
+    const ts = now();
+    const row: Imaging = {
+      date: day,
+      modality: mapModality(result.modality),
+      findings_summary: result.finding_summary,
+      notes: `Patient interpretation: ${result.status}.`,
+      source_memo_id: memo.id,
+      source_appointment_id: matched?.id,
+      created_at: ts,
+      updated_at: ts,
+    };
+    const id = (await db.imaging.add(row)) as number;
+    patches.push({
+      table: "imaging",
+      row_id: id,
+      fields: {
+        modality: row.modality,
+        findings_summary: row.findings_summary,
+        date: row.date,
+      },
+      op: "create",
+      applied_at: ts,
+    });
+  }
+  return patches;
+}
+
+// Slice 5: apply a lab result from a memo. Three branches:
+//   1. Numeric value + match in known LabResult typed fields →
+//      create a new labs row (when createNew=true) with the typed
+//      analyte filled and source: "patient_self_report".
+//   2. Match against an existing same-day labs row → safe-fill the
+//      missing analyte if present (when createNew=true).
+//   3. Always — link to the matched bloods appointment (auto).
+async function applyLabResult(
+  memo: VoiceMemo,
+  result: NonNullable<VoiceMemoParsedFields["lab_results"]>[number],
+  createNew: boolean,
+): Promise<AppliedPatch[]> {
+  const patches: AppliedPatch[] = [];
+  const day = result.date ?? memo.day ?? localDayISO(memo.recorded_at);
+
+  // Always try to link a matching bloods appointment first — silent.
+  const matched = await findAppointmentForLab(day);
+  if (matched?.id) {
+    const linkPatch = await linkAppointment(
+      memo,
+      matched,
+      `From voice memo: ${result.name} — ${result.value ?? result.status}.`,
+    );
+    if (linkPatch) patches.push(linkPatch);
+  }
+
+  if (!createNew) return patches;
+
+  const numeric = extractNumericValue(result.value);
+  const fieldKey = mapLabName(result.name);
+  // Without a numeric value mapped to a known typed analyte we don't
+  // touch the labs table — the qualitative mention stays on the memo
+  // (and on the linked appointment's notes). Per the user's design.
+  if (numeric === null || !fieldKey) return patches;
+
+  const ts = now();
+  const existing = await findExistingLabRow(day);
+
+  if (existing?.id) {
+    // Safe-fill: only write when the analyte slot is empty. Don't
+    // overwrite a value Thomas imported from Epworth earlier.
+    const existingValue = (existing as unknown as Record<string, unknown>)[
+      fieldKey
+    ];
+    if (typeof existingValue === "number") return patches;
+    await db.labs.update(existing.id, {
+      [fieldKey]: numeric,
+      updated_at: ts,
+    });
+    patches.push({
+      table: "labs",
+      row_id: existing.id,
+      fields: { [fieldKey]: numeric },
+      prior_fields: { [fieldKey]: null },
+      op: "update",
+      applied_at: ts,
+    });
+    return patches;
+  }
+
+  const row: LabResult = {
+    date: day,
+    [fieldKey]: numeric,
+    source: "patient_self_report",
+    source_memo_id: memo.id,
+    source_appointment_id: matched?.id,
+    created_at: ts,
+    updated_at: ts,
+  } as LabResult;
+  const id = (await db.labs.add(row)) as number;
+  patches.push({
+    table: "labs",
+    row_id: id,
+    fields: { date: day, [fieldKey]: numeric, source: "patient_self_report" },
+    op: "create",
+    applied_at: ts,
+  });
+  return patches;
 }
 
 // Pull just the daily-form shape out of a parsed result. Keeps the
@@ -438,12 +657,14 @@ export async function undoAppliedPatch(
 }
 
 async function deleteRow(
-  table: "daily_entries" | "life_events" | "appointments",
+  table: AppliedPatch["table"],
   id: number,
 ): Promise<void> {
   if (table === "daily_entries") await db.daily_entries.delete(id);
   else if (table === "life_events") await db.life_events.delete(id);
-  else await db.appointments.delete(id);
+  else if (table === "appointments") await db.appointments.delete(id);
+  else if (table === "imaging") await db.imaging.delete(id);
+  else if (table === "labs") await db.labs.delete(id);
 }
 
 async function revertUpdate(patch: import("~/types/voice-memo").AppliedPatch): Promise<void> {
@@ -469,6 +690,42 @@ async function revertUpdate(patch: import("~/types/voice-memo").AppliedPatch): P
     }
     next.updated_at = ts;
     await db.daily_entries.put(next);
+    return;
+  }
+  if (patch.table === "appointments") {
+    // Slice 5: undoing a memo→appointment link restores the prior
+    // status (e.g. "scheduled") and notes, and clears the
+    // source_memo_id we stamped.
+    const row = await db.appointments.get(patch.row_id);
+    if (!row) return;
+    const prior = patch.prior_fields ?? {};
+    const next: Appointment = { ...row, updated_at: ts };
+    if (typeof prior.status === "string") {
+      next.status = prior.status as Appointment["status"];
+    }
+    if ("notes" in prior) {
+      const v = prior.notes;
+      next.notes = typeof v === "string" && v.length > 0 ? v : undefined;
+    }
+    delete (next as unknown as Record<string, unknown>).source_memo_id;
+    await db.appointments.put(next);
+    return;
+  }
+  if (patch.table === "labs") {
+    const row = await db.labs.get(patch.row_id);
+    if (!row) return;
+    const next = { ...row, updated_at: ts } as LabResult;
+    const prior = patch.prior_fields ?? {};
+    const nextRecord = next as unknown as Record<string, unknown>;
+    for (const k of keys) {
+      const restoredValue = prior[k];
+      if (restoredValue === null || restoredValue === undefined) {
+        delete nextRecord[k];
+      } else {
+        nextRecord[k] = restoredValue;
+      }
+    }
+    await db.labs.put(next);
     return;
   }
   // life_events and appointments don't currently emit `update` patches

--- a/src/lib/voice-memo/match.ts
+++ b/src/lib/voice-memo/match.ts
@@ -1,0 +1,219 @@
+import { db } from "~/lib/db/dexie";
+import type { Appointment } from "~/types/appointment";
+import type { Imaging, LabResult } from "~/types/clinical";
+import type { VoiceMemoParsedFields } from "~/types/voice-memo";
+
+// Matching helpers for the voice-memo apply step. Job is to answer:
+// "did dad already have an appointment on the books for this scan /
+// blood test, or is this an unprompted mention?" Linking the memo to
+// existing rows preserves the schedule's source-of-truth status; only
+// truly novel mentions create new clinical entries (and even those
+// require an explicit "Add new scan/test" tap on the preview).
+
+const APPOINTMENT_LOOKBACK_DAYS = 14;
+const APPOINTMENT_LOOKAHEAD_DAYS = 7;
+
+type ImagingModality = NonNullable<
+  VoiceMemoParsedFields["imaging_results"]
+>[number]["modality"];
+
+// Map the memo's lowercase modality enum to the Imaging table's
+// uppercase one. Memo enum widens to "xray" / "bone_scan" which the
+// Imaging table doesn't have — those collapse to "other" so we never
+// drop an entry on a typo-by-design.
+export function mapModality(m: ImagingModality): Imaging["modality"] {
+  switch (m) {
+    case "ct":
+      return "CT";
+    case "mri":
+      return "MRI";
+    case "pet":
+      return "PET";
+    case "ultrasound":
+      return "US";
+    default:
+      return "other";
+  }
+}
+
+// Words that strongly suggest a particular modality when found in an
+// appointment title. Order matters — PET wins over CT because a
+// "PET-CT" appointment is technically both but most clinically a PET.
+const MODALITY_KEYWORDS: Record<ImagingModality, string[]> = {
+  pet: ["pet"],
+  mri: ["mri"],
+  ct: ["ct ", "ct-", "ct,", "ct.", "ct\\b", "computed tomography"],
+  ultrasound: ["ultrasound", "us "],
+  xray: ["x-ray", "xray", "x ray"],
+  bone_scan: ["bone scan", "bone-scan"],
+  other: [],
+};
+
+// Find a recent appointment that this imaging memo is most likely
+// reporting on. Returns null when no match — caller surfaces an
+// "Add new scan/test" CTA in that case.
+//
+// Window: 14 days back, 7 days forward (memo can describe a result
+// that arrived right after the scan, or a result the patient already
+// got even though our local appointment hasn't been marked attended).
+export async function findAppointmentForImaging(
+  modality: ImagingModality,
+  memoDay: string,
+): Promise<Appointment | null> {
+  const window = appointmentWindow(memoDay);
+  const candidates = await db.appointments
+    .where("starts_at")
+    .between(window.from, window.to, true, true)
+    .toArray();
+  return pickBestImagingMatch(candidates, modality);
+}
+
+function pickBestImagingMatch(
+  rows: Appointment[],
+  modality: ImagingModality,
+): Appointment | null {
+  const keywords = MODALITY_KEYWORDS[modality] ?? [];
+  const scored = rows
+    .filter((a) => a.status !== "cancelled")
+    .map((a) => ({ row: a, score: scoreImagingMatch(a, modality, keywords) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score);
+  return scored[0]?.row ?? null;
+}
+
+function scoreImagingMatch(
+  appt: Appointment,
+  modality: ImagingModality,
+  keywords: string[],
+): number {
+  let score = 0;
+  if (appt.kind === "scan") score += 5;
+  else if (appt.kind === "procedure") score += 2;
+  else if (appt.kind === "other") score += 1;
+  // Title fuzzy-match (case-insensitive substring).
+  const haystack = `${appt.title ?? ""} ${appt.notes ?? ""}`.toLowerCase();
+  for (const kw of keywords) {
+    if (kw.includes("\\b")) {
+      // Treat as a regex word-boundary check.
+      const re = new RegExp(kw.replace(/\\b/g, "\\b"), "i");
+      if (re.test(haystack)) {
+        score += 4;
+        break;
+      }
+    } else if (haystack.includes(kw)) {
+      score += 4;
+      break;
+    }
+  }
+  return score;
+}
+
+// Lab name → typed LabResult key. Returns null when the memo's name
+// doesn't fuzzy-map to one of the known typed analytes — in that case
+// the qualitative mention stays on the memo / appointment notes only.
+export function mapLabName(rawName: string): keyof LabResult | null {
+  const n = rawName.toLowerCase().replace(/[\s-_]+/g, " ").trim();
+  // Tumour markers
+  if (/(ca\s*19[\s.\-]?9|ca199)/.test(n)) return "ca199";
+  if (n === "cea" || n.startsWith("cea ")) return "cea";
+  if (n === "ldh" || n.startsWith("ldh ")) return "ldh";
+  // Nutrition / inflammation
+  if (n.includes("prealbumin")) return "prealbumin";
+  if (n.includes("albumin")) return "albumin";
+  if (n === "crp" || n.includes("c reactive")) return "crp";
+  // Haematology
+  if (n.includes("hemoglobin") || n.includes("haemoglobin") || n === "hb" || n === "hgb") return "hemoglobin";
+  if (n.includes("hematocrit") || n.includes("haematocrit") || n === "hct") return "hematocrit";
+  if (n === "wbc" || n.includes("white cell") || n.includes("white count")) return "wbc";
+  if (n.includes("neutrophil")) return "neutrophils";
+  if (n.includes("lymphocyte")) return "lymphocytes";
+  if (n.includes("platelet") || n === "plt") return "platelets";
+  // LFTs
+  if (n === "alt") return "alt";
+  if (n === "ast") return "ast";
+  if (n === "ggt") return "ggt";
+  if (n === "alp" || n.includes("alkaline phos")) return "alp";
+  if (n.includes("bilirubin")) return "bilirubin";
+  // Renal / electrolytes
+  if (n.includes("creatinine")) return "creatinine";
+  if (n === "urea" || n === "bun") return "urea";
+  if (n === "sodium" || n === "na") return "sodium";
+  if (n === "potassium" || n === "k") return "potassium";
+  if (n.includes("calcium")) return "calcium";
+  if (n.includes("magnesium")) return "magnesium";
+  if (n.includes("phosphate")) return "phosphate";
+  // Metabolic
+  if (n === "glucose" || n.includes("blood sugar")) return "glucose";
+  if (n.includes("hba1c") || n.includes("a1c")) return "hba1c";
+  // Micronutrients
+  if (n.includes("ferritin")) return "ferritin";
+  if (n.includes("vitamin d") || n === "vit d") return "vit_d";
+  if (n.includes("b12")) return "b12";
+  if (n === "folate") return "folate";
+  return null;
+}
+
+// Pull a plain number out of a free-text lab value. Tolerates
+// units in either direction ("28 U/mL", "5.2 ×10^9/L"). Returns
+// null when the value is qualitative ("normal", "high") so the
+// caller can route accordingly.
+export function extractNumericValue(value: string | undefined | null): number | null {
+  if (!value) return null;
+  // Strip common decoration before parseFloat.
+  const cleaned = value
+    .replace(/[,]/g, "")
+    .replace(/[<>≤≥]/g, "")
+    .trim();
+  const m = cleaned.match(/-?\d+(\.\d+)?/);
+  if (!m) return null;
+  const n = Number(m[0]);
+  return Number.isFinite(n) ? n : null;
+}
+
+// Find an existing labs row for this date (any source). Used to
+// dedupe the memo's mention against a row that's already there
+// (e.g. labs were imported by Thomas earlier). When matched, the
+// caller may add the memo's value to a missing analyte slot.
+export async function findExistingLabRow(
+  day: string,
+): Promise<LabResult | null> {
+  const rows = await db.labs.where("date").equals(day).toArray();
+  return rows[0] ?? null;
+}
+
+export async function findAppointmentForLab(
+  memoDay: string,
+): Promise<Appointment | null> {
+  const window = appointmentWindow(memoDay);
+  const rows = await db.appointments
+    .where("starts_at")
+    .between(window.from, window.to, true, true)
+    .toArray();
+  const scored = rows
+    .filter((a) => a.status !== "cancelled")
+    .map((a) => ({ row: a, score: scoreLabMatch(a) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score);
+  return scored[0]?.row ?? null;
+}
+
+function scoreLabMatch(appt: Appointment): number {
+  let score = 0;
+  if (appt.kind === "blood_test") score += 5;
+  else if (appt.kind === "clinic") score += 1;
+  return score;
+}
+
+// 14 days back, 7 days forward — clipped to a reasonable timestamp
+// range so Dexie's between() index walk stays small.
+function appointmentWindow(memoDay: string): { from: string; to: string } {
+  const d = new Date(`${memoDay}T00:00:00`);
+  const from = new Date(d);
+  from.setDate(from.getDate() - APPOINTMENT_LOOKBACK_DAYS);
+  const to = new Date(d);
+  to.setDate(to.getDate() + APPOINTMENT_LOOKAHEAD_DAYS);
+  return {
+    from: from.toISOString().slice(0, 10),
+    to: to.toISOString().slice(0, 19) + "Z",
+  };
+}

--- a/src/lib/voice-memo/parse-schema.ts
+++ b/src/lib/voice-memo/parse-schema.ts
@@ -192,6 +192,67 @@ export const VoiceMemoParseSchema = z.object({
       "Non-clinical content. Set when the patient mentions food, family, practice, goals, or mood. Null otherwise.",
     ),
 
+  // ---- Imaging results the patient mentions (PET, CT, MRI, ultrasound,
+  //      bone scan). Strictly clinical — NEVER goes into the personal
+  //      block. Surfaced in the preview as info chips; not auto-filed
+  //      into /imaging because those rows have stricter schemas that
+  //      need explicit confirmation.
+  imaging_results: z
+    .array(
+      z.object({
+        modality: z
+          .enum(["pet", "ct", "mri", "ultrasound", "xray", "bone_scan", "other"])
+          .describe("Scan type. Use 'other' rather than guessing when ambiguous."),
+        finding_summary: z
+          .string()
+          .describe("One short phrase: 'all clear', 'liver lesion stable', 'new node in mediastinum'."),
+        status: z
+          .enum(["clear", "stable", "improvement", "progression", "unclear"])
+          .describe("Patient's interpretation of the result."),
+        date: z
+          .string()
+          .nullish()
+          .describe("ISO date when stated; null otherwise."),
+      }),
+    )
+    .nullish()
+    .describe(
+      "Imaging the patient is reporting on. Empty / null when none. Always clinical, never personal.",
+    ),
+
+  // ---- Lab / blood results the patient mentions (white cells, CA 19-9,
+  //      CEA, LFTs, etc.). Strictly clinical, surfaced as preview chips.
+  lab_results: z
+    .array(
+      z.object({
+        name: z
+          .string()
+          .describe("Lab name as the patient said it: 'white cells', 'CA 19-9', 'liver enzymes'."),
+        value: z
+          .string()
+          .nullish()
+          .describe("Numeric value or descriptor as stated; null when not given."),
+        status: z
+          .enum(["normal", "raised", "low", "abnormal", "unstated"])
+          .describe("Patient's interpretation of the result."),
+        date: z.string().nullish(),
+      }),
+    )
+    .nullish()
+    .describe(
+      "Lab / blood-test mentions. Empty / null when none. Always clinical, never personal.",
+    ),
+
+  // ---- Follow-up questions to surface back to the patient. Lets the
+  //      app feel like a thoughtful nurse / dietician / physio gently
+  //      asking what's missing. Max 2 — we don't interrogate.
+  follow_up_questions: z
+    .array(z.string())
+    .nullish()
+    .describe(
+      "0–2 short questions you'd ask if you were a thoughtful nurse / dietician / physio reviewing this memo. Ask only when something feels genuinely incomplete or worth probing (e.g. duration, severity, what triggered it). Phrase warmly, in the memo's language. Skip entirely when the memo is comprehensive.",
+    ),
+
   confidence: ConfidenceEnum.describe(
     "Overall extraction confidence. high: explicit numerics or unambiguous descriptions. medium: clear qualitative anchors. low: only vague mentions, transcript noise, or speech-recognition garbage.",
   ),
@@ -217,7 +278,9 @@ Output rules:
 4. \`notes\` is reserved for short clinical addenda that didn't fit a structured field (a taste change, a side-effect attribution). Personal content (food, family, practice, goals, mood) belongs in the \`personal\` block — never in \`notes\`.
 5. \`clinic_visit\` only when the patient describes a clinical encounter that already happened. Do not invent providers; resolve nicknames only when context is clear ("Sumi" → "A/Prof Sumitra Ananda" when the memo is about oncology). \`null\` otherwise.
 6. \`appointments_mentioned\` only for events that haven't happened yet. Set \`confidence: high\` only when both date and title are concrete; vague mentions ("scan sometime next week") are medium or low and won't auto-schedule downstream. Empty array when nothing concrete.
-7. \`personal\` is the diary half — populate when the patient mentions food, family, practice, goals, or mood. Inner string-array fields are empty arrays when nothing matches; \`mood_narrative\` and \`observations\` are \`null\` when nothing matches. Set the whole \`personal\` object to \`null\` only when the memo is purely clinical with no personal flavour at all.
-8. Set the top-level \`confidence\` honestly. low when transcripts are short, garbled, or only mention vague feelings. high only when the memo carries clear, unambiguous structured signal.
-9. Never invent specific numbers, weights, dates, or medications.`;
+7. \`imaging_results\` and \`lab_results\` are STRICTLY clinical — never put scan or blood-test mentions in \`personal\` or \`notes\`. "PET CT clear", "CT stable", "white cells normal", "CA 19-9 dropped" are imaging or lab entries with their own structured fields. Empty / null when none.
+8. \`personal\` is the diary half — populate when the patient mentions food, family, practice, goals, or mood. Inner string-array fields are empty arrays when nothing matches; \`mood_narrative\` and \`observations\` are \`null\` when nothing matches. Set the whole \`personal\` object to \`null\` only when the memo is purely clinical with no personal flavour at all. Scan / lab / medication mentions belong to their clinical fields, NOT here.
+9. \`follow_up_questions\`: act like a thoughtful nurse / dietician / physio reading dad's memo. If something feels incomplete or worth probing — duration, severity, what triggered it, what helped — ask 1 or 2 short, warm questions in the memo's language. Skip entirely when the memo is comprehensive. Never ask more than 2.
+10. Set the top-level \`confidence\` honestly. low when transcripts are short, garbled, or only mention vague feelings. high only when the memo carries clear, unambiguous structured signal.
+11. Never invent specific numbers, weights, dates, or medications.`;
 }

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -152,6 +152,11 @@ export interface Appointment {
   // MHR appointment PDF). See SourceSystem / PdfBlob in ~/types/clinical.
   source_system?: SourceSystem;
   source_pdf_id?: number;
+  // Slice 5: voice-memo provenance. When a memo was matched to this
+  // appointment (e.g. dad reporting on a PET CT result for a
+  // previously-scheduled scan), the most recent memo id that linked
+  // here. Future linkings can use linked_records[] for full history.
+  source_memo_id?: number;
   created_at: string;
   updated_at: string;
 }

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -242,6 +242,13 @@ export interface LabResult {
   // Provenance — see SourceSystem / PdfBlob above.
   source_system?: SourceSystem;
   source_pdf_id?: number;
+  // Slice 5: voice-memo provenance. When the patient quoted a lab
+  // value in a memo, source_memo_id ties the labs row back to the
+  // recording; source_appointment_id ties it to the bloods
+  // appointment that produced the value. Both non-indexed → no
+  // Dexie schema bump needed.
+  source_memo_id?: number;
+  source_appointment_id?: number;
   created_at: string;
   updated_at: string;
 }
@@ -255,6 +262,9 @@ export interface Imaging {
   notes?: string;
   source_system?: SourceSystem;
   source_pdf_id?: number;
+  // Slice 5: same voice-memo provenance pair as LabResult above.
+  source_memo_id?: number;
+  source_appointment_id?: number;
   created_at: string;
   updated_at: string;
 }

--- a/src/types/voice-memo.ts
+++ b/src/types/voice-memo.ts
@@ -96,6 +96,29 @@ export interface VoiceMemoParsedFields {
   // patient can see exactly which forms the AI updated for them.
   applied_patches?: AppliedPatch[];
 
+  // ----- Slice 4: imaging + lab results the patient mentioned -----
+  // Surfaced as preview chips. NOT auto-filed into /imaging or /labs
+  // — those tables have stricter schemas. Stays on the memo only.
+  imaging_results?: Array<{
+    modality: "pet" | "ct" | "mri" | "ultrasound" | "xray" | "bone_scan" | "other";
+    finding_summary: string;
+    status: "clear" | "stable" | "improvement" | "progression" | "unclear";
+    date?: string;
+  }>;
+  lab_results?: Array<{
+    name: string;
+    value?: string;
+    status: "normal" | "raised" | "low" | "abnormal" | "unstated";
+    date?: string;
+  }>;
+
+  // ----- Slice 4: dialogue-vibe follow-up questions -----
+  // 0–2 short questions Claude would ask if it were a thoughtful
+  // nurse / dietician / physio reading the memo. Surfaced under the
+  // preview; each one offers a "Record answer" affordance that opens
+  // the diary recorder.
+  follow_up_questions?: string[];
+
   // Confidence in the overall parse. Only `high` triggers daily_entries
   // safe-fill; any value still appears on the memo card so the patient
   // can verify and correct.

--- a/src/types/voice-memo.ts
+++ b/src/types/voice-memo.ts
@@ -175,7 +175,9 @@ export interface AppliedPatch {
   table:
     | "daily_entries"
     | "life_events"
-    | "appointments";
+    | "appointments"
+    | "imaging"
+    | "labs";
   // The local id of the row written or updated.
   row_id: number;
   // Fields touched on that row, with the value the memo supplied. We

--- a/tests/unit/voice-memo-link.test.ts
+++ b/tests/unit/voice-memo-link.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { db } from "~/lib/db/dexie";
+import {
+  extractNumericValue,
+  findAppointmentForImaging,
+  findAppointmentForLab,
+  mapLabName,
+  mapModality,
+} from "~/lib/voice-memo/match";
+import { applyMemoPatches } from "~/lib/voice-memo/apply";
+import { persistVoiceMemo } from "~/lib/voice-memo/persist";
+import type { Appointment } from "~/types/appointment";
+import type { VoiceMemoParsedFields } from "~/types/voice-memo";
+
+beforeEach(async () => {
+  await db.delete();
+  await db.open();
+});
+
+const ts = "2026-04-29T08:00:00";
+
+async function makeMemo(parsed: VoiceMemoParsedFields, day = "2026-04-29") {
+  const { memo_id } = await persistVoiceMemo({
+    blob: new Blob([new Uint8Array(8)], { type: "audio/webm" }),
+    mime: "audio/webm",
+    duration_ms: 4000,
+    transcript: "test",
+    locale: "en",
+    entered_by: "hulin",
+    source_screen: "diary",
+    recorded_at: `${day}T08:00:00`,
+  });
+  await db.voice_memos.update(memo_id, {
+    parsed_fields: parsed,
+    updated_at: ts,
+  });
+  return memo_id;
+}
+
+async function makeAppointment(partial: Partial<Appointment>): Promise<number> {
+  const row: Appointment = {
+    kind: "scan",
+    title: "PET-CT scan",
+    starts_at: "2026-04-29T07:00:00",
+    status: "scheduled",
+    created_at: ts,
+    updated_at: ts,
+    ...partial,
+  } as Appointment;
+  return (await db.appointments.add(row)) as number;
+}
+
+describe("mapModality + mapLabName", () => {
+  it("maps memo modality to Imaging table enum", () => {
+    expect(mapModality("pet")).toBe("PET");
+    expect(mapModality("ct")).toBe("CT");
+    expect(mapModality("mri")).toBe("MRI");
+    expect(mapModality("ultrasound")).toBe("US");
+    expect(mapModality("xray")).toBe("other");
+    expect(mapModality("bone_scan")).toBe("other");
+  });
+
+  it("maps free-text lab names to typed LabResult keys", () => {
+    expect(mapLabName("CA 19-9")).toBe("ca199");
+    expect(mapLabName("ca199")).toBe("ca199");
+    expect(mapLabName("CEA")).toBe("cea");
+    expect(mapLabName("white cells")).toBe("wbc");
+    expect(mapLabName("hemoglobin")).toBe("hemoglobin");
+    expect(mapLabName("haemoglobin")).toBe("hemoglobin");
+    expect(mapLabName("Vitamin D")).toBe("vit_d");
+    expect(mapLabName("absolute neutrophils")).toBe("neutrophils");
+    // Unknown returns null so the apply step skips writing to /labs.
+    expect(mapLabName("some random analyte")).toBeNull();
+  });
+
+  it("extracts numeric values out of decorated free-text", () => {
+    expect(extractNumericValue("28")).toBe(28);
+    expect(extractNumericValue("28 U/mL")).toBe(28);
+    expect(extractNumericValue("5.2 ×10^9/L")).toBe(5.2);
+    expect(extractNumericValue("<0.5")).toBe(0.5);
+    expect(extractNumericValue("normal")).toBeNull();
+    expect(extractNumericValue(undefined)).toBeNull();
+    expect(extractNumericValue("")).toBeNull();
+  });
+});
+
+describe("findAppointmentForImaging", () => {
+  it("returns the closest scan appointment within the look-back window", async () => {
+    await makeAppointment({
+      title: "Old PET scan",
+      starts_at: "2026-04-10T07:00:00", // 19 days back — outside window
+    });
+    const recentId = await makeAppointment({
+      title: "PET-CT scan at Epworth",
+      starts_at: "2026-04-22T07:00:00", // 7 days back — inside window
+    });
+    const match = await findAppointmentForImaging("pet", "2026-04-29");
+    expect(match?.id).toBe(recentId);
+  });
+
+  it("ignores cancelled appointments", async () => {
+    await makeAppointment({
+      title: "PET CT cancelled",
+      starts_at: "2026-04-25T07:00:00",
+      status: "cancelled",
+    });
+    const match = await findAppointmentForImaging("pet", "2026-04-29");
+    expect(match).toBeNull();
+  });
+
+  it("scores blood-test kinds higher when looking for a lab", async () => {
+    const bloods = await makeAppointment({
+      kind: "blood_test",
+      title: "Routine bloods",
+      starts_at: "2026-04-28T08:00:00",
+    });
+    await makeAppointment({
+      kind: "clinic",
+      title: "Sumi consult",
+      starts_at: "2026-04-28T10:00:00",
+    });
+    const match = await findAppointmentForLab("2026-04-29");
+    expect(match?.id).toBe(bloods);
+  });
+});
+
+describe("applyMemoPatches — imaging linking", () => {
+  it("auto-links a memo to an existing scan appointment without creating a new imaging row", async () => {
+    const apptId = await makeAppointment({
+      title: "PET-CT scan",
+      starts_at: "2026-04-29T07:00:00",
+      status: "scheduled",
+    });
+    const memoId = await makeMemo({
+      confidence: "high",
+      imaging_results: [
+        {
+          modality: "pet",
+          finding_summary: "all clear",
+          status: "clear",
+        },
+      ],
+    });
+
+    const patches = await applyMemoPatches(memoId);
+
+    // Linked the appointment, did not touch /imaging.
+    expect(patches.some((p) => p.table === "appointments" && p.op === "update")).toBe(true);
+    expect(patches.some((p) => p.table === "imaging")).toBe(false);
+
+    const after = await db.appointments.get(apptId);
+    expect(after?.status).toBe("attended");
+    expect(after?.notes).toContain("all clear");
+    expect(after?.source_memo_id).toBe(memoId);
+    expect(await db.imaging.toArray()).toHaveLength(0);
+  });
+
+  it("creates a new imaging row when the patient ticks the toggle, keyed back to the memo and the appointment", async () => {
+    const apptId = await makeAppointment({
+      title: "CT scan abdomen",
+      starts_at: "2026-04-28T07:00:00",
+      status: "scheduled",
+    });
+    const memoId = await makeMemo({
+      confidence: "high",
+      imaging_results: [
+        {
+          modality: "ct",
+          finding_summary: "no progression",
+          status: "stable",
+        },
+      ],
+    });
+
+    const patches = await applyMemoPatches(memoId, { imaging_create: [true] });
+
+    const imagingPatch = patches.find((p) => p.table === "imaging");
+    expect(imagingPatch?.op).toBe("create");
+    const imaging = await db.imaging.get(imagingPatch!.row_id);
+    expect(imaging?.modality).toBe("CT");
+    expect(imaging?.findings_summary).toBe("no progression");
+    expect(imaging?.source_memo_id).toBe(memoId);
+    expect(imaging?.source_appointment_id).toBe(apptId);
+  });
+});
+
+describe("applyMemoPatches — lab linking", () => {
+  it("links a bloods appointment but skips /labs when value is qualitative", async () => {
+    const apptId = await makeAppointment({
+      kind: "blood_test",
+      title: "Routine bloods",
+      starts_at: "2026-04-29T08:00:00",
+      status: "scheduled",
+    });
+    const memoId = await makeMemo({
+      confidence: "high",
+      lab_results: [
+        { name: "white cells", status: "normal" },
+      ],
+    });
+
+    const patches = await applyMemoPatches(memoId, { lab_create: [true] });
+
+    expect(patches.some((p) => p.table === "appointments")).toBe(true);
+    // Qualitative — no labs row even with the toggle on.
+    expect(patches.some((p) => p.table === "labs")).toBe(false);
+    expect(await db.labs.toArray()).toHaveLength(0);
+
+    const after = await db.appointments.get(apptId);
+    expect(after?.status).toBe("attended");
+    expect(after?.notes).toContain("white cells");
+  });
+
+  it("creates a typed labs row when a numeric value maps to a known analyte", async () => {
+    const memoId = await makeMemo({
+      confidence: "high",
+      lab_results: [
+        { name: "CA 19-9", value: "28", status: "raised" },
+      ],
+    });
+
+    const patches = await applyMemoPatches(memoId, { lab_create: [true] });
+
+    const labsPatch = patches.find((p) => p.table === "labs");
+    expect(labsPatch?.op).toBe("create");
+    const row = await db.labs.get(labsPatch!.row_id);
+    expect(row?.ca199).toBe(28);
+    expect(row?.source).toBe("patient_self_report");
+    expect(row?.source_memo_id).toBe(memoId);
+  });
+
+  it("safe-fills an existing same-day labs row instead of creating a duplicate", async () => {
+    await db.labs.add({
+      date: "2026-04-29",
+      cea: 3.2,
+      source: "epworth",
+      created_at: ts,
+      updated_at: ts,
+    });
+    const memoId = await makeMemo({
+      confidence: "high",
+      lab_results: [
+        { name: "CA 19-9", value: "28", status: "raised" },
+      ],
+    });
+
+    await applyMemoPatches(memoId, { lab_create: [true] });
+
+    const rows = await db.labs.where("date").equals("2026-04-29").toArray();
+    // No duplicate row was created — the memo's value joined the existing one.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ca199).toBe(28);
+    expect(rows[0]?.cea).toBe(3.2); // pre-existing value untouched
+    expect(rows[0]?.source).toBe("epworth"); // source not overwritten
+  });
+});


### PR DESCRIPTION
## Summary

Test-feedback slice addressing all four points from the recent test-run screenshot.

**1. Recording guide.** Idle-state hint on `/diary` recorder card lists what's worth covering — "Try mentioning: sleep, energy, symptoms, food, activity, family, scan or lab results." Sets expectations without quizzing dad. Bilingual.

**2. PET/CT + blood results captured properly.** They were getting routed into `personal` (which we mark "local only"!) instead of into a clinical surface. Two new structured fields:
- `imaging_results: [{modality, finding_summary, status}]`
- `lab_results: [{name, value, status}]`

The prompt now explicitly says scan / blood-test mentions are STRICTLY clinical — never `personal` or `notes`. Both surface in the detail `PreviewForm` as colour-coded chips (`clear` / `stable` / `progression` / `improvement`; `normal` / `raised` / `low` / `abnormal`). Not auto-filed into `/imaging` or `/labs` — those tables benefit from explicit confirmation.

**3. Smoother labels.**
- "Log to forms" → "Save"
- "Logged N items" → "Saved N"
- "Try again" → "Retry"
- "Pick what to log" → "Pick what to save"
- zh "已登入" → "已保存", "审核并登入" → "审核并保存"
- Re-parse button on the preview header was wrapping ("Re-\nparse") on narrow widths — now an icon-only round button with aria-label so it stays a single tappable target.

**4. Follow-up questions for the dialogue vibe.** New `follow_up_questions: string[]` (max 2). Prompt rule 9: *"act like a thoughtful nurse / dietician / physio reading dad's memo. If something feels incomplete or worth probing — duration, severity, what triggered it, what helped — ask 1 or 2 short, warm questions in the memo's language. Skip entirely when comprehensive. Never ask more than 2."*

Surfaced two ways:
- **Inline on `/diary`** under the recent-memo card: "From your AI nurse" header + italic question list + a "want to answer? just record again" hint.
- **On `/memos/[id]`**: standalone `FollowUpsCard` with a "Record answer" link per question that takes the patient back to `/diary`'s recorder.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 89 files / **785 tests** pass
- [ ] Manual: record "Today had 5/10 nausea, ate 2 eggs, PET CT and CT all clear, white cells normal." Inline preview shows daily fields (auto-applied) + Imaging chips (`PET clear`, `CT clear`) + Labs chip (`white cells normal`). Personal block does NOT contain scan/lab content.
- [ ] Manual: record a memo missing duration/severity. AI follow-up appears: "How long did the nausea last?" or similar. Tapping "Record answer" returns to diary recorder.
- [ ] Manual: confirm the labels on the detail page read "Save", "Retry", "Saved N", and the Re-parse icon button doesn't wrap.

## Out of scope

- Auto-filing `imaging_results` and `lab_results` into `/imaging` and `/labs` — those tables have stricter schemas (source, dates, values must coerce). A follow-up slice can wire per-row "Save to /labs" buttons.
- Threading follow-up answers back to the original memo. Today the new memo is parsed independently. If we want explicit threading later, it's a `parent_memo_id` on `voice_memos`.

https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU

---
_Generated by [Claude Code](https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU)_