### PR TITLE
refactor(utils/date): consolidate duplicated date/time helpers

### DIFF
--- a/src/app/memos/[id]/page.tsx
+++ b/src/app/memos/[id]/page.tsx
@@ -42,6 +42,7 @@ import type {
   VoiceMemoParsedFields,
 } from "~/types/voice-memo";
 import { cn } from "~/lib/utils/cn";
+import { formatDurationMs } from "~/lib/utils/date";
 
 // Memo detail. Shows the full transcript, audio playback, and Claude's
 // structured parse as a PREVIEW FORM the patient confirms before any
@@ -298,7 +299,7 @@ function PlaybackCard({
     }
   }
 
-  const duration = formatDuration(memo.duration_ms);
+  const duration = formatDurationMs(memo.duration_ms);
 
   return (
     <Card className="p-4">
@@ -1360,9 +1361,3 @@ function hrefForPatch(patch: AppliedPatch): string {
   }
 }
 
-function formatDuration(ms: number): string {
-  const total = Math.max(0, Math.round(ms / 1000));
-  const mins = Math.floor(total / 60);
-  const secs = total % 60;
-  return `${mins}:${String(secs).padStart(2, "0")}`;
-}

--- a/src/app/memos/page.tsx
+++ b/src/app/memos/page.tsx
@@ -19,6 +19,7 @@ import { Card } from "~/components/ui/card";
 import { PageHeader } from "~/components/ui/page-header";
 import { EmptyState } from "~/components/ui/empty-state";
 import type { VoiceMemo } from "~/types/voice-memo";
+import { formatDurationMs } from "~/lib/utils/date";
 
 // Reverse-chronological list of every voice memo. Each row shows
 // timestamp, duration, a transcript snippet, the source (diary / log
@@ -89,7 +90,7 @@ export default function MemosPage() {
 function MemoRow({ memo, locale }: { memo: VoiceMemo; locale: "en" | "zh" }) {
   const state = parseState(memo);
   const time = formatWhen(memo.recorded_at, locale);
-  const duration = formatDuration(memo.duration_ms);
+  const duration = formatDurationMs(memo.duration_ms);
   const snippet = describe(memo, locale);
   const cloudSynced = Boolean(memo.audio_path);
 
@@ -232,13 +233,6 @@ function formatWhen(iso: string, locale: "en" | "zh"): string {
     return format(d, "HH:mm");
   }
   return format(d, locale === "zh" ? "M月d日 HH:mm" : "d MMM, HH:mm");
-}
-
-function formatDuration(ms: number): string {
-  const total = Math.max(0, Math.round(ms / 1000));
-  const mins = Math.floor(total / 60);
-  const secs = total % 60;
-  return `${mins}:${String(secs).padStart(2, "0")}`;
 }
 
 function sourceLabel(

--- a/src/app/nutrition/[id]/page.tsx
+++ b/src/app/nutrition/[id]/page.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { Field, Textarea, TextInput } from "~/components/ui/field";
 import { cn } from "~/lib/utils/cn";
+import { formatHHMM as toHHMM } from "~/lib/utils/date";
 import type { MealItem, MealType } from "~/types/nutrition";
 
 // Edit screen for a single meal_entry. Patient can change:
@@ -354,10 +355,6 @@ function ItemRow({ item, locale }: { item: MealItem; locale: "en" | "zh" }) {
 function mealLabel(m: MealType, locale: string): string {
   if (locale !== "zh") return m;
   return { breakfast: "早餐", lunch: "午餐", dinner: "晚餐", snack: "加餐" }[m];
-}
-
-function toHHMM(d: Date): string {
-  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
 function assembleLoggedAt(date: string, hhmm: string): string {

--- a/src/app/nutrition/log/page.tsx
+++ b/src/app/nutrition/log/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, Check, Sparkles, Clock, Loader2 } from "lucide-react";
-import { todayISO } from "~/lib/utils/date";
+import { currentHHMM, todayISO } from "~/lib/utils/date";
 import { useLocale } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { Card } from "~/components/ui/card";
@@ -398,13 +398,6 @@ function mealLabel(m: MealType, locale: string): string {
 
 function round1(n: number): number {
   return Math.round(n * 10) / 10;
-}
-
-// Current local time as "HH:MM" — the value the <input type="time">
-// expects. Padded to two digits in each segment.
-function currentHHMM(): string {
-  const d = new Date();
-  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
 // Combine a YYYY-MM-DD day and a HH:MM time into a local-zone ISO

--- a/src/components/dashboard/practices-card.tsx
+++ b/src/components/dashboard/practices-card.tsx
@@ -16,7 +16,7 @@ import { expectedDosesToday } from "~/lib/medication/log";
 import type { Medication } from "~/types/medication";
 import { Check, ChevronRight, Pause, Play, Sparkles, X } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
-import { todayISO } from "~/lib/utils/date";
+import { todayISO, formatClockSeconds } from "~/lib/utils/date";
 
 // Best-effort duration parse: "20 min", "10 breaths", "5m", "1h". Falls back
 // to 5 minutes when the dose string doesn't mention a time unit.
@@ -30,13 +30,6 @@ function durationSeconds(dose: string | undefined): number {
   const sec = s.match(/(\d+)\s*s/);
   if (sec) return Number(sec[1]);
   return 5 * 60;
-}
-
-function formatClock(sec: number): string {
-  const abs = Math.max(0, Math.round(sec));
-  const mm = Math.floor(abs / 60).toString().padStart(2, "0");
-  const ss = (abs % 60).toString().padStart(2, "0");
-  return `${mm}:${ss}`;
 }
 
 /**
@@ -273,7 +266,7 @@ function PracticeRow({
       {running && (
         <div className="mt-2 flex items-center gap-2 border-t border-ink-100 pt-2">
           <span className="mono text-[18px] font-medium tabular-nums text-ink-900">
-            {formatClock(remaining ?? 0)}
+            {formatClockSeconds(remaining ?? 0)}
           </span>
           <div className="flex-1" />
           <button

--- a/src/components/diary/voice-memo-card.tsx
+++ b/src/components/diary/voice-memo-card.tsx
@@ -15,6 +15,7 @@ import type { VoiceMemo, VoiceMemoParsedFields } from "~/types/voice-memo";
 import { resolveVoiceMemoAudioUrl } from "~/lib/voice-memo/cloud";
 import { Card } from "~/components/ui/card";
 import { cn } from "~/lib/utils/cn";
+import { formatDurationMs, formatHHMM } from "~/lib/utils/date";
 
 // Diary card for one voice memo. Shows the recorded time, duration,
 // transcript, and an inline play button. Audio is fetched lazily —
@@ -74,8 +75,8 @@ export function VoiceMemoCard({ memo, locale }: VoiceMemoCardProps) {
     }
   }
 
-  const time = formatTime(memo.recorded_at, locale);
-  const duration = formatDuration(memo.duration_ms);
+  const time = formatHHMM(new Date(memo.recorded_at));
+  const duration = formatDurationMs(memo.duration_ms);
   const cloudState: "synced" | "local" =
     memo.audio_path ? "synced" : "local";
 
@@ -162,20 +163,6 @@ export function VoiceMemoCard({ memo, locale }: VoiceMemoCardProps) {
       />
     </Card>
   );
-}
-
-function formatTime(iso: string, locale: "en" | "zh"): string {
-  const d = new Date(iso);
-  const hh = String(d.getHours()).padStart(2, "0");
-  const mm = String(d.getMinutes()).padStart(2, "0");
-  return locale === "zh" ? `${hh}:${mm}` : `${hh}:${mm}`;
-}
-
-function formatDuration(ms: number): string {
-  const total = Math.max(0, Math.round(ms / 1000));
-  const mins = Math.floor(total / 60);
-  const secs = total % 60;
-  return `${mins}:${String(secs).padStart(2, "0")}`;
 }
 
 function ReviewLink({

--- a/src/components/ingest/preview-diff.tsx
+++ b/src/components/ingest/preview-diff.tsx
@@ -33,6 +33,7 @@ import {
   PencilLine,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import { toDatetimeLocalInput as toDatetimeLocal } from "~/lib/utils/date";
 
 const OP_ICON: Record<IngestOpKind, React.ComponentType<{ className?: string }>> = {
   add_appointment: CalendarPlus,
@@ -579,16 +580,6 @@ function FieldRow({
       {children}
     </label>
   );
-}
-
-function toDatetimeLocal(iso?: string): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
-    d.getHours(),
-  )}:${pad(d.getMinutes())}`;
 }
 
 function fromDatetimeLocal(v: string): string | undefined {

--- a/src/components/nutrition/meal-timeline.tsx
+++ b/src/components/nutrition/meal-timeline.tsx
@@ -7,6 +7,7 @@ import { listMealsForDate } from "~/lib/nutrition/queries";
 import { Card, CardContent } from "~/components/ui/card";
 import { useLocale } from "~/hooks/use-translate";
 import { cn } from "~/lib/utils/cn";
+import { formatHHMM as formatTime } from "~/lib/utils/date";
 import type { MealEntry, MealType } from "~/types/nutrition";
 
 // Visual day-clock for meal timing. Designed for "small frequent meals"
@@ -218,12 +219,6 @@ function buildStats(meals: ReadonlyArray<MealEntry>): Stats {
 
 function parseLocalDate(iso: string): Date {
   return new Date(iso);
-}
-
-function formatTime(d: Date): string {
-  const hh = String(d.getHours()).padStart(2, "0");
-  const mm = String(d.getMinutes()).padStart(2, "0");
-  return `${hh}:${mm}`;
 }
 
 function formatGap(min: number, locale: string): string {

--- a/src/components/nutrition/weekly-summary.tsx
+++ b/src/components/nutrition/weekly-summary.tsx
@@ -8,7 +8,7 @@ import { defaultTargets } from "~/lib/nutrition/calculator";
 import { Card, CardContent } from "~/components/ui/card";
 import { useLocale } from "~/hooks/use-translate";
 import { TargetBar } from "./macro-bar";
-import { todayISO } from "~/lib/utils/date";
+import { shiftDateISO, todayISO } from "~/lib/utils/date";
 
 // 7-day rolling protein and net carbs trend. The numbers that matter
 // most for mPDAC+chemo function preservation.
@@ -110,12 +110,7 @@ export function WeeklySummary() {
 }
 
 function isoDaysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
+  return shiftDateISO(todayISO(), -n);
 }
 
 function dayLabel(iso: string, locale: string): string {

--- a/src/components/schedule/appointment-form.tsx
+++ b/src/components/schedule/appointment-form.tsx
@@ -14,6 +14,7 @@ import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
 import { Field, TextInput, Textarea } from "~/components/ui/field";
 import { PrepEditor } from "~/components/schedule/prep-editor";
+import { toDatetimeLocalInput as toLocalInput } from "~/lib/utils/date";
 import { AttendeeChips } from "~/components/schedule/attendee-chips";
 
 const KINDS: AppointmentKind[] = [
@@ -351,10 +352,3 @@ export function AppointmentForm({
   );
 }
 
-function toLocalInput(iso: string | undefined): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}

--- a/src/components/schedule/prep-editor.tsx
+++ b/src/components/schedule/prep-editor.tsx
@@ -12,6 +12,7 @@ import type {
 import { Field, TextInput } from "~/components/ui/field";
 import { Button } from "~/components/ui/button";
 import { Plus, Trash2 } from "lucide-react";
+import { toDatetimeLocalInput as toLocalInput } from "~/lib/utils/date";
 
 // Reusable prep-item editor — used in the appointment form (on
 // create / edit) and surfaced on the detail page when the patient
@@ -192,10 +193,3 @@ export function PrepEditor({
   );
 }
 
-function toLocalInput(iso: string | undefined): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}

--- a/src/components/tasks/preset-picker.tsx
+++ b/src/components/tasks/preset-picker.tsx
@@ -10,13 +10,7 @@ import { todayISO } from "~/lib/utils/date";
 import { cn } from "~/lib/utils/cn";
 import { Card, CardContent } from "~/components/ui/card";
 import { Plus, Check } from "lucide-react";
-
-function toISODate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${dd}`;
-}
+import { formatLocalDateISO as toISODate } from "~/lib/utils/date";
 
 export function PresetPicker() {
   const locale = useLocale();

--- a/src/lib/diary/build.ts
+++ b/src/lib/diary/build.ts
@@ -2,7 +2,7 @@ import { db } from "~/lib/db/dexie";
 import type { DailyEntry, LabResult } from "~/types/clinical";
 import type { LogEventRow, AgentRunRow } from "~/types/agent";
 import type { VoiceMemo } from "~/types/voice-memo";
-import { isoDatePart, todayISO } from "~/lib/utils/date";
+import { isoDatePart, shiftDateISO, todayISO } from "~/lib/utils/date";
 
 // One day in the diary timeline. Aggregates everything the patient
 // generated or had recorded for that calendar date — voice memos,
@@ -37,7 +37,7 @@ export async function buildDiaryDays(
   opts: BuildDiaryDaysOptions = {},
 ): Promise<DiaryDay[]> {
   const to = opts.to ?? todayISO();
-  const from = opts.from ?? defaultFrom(to, 30);
+  const from = opts.from ?? shiftDateISO(to, -30);
   const includeEmpty = opts.includeEmpty ?? false;
 
   const [memos, dailies, logs, labs, runs] = await Promise.all([
@@ -117,7 +117,7 @@ export async function buildDiaryDays(
   // weeks and we want them to see "nothing recorded" rather than a
   // jump in time).
   if (includeEmpty) {
-    for (let day = to; day >= from; day = prevDay(day)) {
+    for (let day = to; day >= from; day = shiftDateISO(day, -1)) {
       ensure(day);
     }
   }
@@ -125,20 +125,3 @@ export async function buildDiaryDays(
   return Array.from(byDay.values()).sort((a, b) => b.day.localeCompare(a.day));
 }
 
-function defaultFrom(to: string, days: number): string {
-  const d = new Date(to);
-  d.setDate(d.getDate() - days);
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
-}
-
-function prevDay(day: string): string {
-  const d = new Date(day);
-  d.setDate(d.getDate() - 1);
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
-}

--- a/src/lib/nutrition/symptom-context.ts
+++ b/src/lib/nutrition/symptom-context.ts
@@ -1,5 +1,5 @@
 import { db } from "~/lib/db/dexie";
-import { todayISO } from "~/lib/utils/date";
+import { shiftDateISO, todayISO } from "~/lib/utils/date";
 import type { DailyEntry } from "~/types/clinical";
 
 // Symptom-aware context for the food picker and JPCC playbooks.
@@ -45,7 +45,7 @@ export async function loadSymptomContext(
   date = todayISO(),
 ): Promise<NutritionSymptomContext> {
   const today = await loadDayEntry(date);
-  const fallback = today ? null : await loadDayEntry(daysAgo(date, 1));
+  const fallback = today ? null : await loadDayEntry(shiftDateISO(date, -1));
   const entry = today ?? fallback;
   if (!entry) {
     return { flags: [], recommendEasyDigest: false };
@@ -86,14 +86,6 @@ async function loadDayEntry(date: string): Promise<DailyEntry | undefined> {
   return db.daily_entries.where("date").equals(date).first();
 }
 
-function daysAgo(iso: string, n: number): string {
-  const d = new Date(iso);
-  d.setDate(d.getDate() - n);
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
-}
 
 export const SYMPTOM_LABEL: Record<
   SymptomFlag,

--- a/src/lib/state/detectors/social-isolation.ts
+++ b/src/lib/state/detectors/social-isolation.ts
@@ -24,6 +24,7 @@ import type {
   SignalEvidence,
   SuggestedAction,
 } from "./types";
+import { isoWeekKey, shiftIsoDays as shiftDays } from "~/lib/utils/date";
 
 const DETECTOR_ID = "social_isolation";
 const METRIC_ID = "meaningful_interactions";
@@ -178,31 +179,6 @@ function actionsForCause(causeId: string): SuggestedAction[] {
         },
       ];
   }
-}
-
-function isoWeekKey(iso: string): string {
-  const d = new Date(iso);
-  const target = new Date(d.valueOf());
-  const dayNr = (d.getUTCDay() + 6) % 7;
-  target.setUTCDate(target.getUTCDate() - dayNr + 3);
-  const firstThursday = new Date(
-    Date.UTC(target.getUTCFullYear(), 0, 4),
-  );
-  const weekNr =
-    1 +
-    Math.round(
-      ((target.valueOf() - firstThursday.valueOf()) / 86_400_000 -
-        3 +
-        ((firstThursday.getUTCDay() + 6) % 7)) /
-        7,
-    );
-  return `${target.getUTCFullYear()}-W${String(weekNr).padStart(2, "0")}`;
-}
-
-function shiftDays(iso: string, days: number): string {
-  const d = new Date(iso);
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString();
 }
 
 export const socialIsolationDetector: Detector = {

--- a/src/lib/state/detectors/steps-decline.ts
+++ b/src/lib/state/detectors/steps-decline.ts
@@ -30,6 +30,7 @@ import type {
   SignalEvidence,
   SuggestedAction,
 } from "./types";
+import { isoWeekKey, shiftIsoDays as shiftDays } from "~/lib/utils/date";
 
 const DETECTOR_ID = "steps_decline";
 const METRIC_ID = "steps";
@@ -256,35 +257,6 @@ function actionsForCause(causeId: string): SuggestedAction[] {
     default:
       return [];
   }
-}
-
-// One signal per ISO week — drifts persist across days, so we dedupe at the
-// week granularity. If a drift continues across a week boundary the
-// following evaluation produces a fresh fired_for, which is the right
-// behaviour (a persistent drift warrants a fresh surface).
-function isoWeekKey(iso: string): string {
-  const d = new Date(iso);
-  const target = new Date(d.valueOf());
-  const dayNr = (d.getUTCDay() + 6) % 7;
-  target.setUTCDate(target.getUTCDate() - dayNr + 3);
-  const firstThursday = new Date(
-    Date.UTC(target.getUTCFullYear(), 0, 4),
-  );
-  const weekNr =
-    1 +
-    Math.round(
-      ((target.valueOf() - firstThursday.valueOf()) / 86_400_000 -
-        3 +
-        ((firstThursday.getUTCDay() + 6) % 7)) /
-        7,
-    );
-  return `${target.getUTCFullYear()}-W${String(weekNr).padStart(2, "0")}`;
-}
-
-function shiftDays(iso: string, days: number): string {
-  const d = new Date(iso);
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString();
 }
 
 export const stepsDeclineDetector: Detector = {

--- a/src/lib/tasks/engine.ts
+++ b/src/lib/tasks/engine.ts
@@ -6,13 +6,7 @@ import type {
   TaskInstance,
 } from "~/types/task";
 import type { CycleContext } from "~/types/treatment";
-
-function toISODate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${dd}`;
-}
+import { formatLocalDateISO as toISODate } from "~/lib/utils/date";
 
 export function nextRecurringDueDate(task: PatientTask, today: Date): string {
   if (task.schedule_kind !== "recurring") return task.due_date ?? toISODate(today);

--- a/src/lib/treatment/calendar-sync.ts
+++ b/src/lib/treatment/calendar-sync.ts
@@ -15,6 +15,7 @@
 
 import { db, now } from "~/lib/db/dexie";
 import { PROTOCOL_BY_ID } from "~/config/protocols";
+import { formatLocalDateISO, formatHHMM } from "~/lib/utils/date";
 import type { Appointment } from "~/types/appointment";
 import type { Protocol, TreatmentCycle } from "~/types/treatment";
 import type { LocalizedText } from "~/types/treatment";
@@ -89,10 +90,7 @@ export function deriveCycleAppointments(
       const end = new Date(start.getTime() + defaultDurationMinutes * 60_000);
       // Match the offset-free "YYYY-MM-DDTHH:MM:SS" shape of starts_at
       // so the two align visually in the schedule form.
-      const pad = (n: number) => String(n).padStart(2, "0");
-      return `${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(
-        end.getDate(),
-      )}T${pad(end.getHours())}:${pad(end.getMinutes())}:00`;
+      return `${formatLocalDateISO(end)}T${formatHHMM(end)}:00`;
     })();
     const record = cycle.day_records?.find((r) => r.day === day);
     out.push({

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -2,12 +2,22 @@ import { format, parseISO } from "date-fns";
 
 export type Locale = "en" | "zh";
 
+// Two-digit zero-padding helper. Used by every other formatter in this
+// module — keeps callers from re-introducing String(...).padStart(2, "0")
+// inline.
+export function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+// Format a `Date` (any) as YYYY-MM-DD using its *local* date parts. The
+// ISO-string variants (`localDayISO`, `isoDatePart`) below are the same
+// idea expressed against a string input.
+export function formatLocalDateISO(d: Date): string {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
 export function todayISO(): string {
-  const d = new Date();
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
+  return formatLocalDateISO(new Date());
 }
 
 // Return the YYYY-MM-DD prefix of any ISO datetime string. Used widely for
@@ -21,11 +31,83 @@ export function isoDatePart(iso: string): string {
 // 23:50 AEST should belong to that evening's diary, not tomorrow's
 // UTC date.
 export function localDayISO(iso: string): string {
+  return formatLocalDateISO(new Date(iso));
+}
+
+// Shift a YYYY-MM-DD date by N (positive or negative) calendar days using
+// local-zone arithmetic. Replaces the half-dozen `defaultFrom`/`prevDay`/
+// `daysAgo`/`isoDaysAgo` helpers that duplicated the same Date+setDate
+// dance.
+export function shiftDateISO(date: string, days: number): string {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return formatLocalDateISO(d);
+}
+
+// Local "HH:MM" for a Date — the value an `<input type="time">` element
+// expects.
+export function formatHHMM(d: Date): string {
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+}
+
+// Current local time as "HH:MM".
+export function currentHHMM(): string {
+  return formatHHMM(new Date());
+}
+
+// Render an ISO timestamp as the offset-free shape `<input
+// type="datetime-local">` requires: "YYYY-MM-DDTHH:MM". Returns "" for
+// missing or unparseable inputs so callers can drop their own
+// Number.isNaN guards.
+export function toDatetimeLocalInput(iso: string | undefined): string {
+  if (!iso) return "";
   const d = new Date(iso);
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
+  if (Number.isNaN(d.getTime())) return "";
+  return `${formatLocalDateISO(d)}T${formatHHMM(d)}`;
+}
+
+// Format milliseconds as "m:ss" (no leading zero on minutes — voice memo
+// playback / recording convention).
+export function formatDurationMs(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${mins}:${pad2(secs)}`;
+}
+
+// Format a number of seconds as "mm:ss" (zero-padded minutes — countdown
+// timer convention).
+export function formatClockSeconds(seconds: number): string {
+  const abs = Math.max(0, Math.round(seconds));
+  return `${pad2(Math.floor(abs / 60))}:${pad2(abs % 60)}`;
+}
+
+// ISO 8601 week key in "YYYY-Www" form — used by detectors that dedupe
+// signals to one per week. Pulled out of two near-identical detector
+// helpers to keep the week math in one place.
+export function isoWeekKey(iso: string): string {
+  const d = new Date(iso);
+  const target = new Date(d.valueOf());
+  const dayNr = (d.getUTCDay() + 6) % 7;
+  target.setUTCDate(target.getUTCDate() - dayNr + 3);
+  const firstThursday = new Date(Date.UTC(target.getUTCFullYear(), 0, 4));
+  const weekNr =
+    1 +
+    Math.round(
+      ((target.valueOf() - firstThursday.valueOf()) / 86_400_000 -
+        3 +
+        ((firstThursday.getUTCDay() + 6) % 7)) /
+        7,
+    );
+  return `${target.getUTCFullYear()}-W${pad2(weekNr)}`;
+}
+
+// Shift an ISO datetime string by N UTC days, preserving the time-of-day
+// component.
+export function shiftIsoDays(iso: string, days: number): string {
+  const d = new Date(iso);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString();
 }
 
 // BCP-47 language tag for the patient's locale. Centralised so the zh-CN /


### PR DESCRIPTION
## Summary

Code-debt cleanup pass focused on a single duplication hot-spot: ~12
files each carried their own copy of the same date/time formatting
helpers (`toISODate(d)`, `pad`, `formatDuration(ms)`, `formatClock(sec)`,
`toLocalInput(iso)`, `daysAgo(n)`, `prevDay`, `defaultFrom`,
`isoWeekKey`, `shiftDays`, etc.). Consolidated everything into
`src/lib/utils/date.ts` and replaced the inline copies.

### New helpers in `src/lib/utils/date.ts`

- `pad2(n)` — two-digit zero-padding
- `formatLocalDateISO(Date)` — Date → `YYYY-MM-DD` (local zone)
- `shiftDateISO(date, days)` — replaces `defaultFrom` / `prevDay` /
  `daysAgo` / `isoDaysAgo`
- `formatHHMM(Date)` / `currentHHMM()` — HH:MM in local zone
- `toDatetimeLocalInput(iso)` — ISO → `<input type="datetime-local">`
  shape, returns `""` for missing/unparseable input
- `formatDurationMs(ms)` — voice-memo `m:ss` convention
- `formatClockSeconds(s)` — countdown `mm:ss` convention
- `isoWeekKey(iso)` / `shiftIsoDays(iso, days)` — pulled out of two
  near-identical detector copies

### Files migrated

- `src/lib/diary/build.ts`
- `src/lib/nutrition/symptom-context.ts`
- `src/lib/state/detectors/{steps-decline,social-isolation}.ts`
- `src/lib/tasks/engine.ts`
- `src/lib/treatment/calendar-sync.ts`
- `src/components/dashboard/practices-card.tsx`
- `src/components/diary/voice-memo-card.tsx`
- `src/components/ingest/preview-diff.tsx`
- `src/components/nutrition/{meal-timeline,weekly-summary}.tsx`
- `src/components/schedule/{appointment-form,prep-editor}.tsx`
- `src/components/tasks/preset-picker.tsx`
- `src/app/memos/{page,[id]/page}.tsx`
- `src/app/nutrition/{log/page,[id]/page}.tsx`

Net `+119 / −200` across 19 files. No behaviour changes — every helper
is line-for-line equivalent to the local copy it replaces.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — all 799 unit tests pass (90 files)
- [ ] Manual smoke (diary, memos, nutrition log, schedule form, dashboard
      practices timer) before merge

https://claude.ai/code/session_013vUnpcsbPifeADoxr4or4G

---
_Generated by [Claude Code](https://claude.ai/code/session_013vUnpcsbPifeADoxr4or4G)_