### PR TITLE
Dashboard: remove stale UI and feed truncation

### DIFF
--- a/src/components/dashboard/memo-followups-card.tsx
+++ b/src/components/dashboard/memo-followups-card.tsx
@@ -15,7 +15,6 @@ import { useLocale } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
 import { Card } from "~/components/ui/card";
-import { Alert } from "~/components/ui/alert";
 import { cn } from "~/lib/utils/cn";
 
 // Dashboard surface for the AI nurse's follow-up questions. Reads
@@ -100,14 +99,9 @@ export function MemoFollowUpsCard() {
         </Link>
       </div>
 
+      {voice && (
       <div className="mt-3 border-t border-ink-100 pt-3">
-        {!voice ? (
-          <Alert variant="info" role="status" className="text-[12px]">
-            {locale === "zh"
-              ? "此浏览器不支持录音，去 /diary 用其他设备答复。"
-              : "This browser can't record audio. Open /diary on another device to answer."}
-          </Alert>
-        ) : !showRecorder && !recording && !transcribing ? (
+        {!showRecorder && !recording && !transcribing ? (
           <button
             type="button"
             onClick={() => {
@@ -168,12 +162,13 @@ export function MemoFollowUpsCard() {
             </div>
           </div>
         )}
-        {voice?.error && (
+        {voice.error && (
           <p className="mt-2 text-[11.5px] text-[var(--warn)]">
             {voice.error}
           </p>
         )}
       </div>
+      )}
     </Card>
   );
 }

--- a/src/components/dashboard/next-clinic-card.tsx
+++ b/src/components/dashboard/next-clinic-card.tsx
@@ -35,6 +35,10 @@ export function NextClinicCard() {
   }, [appointments]);
 
   if (!next) return null;
+  // Without a row id we can't deep-link into the appointment detail —
+  // falling back to the /schedule list is a backtracking dead-end where
+  // the patient lands on a list and has to find the row again.
+  if (!next.id) return null;
   // ScheduleCard already shows today + tomorrow appointments. Suppress this
   // dedicated card when the next clinic is already in that window so the
   // dashboard doesn't surface the same appointment twice.
@@ -118,7 +122,7 @@ export function NextClinicCard() {
           </div>
         </div>
         <Link
-          href={next.id ? `/schedule/${next.id}` : "/schedule"}
+          href={`/schedule/${next.id}`}
           className="inline-flex shrink-0 items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-[11px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
         >
           {locale === "zh" ? "打开" : "Open"}

--- a/src/components/dashboard/quick-checkin-card.tsx
+++ b/src/components/dashboard/quick-checkin-card.tsx
@@ -13,6 +13,10 @@ import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils/cn";
 import { Check, Thermometer } from "lucide-react";
 
+// Once a daily entry exists, the today-feed surfaces it as a feed item;
+// keeping a "Saved for today" card around here is dead UI that pushes
+// real ranked content further down the dashboard.
+
 const SCALES = [
   {
     key: "energy",
@@ -66,12 +70,10 @@ export function QuickCheckinCard() {
   const [feverTemp, setFeverTemp] = useState("");
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [justSaved, setJustSaved] = useState(false);
 
-  // After save, the live query picks up `existing` and unmounts this card.
-  // The transient "Saved" flash below bridges the gap so the patient sees
-  // acknowledgment before the card disappears.
-  if (existing && !justSaved) return null;
+  // Hide once today's entry exists — the today-feed already shows it
+  // as a ranked item, so a standalone acknowledgement card is stale UI.
+  if (existing) return null;
 
   async function save() {
     setSaving(true);
@@ -112,7 +114,8 @@ export function QuickCheckinCard() {
             : "Saved, but the alert check didn't run.",
         );
       }
-      setJustSaved(true);
+      // The live query for `existing` picks up the new row and the
+      // `if (existing) return null` gate above unmounts this card.
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error("[quick-checkin] save failed", err);
@@ -124,37 +127,6 @@ export function QuickCheckinCard() {
     } finally {
       setSaving(false);
     }
-  }
-
-  if (justSaved) {
-    return (
-      <Card className="p-5">
-        <div className="flex items-start gap-3">
-          <div
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
-            style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
-          >
-            <Check className="h-4 w-4" strokeWidth={3} />
-          </div>
-          <div className="flex-1">
-            <div className="text-[13px] font-semibold text-ink-900">
-              {locale === "zh" ? "今日已记录" : "Saved for today"}
-            </div>
-            <p className="mt-0.5 text-[12.5px] text-ink-500">
-              {locale === "zh"
-                ? "想补充细节？"
-                : "Want to add detail?"}{" "}
-              <Link
-                href="/daily/new"
-                className="text-[var(--tide-2)] hover:underline"
-              >
-                {locale === "zh" ? "完整日志" : "Full log"}
-              </Link>
-            </p>
-          </div>
-        </div>
-      </Card>
-    );
   }
 
   return (

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -15,8 +15,6 @@ import type { AgentId } from "~/types/agent";
 import { cn } from "~/lib/utils/cn";
 import {
   Sparkles,
-  ChevronDown,
-  ChevronUp,
   Sun,
   Cloud,
   ShieldAlert,
@@ -98,11 +96,8 @@ export function TodayFeed({
   );
   const model = useDefaultAiModel();
 
-  const [expanded, setExpanded] = useState(false);
   const [narrative, setNarrative] = useState<string | null>(null);
   const [narrativeLoading, setNarrativeLoading] = useState(false);
-
-  const visible = expanded ? feed : feed.slice(0, 6);
 
   // Signature of feed contents — stable unless the feed actually changes.
   // Prevents the narrative fetch from re-firing on every parent re-render.
@@ -223,31 +218,10 @@ export function TodayFeed({
       )}
 
       <ul className="space-y-2">
-        {visible.map((item) => (
+        {feed.map((item) => (
           <FeedRow key={item.id} item={item} />
         ))}
       </ul>
-
-      {feed.length > 6 && (
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className="eyebrow mx-auto flex items-center gap-1.5 text-ink-500 hover:text-ink-900"
-        >
-          {expanded
-            ? locale === "zh"
-              ? "收起"
-              : "Show less"
-            : locale === "zh"
-              ? `再看 ${feed.length - 6} 条`
-              : `Show ${feed.length - 6} more`}
-          {expanded ? (
-            <ChevronUp className="h-3 w-3" />
-          ) : (
-            <ChevronDown className="h-3 w-3" />
-          )}
-        </button>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Audited the patient dashboard against the project's stated philosophy ("single channel out / stack-ranked, not stashed") and shipped four targeted fixes that remove dead UI and reduce backtracking. Scope was deliberately narrow — no large refactors, no behaviour changes outside the four cards touched.

## What changed

- **`today-feed.tsx`** — Drop the 6-item collapse. The feed is the ranked channel; hiding items #7+ behind a "Show more" button buries items the rank order says the patient should see right now. Removes `expanded` state, the toggle button, and `ChevronUp/Down` imports.

- **`quick-checkin-card.tsx`** — Stop rendering the persistent "Saved for today — Want to add detail?" card after a quick check-in is saved. The today-feed already surfaces the new daily entry as a ranked item, so the standalone acknowledgement card was stale UI taking up dashboard space until the next reload. Removes `justSaved` state and the saved-state JSX block; `existing` (live-queried) is now the only gate.

- **`next-clinic-card.tsx`** — Return `null` early when the next appointment has no row id. Previously the "Open" link fell back to `/schedule` (a list view), which is a backtracking dead-end where the patient lands and has to find the appointment again.

- **`memo-followups-card.tsx`** — Drop the "this browser can't record audio — open /diary on another device" alert on browsers without voice support. The card already has a chevron link to the full memo at `/memos/<id>`, so the alert was a redundant nag with no action surface. The whole recorder block is now wrapped in `{voice && (...)}`.

## Findings I deliberately did not act on

- **14+ stacked dashboard cards** (`src/app/page.tsx`) — direct violation of the "single channel out" philosophy, but consolidating into the unified feed is a multi-week design refactor, not a bug-fix pass.
- **29 top-level routes** in `src/app/` — same scope concern.
- **PillarTiles ↔ TodayFeed information overlap** — they're different surfaces (sparkline visualisations vs ranked text feed), not strictly redundant.

These are flagged here for follow-up, not in the diff.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 799/799 pass (all 90 unit-test files)
- [x] `pnpm lint` — no warnings or errors
- [ ] Manual smoke test of the four cards on the dashboard at runtime


---
_Generated by [Claude Code](https://claude.ai/code/session_011obWqJAJfweQprKskitZ2L)_