### PR TITLE
Memos: chemo recognised, AI nurse asks for ratings, dashboard surface

### DIFF
--- a/src/app/memos/[id]/page.tsx
+++ b/src/app/memos/[id]/page.tsx
@@ -589,11 +589,19 @@ function PreviewForm({
       )}
 
       {!hasDaily && !visit?.summary && appts.length === 0 && meds.length === 0 && (parsed.imaging_results?.length ?? 0) === 0 && (parsed.lab_results?.length ?? 0) === 0 && (
-        <Alert variant="info" role="status">
-          {locale === "zh"
-            ? "AI 没有从这段录音里抽出任何临床数据。可以重新识别，或者就把它当作个人日记保存。"
-            : "Claude didn't pull any clinical data from this memo. You can re-parse, or just keep it as a diary entry."}
-        </Alert>
+        parsed.personal ? (
+          <Alert variant="info" role="status">
+            {locale === "zh"
+              ? "AI 没有抽出可写入表单的临床字段，但下方的个人日记内容已记录。觉得遗漏了什么可以重新识别。"
+              : "No structured clinical fields to save, but the personal diary content was captured below. Re-parse if you think something was missed."}
+          </Alert>
+        ) : (
+          <Alert variant="info" role="status">
+            {locale === "zh"
+              ? "AI 没有从这段录音里抽出任何内容。可以重新识别，或者就把它当作纯录音保存。"
+              : "Claude didn't pull anything from this memo. You can re-parse, or just keep it as a recording."}
+          </Alert>
+        )
       )}
 
       {error && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import { NextClinicCard } from "~/components/dashboard/next-clinic-card";
 import { ScheduleCard } from "~/components/dashboard/schedule-card";
 import { ChangeSignalsCard } from "~/components/dashboard/change-signals-card";
 import { MedicationPromptsCard } from "~/components/dashboard/medication-prompts-card";
+import { MemoFollowUpsCard } from "~/components/dashboard/memo-followups-card";
 import { PracticesCard } from "~/components/dashboard/practices-card";
 import { NutritionCard } from "~/components/dashboard/nutrition-card";
 import { TodayFeed } from "~/components/dashboard/today-feed";
@@ -147,6 +148,8 @@ export default function DashboardPage() {
       <ChangeSignalsCard />
 
       <MedicationPromptsCard />
+
+      <MemoFollowUpsCard />
 
       <QuickCheckinCard />
 

--- a/src/components/dashboard/memo-followups-card.tsx
+++ b/src/components/dashboard/memo-followups-card.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import {
+  Mic,
+  MicOff,
+  Loader2,
+  ChevronRight,
+  Sparkles,
+} from "lucide-react";
+import { db } from "~/lib/db/dexie";
+import { useLocale } from "~/hooks/use-translate";
+import { useUIStore } from "~/stores/ui-store";
+import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
+import { Card } from "~/components/ui/card";
+import { Alert } from "~/components/ui/alert";
+import { cn } from "~/lib/utils/cn";
+
+// Dashboard surface for the AI nurse's follow-up questions. Reads
+// the most recent voice memo; if its parse left 1–2 follow-ups, we
+// show them with the same recording flow as /diary inline. Once dad
+// records an answer, the new memo becomes the most recent — its own
+// follow-ups (or none) replace the surface, so the card naturally
+// disappears when the dialogue is "complete".
+//
+// Auto-hides when:
+//   · No memos exist
+//   · Latest memo has no parsed_fields yet (still parsing)
+//   · Latest memo has no follow-up questions
+//   · Latest memo is older than 48h (stale prompts feel intrusive)
+
+const STALE_AFTER_MS = 48 * 60 * 60 * 1000;
+
+export function MemoFollowUpsCard() {
+  const locale = useLocale();
+  const enteredBy = useUIStore((s) => s.enteredBy);
+  const latestMemo = useLiveQuery(
+    () =>
+      db.voice_memos
+        .orderBy("recorded_at")
+        .reverse()
+        .first(),
+    [],
+  );
+
+  const [showRecorder, setShowRecorder] = useState(false);
+  const voice = useVoiceTranscription({
+    locale,
+    source: "diary",
+    enteredBy,
+    onTranscribed: () => {
+      // The new memo becomes the latest → useLiveQuery picks it up
+      // and this component re-renders with the new (or no) follow-ups.
+    },
+  });
+
+  // Reset the recorder UI whenever we move to a new memo's follow-ups
+  // (i.e. the patient just answered the previous batch).
+  useEffect(() => {
+    setShowRecorder(false);
+  }, [latestMemo?.id]);
+
+  if (!latestMemo) return null;
+  const questions = latestMemo.parsed_fields?.follow_up_questions ?? [];
+  if (questions.length === 0) return null;
+
+  const recordedAt = new Date(latestMemo.recorded_at).getTime();
+  if (Date.now() - recordedAt > STALE_AFTER_MS) return null;
+
+  const recording = voice?.status === "recording";
+  const transcribing = voice?.status === "transcribing";
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="inline-flex items-center gap-1.5 text-[10.5px] font-medium uppercase tracking-wider text-[var(--tide-2)]">
+            <Sparkles className="h-3 w-3" aria-hidden />
+            {locale === "zh" ? "AI 想问" : "AI nurse asks"}
+          </div>
+          <ul className="mt-2 space-y-1.5">
+            {questions.slice(0, 2).map((q, i) => (
+              <li
+                key={i}
+                className="text-[13.5px] italic leading-snug text-ink-900"
+              >
+                {q}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <Link
+          href={`/memos/${latestMemo.id}`}
+          aria-label={locale === "zh" ? "查看详情" : "Open memo"}
+          className="shrink-0 text-ink-400 hover:text-ink-700"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      <div className="mt-3 border-t border-ink-100 pt-3">
+        {!voice ? (
+          <Alert variant="info" role="status" className="text-[12px]">
+            {locale === "zh"
+              ? "此浏览器不支持录音，去 /diary 用其他设备答复。"
+              : "This browser can't record audio. Open /diary on another device to answer."}
+          </Alert>
+        ) : !showRecorder && !recording && !transcribing ? (
+          <button
+            type="button"
+            onClick={() => {
+              setShowRecorder(true);
+              void voice.start();
+            }}
+            className="inline-flex items-center gap-2 rounded-full bg-ink-900 px-4 py-2 text-[13px] font-medium text-paper hover:scale-[1.02] transition-transform"
+          >
+            <Mic className="h-3.5 w-3.5" />
+            {locale === "zh" ? "录音回答" : "Record answer"}
+          </button>
+        ) : (
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                if (recording) voice.stop();
+                else void voice.start();
+              }}
+              disabled={transcribing}
+              aria-label={
+                recording
+                  ? locale === "zh" ? "停止录音" : "Stop"
+                  : locale === "zh" ? "开始录音" : "Record"
+              }
+              className={cn(
+                "relative flex h-12 w-12 shrink-0 items-center justify-center rounded-full shadow-md transition-all",
+                recording
+                  ? "bg-[var(--warn,#d97706)] text-white"
+                  : "bg-ink-900 text-paper",
+                transcribing && "opacity-60",
+              )}
+            >
+              {recording && (
+                <span className="absolute inset-0 animate-ping rounded-full bg-[var(--warn,#d97706)]/40" />
+              )}
+              {transcribing ? (
+                <Loader2 className="relative h-5 w-5 animate-spin" />
+              ) : recording ? (
+                <MicOff className="relative h-5 w-5" />
+              ) : (
+                <Mic className="relative h-5 w-5" />
+              )}
+            </button>
+            <div className="min-w-0 flex-1">
+              <div className="text-[13px] font-medium text-ink-900">
+                {recording
+                  ? locale === "zh" ? "正在录音…" : "Recording…"
+                  : transcribing
+                    ? locale === "zh" ? "正在识别…" : "Transcribing…"
+                    : locale === "zh" ? "再次轻点开始" : "Tap to start"}
+              </div>
+              {transcribing && voice.liveText && (
+                <div className="mt-1 line-clamp-2 text-[11.5px] text-ink-500">
+                  {voice.liveText}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+        {voice?.error && (
+          <p className="mt-2 text-[11.5px] text-[var(--warn)]">
+            {voice.error}
+          </p>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/lib/voice-memo/apply.ts
+++ b/src/lib/voice-memo/apply.ts
@@ -9,6 +9,7 @@ import type {
 import { localDayISO } from "~/lib/utils/date";
 import {
   extractNumericValue,
+  findAppointmentForClinicVisit,
   findAppointmentForImaging,
   findAppointmentForLab,
   findExistingLabRow,
@@ -95,8 +96,11 @@ export async function applyMemoPatches(
   }
 
   if (apply_visit && parsed.clinical?.clinic_visit) {
-    const visitPatch = await applyClinicVisit(memo, parsed.clinical.clinic_visit);
-    if (visitPatch) patches.push(visitPatch);
+    const visitPatches = await applyClinicVisit(
+      memo,
+      parsed.clinical.clinic_visit,
+    );
+    patches.push(...visitPatches);
   }
 
   if (apply_appts && parsed.clinical?.appointments_mentioned?.length) {
@@ -217,13 +221,39 @@ async function applyDailyFields(
 async function applyClinicVisit(
   memo: VoiceMemo,
   visit: NonNullable<NonNullable<VoiceMemoParsedFields["clinical"]>["clinic_visit"]>,
-): Promise<AppliedPatch | null> {
-  if (!visit.summary) return null;
+): Promise<AppliedPatch[]> {
+  if (!visit.summary) return [];
   const ts = now();
   const event_date = visit.visit_date ?? memo.day ?? localDayISO(memo.recorded_at);
+  const patches: AppliedPatch[] = [];
+
+  // Auto-link first: if there's a matching appointment in the
+  // window, flip its status to attended and append the memo's
+  // summary/key-points to its notes. Source of truth stays on the
+  // schedule; the life_events row below becomes the human-readable
+  // timeline anchor.
+  const matched = await findAppointmentForClinicVisit(
+    visit.kind,
+    visit.provider ?? undefined,
+    event_date,
+  );
+  if (matched?.id) {
+    const linkPatch = await linkAppointment(
+      memo,
+      matched,
+      formatVisitAttribution(visit),
+    );
+    if (linkPatch) patches.push(linkPatch);
+  }
+
   const titleParts: string[] = [];
-  if (visit.provider) titleParts.push(`Visit — ${visit.provider}`);
+  if (visit.kind === "chemo") titleParts.push("Chemo session");
+  else if (visit.kind === "scan") titleParts.push("Scan visit");
+  else if (visit.kind === "blood_test") titleParts.push("Bloods");
+  else if (visit.kind === "procedure") titleParts.push("Procedure");
+  else if (visit.kind === "ed") titleParts.push("ED visit");
   else titleParts.push("Clinic visit");
+  if (visit.provider) titleParts.push(`— ${visit.provider}`);
   const title = titleParts.join(" ");
 
   const notesLines: string[] = [visit.summary];
@@ -252,15 +282,30 @@ async function applyClinicVisit(
     category: "medical",
     summary: visit.summary,
   };
+  if (visit.kind) fields.kind = visit.kind;
   if (visit.provider) fields.provider = visit.provider;
   if (visit.location) fields.location = visit.location;
-  return {
+  patches.push({
     table: "life_events",
     row_id: id,
     fields,
     op: "create",
     applied_at: ts,
-  };
+  });
+
+  return patches;
+}
+
+function formatVisitAttribution(
+  visit: NonNullable<
+    NonNullable<VoiceMemoParsedFields["clinical"]>["clinic_visit"]
+  >,
+): string {
+  const lines: string[] = [`From voice memo: ${visit.summary}`];
+  if (visit.key_points?.length) {
+    for (const k of visit.key_points) lines.push(`• ${k}`);
+  }
+  return lines.join("\n");
 }
 
 async function applyAppointment(

--- a/src/lib/voice-memo/match.ts
+++ b/src/lib/voice-memo/match.ts
@@ -204,6 +204,73 @@ function scoreLabMatch(appt: Appointment): number {
   return score;
 }
 
+// Find a recent appointment that this clinic-visit memo is most
+// likely reporting on. Maps memo-side kinds (including "ed", which
+// has no Appointment.kind counterpart) to the closest Appointment
+// kind. Provider name fuzzy-match adds to the score so a "Sumi
+// consult" appointment beats a generic clinic on the same day.
+type ClinicVisitKind =
+  | "clinic"
+  | "chemo"
+  | "scan"
+  | "blood_test"
+  | "procedure"
+  | "ed"
+  | "other";
+
+export async function findAppointmentForClinicVisit(
+  kind: ClinicVisitKind | undefined,
+  provider: string | undefined,
+  memoDay: string,
+): Promise<Appointment | null> {
+  const window = appointmentWindow(memoDay);
+  const rows = await db.appointments
+    .where("starts_at")
+    .between(window.from, window.to, true, true)
+    .toArray();
+  const scored = rows
+    .filter((a) => a.status !== "cancelled")
+    .map((a) => ({ row: a, score: scoreVisitMatch(a, kind, provider) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score);
+  return scored[0]?.row ?? null;
+}
+
+function scoreVisitMatch(
+  appt: Appointment,
+  kind: ClinicVisitKind | undefined,
+  provider: string | undefined,
+): number {
+  let score = 0;
+  // Map the memo's kind to the Appointment table's kind. ED visits
+  // don't have a dedicated Appointment kind — match against "other"
+  // appointments that mention emergency in the title.
+  const want: Appointment["kind"] | "ed_other" =
+    kind === "ed" ? "ed_other" : (kind ?? "clinic");
+  if (want !== "ed_other" && appt.kind === want) score += 5;
+  else if (want === "clinic" && appt.kind === "clinic") score += 5;
+  else if (want === "ed_other" && appt.kind === "other") {
+    const t = `${appt.title ?? ""} ${appt.notes ?? ""}`.toLowerCase();
+    if (/(emergency|ed |急诊)/.test(t)) score += 4;
+  }
+  // Provider name fuzzy-match — matches first name OR last name OR
+  // the full string the patient said. Case-insensitive substring.
+  if (provider) {
+    const haystack = `${appt.doctor ?? ""} ${appt.title ?? ""}`.toLowerCase();
+    const tokens = provider
+      .toLowerCase()
+      .split(/[\s\-/]+/)
+      .filter((t) => t.length >= 3);
+    for (const t of tokens) {
+      if (haystack.includes(t)) {
+        score += 3;
+        break;
+      }
+    }
+  }
+  return score;
+}
+
 // 14 days back, 7 days forward — clipped to a reasonable timestamp
 // range so Dexie's between() index walk stays small.
 function appointmentWindow(memoDay: string): { from: string; to: string } {

--- a/src/lib/voice-memo/parse-schema.ts
+++ b/src/lib/voice-memo/parse-schema.ts
@@ -93,6 +93,20 @@ export const VoiceMemoParseSchema = z.object({
   //      nullable to keep the optional-parameter count at zero.
   clinic_visit: z
     .object({
+      kind: z
+        .enum([
+          "clinic",
+          "chemo",
+          "scan",
+          "blood_test",
+          "procedure",
+          "ed",
+          "other",
+        ])
+        .nullish()
+        .describe(
+          "Kind of clinical encounter the memo describes. Use 'chemo' for any infusion/chemotherapy session (化疗/输液), 'scan' for imaging visits, 'blood_test' for blood draws (抽血), 'procedure' for biopsies/operations (活检/手术), 'ed' for emergency-department visits, 'clinic' for consult appointments. Maps to existing appointment kinds so the apply step can flip a matching scheduled appointment to attended.",
+        ),
       visit_date: z
         .string()
         .nullish()
@@ -108,11 +122,11 @@ export const VoiceMemoParseSchema = z.object({
       key_points: z
         .array(z.string())
         .nullish()
-        .describe("Decisions made / instructions given / dosage changes. Null when none."),
+        .describe("Decisions made / instructions given / dosage changes / observations during the encounter (e.g. 'felt normal during the infusion', 'ate a sandwich, drank water'). Null when none."),
     })
     .nullish()
     .describe(
-      "Set only when the patient describes a clinical encounter that already happened. Null for symptom-only memos.",
+      "Set whenever the memo describes a clinical encounter that already happened — clinic consult, chemo / infusion session, scan, blood draw, procedure, or ED visit. Set even when the memo is narratively personal (e.g. 'wife came with me to chemo'); the encounter still warrants a clinic_visit. Null only when the memo is pure symptom logging or non-clinical.",
     ),
 
   // ---- Future appointments mentioned. Tolerant of missing key.
@@ -250,7 +264,7 @@ export const VoiceMemoParseSchema = z.object({
     .array(z.string())
     .nullish()
     .describe(
-      "0–2 short questions you'd ask if you were a thoughtful nurse / dietician / physio reviewing this memo. Ask only when something feels genuinely incomplete or worth probing (e.g. duration, severity, what triggered it). Phrase warmly, in the memo's language. Skip entirely when the memo is comprehensive.",
+      "0–2 short questions a thoughtful clinical-tracking nurse would ask. Each question MUST elicit an objective rating or count, never a yes/no. Anchor on the project's standard scales: 0–10 for energy / sleep_quality / appetite / pain / mood / nausea / fatigue / anorexia / abdominal_pain, CTCAE 0–4 for neuropathy, hours for sleep duration, kg for weight, count for diarrhoea episodes. Examples: 'On a 0–10 scale, how strong was the nausea during the infusion?' / '今天最痛的时候 0 到 10 是几分？' / 'How many hours did you sleep last night?'. NEVER ask 'did you feel X' or 'was it Y'. Skip entirely when the memo is already concrete. Phrase warmly, in the memo's language.",
     ),
 
   confidence: ConfidenceEnum.describe(
@@ -276,11 +290,11 @@ Output rules:
 2. Neuropathy is CTCAE 0–4. Be conservative: vague tingling is grade 1, only set ≥2 if the patient describes interference with hand or foot function. \`null\` otherwise.
 3. Booleans only flip true. Set \`null\` rather than \`false\` when the patient doesn't mention the symptom — silence is not denial.
 4. \`notes\` is reserved for short clinical addenda that didn't fit a structured field (a taste change, a side-effect attribution). Personal content (food, family, practice, goals, mood) belongs in the \`personal\` block — never in \`notes\`.
-5. \`clinic_visit\` only when the patient describes a clinical encounter that already happened. Do not invent providers; resolve nicknames only when context is clear ("Sumi" → "A/Prof Sumitra Ananda" when the memo is about oncology). \`null\` otherwise.
+5. \`clinic_visit\` covers ANY past clinical encounter — clinic consult, chemo / infusion session, scan, blood draw, procedure, ED visit. Set it whenever the memo says "had / went to / just got back from / 化疗 / 来做 / 看了医生 / 抽血 / 扫描 / 活检", even when the rest of the memo is narratively personal (e.g. who came with the patient, what they ate during the infusion). Set \`kind\` to map the encounter to the matching appointment kind. Do not invent providers; resolve nicknames only when context is clear ("Sumi" → "A/Prof Sumitra Ananda" when the memo is about oncology). \`null\` only for pure symptom-log or non-clinical memos.
 6. \`appointments_mentioned\` only for events that haven't happened yet. Set \`confidence: high\` only when both date and title are concrete; vague mentions ("scan sometime next week") are medium or low and won't auto-schedule downstream. Empty array when nothing concrete.
 7. \`imaging_results\` and \`lab_results\` are STRICTLY clinical — never put scan or blood-test mentions in \`personal\` or \`notes\`. "PET CT clear", "CT stable", "white cells normal", "CA 19-9 dropped" are imaging or lab entries with their own structured fields. Empty / null when none.
-8. \`personal\` is the diary half — populate when the patient mentions food, family, practice, goals, or mood. Inner string-array fields are empty arrays when nothing matches; \`mood_narrative\` and \`observations\` are \`null\` when nothing matches. Set the whole \`personal\` object to \`null\` only when the memo is purely clinical with no personal flavour at all. Scan / lab / medication mentions belong to their clinical fields, NOT here.
-9. \`follow_up_questions\`: act like a thoughtful nurse / dietician / physio reading dad's memo. If something feels incomplete or worth probing — duration, severity, what triggered it, what helped — ask 1 or 2 short, warm questions in the memo's language. Skip entirely when the memo is comprehensive. Never ask more than 2.
+8. \`personal\` is the diary half — populate when the patient mentions food, family, practice, goals, or mood. Inner string-array fields are empty arrays when nothing matches; \`mood_narrative\` and \`observations\` are \`null\` when nothing matches. Set the whole \`personal\` object to \`null\` only when the memo is purely clinical with no personal flavour at all. Scan / lab / medication mentions belong to their clinical fields, NOT here. Family / food / practice / goals during a clinical encounter still go here, AND the encounter itself goes in \`clinic_visit\` — both can be populated together.
+9. \`follow_up_questions\`: act like a clinical-tracking nurse who needs objective ratings to log. Each question MUST anchor on a numeric scale or concrete count — NEVER yes/no. Use 0–10 for energy / sleep / appetite / pain / mood / nausea / fatigue / abdominal pain, CTCAE 0–4 for neuropathy, hours for sleep duration, count for diarrhoea, kg for weight. Bad: "did you feel tired?" / "was the nausea bad?". Good: "On a 0–10 scale, how strong was the nausea during the infusion?" / "今天最累的时候 0 到 10 是几分？". Skip entirely when the memo is already concrete. Never ask more than 2.
 10. Set the top-level \`confidence\` honestly. low when transcripts are short, garbled, or only mention vague feelings. high only when the memo carries clear, unambiguous structured signal.
 11. Never invent specific numbers, weights, dates, or medications.`;
 }

--- a/src/types/voice-memo.ts
+++ b/src/types/voice-memo.ts
@@ -128,8 +128,18 @@ export interface VoiceMemoParsedFields {
 export interface VoiceMemoClinicalParse {
   // The patient describing a clinic visit they just had. Captured as
   // a `life_events` row (category = medical, is_memory = false) so the
-  // diary timeline picks it up.
+  // diary timeline picks it up. `kind` matches Appointment.kind so the
+  // apply step can flip a previously-scheduled appointment to attended
+  // (chemo session → matching chemo appointment, etc.).
   clinic_visit?: {
+    kind?:
+      | "clinic"
+      | "chemo"
+      | "scan"
+      | "blood_test"
+      | "procedure"
+      | "ed"
+      | "other";
     visit_date?: string;        // ISO date — defaults to memo's recorded_at day
     provider?: string;          // "A/Prof Sumitra Ananda" / "Sumi" / "苏米"
     location?: string;

--- a/tests/unit/voice-memo-link.test.ts
+++ b/tests/unit/voice-memo-link.test.ts
@@ -185,6 +185,88 @@ describe("applyMemoPatches — imaging linking", () => {
   });
 });
 
+describe("applyMemoPatches — clinic_visit linking", () => {
+  it("links a chemo memo to a scheduled chemo appointment + creates the life_event", async () => {
+    const apptId = await makeAppointment({
+      kind: "chemo",
+      title: "Cycle 1 chemo",
+      starts_at: "2026-04-29T11:00:00",
+      status: "scheduled",
+    });
+    const memoId = await makeMemo({
+      confidence: "high",
+      clinical: {
+        clinic_visit: {
+          kind: "chemo",
+          summary: "First chemo session, felt normal throughout. Wife and son came along.",
+          key_points: ["Ate sandwich and cheese during infusion", "Drank water"],
+        },
+      },
+    });
+
+    const patches = await applyMemoPatches(memoId);
+
+    // Two patches: appointment status flip + life_events create.
+    expect(patches.some((p) => p.table === "appointments" && p.op === "update")).toBe(true);
+    expect(patches.some((p) => p.table === "life_events" && p.op === "create")).toBe(true);
+
+    const after = await db.appointments.get(apptId);
+    expect(after?.status).toBe("attended");
+    expect(after?.notes).toContain("First chemo session");
+    expect(after?.notes).toContain("Ate sandwich");
+    expect(after?.source_memo_id).toBe(memoId);
+  });
+
+  it("creates a life_event without linking when no matching appointment exists", async () => {
+    const memoId = await makeMemo({
+      confidence: "high",
+      clinical: {
+        clinic_visit: {
+          kind: "chemo",
+          summary: "Unscheduled chemo at private clinic.",
+        },
+      },
+    });
+
+    const patches = await applyMemoPatches(memoId);
+
+    expect(patches.some((p) => p.table === "appointments")).toBe(false);
+    const lifePatch = patches.find((p) => p.table === "life_events");
+    expect(lifePatch?.op).toBe("create");
+    const event = await db.life_events.get(lifePatch!.row_id);
+    expect(event?.title).toContain("Chemo session");
+    expect(event?.category).toBe("medical");
+  });
+
+  it("scores the matching appointment higher when provider name overlaps", async () => {
+    await makeAppointment({
+      kind: "clinic",
+      title: "Generic clinic",
+      starts_at: "2026-04-29T09:00:00",
+    });
+    const sumiId = await makeAppointment({
+      kind: "clinic",
+      title: "A/Prof Sumitra Ananda — review",
+      doctor: "A/Prof Sumitra Ananda",
+      starts_at: "2026-04-29T10:00:00",
+    });
+    const memoId = await makeMemo({
+      confidence: "high",
+      clinical: {
+        clinic_visit: {
+          kind: "clinic",
+          provider: "Sumitra Ananda",
+          summary: "Reviewed scan results, holding gem next week.",
+        },
+      },
+    });
+
+    const patches = await applyMemoPatches(memoId);
+    const apptPatch = patches.find((p) => p.table === "appointments");
+    expect(apptPatch?.row_id).toBe(sumiId);
+  });
+});
+
 describe("applyMemoPatches — lab linking", () => {
   it("links a bloods appointment but skips /labs when value is qualitative", async () => {
     const apptId = await makeAppointment({


### PR DESCRIPTION
## Summary

Three fixes from your test of the chemo memo + the AI-nurse feedback:

**1. Chemo memos no longer fall through the gap.** Your transcript (*"今天儿子和老婆在陪我来做第一次化疗…"*) was a clinical encounter narrated personally — chemo session with family present, food eaten, no symptoms. Claude was treating it as diary-only. Two changes:

- Schema: `clinic_visit` gains a `kind` enum (`clinic` / `chemo` / `scan` / `blood_test` / `procedure` / `ed` / `other`) so the apply step can match against the existing `Appointment.kind`.
- Prompt: explicit — *"clinic_visit covers ANY past clinical encounter — clinic consult, chemo / infusion session, scan, blood draw, procedure, ED visit. Set it whenever the memo says 'had / went to / just got back from / 化疗 / 来做 / 看了医生 / 抽血 / 扫描 / 活检', even when the rest of the memo is narratively personal."*
- Apply: `applyClinicVisit` now tries `findAppointmentForClinicVisit(kind, provider, day)` against the 14-day-back window. On match → silent auto-link (status flip + notes append + `source_memo_id`); on no match → just the `life_events` row as before. Provider-name fuzzy-match disambiguates same-day clinics.

**2. AI nurse questions are now objective.** *"did you feel tired"* gone. Prompt mandates numeric anchors:

> "Each question MUST anchor on a numeric scale or concrete count — NEVER yes/no. Use 0–10 for energy / sleep / appetite / pain / mood / nausea / fatigue / abdo pain, CTCAE 0–4 for neuropathy, hours / count / kg for the rest. Bad: 'did you feel tired?'. Good: 'On a 0–10 scale, how strong was the nausea during the infusion?' / '今天最累的时候 0 到 10 是几分？'"

When dad answers, the next memo's parse picks up the numerics on the same standard scales the daily form uses.

**3. Dashboard MemoFollowUpsCard.** New top-priority card on `/` that surfaces the latest memo's follow-up questions with the same recording flow inline as `/diary`. Tap "Record answer" → mic + live transcript right there. Once dad records, the new memo becomes the latest and the card updates (or disappears) automatically. Auto-hides when no memos / no follow-ups / latest is >48h old.

**Bonus:** the "Claude didn't pull any clinical data" alert now distinguishes "personal content was captured" from "nothing extracted" — felt dismissive after a chemo memo when only the personal half was visible.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 90 files / **799 tests** pass (3 new for chemo linking, no-match fallback, provider disambiguation)
- [ ] Manual: book a chemo appointment for today, then record the chemo memo from your test. Detail page shows clinic_visit chip + family/food in personal; appointment status flips to attended with the memo summary appended to its notes.
- [ ] Manual: record a vague memo ("today was rough"). AI nurse questions on the dashboard ask for 0–10 ratings, never yes/no.
- [ ] Manual: dashboard card appears under medication-prompts; tapping "Record answer" expands to the inline mic without leaving `/`.

https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU

---
_Generated by [Claude Code](https://claude.ai/code/session_0138zbu3U5eYYhEoodtkjATU)_