### PR TITLE
Digestive tracking + multi-day AI nudge cadence (Option B)

### DIFF
--- a/src/agents/nutrition/role.md
+++ b/src/agents/nutrition/role.md
@@ -1,6 +1,6 @@
 # Nutrition agent — role
 
-You are the nutrition specialist on a multidisciplinary team caring for a patient with {diagnosis_full}. The patient is {patient_initials}; the primary carer (often a clinician relative) collaborates through the platform.
+You are the **AI Dietician** on a multidisciplinary team caring for a patient with {diagnosis_full}. The patient is {patient_initials}; the primary carer (often a clinician relative) collaborates through the platform. Your patient-facing voice is "AI Dietician" — when speaking to the patient in `daily_report` or `nudges`, identify yourself as such if a self-reference is needed.
 
 ## Your remit
 
@@ -10,11 +10,12 @@ You are the nutrition specialist on a multidisciplinary team caring for a patien
 4. **Pancreatic enzyme replacement therapy (PERT / Creon).** Missed PERT before fatty meals → steatorrhoea + malabsorption. Flag anywhere you notice PERT wasn't taken.
 5. **Hydration.** Especially during / after chemo infusions. Flag reports of dark urine, dry mouth, orthostatic symptoms.
 6. **GI toxicity interfering with eating** (mucositis, nausea, early satiety). Your job is the eating consequence; the toxicity agent owns the symptom itself.
+7. **Digestive output (end-to-end input → output).** PDAC + GnP makes stool form, frequency, oil content, and colour the single most informative signal for PERT (Creon) titration. When the patient mentions stools, classify them: count in 24 h, predominant Bristol type (1–7), urgency, oil/film, colour. **Loose form (Bristol 6–7) plus oily/floating stool is the steatorrhoea signature — almost always means PERT was under-dosed for the day's fat intake.** Pale or clay-coloured stools point to biliary obstruction; raise to clinical agent. Never invent these — leave them off if the patient didn't say.
 
 ## Filings you may emit
 
 You can write to these Dexie tables via `filings`:
-- `daily_entries` (strategy `upsert_by_date` with key `{ date: "YYYY-MM-DD" }`). Allowed fields: `protein_grams`, `meals_count`, `snacks_count`, `fluids_ml`, `appetite` (0–10), `nausea` (0–10), `weight_kg`.
+- `daily_entries` (strategy `upsert_by_date` with key `{ date: "YYYY-MM-DD" }`). Allowed fields: `protein_grams`, `meals_count`, `snacks_count`, `fluids_ml`, `appetite` (0–10), `nausea` (0–10), `weight_kg`, `stool_count` (integer), `stool_bristol` (1–7), `stool_urgency` (bool), `stool_oil` (bool, oil droplets / floating / sticky), `stool_blood` (bool — but co-emit a red `stool_blood_red` safety flag), `stool_color` (one of normal/pale/yellow/green/dark/black/red), `pert_with_meals_today` (one of all/some/none/na), `steatorrhoea` (bool, the coarse fallback).
 - `life_events` (strategy `add`) — only for notable diet-related events (e.g., "couldn't eat all day", "started new supplement").
 
 Never invent numbers. If the patient said "some protein", leave protein_grams out. If they said "about 25 g", use 25. Prefer under-filing to guessing.
@@ -22,6 +23,18 @@ Never invent numbers. If the patient said "some protein", leave protein_grams ou
 ## Cadence
 
 You run **once daily** by default (or on-demand). One invocation = one batch of referrals from the last day. Your `daily_report` is the morning brief dad will see in the feed; speak directly to him.
+
+## Multi-day follow-ups
+
+You may emit `follow_ups[]` — questions you want resurfaced in the feed in 1–7 days. Use this when a single observation isn't enough and you genuinely need a second data point to act. Examples:
+
+- Loose stools yesterday + Creon mentioned → follow up in 2 days asking if stool form returned to Bristol 3–4 after taking Creon with every fatty meal. `question_key: "nutrition.pert_titration_check"`.
+- New supplement / ONS started → follow up in 5 days asking how it's sitting and whether weight or appetite shifted. `question_key: "nutrition.ons_tolerance_check"`.
+- Weight dropped > 1 kg week-on-week → follow up in 3 days for a re-weigh, not the next morning. `question_key: "nutrition.weight_recheck"`.
+
+Re-emit the same `question_key` on every run while the underlying condition persists — the persistence layer dedupes by superseding the older row. Drop the follow-up entirely once the condition resolves; the system will mark it stale.
+
+Cap yourself at 2 active follow-ups at any time. The patient sees a **single channel out** — too many open loops feels like nagging.
 
 ## Feedback loop (read carefully)
 

--- a/src/agents/schema.ts
+++ b/src/agents/schema.ts
@@ -36,6 +36,16 @@ const followUpQuestionSchema = z.object({
   kind: z.enum(["numeric", "yesno", "text", "scale_0_10"]),
 });
 
+// Multi-day follow-up. Mirrors AgentFollowUp in src/types/agent.ts.
+// Persisted into agent_followups; re-surfaces in the feed when due.
+const followUpSchema = z.object({
+  question_key: z.string(),
+  ask_in_days: z.number().int().min(0).max(30),
+  prompt: localizedString,
+  reason: localizedString.optional(),
+  priority: z.number().optional(),
+});
+
 const feedItemSchema = z.object({
   id: z.string(),
   priority: z.number(),
@@ -68,6 +78,7 @@ export const AgentOutputSchema = z.object({
   filings: z.array(dexiePatchSchema),
   questions: z.array(followUpQuestionSchema),
   nudges: z.array(feedItemSchema),
+  follow_ups: z.array(followUpSchema).optional(),
   state_diff: z.string(),
 });
 

--- a/src/agents/toxicity/role.md
+++ b/src/agents/toxicity/role.md
@@ -1,26 +1,36 @@
 # Toxicity agent — role
 
-You are the drug-toxicity specialist on a multidisciplinary team caring for {patient_initials}, a patient with {diagnosis_full}. Your whole job is catching **axis-3 drift** — treatment-driven toxicity that, if ignored, causes permanent performance-status loss and breaks trial eligibility for daraxonrasib (RASolute 303 / 302).
+You are the **AI Nurse** on a multidisciplinary team caring for {patient_initials}, a patient with {diagnosis_full}. Your whole job is catching **axis-3 drift** — treatment-driven toxicity that, if ignored, causes permanent performance-status loss and breaks trial eligibility for daraxonrasib (RASolute 303 / 302). Your patient-facing voice is "AI Nurse" — when self-reference is needed in `daily_report` or `nudges`, identify yourself as such.
 
 ## Your remit
 
 1. **Peripheral neuropathy** (paclitaxel-driven). Grade per CTCAE. Any patient-reported progression from "tingling at fingertips" → "numbness" → "interfering with buttons / writing / walking" is a level up the ladder. Flag any new motor involvement or proximal spread as red.
 2. **Cold dysaesthesia** (oxaliplatin if ever added; paclitaxel less so). Any report of cold-triggered throat/hand pain near infusion day is yellow minimum.
 3. **Mouth sores / mucositis** — flag moderate (WHO grade 2+: interferes with eating) as yellow.
-4. **Diarrhoea / constipation** — flag ≥ 4 BMs above baseline as yellow, ≥ 7 or bloody as orange.
+4. **Diarrhoea / constipation** — flag ≥ 4 BMs above baseline as yellow, ≥ 7 or bloody as orange. **Visible blood, melaena, or black stool is RED** — co-file a `stool_blood_red` safety flag and call it out in `daily_report`. When the patient describes stool form, capture the predominant Bristol type (1–7), urgency, and any oily / floating / sticky stool — Bristol 6–7 with oil is steatorrhoea (PERT under-titration; nutrition agent owns the eating consequence, but you own the toxicity-grading).
 5. **Fever / chills in the nadir window** (day 8–14 post-GnP) → febrile neutropenia concern → **red**. Always co-file a safety_flag with rule_id `febrile_neutropenia_red` so the zone engine picks it up.
 6. **Fatigue, dyspnoea on exertion, bruising, petechiae** — these can be cytopenia surrogates; clinical agent confirms via labs.
 
 ## Filings you may emit
 
-- `daily_entries` (upsert_by_date): `neuropathy_hands` (0–4), `neuropathy_feet` (0–4), `cold_dysaesthesia` (bool), `mouth_sores` (0–4), `diarrhoea_count`, `constipation_days`, `fever_c`, `bruising`, `dyspnoea`.
+- `daily_entries` (upsert_by_date): `neuropathy_hands` (0–4), `neuropathy_feet` (0–4), `cold_dysaesthesia` (bool), `mouth_sores` (0–4), `diarrhoea_count`, `constipation_days`, `fever_c`, `bruising`, `dyspnoea`, plus the GI fields shared with the dietician: `stool_count`, `stool_bristol` (1–7), `stool_urgency` (bool), `stool_blood` (bool), `stool_oil` (bool), `stool_color` (normal/pale/yellow/green/dark/black/red).
 - `life_events` (add) for anything that doesn't fit a daily field.
 
 Never invent grades. If patient said "tingling a bit more", that's a narrative — leave the numeric ungraded unless they gave you an unambiguous description.
 
 ## Cadence
 
-You run **once daily** by default (or on-demand). One invocation = one batch of referrals from the last day. Your `daily_report` is the morning brief dad sees in the feed.
+You run **once daily** by default (or on-demand). The cadence engine boosts your prompt frequency to daily during the **nadir window** (cycle days 7–14) when febrile-neutropenia and mucositis risk peaks. One invocation = one batch of referrals from the last day. Your `daily_report` is the morning brief dad sees in the feed.
+
+## Multi-day follow-ups
+
+You may emit `follow_ups[]` — questions you want resurfaced in the feed in 1–7 days. Use this to re-check toxicity that needs more than one data point. Examples:
+
+- Tingling stepped up half a notch → follow up in 3 days asking whether it's held, progressed, or eased. `question_key: "toxicity.neuropathy_recheck"`.
+- Loose stools today → follow up in 2 days asking if they've settled. `question_key: "toxicity.diarrhoea_recheck"`.
+- New mouth sores → follow up in 2 days for severity + eating impact. `question_key: "toxicity.mucositis_recheck"`.
+
+Re-emit the same `question_key` while the condition persists — the persistence layer dedupes by superseding. Drop the follow-up once the condition resolves. Cap yourself at 2 active follow-ups at any time. Single channel out — don't pile up open loops.
 
 ## Feedback loop (read carefully)
 

--- a/src/components/daily/daily-wizard.tsx
+++ b/src/components/daily/daily-wizard.tsx
@@ -31,6 +31,7 @@ import {
   SkipForward,
   Check,
   X,
+  Droplet,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 
@@ -121,6 +122,24 @@ const CATS = [
       "diarrhoea_count",
       "new_bruising",
       "dyspnoea",
+    ],
+  },
+  {
+    id: "digestion",
+    icon: Droplet,
+    title: { en: "Digestion", zh: "消化" } as Bilingual,
+    hint: {
+      en: "Stools, oil/colour, PERT (Creon)",
+      zh: "排便、油脂/颜色、胰酶 (Creon)",
+    } as Bilingual,
+    fields: [
+      "stool_count",
+      "stool_bristol",
+      "stool_urgency",
+      "stool_oil",
+      "stool_blood",
+      "stool_color",
+      "pert_with_meals_today",
     ],
   },
   {
@@ -871,6 +890,10 @@ function CategoryFields({
     );
   }
 
+  if (catId === "digestion") {
+    return <DigestionFields draft={draft} patch={patch} locale={locale} />;
+  }
+
   if (catId === "reflection") {
     return (
       <Field label={L("Reflection", "反思")}>
@@ -893,6 +916,213 @@ function CategoryFields({
   }
 
   return null;
+}
+
+function DigestionFields({
+  draft,
+  patch,
+  locale,
+}: {
+  draft: Draft;
+  patch: <K extends keyof DailyEntry>(k: K, v: DailyEntry[K] | undefined) => void;
+  locale: "en" | "zh";
+}) {
+  const L = useL();
+  // Bristol scale picker — 7 segmented buttons, short bilingual label
+  // under each. We deliberately use plain numbers + words (no images)
+  // to keep this small, fast, and acceptable in tone (no graphics of
+  // stool on the daily wizard).
+  const BRISTOL: Array<{
+    n: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+    label: { en: string; zh: string };
+  }> = [
+    { n: 1, label: { en: "Hard lumps", zh: "硬块" } },
+    { n: 2, label: { en: "Lumpy", zh: "成块" } },
+    { n: 3, label: { en: "Cracked", zh: "条裂" } },
+    { n: 4, label: { en: "Smooth", zh: "光滑" } },
+    { n: 5, label: { en: "Soft", zh: "软" } },
+    { n: 6, label: { en: "Mushy", zh: "糊状" } },
+    { n: 7, label: { en: "Liquid", zh: "水样" } },
+  ];
+  const COLORS: Array<{
+    v: NonNullable<DailyEntry["stool_color"]>;
+    label: { en: string; zh: string };
+  }> = [
+    { v: "normal", label: { en: "Brown", zh: "棕色" } },
+    { v: "pale", label: { en: "Pale / clay", zh: "灰白" } },
+    { v: "yellow", label: { en: "Yellow", zh: "黄色" } },
+    { v: "green", label: { en: "Green", zh: "绿色" } },
+    { v: "dark", label: { en: "Dark", zh: "深色" } },
+    { v: "black", label: { en: "Black", zh: "黑色" } },
+    { v: "red", label: { en: "Red", zh: "红色" } },
+  ];
+  const PERT: Array<{
+    v: NonNullable<DailyEntry["pert_with_meals_today"]>;
+    label: { en: string; zh: string };
+  }> = [
+    { v: "all", label: { en: "Every fatty meal", zh: "每次高脂餐" } },
+    { v: "some", label: { en: "Missed some", zh: "漏了几次" } },
+    { v: "none", label: { en: "None today", zh: "今天没吃" } },
+    { v: "na", label: { en: "No fatty meals", zh: "无高脂餐" } },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <Field
+        label={L("Bowel motions in 24 h", "24 小时排便次数")}
+        hint={L(
+          "Total count, including any loose ones",
+          "包含稀便在内的总次数",
+        )}
+      >
+        <TextInput
+          type="number"
+          inputMode="numeric"
+          value={draft.stool_count ?? ""}
+          onChange={(e) =>
+            patch(
+              "stool_count",
+              e.target.value === "" ? undefined : Number(e.target.value),
+            )
+          }
+        />
+      </Field>
+
+      <div className="space-y-1.5">
+        <div className="text-[12.5px] text-ink-700">
+          {L(
+            "Bristol type (predominant)",
+            "Bristol 类型（主要形态）",
+          )}
+        </div>
+        <div className="grid grid-cols-7 gap-1">
+          {BRISTOL.map((b) => {
+            const active = draft.stool_bristol === b.n;
+            return (
+              <button
+                key={b.n}
+                type="button"
+                onClick={() =>
+                  patch("stool_bristol", active ? undefined : b.n)
+                }
+                aria-pressed={active}
+                className={cn(
+                  "rounded-md border px-1 py-2 text-center text-[11px] transition-colors",
+                  active
+                    ? "border-ink-900 bg-ink-900 text-paper"
+                    : "border-ink-100 bg-paper-2 hover:border-ink-300",
+                )}
+              >
+                <div className="mono text-[12px] font-semibold tabular-nums">
+                  {b.n}
+                </div>
+                <div
+                  className={cn(
+                    "mt-0.5 text-[10px] leading-tight",
+                    active ? "text-paper/70" : "text-ink-500",
+                  )}
+                >
+                  {b.label[locale]}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+        <div className="text-[10.5px] text-ink-400">
+          {L(
+            "1–2 constipated · 3–4 normal · 5 soft · 6–7 loose",
+            "1–2 便秘 · 3–4 正常 · 5 偏软 · 6–7 稀便",
+          )}
+        </div>
+      </div>
+
+      <Toggle
+        label={L("Urgency or near-incontinence", "便急或近失禁")}
+        checked={draft.stool_urgency ?? false}
+        onChange={(v) => patch("stool_urgency", v ? true : undefined)}
+      />
+      <Toggle
+        label={L(
+          "Oily, floating, or sticky stool",
+          "油腻 / 漂浮 / 黏腻便",
+        )}
+        checked={draft.stool_oil ?? false}
+        onChange={(v) => patch("stool_oil", v ? true : undefined)}
+      />
+      <Toggle
+        label={L(
+          "Visible blood, melaena, or black stool (call the team)",
+          "可见血便、柏油样或黑便（请联系团队）",
+        )}
+        checked={draft.stool_blood ?? false}
+        onChange={(v) => patch("stool_blood", v ? true : undefined)}
+      />
+
+      <div className="space-y-1.5">
+        <div className="text-[12.5px] text-ink-700">
+          {L("Colour", "颜色")}
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {COLORS.map((c) => {
+            const active = draft.stool_color === c.v;
+            return (
+              <button
+                key={c.v}
+                type="button"
+                onClick={() =>
+                  patch("stool_color", active ? undefined : c.v)
+                }
+                aria-pressed={active}
+                className={cn(
+                  "rounded-full border px-2.5 py-1 text-[11.5px] transition-colors",
+                  active
+                    ? "border-ink-900 bg-ink-900 text-paper"
+                    : "border-ink-100 bg-paper-2 hover:border-ink-300",
+                )}
+              >
+                {c.label[locale]}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="text-[12.5px] text-ink-700">
+          {L(
+            "PERT (Creon) with fatty meals today",
+            "今天高脂餐时的胰酶 (Creon)",
+          )}
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {PERT.map((p) => {
+            const active = draft.pert_with_meals_today === p.v;
+            return (
+              <button
+                key={p.v}
+                type="button"
+                onClick={() =>
+                  patch(
+                    "pert_with_meals_today",
+                    active ? undefined : p.v,
+                  )
+                }
+                aria-pressed={active}
+                className={cn(
+                  "rounded-full border px-2.5 py-1 text-[11.5px] transition-colors",
+                  active
+                    ? "border-ink-900 bg-ink-900 text-paper"
+                    : "border-ink-100 bg-paper-2 hover:border-ink-300",
+                )}
+              >
+                {p.label[locale]}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function PracticeFields({

--- a/src/config/agent-cadence.ts
+++ b/src/config/agent-cadence.ts
@@ -1,0 +1,160 @@
+import type { AgentId } from "~/types/agent";
+import type { LocalizedText } from "~/types/localized";
+import type { CycleContext } from "~/types/treatment";
+
+// Per-discipline cadence config. Each agent has a patient-facing
+// "voice" (AI Nurse / AI Dietician / AI Physio) and a default cadence
+// — what days of the week it offers a check-in nudge in the absence of
+// any other signal. The cycle-aware multiplier lets the toxicity / nurse
+// agent ride harder during the nadir window and back off in the recovery
+// week, matching the actual clinical risk profile of GnP.
+//
+// CLAUDE.md guardrails enforced here:
+//   - No new top-level patient screen.
+//   - Hard daily cap so the feed never feels overbearing.
+//   - Suppress all discipline cadence prompts entirely if the patient is
+//     currently in a red zone — the safety alert owns the channel that
+//     day; we don't pile on with check-ins.
+
+export interface AgentVoice {
+  display_name: LocalizedText;
+  // Lower-case slug used inside feed.source ("agent_voice:dietician").
+  slug: string;
+  icon: string;
+  // Default per-week cadence — true = the agent offers a daily-style
+  // check-in nudge that day if the patient hasn't already produced
+  // signal. Sunday=0 … Saturday=6.
+  weekly_pattern: readonly [boolean, boolean, boolean, boolean, boolean, boolean, boolean];
+  // Optional copy for the cadence prompt that surfaces on a "due" day.
+  cadence_prompt: LocalizedText;
+}
+
+// One row per AgentId, even agents that don't yet expose a voice (clinical,
+// treatment) — keeps the type total. The feed-renderer reads this to swap
+// the generic agent title ("Nutrition") for the patient-facing voice ("AI
+// Dietician") on the agent_run feed cards.
+export const AGENT_VOICES: Record<AgentId, AgentVoice> = {
+  nutrition: {
+    display_name: { en: "AI Dietician", zh: "AI 营养师" },
+    slug: "dietician",
+    icon: "salad",
+    // Daily — diet/GI is the highest-frequency loop for PDAC.
+    weekly_pattern: [true, true, true, true, true, true, true],
+    cadence_prompt: {
+      en: "Quick check-in — how were meals, fluids, and stools today?",
+      zh: "简单回顾 —— 今日的正餐、饮水和排便情况如何？",
+    },
+  },
+  toxicity: {
+    display_name: { en: "AI Nurse", zh: "AI 护士" },
+    slug: "nurse",
+    icon: "thermo",
+    // Daily during the nadir window (handled by cycle multiplier);
+    // otherwise Mon / Wed / Fri to keep the channel quiet between dose
+    // weeks.
+    weekly_pattern: [false, true, false, true, false, true, false],
+    cadence_prompt: {
+      en: "Anything new with neuropathy, mouth, or bowels since yesterday?",
+      zh: "自昨日以来神经病变、口腔或肠道有无新变化？",
+    },
+  },
+  rehabilitation: {
+    display_name: { en: "AI Physio", zh: "AI 物理治疗师" },
+    slug: "physio",
+    icon: "walk",
+    // Mon / Wed / Fri — matches the resistance-training cadence the
+    // exercise physiology guidance recommends.
+    weekly_pattern: [false, true, false, true, false, true, false],
+    cadence_prompt: {
+      en: "Time for a quick movement check — walking minutes, any resistance work?",
+      zh: "活动情况快报 —— 今天步行多少分钟？是否做了阻力训练？",
+    },
+  },
+  clinical: {
+    display_name: { en: "AI Clinician", zh: "AI 临床医师" },
+    slug: "clinician",
+    icon: "pulse",
+    // No weekly cadence — clinical reasoning runs only when there's a
+    // referral (lab, imaging, decision). All-false pattern means the
+    // cadence engine never proactively prompts; the agent still runs
+    // on demand and on the daily batch.
+    weekly_pattern: [false, false, false, false, false, false, false],
+    cadence_prompt: {
+      en: "",
+      zh: "",
+    },
+  },
+  treatment: {
+    display_name: { en: "AI Treatment", zh: "AI 化疗助手" },
+    slug: "treatment",
+    icon: "pill",
+    weekly_pattern: [false, false, false, false, false, false, false],
+    cadence_prompt: {
+      en: "",
+      zh: "",
+    },
+  },
+  psychology: {
+    display_name: { en: "AI Companion", zh: "AI 心境陪伴" },
+    slug: "companion",
+    icon: "moon",
+    // Twice a week (Tue / Sat) — gentle. Daily psych prompts erode
+    // signal and risk feeling pestering on tough days.
+    weekly_pattern: [false, false, true, false, false, false, true],
+    cadence_prompt: {
+      en: "How are mood, sleep, and your practice sitting with you today?",
+      zh: "今天的心情、睡眠和修习状态如何？",
+    },
+  },
+};
+
+// Hard cap on combined discipline cadence prompts in a single feed
+// compose. Safety alerts, follow-ups, and agent daily reports are NOT
+// counted against this cap — only the cadence prompts produced by this
+// module.
+export const MAX_CADENCE_PROMPTS_PER_DAY = 2;
+
+// Hard cap on resurfaced multi-day follow-ups in a single feed compose.
+// Combined with the prompt cap above, the patient sees at most ~5
+// discipline-driven items per day, sitting under safety + treatment +
+// task items.
+export const MAX_FOLLOW_UPS_PER_DAY = 3;
+
+// Suppress all discipline cadence prompts entirely when this many or
+// more red zone alerts are active — don't pile cheerful check-ins on
+// top of a safety event.
+export const RED_ZONE_SUPPRESSION_COUNT = 1;
+
+// Base priority for cadence prompts in the feed. Sits below safety
+// (0–30), treatment / task / cycle-relevant (30–50), but above gentle
+// trend nudges (≥ 60).
+export const CADENCE_PROMPT_PRIORITY = 55;
+
+// Base priority for resurfaced follow-ups. Slightly higher than a
+// fresh cadence prompt because the patient already heard the question
+// once and there's a real reason to ask again.
+export const FOLLOW_UP_PRIORITY = 40;
+
+export interface CadenceMultiplierInputs {
+  agentId: AgentId;
+  cycleContext: CycleContext | null;
+}
+
+// Cycle-aware boost: during the nadir window (cycle days 7–14 of GnP),
+// the toxicity / nurse cadence flips to daily so we catch febrile
+// neutropenia, mucositis, and diarrhoea early. During the recovery
+// week, dietician stays daily but physio softens.
+//
+// Returns `true` if the agent should prompt today regardless of its
+// weekly_pattern; `false` to follow the static pattern; `null` to
+// suppress entirely (e.g. red zone is active and the cap kicked in).
+export function shouldPromptOverride(
+  inputs: CadenceMultiplierInputs,
+): boolean | null {
+  const { agentId, cycleContext } = inputs;
+  if (!cycleContext) return false;
+  const phase = cycleContext.phase?.key;
+  if (agentId === "toxicity" && phase === "nadir") return true;
+  if (agentId === "nutrition" && phase === "nadir") return true;
+  return false;
+}

--- a/src/config/thresholds.json
+++ b/src/config/thresholds.json
@@ -34,5 +34,14 @@
   "nutrition": {
     "albumin_yellow": 30,
     "albumin_orange": 25
+  },
+  "gi": {
+    "loose_stool_bristol_min": 6,
+    "loose_stool_persistent_yellow_days": 3,
+    "loose_stool_persistent_orange_days": 5,
+    "stool_count_yellow": 4,
+    "stool_count_orange": 7,
+    "constipation_bristol_max": 2,
+    "constipation_yellow_days": 3
   }
 }

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -33,6 +33,7 @@ import type {
 } from "~/types/medication";
 import type {
   AgentFeedbackRow,
+  AgentFollowUpRow,
   AgentRunRow,
   AgentStateRow,
   LogEventRow,
@@ -88,6 +89,10 @@ export class AnchorDB extends Dexie {
   log_events!: Table<LogEventRow, number>;
   agent_runs!: Table<AgentRunRow, number>;
   agent_feedback!: Table<AgentFeedbackRow, number>;
+  // v23: multi-day follow-up loop. Each row is one question an agent
+  // promised to revisit; the feed composer re-surfaces it when `due_at`
+  // matures.
+  agent_followups!: Table<AgentFollowUpRow, number>;
   appointments!: Table<Appointment, number>;
   appointment_links!: Table<AppointmentLink, number>;
   care_team!: Table<CareTeamMember, number>;
@@ -368,6 +373,19 @@ export class AnchorDB extends Dexie {
       voice_memos:
         "++id, recorded_at, day, log_event_id, audio_media_id, " +
         "source_screen, entered_by",
+    });
+    // v23: agent multi-day follow-up loop. One row per outstanding
+    // question an agent promised to revisit. The feed composer reads
+    // unresolved rows whose `due_at <= today`. Compound
+    // [agent_id+question_key] supports the supersede path: when an
+    // agent re-emits a follow-up with the same key, we resolve the
+    // older row and add a fresh one. `due_at` is indexed because the
+    // composer's hot query is "show me all matured, unresolved
+    // follow-ups across all agents".
+    this.version(23).stores({
+      agent_followups:
+        "++id, agent_id, question_key, due_at, asked_at, resolved_at, " +
+        "[agent_id+question_key]",
     });
   }
 }

--- a/src/lib/log/run-agents.ts
+++ b/src/lib/log/run-agents.ts
@@ -1,12 +1,14 @@
 import { db, now } from "~/lib/db/dexie";
 import type {
   AgentFeedbackRow,
+  AgentFollowUp,
   AgentId,
   AgentOutput,
   AgentRunRow,
   DexiePatch,
   LogEventRow,
 } from "~/types/agent";
+import { FOLLOW_UP_PRIORITY } from "~/config/agent-cadence";
 import type { Locale } from "~/types/clinical";
 import { agentsForTags } from "~/agents/routing";
 import { HttpError, postJson } from "~/lib/utils/http";
@@ -100,6 +102,12 @@ export async function runAgentClient(
   await rewriteAgentState(args.agentId, body.output.state_diff);
   await applyFilings(body.output.filings);
   await promoteSafetyFlags(args.agentId, body.output.safety_flags, body.ran_at);
+  await persistFollowUps(
+    args.agentId,
+    body.output.follow_ups ?? [],
+    body.ran_at,
+    runId,
+  );
   await markConsumed(referralIds, runId);
 
   return runId;
@@ -247,6 +255,57 @@ async function promoteSafetyFlags(
       created_at: ts,
       updated_at: ts,
     });
+  }
+}
+
+// Persist multi-day follow-ups emitted by an agent. Supersede semantics:
+// when a fresh row arrives with the same (agent_id, question_key) as an
+// older unresolved row, mark the old row resolved (`agent_supersede`)
+// and add the new one. This means an agent can re-emit the same
+// question on every run while a condition persists; the patient sees
+// the freshest copy in the feed, never duplicates.
+async function persistFollowUps(
+  agentId: AgentId,
+  followUps: readonly AgentFollowUp[],
+  ranAt: string,
+  runId: number,
+): Promise<void> {
+  for (const fu of followUps) {
+    try {
+      const due = new Date(ranAt);
+      due.setUTCDate(due.getUTCDate() + Math.max(0, fu.ask_in_days));
+      const dueIso = due.toISOString();
+
+      const existing = await db.agent_followups
+        .where("[agent_id+question_key]")
+        .equals([agentId, fu.question_key])
+        .filter((r) => !r.resolved_at)
+        .toArray();
+      for (const old of existing) {
+        if (typeof old.id === "number") {
+          await db.agent_followups.update(old.id, {
+            resolved_at: ranAt,
+            resolved_by: "agent_supersede",
+          });
+        }
+      }
+
+      await db.agent_followups.add({
+        agent_id: agentId,
+        question_key: fu.question_key,
+        asked_at: ranAt,
+        due_at: dueIso,
+        prompt_en: fu.prompt.en,
+        prompt_zh: fu.prompt.zh,
+        reason_en: fu.reason?.en,
+        reason_zh: fu.reason?.zh,
+        priority: fu.priority ?? FOLLOW_UP_PRIORITY,
+        source_run_id: runId,
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("[log] follow-up persist failed", fu, err);
+    }
   }
 }
 

--- a/src/lib/log/tag.ts
+++ b/src/lib/log/tag.ts
@@ -23,6 +23,12 @@ const RULES: Rule[] = [
       /\b(protein|meal|ate|eat|eating|breakfast|lunch|dinner|snack|kcal|calor|carb|fat|shake|drink|fluid|water|appetite|nausea|vomit|pert|creon|enzyme)\b/,
       /\b\d+\s*g(?:rams?)?\b/, // "25g", "30 grams"
       /[饱饭饮食蛋白质喝吃奶液腰肠药]/, // 饱/饭/饮/食/蛋白质/喝/吃/奶/液/胰肠药
+      // Stool / digestive output signals route to diet because the
+      // dietician owns PERT-titration consequences. They also match
+      // the toxicity rule below — the patient gets fanned to both
+      // agents, which is correct.
+      /\b(stool\w*|bristol|bowel\s*motion|bm\b|poo|poop|loose\s*stool|watery|oily|float\w*|steator\w*)\b/,
+      /[便屎泻稀油浮]/, // 便/屎/泻/稀/油/浮
     ],
   },
   {
@@ -30,6 +36,10 @@ const RULES: Rule[] = [
     patterns: [
       /\b(tingl\w*|numb\w*|neuropath\w*|pins and needles|cold sensit\w*|cold dys|mouth sore|oral ulcer|bruis\w*|bleed\w*|rash|hand.?foot|alopecia|hair loss|diarrh\w*|constipat\w*|dyspn\w*|shortness of breath|sob\b|chill\w*|fever|rigor)\b/,
       /[麻刺痛膚膚发热冒汗饭泻便秘呲噪滑滑]/, // 麻/刺/痛/肤/发热/冒汗/泻/便秘/呕/
+      // Stool quality / blood / colour cues — these need toxicity
+      // grading even when the dietician also picks them up.
+      /\b(loose\s*stool|watery|black\s*stool|melaena|melena|blood\w*\s*stool|red\s*stool|pale\s*stool|clay\s*stool|urgency|incontinen\w*)\b/,
+      /[黑便血便稀便急便]/, // 黑便/血便/稀便/急便
     ],
   },
   {

--- a/src/lib/nudges/agent-runs.ts
+++ b/src/lib/nudges/agent-runs.ts
@@ -1,5 +1,6 @@
 import type { AgentRunRow, AgentId } from "~/types/agent";
 import type { FeedItem } from "~/types/feed";
+import { AGENT_VOICES } from "~/config/agent-cadence";
 
 // Convert the latest run per agent into feed items. Each agent's most
 // recent run becomes one card; older runs are not surfaced (they live in
@@ -42,14 +43,15 @@ function runToFeedItem(run: AgentRunRow): FeedItem | null {
         ? "caution"
         : "info";
 
+  const voice = AGENT_VOICES[run.agent_id];
   return {
     id: `agent_run_${run.agent_id}_${run.id}`,
     priority,
     category: AGENT_FEED_CATEGORY[run.agent_id],
     tone,
-    title: AGENT_FEED_TITLE[run.agent_id],
+    title: voice.display_name,
     body: report,
-    icon: AGENT_ICON[run.agent_id],
+    icon: voice.icon,
     source: `agent:${run.agent_id}`,
     meta: {
       kind: "agent_run",
@@ -66,22 +68,4 @@ const AGENT_FEED_CATEGORY: Record<AgentId, FeedItem["category"]> = {
   rehabilitation: "body",
   treatment: "treatment",
   psychology: "encouragement",
-};
-
-const AGENT_FEED_TITLE: Record<AgentId, FeedItem["title"]> = {
-  nutrition: { en: "Nutrition", zh: "营养" },
-  toxicity: { en: "Toxicity", zh: "毒性反应" },
-  clinical: { en: "Clinical", zh: "临床" },
-  rehabilitation: { en: "Rehabilitation", zh: "康复" },
-  treatment: { en: "Treatment", zh: "化疗" },
-  psychology: { en: "Mind", zh: "心境" },
-};
-
-const AGENT_ICON: Record<AgentId, string> = {
-  nutrition: "food",
-  toxicity: "thermo",
-  clinical: "pulse",
-  rehabilitation: "walk",
-  treatment: "pill",
-  psychology: "moon",
 };

--- a/src/lib/nudges/cadence-prompts.ts
+++ b/src/lib/nudges/cadence-prompts.ts
@@ -1,0 +1,130 @@
+import type { FeedItem } from "~/types/feed";
+import type { AgentId } from "~/types/agent";
+import type { CycleContext } from "~/types/treatment";
+import type { DailyEntry, ZoneAlert } from "~/types/clinical";
+import {
+  AGENT_VOICES,
+  CADENCE_PROMPT_PRIORITY,
+  MAX_CADENCE_PROMPTS_PER_DAY,
+  RED_ZONE_SUPPRESSION_COUNT,
+  shouldPromptOverride,
+} from "~/config/agent-cadence";
+
+// Per-discipline daily / weekly cadence prompts. Each discipline (AI
+// Dietician, AI Nurse, AI Physio, AI Companion) has its own weekly
+// cadence pattern in agent-cadence.ts. This module turns that pattern
+// — plus today's cycle context, today's daily entry, and active zone
+// alerts — into a small set of feed items.
+//
+// Hard guardrails:
+//   - Suppress all cadence prompts entirely if any red zone alert is
+//     active (RED_ZONE_SUPPRESSION_COUNT). Safety owns the channel.
+//   - Skip a discipline's prompt if the patient already touched its
+//     domain today (e.g. dietician quiet if meals + stool already
+//     logged) — we don't pester for redundant input.
+//   - Cap total prompts at MAX_CADENCE_PROMPTS_PER_DAY.
+
+export interface CadenceInputs {
+  todayISO: string; // YYYY-MM-DD
+  cycleContext: CycleContext | null;
+  todayDaily: DailyEntry | null;
+  activeAlerts: ZoneAlert[];
+}
+
+export function computeCadencePrompts(inputs: CadenceInputs): FeedItem[] {
+  const redCount = inputs.activeAlerts.filter(
+    (a) => !a.resolved && a.zone === "red",
+  ).length;
+  if (redCount >= RED_ZONE_SUPPRESSION_COUNT) return [];
+
+  const dow = new Date(inputs.todayISO + "T12:00:00").getDay();
+  const out: FeedItem[] = [];
+
+  // Order matters when the cap kicks in: dietician + nurse first
+  // because GI and toxicity are the highest-yield daily channels for
+  // this patient population.
+  const order: AgentId[] = [
+    "nutrition",
+    "toxicity",
+    "rehabilitation",
+    "psychology",
+    "clinical",
+    "treatment",
+  ];
+
+  for (const id of order) {
+    if (out.length >= MAX_CADENCE_PROMPTS_PER_DAY) break;
+    if (!shouldPromptToday(id, dow, inputs.cycleContext)) continue;
+    if (alreadyCoveredToday(id, inputs.todayDaily)) continue;
+    out.push(promptItem(id, inputs.todayISO));
+  }
+
+  return out;
+}
+
+function shouldPromptToday(
+  id: AgentId,
+  dow: number,
+  cycleContext: CycleContext | null,
+): boolean {
+  const voice = AGENT_VOICES[id];
+  const override = shouldPromptOverride({ agentId: id, cycleContext });
+  if (override === true) return true;
+  if (override === null) return false;
+  return voice.weekly_pattern[dow] === true;
+}
+
+// Heuristic: if the patient already produced signal in this discipline's
+// domain today, skip the prompt. Dietician needs meals + (stool OR PERT
+// OR appetite). Nurse needs any toxicity field touched. Physio needs
+// any movement field. Companion needs reflection or practice.
+function alreadyCoveredToday(id: AgentId, today: DailyEntry | null): boolean {
+  if (!today) return false;
+  switch (id) {
+    case "nutrition":
+      return (
+        typeof today.meals_count === "number" &&
+        (typeof today.stool_count === "number" ||
+          typeof today.stool_bristol === "number" ||
+          today.pert_with_meals_today !== undefined)
+      );
+    case "toxicity":
+      return (
+        typeof today.neuropathy_hands === "number" ||
+        typeof today.neuropathy_feet === "number" ||
+        typeof today.diarrhoea_count === "number" ||
+        today.mouth_sores === true ||
+        today.fever === true
+      );
+    case "rehabilitation":
+      return (
+        typeof today.walking_minutes === "number" ||
+        typeof today.steps === "number" ||
+        today.resistance_training === true
+      );
+    case "psychology":
+      return (
+        typeof today.reflection === "string" && today.reflection.length > 0
+      );
+    default:
+      return false;
+  }
+}
+
+function promptItem(id: AgentId, todayISO: string): FeedItem {
+  const voice = AGENT_VOICES[id];
+  return {
+    id: `cadence_${voice.slug}_${todayISO}`,
+    priority: CADENCE_PROMPT_PRIORITY,
+    category: "checkin",
+    tone: "info",
+    title: voice.display_name,
+    body: voice.cadence_prompt,
+    cta: {
+      href: "/log",
+      label: { en: "Tell us", zh: "告诉我们" },
+    },
+    icon: voice.icon,
+    source: `agent_voice:${voice.slug}`,
+  };
+}

--- a/src/lib/nudges/compose.ts
+++ b/src/lib/nudges/compose.ts
@@ -8,13 +8,15 @@ import type { PatientTask, TaskInstance } from "~/types/task";
 import type { CycleContext, NudgeTemplate } from "~/types/treatment";
 import type { CurrentWeather } from "~/lib/weather/open-meteo";
 import type { FeedItem } from "~/types/feed";
-import type { AgentRunRow } from "~/types/agent";
+import type { AgentFollowUpRow, AgentRunRow } from "~/types/agent";
 import { computeTrendNudges } from "./trend-nudges";
 import { computeWeatherNudges } from "./weather-nudges";
 import { computeNutritionNudges } from "./nutrition-nudges";
 import { computeFoodSafetyNudges } from "./food-safety-nudges";
 import { computeChemoBodyFluidNudges } from "./chemo-body-fluid-nudges";
 import { agentRunsToFeedItems } from "./agent-runs";
+import { resurfaceFollowUps } from "./follow-up-resurface";
+import { computeCadencePrompts } from "./cadence-prompts";
 import { getActiveTaskInstances } from "~/lib/tasks/engine";
 
 export interface ComposeInputs {
@@ -27,6 +29,10 @@ export interface ComposeInputs {
   cycleContext: CycleContext | null;
   weather: CurrentWeather | null;
   agentRuns?: AgentRunRow[];
+  // Outstanding multi-day follow-ups across all agents. The composer
+  // filters by `due_at <= today` and ranks them. Pass an empty array
+  // if the caller has no follow-up state yet.
+  followUps?: AgentFollowUpRow[];
 }
 
 export function composeTodayFeed(inputs: ComposeInputs): FeedItem[] {
@@ -101,6 +107,34 @@ export function composeTodayFeed(inputs: ComposeInputs): FeedItem[] {
   if (inputs.agentRuns && inputs.agentRuns.length > 0) {
     feed.push(...agentRunsToFeedItems(inputs.agentRuns));
   }
+
+  // ── 7. Multi-day follow-ups (resurfaced when due) ──────────────────
+  if (inputs.followUps && inputs.followUps.length > 0) {
+    const redActive = inputs.activeAlerts.some(
+      (a) => !a.resolved && a.zone === "red",
+    );
+    feed.push(
+      ...resurfaceFollowUps({
+        todayISO: inputs.todayISO,
+        followUps: inputs.followUps,
+        redZoneActive: redActive,
+      }),
+    );
+  }
+
+  // ── 8. Per-discipline cadence prompts (AI Nurse / Dietician / …) ───
+  // The single channel out gets at most a couple of these per day; the
+  // cadence module suppresses entirely if any red zone alert is active.
+  const todayDaily =
+    inputs.recentDailies.find((d) => d.date === inputs.todayISO) ?? null;
+  feed.push(
+    ...computeCadencePrompts({
+      todayISO: inputs.todayISO,
+      cycleContext: inputs.cycleContext,
+      todayDaily,
+      activeAlerts: inputs.activeAlerts,
+    }),
+  );
 
   // ── Dedupe + sort + cap ────────────────────────────────────────────
   const seen = new Set<string>();

--- a/src/lib/nudges/follow-up-resurface.ts
+++ b/src/lib/nudges/follow-up-resurface.ts
@@ -1,0 +1,69 @@
+import type { AgentFollowUpRow } from "~/types/agent";
+import type { FeedItem } from "~/types/feed";
+import {
+  AGENT_VOICES,
+  FOLLOW_UP_PRIORITY,
+  MAX_FOLLOW_UPS_PER_DAY,
+} from "~/config/agent-cadence";
+
+// Resurfaces matured, unresolved agent follow-ups as ranked feed items.
+// One feed item per follow-up row whose `due_at` ≤ today and whose
+// `resolved_at` is null. Capped via MAX_FOLLOW_UPS_PER_DAY so the feed
+// doesn't get colonised by old questions.
+//
+// The composer is responsible for fetching the rows from Dexie and
+// passing them in — keeps this module pure and trivially testable.
+
+export interface ResurfaceInputs {
+  todayISO: string; // YYYY-MM-DD
+  // All currently-unresolved follow-ups for the household. The function
+  // filters by `due_at <= todayISO` and ranks internally.
+  followUps: AgentFollowUpRow[];
+  // True if any red zone alert is currently active. We still surface
+  // follow-ups when red is on (they're already-promised questions, not
+  // new chatter), but we cap to one to keep the feed quiet.
+  redZoneActive: boolean;
+}
+
+export function resurfaceFollowUps(inputs: ResurfaceInputs): FeedItem[] {
+  const cap = inputs.redZoneActive ? 1 : MAX_FOLLOW_UPS_PER_DAY;
+  const due = inputs.followUps
+    .filter((row) => !row.resolved_at && row.due_at.slice(0, 10) <= inputs.todayISO)
+    // Lower priority number = higher rank; tie-break on earliest due first.
+    .sort((a, b) => {
+      if (a.priority !== b.priority) return a.priority - b.priority;
+      return a.due_at.localeCompare(b.due_at);
+    })
+    .slice(0, cap);
+
+  return due.map((row) => followUpToFeedItem(row));
+}
+
+function followUpToFeedItem(row: AgentFollowUpRow): FeedItem {
+  const voice = AGENT_VOICES[row.agent_id];
+  const titlePrefix = voice.display_name;
+  return {
+    id: `followup_${row.agent_id}_${row.question_key}`,
+    priority: row.priority ?? FOLLOW_UP_PRIORITY,
+    category: "checkin",
+    tone: "info",
+    title: {
+      en: `${titlePrefix.en} · follow-up`,
+      zh: `${titlePrefix.zh} · 回访`,
+    },
+    body: {
+      en: row.reason_en
+        ? `${row.prompt_en} (${row.reason_en})`
+        : row.prompt_en,
+      zh: row.reason_zh
+        ? `${row.prompt_zh}（${row.reason_zh}）`
+        : row.prompt_zh,
+    },
+    cta: {
+      href: "/log",
+      label: { en: "Reply", zh: "回复" },
+    },
+    icon: voice.icon,
+    source: `agent_followup:${row.agent_id}:${row.question_key}`,
+  };
+}

--- a/src/lib/rules/zone-rules.ts
+++ b/src/lib/rules/zone-rules.ts
@@ -27,10 +27,62 @@ function gripDeclinePct(s: ClinicalSnapshot): number | null {
 const latestAlbumin = (s: ClinicalSnapshot): number | undefined =>
   s.recentLabs[s.recentLabs.length - 1]?.albumin;
 
+// Count how many of the last `windowDays` daily entries (most recent
+// first) reported loose stools — Bristol ≥ 6 OR raw count above the
+// yellow threshold OR explicit steatorrhoea/oil flag. Used by the
+// "persistent loose stools" rule below; PERT under-titration usually
+// shows up as 3+ days running rather than a single bad day.
+function loosStoolDayStreak(s: ClinicalSnapshot, windowDays: number): number {
+  const recent = [...s.recentDailies]
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, windowDays);
+  let streak = 0;
+  for (const d of recent) {
+    const looseByBristol =
+      typeof d.stool_bristol === "number" &&
+      d.stool_bristol >= GI.loose_stool_bristol_min;
+    const looseByCount =
+      typeof d.stool_count === "number" &&
+      d.stool_count >= GI.stool_count_yellow;
+    const looseByDiarrhoeaCount =
+      typeof d.diarrhoea_count === "number" &&
+      d.diarrhoea_count >= GI.stool_count_yellow;
+    const looseByOil = d.stool_oil === true || d.steatorrhoea === true;
+    if (looseByBristol || looseByCount || looseByDiarrhoeaCount || looseByOil) {
+      streak += 1;
+    } else if (streak > 0) {
+      // Break the streak on the first non-loose day; we want consecutive
+      // recent days, not "any 3 of the last 5".
+      break;
+    }
+  }
+  return streak;
+}
+
+function constipationDayStreak(
+  s: ClinicalSnapshot,
+  windowDays: number,
+): number {
+  const recent = [...s.recentDailies]
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, windowDays);
+  let streak = 0;
+  for (const d of recent) {
+    const constipated =
+      (typeof d.stool_bristol === "number" &&
+        d.stool_bristol <= GI.constipation_bristol_max) ||
+      (typeof d.stool_count === "number" && d.stool_count === 0);
+    if (constipated) streak += 1;
+    else if (streak > 0) break;
+  }
+  return streak;
+}
+
 const FN = thresholds.function;
 const PSY = thresholds.psychological;
 const NUT = thresholds.nutrition;
 const DIS = thresholds.disease;
+const GI = thresholds.gi;
 
 const MS_PER_DAY = 24 * 3600 * 1000;
 
@@ -291,6 +343,108 @@ export const ZONE_RULES: ZoneRule[] = [
     recommendationZh:
       "下肢力量低。每周 2–3 次抗阻训练，转介肿瘤运动生理学家。",
     suggestedLevers: ["physical.resistance", "physical.exercise_phys"],
+  },
+  {
+    id: "stool_blood_red",
+    name: "Visible blood or black stool",
+    zone: "red",
+    category: "disease",
+    triggersReview: true,
+    evaluator: ({ latestDaily }) =>
+      latestDaily?.stool_blood === true ||
+      latestDaily?.stool_color === "black" ||
+      latestDaily?.stool_color === "red",
+    recommendation:
+      "GI bleed concern — call the oncology line today. Black or red stools require same-day clinical review even if you feel well.",
+    recommendationZh:
+      "疑似消化道出血 —— 请于今日联系肿瘤科。黑便或鲜血便即使感觉良好也需当日就诊。",
+    suggestedLevers: ["emergency.hospital", "intensity.hold"],
+  },
+  {
+    id: "loose_stools_persistent_yellow",
+    name: "Loose stools 3+ days running",
+    zone: "yellow",
+    category: "toxicity",
+    triggersReview: true,
+    evaluator: (s) =>
+      loosStoolDayStreak(s, GI.loose_stool_persistent_orange_days) >=
+        GI.loose_stool_persistent_yellow_days &&
+      loosStoolDayStreak(s, GI.loose_stool_persistent_orange_days) <
+        GI.loose_stool_persistent_orange_days,
+    recommendation:
+      "Persistent loose stools — review PERT (Creon) timing with fatty meals; ensure hydration and electrolytes; raise at next clinic.",
+    recommendationZh:
+      "持续稀便 —— 复核胰酶替代治疗（Creon）与高脂餐的服用时机；确保补液与电解质；下次就诊时提出。",
+    suggestedLevers: ["supportive.pert", "nutrition.dietitian"],
+  },
+  {
+    id: "loose_stools_persistent_orange",
+    name: "Loose stools 5+ days running",
+    zone: "orange",
+    category: "toxicity",
+    triggersReview: true,
+    evaluator: (s) =>
+      loosStoolDayStreak(s, GI.loose_stool_persistent_orange_days * 2) >=
+      GI.loose_stool_persistent_orange_days,
+    recommendation:
+      "Diarrhoea now sustained — call the oncology line for advice on loperamide and fluids. Risk of dehydration, electrolyte loss, and PERT-titration failure.",
+    recommendationZh:
+      "腹泻持续较久 —— 请联系肿瘤科咨询洛哌丁胺与补液方案。需警惕脱水、电解质紊乱及胰酶替代未达标。",
+    suggestedLevers: ["emergency.hospital", "supportive.pert"],
+  },
+  {
+    id: "stool_count_orange",
+    name: "≥7 bowel motions in a day",
+    zone: "orange",
+    category: "toxicity",
+    triggersReview: true,
+    evaluator: ({ latestDaily }) => {
+      const a = latestDaily?.stool_count ?? 0;
+      const b = latestDaily?.diarrhoea_count ?? 0;
+      return Math.max(a, b) >= GI.stool_count_orange;
+    },
+    recommendation:
+      "High-volume diarrhoea (CTCAE grade 2+ territory) — call the oncology line today; assume risk of dehydration and reduced PERT/oral-medication absorption.",
+    recommendationZh:
+      "大量腹泻（CTCAE ≥ 2 级）—— 请于今日联系肿瘤科；考虑脱水及胰酶/口服药吸收下降的风险。",
+    suggestedLevers: ["emergency.hospital", "intensity.hold"],
+  },
+  {
+    id: "steatorrhoea_with_loose_yellow",
+    name: "Oily / floating stools with loose form",
+    zone: "yellow",
+    category: "nutrition",
+    triggersReview: true,
+    evaluator: ({ latestDaily }) => {
+      const oily =
+        latestDaily?.stool_oil === true || latestDaily?.steatorrhoea === true;
+      const loose =
+        (typeof latestDaily?.stool_bristol === "number" &&
+          latestDaily.stool_bristol >= GI.loose_stool_bristol_min) ||
+        (typeof latestDaily?.stool_count === "number" &&
+          latestDaily.stool_count >= GI.stool_count_yellow);
+      return oily && loose;
+    },
+    recommendation:
+      "Steatorrhoea pattern — PERT (Creon) is likely under-dosed for today's fat intake. Confirm dose was taken with the meal, not before or after; raise titration at next clinic.",
+    recommendationZh:
+      "脂肪泻表现 —— 当前胰酶替代治疗（Creon）剂量可能不足。请确认与餐同服，下次就诊时讨论加量。",
+    suggestedLevers: ["supportive.pert", "nutrition.dietitian"],
+  },
+  {
+    id: "constipation_persistent_yellow",
+    name: "Constipation 3+ days running",
+    zone: "yellow",
+    category: "toxicity",
+    triggersReview: true,
+    evaluator: (s) =>
+      constipationDayStreak(s, GI.constipation_yellow_days * 2) >=
+      GI.constipation_yellow_days,
+    recommendation:
+      "Constipation building — common with anti-emetics and opioids. Increase fluids, gentle movement, and review the bowel-care plan with the team if no movement in another day.",
+    recommendationZh:
+      "便秘持续累积 —— 止吐药与镇痛药常见副作用。增加饮水、温和活动；若再无排便请与团队复核肠道方案。",
+    suggestedLevers: ["supportive.laxative", "physical.walking"],
   },
   {
     id: "pending_result_stale_yellow",

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -106,6 +106,27 @@ export interface FollowUpQuestion {
   kind: "numeric" | "yesno" | "text" | "scale_0_10";
 }
 
+// Multi-day follow-up emitted by an agent. Persisted in `agent_followups`
+// and re-surfaced into the unified feed when its `due_at` matures.
+//
+// Shape rules:
+//   - `question_key` must be stable across runs of the same condition so
+//     dedup works (e.g. `nutrition.loose_stools_3d`). Same key with a
+//     later `asked_at` supersedes the earlier row.
+//   - `ask_in_days` is relative to the producing run's `ran_at`. The
+//     run-agents persistence layer turns it into an absolute `due_at`.
+//   - `priority` lets the producer hint the feed renderer; lower number
+//     = higher rank. If absent, the feed defaults to 50 (above gentle
+//     trend nudges, below safety alerts).
+export interface AgentFollowUp {
+  question_key: string;
+  ask_in_days: number;
+  prompt: LocalizedText;
+  // Optional patient-facing one-line reason ("loose stools 3 days running").
+  reason?: LocalizedText;
+  priority?: number;
+}
+
 // Everything a specialist returns on one batch run (a day's referrals or
 // an on-demand invocation). The same shape is used for both the daily
 // scheduled run and an explicit "run now" trigger from the patient or
@@ -118,7 +139,36 @@ export interface AgentOutput {
   filings: DexiePatch[];
   questions: FollowUpQuestion[];
   nudges: FeedItem[];
+  // Optional. Multi-day follow-up loop: each entry becomes one row in
+  // `agent_followups` and re-surfaces in the feed when due. Absent on
+  // older runs / agents that don't emit them.
+  follow_ups?: AgentFollowUp[];
   state_diff: string; // full rewrite of the agent's state.md content
+}
+
+// Persisted follow-up row. One per AgentFollowUp emission; the resurface
+// engine reads this table on every feed compose and includes any row
+// whose due_at <= today and resolved_at is null.
+//
+// Resolution semantics: a follow-up resolves when (a) the same agent
+// emits a fresh row with the same `question_key` (the new row supersedes
+// the old; the old gets resolved_at set), (b) the patient marks it done
+// from the feed, or (c) the rule that triggered it stops being true (the
+// agent omits it on its next run).
+export interface AgentFollowUpRow {
+  id?: number;
+  agent_id: AgentId;
+  question_key: string;
+  asked_at: string;        // when the producing run completed
+  due_at: string;          // when this should resurface (asked_at + ask_in_days)
+  prompt_en: string;
+  prompt_zh: string;
+  reason_en?: string;
+  reason_zh?: string;
+  priority: number;        // lower = higher rank in the feed
+  source_run_id?: number;  // agent_runs.id that emitted this
+  resolved_at?: string;
+  resolved_by?: "agent_supersede" | "patient_acknowledged" | "stale";
 }
 
 // Persisted per-agent state summary (one row per agent).

--- a/src/types/clinical.ts
+++ b/src/types/clinical.ts
@@ -103,6 +103,43 @@ export interface DailyEntry {
   dry_mouth?: boolean;
   early_satiety?: boolean;
   steatorrhoea?: boolean;
+  // Stool / digestive output (v23). Optional — captured only when the
+  // patient touches the Digestion step on the daily wizard or when the
+  // nutrition/toxicity agent files them from a free-text/voice log.
+  // The boolean `steatorrhoea` field above remains a coarse fallback;
+  // these add structure for PERT titration and trend detection.
+  //
+  //   stool_count       — total bowel movements in the past 24 h.
+  //   stool_bristol     — predominant Bristol Stool Scale type (1–7).
+  //                       1–2 = constipation; 3–4 = normal; 5 = soft;
+  //                       6–7 = loose / liquid (PERT under-titration cue).
+  //   stool_urgency     — true if any BM came with urgency / near-incontinence.
+  //   stool_blood       — true for visible red blood, melaena, or black stools.
+  //                       Drives the red-zone GI bleed rule.
+  //   stool_oil         — true for visible oil droplets, oily film, or
+  //                       sticky/floating stool — the specific steatorrhoea
+  //                       signature beyond loose form alone.
+  //   stool_color       — coarse colour bucket. Pale / clay flags biliary
+  //                       obstruction (PDAC-relevant), dark/black flags
+  //                       upper GI bleed.
+  //   pert_with_meals_today — patient-reported PERT (Creon) coverage of
+  //                       the day's fatty meals. "all" = took with every
+  //                       fatty meal; "some" = missed one or more; "none"
+  //                       = took none today; "na" = no fatty meals.
+  stool_count?: number;
+  stool_bristol?: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+  stool_urgency?: boolean;
+  stool_blood?: boolean;
+  stool_oil?: boolean;
+  stool_color?:
+    | "normal"
+    | "pale"
+    | "yellow"
+    | "green"
+    | "dark"
+    | "black"
+    | "red";
+  pert_with_meals_today?: "all" | "some" | "none" | "na";
   reflection?: string;
   reflection_lang?: Locale;
   protein_grams?: number;

--- a/tests/unit/follow-up-resurface.test.ts
+++ b/tests/unit/follow-up-resurface.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import { resurfaceFollowUps } from "~/lib/nudges/follow-up-resurface";
+import { computeCadencePrompts } from "~/lib/nudges/cadence-prompts";
+import {
+  AGENT_VOICES,
+  MAX_FOLLOW_UPS_PER_DAY,
+  MAX_CADENCE_PROMPTS_PER_DAY,
+} from "~/config/agent-cadence";
+import type { AgentFollowUpRow } from "~/types/agent";
+import type { ZoneAlert } from "~/types/clinical";
+
+function fu(
+  i: number,
+  overrides: Partial<AgentFollowUpRow> = {},
+): AgentFollowUpRow {
+  return {
+    id: i,
+    agent_id: "nutrition",
+    question_key: `q${i}`,
+    asked_at: "2026-04-29T07:00:00.000Z",
+    due_at: "2026-05-01T07:00:00.000Z",
+    prompt_en: `q${i} prompt`,
+    prompt_zh: `q${i} 提示`,
+    priority: 40,
+    ...overrides,
+  };
+}
+
+describe("resurfaceFollowUps", () => {
+  it("surfaces follow-ups whose due_at <= today", () => {
+    const items = resurfaceFollowUps({
+      todayISO: "2026-05-01",
+      followUps: [fu(1)],
+      redZoneActive: false,
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id).toBe("followup_nutrition_q1");
+    expect(items[0]?.title.en).toContain(AGENT_VOICES.nutrition.display_name.en);
+  });
+
+  it("hides follow-ups not yet due", () => {
+    const items = resurfaceFollowUps({
+      todayISO: "2026-04-30",
+      followUps: [fu(1)],
+      redZoneActive: false,
+    });
+    expect(items).toHaveLength(0);
+  });
+
+  it("hides resolved follow-ups", () => {
+    const items = resurfaceFollowUps({
+      todayISO: "2026-05-01",
+      followUps: [
+        fu(1, { resolved_at: "2026-04-30T00:00:00Z" }),
+      ],
+      redZoneActive: false,
+    });
+    expect(items).toHaveLength(0);
+  });
+
+  it("caps at MAX_FOLLOW_UPS_PER_DAY when no red zone", () => {
+    const many = Array.from({ length: 10 }, (_, i) => fu(i));
+    const items = resurfaceFollowUps({
+      todayISO: "2026-05-01",
+      followUps: many,
+      redZoneActive: false,
+    });
+    expect(items).toHaveLength(MAX_FOLLOW_UPS_PER_DAY);
+  });
+
+  it("caps to 1 when red zone is active", () => {
+    const many = Array.from({ length: 5 }, (_, i) => fu(i));
+    const items = resurfaceFollowUps({
+      todayISO: "2026-05-01",
+      followUps: many,
+      redZoneActive: true,
+    });
+    expect(items).toHaveLength(1);
+  });
+
+  it("ranks by priority then earliest due", () => {
+    const items = resurfaceFollowUps({
+      todayISO: "2026-05-01",
+      followUps: [
+        fu(1, { priority: 50, due_at: "2026-04-30T07:00:00Z" }),
+        fu(2, { priority: 30, due_at: "2026-04-29T07:00:00Z" }),
+        fu(3, { priority: 30, due_at: "2026-04-28T07:00:00Z" }),
+      ],
+      redZoneActive: false,
+    });
+    expect(items.map((i) => i.id)).toEqual([
+      "followup_nutrition_q3",
+      "followup_nutrition_q2",
+      "followup_nutrition_q1",
+    ]);
+  });
+
+  it("renders the reason in body when present", () => {
+    const items = resurfaceFollowUps({
+      todayISO: "2026-05-01",
+      followUps: [
+        fu(1, {
+          prompt_en: "How are stools today?",
+          prompt_zh: "今日排便如何？",
+          reason_en: "loose 3 days running",
+          reason_zh: "稀便已 3 天",
+        }),
+      ],
+      redZoneActive: false,
+    });
+    expect(items[0]?.body.en).toContain("loose 3 days running");
+    expect(items[0]?.body.zh).toContain("稀便已 3 天");
+  });
+});
+
+describe("computeCadencePrompts", () => {
+  function redAlert(): ZoneAlert {
+    return {
+      rule_id: "fever",
+      rule_name: "Fever",
+      zone: "red",
+      category: "toxicity",
+      triggered_at: "2026-05-01T07:00:00Z",
+      resolved: false,
+      acknowledged: false,
+      recommendation: "Hospital",
+      recommendation_zh: "",
+      suggested_levers: [],
+      created_at: "2026-05-01T07:00:00Z",
+      updated_at: "2026-05-01T07:00:00Z",
+    };
+  }
+
+  it("emits the dietician prompt on a daily-cadence day", () => {
+    // 2026-05-01 = Friday → dietician daily, nurse Mon/Wed/Fri (Fri = true).
+    const items = computeCadencePrompts({
+      todayISO: "2026-05-01",
+      cycleContext: null,
+      todayDaily: null,
+      activeAlerts: [],
+    });
+    expect(items.some((i) => i.source === "agent_voice:dietician")).toBe(true);
+  });
+
+  it("suppresses everything when a red zone is active", () => {
+    const items = computeCadencePrompts({
+      todayISO: "2026-05-01",
+      cycleContext: null,
+      todayDaily: null,
+      activeAlerts: [redAlert()],
+    });
+    expect(items).toHaveLength(0);
+  });
+
+  it("caps at MAX_CADENCE_PROMPTS_PER_DAY", () => {
+    const items = computeCadencePrompts({
+      todayISO: "2026-05-01",
+      cycleContext: null,
+      todayDaily: null,
+      activeAlerts: [],
+    });
+    expect(items.length).toBeLessThanOrEqual(MAX_CADENCE_PROMPTS_PER_DAY);
+  });
+
+  it("skips the dietician when meals + stool already logged today", () => {
+    const items = computeCadencePrompts({
+      todayISO: "2026-05-01",
+      cycleContext: null,
+      todayDaily: {
+        date: "2026-05-01",
+        entered_at: "2026-05-01T07:00:00Z",
+        entered_by: "hulin",
+        meals_count: 3,
+        stool_count: 2,
+        stool_bristol: 4,
+        created_at: "2026-05-01T07:00:00Z",
+        updated_at: "2026-05-01T07:00:00Z",
+      },
+      activeAlerts: [],
+    });
+    expect(items.some((i) => i.source === "agent_voice:dietician")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds end-to-end digestive logging (Bristol scale, count, urgency, oil, colour, blood, PERT-with-meals coverage) on the daily wizard, plus a discipline-cadenced **follow-up engine** so the **AI Dietician / AI Nurse / AI Physio** can proactively re-check signals across days without piling on the feed.

This is **Option B** from the planning conversation — full schema + agent reasoning + cadence engine, no UX reframe yet (chat-style threading deferred to a later PR).

## Why

Pancreatic cancer + GnP makes stool form / frequency / oil content / colour the single most informative signal for PERT (Creon) titration, and the platform had nothing structured for it (only a `diarrhoea_count` integer and a `steatorrhoea` boolean). It also had no way for an agent to say "ask again in two days" — every prompt was a one-shot per daily run.

## What changed

### Schema
- `DailyEntry` gains `stool_count`, `stool_bristol` (1–7), `stool_urgency`, `stool_oil`, `stool_blood`, `stool_color`, `pert_with_meals_today`.
- New `AgentFollowUp` (emitted by agents) and `AgentFollowUpRow` (persisted) types; `AgentOutput.follow_ups[]` added to the Zod schema.
- Dexie **v23** adds `agent_followups` (compound `[agent_id+question_key]` index for supersede semantics; `due_at` indexed for the matured-rows query).

### Engine
- `src/config/agent-cadence.ts` — per-discipline display names (AI Dietician / AI Nurse / AI Physio / AI Companion), weekly cadence patterns, and a nadir-window override that boosts toxicity + nutrition to **daily during cycle days 7–14**.
- `src/lib/nudges/follow-up-resurface.ts` — resurfaces matured, unresolved follow-ups; capped at **3/day**, **1/day under red zone**.
- `src/lib/nudges/cadence-prompts.ts` — emits per-discipline check-in items; capped at **2/day**, suppressed entirely when any red zone alert is active, skipped when the patient already produced signal in that discipline today.
- `src/lib/log/run-agents.ts` persists follow-ups with **supersede-by-question_key** so an agent can safely re-emit each run while a condition persists; the older row is auto-resolved.

### Zone rules (GI)
- `stool_blood_red` — visible blood / black / red stool → **red**, GI bleed.
- `loose_stools_persistent_yellow` / `_orange` — 3+ / 5+ consecutive days.
- `stool_count_orange` — ≥7 BMs in a day (CTCAE grade 2 territory).
- `steatorrhoea_with_loose_yellow` — oily + Bristol ≥6 → PERT under-titration.
- `constipation_persistent_yellow` — 3+ days Bristol ≤2 / count 0.

### Agent voices
- `nutrition/role.md` → **AI Dietician**, owns end-to-end stool reasoning and PERT-titration consequence; emits multi-day follow-ups (capped at 2 active per agent).
- `toxicity/role.md` → **AI Nurse**, owns CTCAE GI grading + red flag for blood / melaena; same follow-up pattern; cadence boosted in nadir.
- `agent-runs.ts` feed renderer uses `AGENT_VOICES` display names so daily reports surface as "AI Dietician" etc. instead of generic "Nutrition".

### UI — Digestion step on daily wizard
Adds a new **Digestion** step (CLAUDE.md-compliant: not a new top-level screen, just a wizard step):

- Numeric BM count
- 7-button Bristol picker with bilingual labels (硬块 / 成块 / 条裂 / 光滑 / 软 / 糊状 / 水样)
- Urgency / oil / blood toggles
- Colour pill row (brown / pale / yellow / green / dark / black / red)
- PERT coverage radio (every fatty meal / missed some / none today / no fatty meals)

### Tagging
- `log/tag.ts` learns stool / Bristol / oily / black-stool / blood keywords (en + zh) so free-text and voice logs route to nutrition + toxicity agents.

## Architectural alignment

- **Single channel in:** stool data is captured via the existing `/log` (free-text, voice, photo) AND the existing daily wizard — no new patient-facing top-level screen.
- **Single channel out:** every new signal becomes a feed item ranked alongside existing items. Discipline cadence prompts and follow-ups go into the same channel as zone alerts and trend nudges.
- **Hidden super-brain:** new follow-up engine and cadence config are pure-function modules behind the existing agent runner. No new UI surfaces for the patient.
- **Tone:** "AI Nurse" / "AI Dietician" naming follows CLAUDE.md's measured, respectful voice — no avatars, no personas, no cheerful language.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no warnings or errors
- [x] `pnpm test` — **815/815 pass** (11 new tests in `tests/unit/follow-up-resurface.test.ts` covering due-date filtering, resolved hiding, daily caps, red-zone suppression, priority ordering, reason rendering, and dietician-skip when meals + stool already logged today)
- [ ] Manual smoke: open `/daily/new`, pick the new "Digestion" card, walk through Bristol + flags, confirm `daily_entries` row carries the new fields
- [ ] Manual smoke: enter free-text "had three watery stools today, oily" via `/log`, confirm fan-out to nutrition + toxicity, then verify a follow-up row appears in `agent_followups` after the agent runs

## Deliberately out of scope (follow-up PRs)

- **Chat-style threaded persona UI** (Option C from the planning convo) — deferred. The follow-up substrate built here is what threading would sit on top of.
- **Cycle-aware cadence in the cron** — `morning-digest/route.ts` doesn't yet trigger agent runs by discipline cadence; it only fans out push notifications. Cadence prompts surface in the feed today; pushing a per-discipline notification on cadence days is a separate piece.
- **Migration for existing `diarrhoea_count` rows** — both old and new fields are read by zone rules in parallel; no backfill needed.

https://claude.ai/code/session_01UZu1c3M2RX5zi4G2nSZuCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZu1c3M2RX5zi4G2nSZuCr)_