### PR TITLE
Dashboard: fix lingering save banner + empty pillar-tile column

### DIFF
--- a/src/components/dashboard/pillar-tiles.tsx
+++ b/src/components/dashboard/pillar-tiles.tsx
@@ -515,6 +515,14 @@ export function PillarTiles() {
 
   if (tiles.length === 0) return null;
 
+  // With grid-cols-2, a lone tile (or an odd-numbered last tile) sits
+  // in the left column with an empty hole on the right. When there's
+  // only one tile, render it full-width so the dashboard doesn't show
+  // a half-row of dead space.
+  if (tiles.length === 1) {
+    return <div>{tiles[0]!.node}</div>;
+  }
+
   return (
     <div className="grid grid-cols-2 gap-3">
       {tiles.map((t) => (

--- a/src/components/dashboard/quick-checkin-card.tsx
+++ b/src/components/dashboard/quick-checkin-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
@@ -68,9 +68,18 @@ export function QuickCheckinCard() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [justSaved, setJustSaved] = useState(false);
 
-  // After save, the live query picks up `existing` and unmounts this card.
-  // The transient "Saved" flash below bridges the gap so the patient sees
-  // acknowledgment before the card disappears.
+  // After save, the live query picks up `existing` and would normally
+  // unmount the card. We keep a brief "Saved" acknowledgement visible
+  // for ~2.5s so the patient sees confirmation, then drop back to the
+  // existing-row path which returns null (i.e. the card cleans itself
+  // up automatically). Without this timer the saved banner stayed on
+  // the dashboard for the rest of the session.
+  useEffect(() => {
+    if (!justSaved) return;
+    const id = setTimeout(() => setJustSaved(false), 2500);
+    return () => clearTimeout(id);
+  }, [justSaved]);
+
   if (existing && !justSaved) return null;
 
   async function save() {


### PR DESCRIPTION
## Summary

Two concrete UX bugs surfaced while reviewing the patient dashboard.

- **QuickCheckinCard "Saved for today" never auto-dismissed.** The
  inline comment described it as a "transient flash" before the card
  disappears, but `justSaved` was set to `true` and never reset, so
  the saved banner stayed pinned for the rest of the session even
  though `existing` had already become truthy via the live query.
  Adds a 2.5s timer that flips `justSaved` back, letting the existing
  early return (`if (existing && !justSaved) return null`) unmount the
  card cleanly. The patient now sees the brief acknowledgement the
  comment originally promised.

- **PillarTiles rendered an empty grid column when only one tile was
  visible.** `grid grid-cols-2` with a single child puts the lone
  tile in the left column with a 50% empty hole on the right. When
  the tile array has length 1, render full-width instead.

Other patterns surfaced in the audit (the dashboard's 16 stacked
cards vs. the project's "single feed" philosophy, the patient nav's
14 items, the cluster of bottom-of-page setup nudges) are
intentional per existing comments and out of scope for a targeted
bug-fix pass.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 90 files, 799 tests pass
- [ ] Manual: log a quick check-in, verify the saved banner shows
  briefly then the card disappears
- [ ] Manual: dashboard with exactly one pillar tile (e.g. only
  weather, or only next infusion) renders the tile full-width

https://claude.ai/code/session_01Nd4dD3nSJEAyeFWGkzf6Hb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd4dD3nSJEAyeFWGkzf6Hb)_