### PR TITLE
Food photo 401: show sign-in prompt instead of raw HttpError

### DIFF
--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { format } from "date-fns";
 import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
@@ -20,6 +21,7 @@ import {
   type MealEstimate,
 } from "~/lib/ingest/meal-vision";
 import { todayISO } from "~/lib/utils/date";
+import { HttpError } from "~/lib/utils/http";
 import { Sparkles, Check, Loader2 } from "lucide-react";
 
 export default function MealIngestPage() {
@@ -34,7 +36,21 @@ export default function MealIngestPage() {
     null,
   );
   const [error, setError] = useState<string | null>(null);
+  const [signInRequired, setSignInRequired] = useState(false);
   const [saved, setSaved] = useState<{ proteinAdd: number } | null>(null);
+
+  // Phase 1.1 acceptance: /api/ai/* requires a Supabase session.
+  // Translate the 401 into a sign-in prompt instead of showing the
+  // raw HttpError text.
+  function recordError(e: unknown) {
+    if (e instanceof HttpError && e.status === 401) {
+      setSignInRequired(true);
+      setError(null);
+      return;
+    }
+    setSignInRequired(false);
+    setError(e instanceof Error ? e.message : String(e));
+  }
 
   async function onPhoto(file: File) {
     reset();
@@ -55,11 +71,12 @@ export default function MealIngestPage() {
     if (!prepared) return;
     setBusy("estimate");
     setError(null);
+    setSignInRequired(false);
     try {
       const result = await estimateMeal({ model, image: prepared });
       setEstimate(result);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      recordError(e);
     } finally {
       setBusy(null);
     }
@@ -113,6 +130,7 @@ export default function MealIngestPage() {
     setPreview(null);
     setEstimate(null);
     setError(null);
+    setSignInRequired(false);
     setSaved(null);
   }
 
@@ -205,6 +223,26 @@ export default function MealIngestPage() {
               onDiscard={reset}
               saving={busy === "save"}
             />
+          )}
+
+          {signInRequired && (
+            <Alert variant="warn" dense>
+              <div className="flex flex-col gap-1.5">
+                <span>
+                  {locale === "zh"
+                    ? "AI 餐食识别需要登录后使用。"
+                    : "Sign in to use AI meal analysis."}
+                </span>
+                <Link
+                  href="/login?next=%2Fingest%2Fmeal"
+                  className="self-start"
+                >
+                  <Button size="sm" variant="primary">
+                    {locale === "zh" ? "登录" : "Sign in"}
+                  </Button>
+                </Link>
+              </div>
+            </Alert>
           )}
 
           {error && (

--- a/src/components/nutrition/meal-ingest.tsx
+++ b/src/components/nutrition/meal-ingest.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useRef, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Camera, Loader2, Sparkles, Type, Mic, MicOff } from "lucide-react";
 import { prepareImageForVision } from "~/lib/ingest/image";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
@@ -12,7 +14,9 @@ import type { ParsedMealResult } from "~/lib/nutrition/parser-schema";
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/field";
 import { Card } from "~/components/ui/card";
+import { Alert } from "~/components/ui/alert";
 import { useLocale } from "~/hooks/use-translate";
+import { HttpError } from "~/lib/utils/http";
 import { cn } from "~/lib/utils/cn";
 
 // Two-tab ingest. Photo and text both produce the same ParsedMealResult
@@ -23,10 +27,26 @@ export function MealIngest({
   onParsed: (result: ParsedMealResult, source: "photo" | "text", photoDataUrl?: string) => void;
 }) {
   const locale = useLocale();
+  const pathname = usePathname();
   const [tab, setTab] = useState<"photo" | "text">("photo");
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [signInRequired, setSignInRequired] = useState(false);
+
+  // 401 from the AI route means the Supabase session is missing or
+  // expired (per Phase 1.1 acceptance, /api/ai/* requires auth). Swap
+  // the raw "HTTP 401: ..." text for a sign-in prompt that bounces
+  // back to wherever this component is mounted.
+  function recordError(e: unknown) {
+    if (e instanceof HttpError && e.status === 401) {
+      setSignInRequired(true);
+      setError(null);
+      return;
+    }
+    setSignInRequired(false);
+    setError(e instanceof Error ? e.message : String(e));
+  }
   // Click-to-record voice memo. Tap once to record, tap again to stop;
   // the audio uploads to /api/ai/transcribe (Whisper) and the finalised
   // text appears once. No streaming — what the patient sees is what
@@ -42,13 +62,14 @@ export function MealIngest({
   async function handleFile(file: File) {
     setBusy(true);
     setError(null);
+    setSignInRequired(false);
     try {
       const prepared = await prepareImageForVision(file, { maxEdge: 1600 });
       const result = await parseMealPhoto({ image: prepared, locale });
       const dataUrl = `data:${prepared.mediaType};base64,${prepared.base64}`;
       onParsed(result, "photo", dataUrl);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      recordError(e);
     } finally {
       setBusy(false);
     }
@@ -58,12 +79,13 @@ export function MealIngest({
     if (!text.trim()) return;
     setBusy(true);
     setError(null);
+    setSignInRequired(false);
     try {
       const result = await parseMealText({ text, locale });
       onParsed(result, "text");
       setText("");
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      recordError(e);
     } finally {
       setBusy(false);
     }
@@ -190,6 +212,26 @@ export function MealIngest({
               </div>
             )}
           </div>
+        )}
+
+        {signInRequired && (
+          <Alert variant="warn" dense>
+            <div className="flex flex-col gap-1.5">
+              <span>
+                {locale === "zh"
+                  ? "AI 餐食识别需要登录后使用。"
+                  : "Sign in to use AI meal analysis."}
+              </span>
+              <Link
+                href={`/login?next=${encodeURIComponent(pathname ?? "/nutrition/log")}`}
+                className="self-start"
+              >
+                <Button size="sm" variant="primary">
+                  {locale === "zh" ? "登录" : "Sign in"}
+                </Button>
+              </Link>
+            </div>
+          </Alert>
         )}
 
         {error && (


### PR DESCRIPTION
## Summary

- The food-photo flow rendered `HTTP 401: {"error":"unauthenticated"}` straight into the error alert when the user was signed out, which gave nothing actionable.
- The 401 is **intentional** — `tests/unit/api-auth.test.ts:1-5` documents `/api/ai/parse-meal` and `/api/ai/ingest-meal` as Phase 1.1 acceptance routes that must reject unauthenticated callers. Server stays as-is.
- Fix is on the client: detect `HttpError.status === 401` in the catch blocks of `MealIngest` (photo + text paths) and `/ingest/meal` page (estimate path), and replace the raw text with a bilingual "Sign in to use AI meal analysis" Alert plus a Button linking to `/login?next=<current-path>`.

Touched:
- `src/components/nutrition/meal-ingest.tsx` — `handleFile` and `handleText` now route 401s through a `recordError` helper that flips a `signInRequired` flag; new Alert renders above the existing error div, with `usePathname()` driving the `next` param.
- `src/app/ingest/meal/page.tsx` — same pattern for `runEstimate`; static `next=/ingest/meal`.

## Test plan

- [ ] Sign out, take a food photo via `/nutrition/log` → "Sign in to use AI meal analysis" alert appears with a Sign in button. Click it → land on `/login?next=%2Fnutrition%2Flog`. Sign in → return to `/nutrition/log` and re-take the photo successfully.
- [ ] Repeat at `/ingest/meal` (Sign-in `next` should be `/ingest/meal`).
- [ ] Trigger a non-401 server error (e.g. malformed image) → existing error div still renders the message; sign-in alert does NOT appear.
- [ ] Sign in flow on the text tab of `MealIngest` shows the same alert when the session is missing.

https://claude.ai/code/session_01W3ED8Vc5MMnnzMcJnaDLSb