### PR TITLE
GI trends section on /nutrition (Bristol 28d, BMs/day, PERT coverage)

### DIFF
--- a/src/app/nutrition/page.tsx
+++ b/src/app/nutrition/page.tsx
@@ -12,6 +12,7 @@ import { HydrationCard } from "~/components/nutrition/hydration-card";
 import { MealTimeline } from "~/components/nutrition/meal-timeline";
 import { MealList } from "~/components/nutrition/meal-list";
 import { WeeklySummary } from "~/components/nutrition/weekly-summary";
+import { GiTrendsSection } from "~/components/nutrition/gi-trends-section";
 
 export default function NutritionPage() {
   const locale = useLocale();
@@ -56,6 +57,8 @@ export default function NutritionPage() {
       </section>
 
       <WeeklySummary />
+
+      <GiTrendsSection />
 
       <section className="grid gap-2 sm:grid-cols-2">
         <Link href="/nutrition/foods" className="a-row dense group justify-between">

--- a/src/components/nutrition/gi-trends-section.tsx
+++ b/src/components/nutrition/gi-trends-section.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useMemo } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { db } from "~/lib/db/dexie";
+import { todayISO } from "~/lib/utils/date";
+import { useLocale } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
+import { Sparkline } from "~/components/ui/sparkline";
+import { TrendChart } from "~/components/charts/trend-chart";
+import {
+  buildGiSeries,
+  summariseGiSeries,
+} from "~/lib/calculations/gi-trends";
+
+const SHORT_WINDOW = 7;
+const LONG_WINDOW = 28;
+
+// AI Dietician's analytical surface for end-to-end input → output.
+// Renders nothing until at least one day in the 28-day window has any
+// GI signal, so the section quietly stays out of the way for users who
+// haven't started filling stool fields yet.
+export function GiTrendsSection() {
+  const locale = useLocale();
+  const today = todayISO();
+
+  const recent = useLiveQuery(async () => {
+    const start = isoDaysAgo(LONG_WINDOW - 1);
+    return db.daily_entries.where("date").between(start, today, true, true).toArray();
+  }, [today]);
+
+  const series28 = useMemo(
+    () => buildGiSeries(recent ?? [], today, LONG_WINDOW),
+    [recent, today],
+  );
+  const series7 = useMemo(
+    () => series28.slice(-SHORT_WINDOW),
+    [series28],
+  );
+  const summary7 = useMemo(() => summariseGiSeries(series7), [series7]);
+
+  if (recent === undefined) return null;
+  if (summary7.days_with_data === 0) return null;
+
+  const bristolPoints = series28.map((g) => ({
+    date: g.date.slice(5), // MM-DD
+    value: g.bristol,
+  }));
+  const countValues = series7.map((g) => g.count ?? 0);
+
+  return (
+    <Card>
+      <CardContent className="space-y-4">
+        <header className="flex items-baseline justify-between">
+          <h2 className="eyebrow">
+            {locale === "zh" ? "消化趋势" : "Digestion trends"}
+          </h2>
+          <span className="mono text-[10px] text-ink-400">
+            {locale === "zh" ? "近 28 天" : "Last 28d"}
+          </span>
+        </header>
+
+        {/* Summary tiles */}
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <Tile
+            label={locale === "zh" ? "排便/日 (7d)" : "BMs/day (7d)"}
+            value={
+              summary7.count_avg !== null
+                ? summary7.count_avg.toFixed(1)
+                : "—"
+            }
+            tone={
+              summary7.count_avg !== null && summary7.count_avg >= 4
+                ? "warn"
+                : "default"
+            }
+          />
+          <Tile
+            label={locale === "zh" ? "Bristol 主形态" : "Bristol mode"}
+            value={
+              summary7.bristol_mode !== null
+                ? bristolLabel(summary7.bristol_mode, locale)
+                : "—"
+            }
+            tone={
+              summary7.bristol_mode !== null &&
+              (summary7.bristol_mode <= 2 || summary7.bristol_mode >= 6)
+                ? "warn"
+                : "default"
+            }
+          />
+          <Tile
+            label={locale === "zh" ? "胰酶覆盖率" : "PERT coverage"}
+            value={
+              summary7.pert_coverage !== null
+                ? `${Math.round(summary7.pert_coverage * 100)}%`
+                : "—"
+            }
+            tone={
+              summary7.pert_coverage !== null && summary7.pert_coverage < 0.7
+                ? "warn"
+                : "default"
+            }
+          />
+          <Tile
+            label={locale === "zh" ? "油脂便天数" : "Oil/film days"}
+            value={String(summary7.oil_days)}
+            tone={summary7.oil_days >= 2 ? "warn" : "default"}
+          />
+        </div>
+
+        {/* 28-day Bristol scatter — domain pinned to 1–7 with normal band */}
+        <div className="relative">
+          <TrendChart
+            data={bristolPoints}
+            label={
+              locale === "zh"
+                ? "Bristol 排便形态 · 28 天"
+                : "Bristol stool form · 28d"
+            }
+            domain={[1, 7]}
+          />
+          <div className="px-4 pb-4 pt-1 text-[10.5px] text-ink-400">
+            {locale === "zh"
+              ? "1–2 便秘 · 3–5 正常区间 · 6–7 稀便"
+              : "1–2 constipated · 3–5 normal band · 6–7 loose"}
+          </div>
+        </div>
+
+        {/* 7-day count sparkline */}
+        <div className="flex items-center justify-between gap-3 rounded-md bg-paper-2/60 p-3">
+          <div className="min-w-0">
+            <div className="text-[12px] font-medium text-ink-900">
+              {locale === "zh"
+                ? "排便次数 · 近 7 天"
+                : "Bowel motions · last 7d"}
+            </div>
+            <div className="mt-0.5 text-[11px] text-ink-500">
+              {summary7.loose_streak > 0
+                ? locale === "zh"
+                  ? `稀便连续 ${summary7.loose_streak} 天`
+                  : `Loose ${summary7.loose_streak} day${summary7.loose_streak === 1 ? "" : "s"} running`
+                : locale === "zh"
+                  ? "未见连续稀便"
+                  : "No loose streak"}
+            </div>
+          </div>
+          <Sparkline values={countValues} width={140} height={36} showDots />
+        </div>
+
+        {/* Footer flags row */}
+        {(summary7.urgency_days > 0 || summary7.blood_days > 0) && (
+          <div className="flex flex-wrap gap-2 text-[11px] text-ink-500">
+            {summary7.urgency_days > 0 && (
+              <Flag>
+                {locale === "zh"
+                  ? `急便 ${summary7.urgency_days} 天 (7d)`
+                  : `Urgency ${summary7.urgency_days}d (7d)`}
+              </Flag>
+            )}
+            {summary7.blood_days > 0 && (
+              <Flag tone="warn">
+                {locale === "zh"
+                  ? `血便/黑便 ${summary7.blood_days} 天 (7d) — 请联系团队`
+                  : `Blood/black ${summary7.blood_days}d (7d) — call the team`}
+              </Flag>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Tile({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone: "default" | "warn";
+}) {
+  return (
+    <div
+      className={
+        "rounded-md border bg-paper-2/60 p-2.5 " +
+        (tone === "warn"
+          ? "border-[var(--warn)]/40"
+          : "border-ink-100")
+      }
+    >
+      <div className="mono text-[9.5px] uppercase tracking-wider text-ink-400">
+        {label}
+      </div>
+      <div
+        className={
+          "mt-0.5 text-[15px] tabular-nums " +
+          (tone === "warn" ? "text-[var(--warn)]" : "text-ink-900")
+        }
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function Flag({
+  children,
+  tone,
+}: {
+  children: React.ReactNode;
+  tone?: "warn";
+}) {
+  return (
+    <span
+      className={
+        "rounded-full border px-2 py-0.5 " +
+        (tone === "warn"
+          ? "border-[var(--warn)]/40 bg-[var(--warn-soft)] text-[var(--warn)]"
+          : "border-ink-100 bg-paper-2")
+      }
+    >
+      {children}
+    </span>
+  );
+}
+
+function bristolLabel(n: number, locale: string): string {
+  const en = ["", "Hard", "Lumpy", "Cracked", "Smooth", "Soft", "Mushy", "Liquid"];
+  const zh = ["", "硬块", "成块", "条裂", "光滑", "软", "糊状", "水样"];
+  const arr = locale === "zh" ? zh : en;
+  return `${n} · ${arr[n] ?? ""}`;
+}
+
+function isoDaysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/src/lib/calculations/gi-trends.ts
+++ b/src/lib/calculations/gi-trends.ts
@@ -1,0 +1,201 @@
+import type { DailyEntry } from "~/types/clinical";
+
+// Pure trend calculators for the GI / digestive surface. Take a slice
+// of daily_entries (chronological order doesn't matter — the helpers
+// sort defensively) and return summary numbers / series the dashboard
+// can drop straight into TrendChart, Sparkline, and tile components.
+//
+// Why this lives separately from `~/lib/calculations/trends.ts`:
+// trends.ts is generic-numeric (movingAverage, percentChange,
+// linearSlope). GI-specific aggregations need to handle the new
+// optional fields with care — preferring `stool_count` over the older
+// `diarrhoea_count`, treating `stool_oil` || `steatorrhoea` as the
+// same signal, and folding `pert_with_meals_today` into a coverage
+// rate. Keeping that domain logic out of the generic helpers keeps
+// trends.ts cheap and testable.
+
+export interface GiDay {
+  date: string;            // YYYY-MM-DD
+  count: number | null;    // BMs (stool_count, falling back to diarrhoea_count)
+  bristol: number | null;  // 1–7 or null
+  oil: boolean;
+  urgency: boolean;
+  blood: boolean;
+  pert?: NonNullable<DailyEntry["pert_with_meals_today"]>;
+}
+
+export interface GiSummary {
+  // Days with any GI signal (count, bristol, oil, urgency, blood, pert).
+  // Used to decide whether to render the section at all.
+  days_with_data: number;
+  // Mean BMs/day across days where a count was recorded. null if the
+  // window has no count data.
+  count_avg: number | null;
+  // Predominant Bristol type across days where it was recorded. null if none.
+  bristol_mode: number | null;
+  // Number of days flagged steatorrhoea-like (oil or older `steatorrhoea`).
+  oil_days: number;
+  // Number of days the patient flagged urgency.
+  urgency_days: number;
+  // Number of days flagged blood / black stool. Should always trigger the
+  // red zone rule too — surfaced here only as a count for the dashboard.
+  blood_days: number;
+  // PERT coverage: fraction in [0,1] of days where the patient said they
+  // took PERT with every fatty meal, out of days where pert_with_meals_today
+  // was set AND not "na" (no fatty meals). null if no eligible days.
+  pert_coverage: number | null;
+  // Current consecutive loose-stool day streak (most recent day backwards).
+  // Loose = Bristol ≥ 6 OR count ≥ 4 OR oil flag.
+  loose_streak: number;
+}
+
+const LOOSE_BRISTOL = 6;
+const LOOSE_COUNT = 4;
+
+// Project a DailyEntry into the lean GiDay shape. Older entries that
+// only filled `diarrhoea_count` still contribute to `count`.
+export function projectGiDay(d: DailyEntry): GiDay {
+  const stool = typeof d.stool_count === "number" ? d.stool_count : null;
+  const diarrhoea =
+    typeof d.diarrhoea_count === "number" ? d.diarrhoea_count : null;
+  return {
+    date: d.date,
+    count: stool ?? diarrhoea,
+    bristol: typeof d.stool_bristol === "number" ? d.stool_bristol : null,
+    oil: d.stool_oil === true || d.steatorrhoea === true,
+    urgency: d.stool_urgency === true,
+    blood: d.stool_blood === true,
+    pert: d.pert_with_meals_today,
+  };
+}
+
+function hasAnyGiSignal(g: GiDay): boolean {
+  return (
+    g.count !== null ||
+    g.bristol !== null ||
+    g.oil ||
+    g.urgency ||
+    g.blood ||
+    g.pert !== undefined
+  );
+}
+
+// Most recent N days of GI projections, oldest → newest. Days without
+// a daily_entry row are emitted as null-filled placeholders so charts
+// can show the full window with gaps.
+export function buildGiSeries(
+  entries: readonly DailyEntry[],
+  todayISO: string,
+  days: number,
+): GiDay[] {
+  const byDate = new Map<string, GiDay>();
+  for (const e of entries) byDate.set(e.date, projectGiDay(e));
+
+  const out: GiDay[] = [];
+  const today = parseIsoDate(todayISO);
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setUTCDate(d.getUTCDate() - i);
+    const iso = isoFromDate(d);
+    out.push(
+      byDate.get(iso) ?? {
+        date: iso,
+        count: null,
+        bristol: null,
+        oil: false,
+        urgency: false,
+        blood: false,
+      },
+    );
+  }
+  return out;
+}
+
+export function summariseGiSeries(series: readonly GiDay[]): GiSummary {
+  const withData = series.filter(hasAnyGiSignal);
+
+  const counts = series
+    .map((g) => g.count)
+    .filter((v): v is number => typeof v === "number");
+  const count_avg =
+    counts.length > 0
+      ? round1(counts.reduce((s, v) => s + v, 0) / counts.length)
+      : null;
+
+  const bristol_mode = mode(
+    series
+      .map((g) => g.bristol)
+      .filter((v): v is number => typeof v === "number"),
+  );
+
+  const oil_days = series.filter((g) => g.oil).length;
+  const urgency_days = series.filter((g) => g.urgency).length;
+  const blood_days = series.filter((g) => g.blood).length;
+
+  const pertEligible = series.filter(
+    (g) => g.pert !== undefined && g.pert !== "na",
+  );
+  const pert_coverage =
+    pertEligible.length > 0
+      ? pertEligible.filter((g) => g.pert === "all").length /
+        pertEligible.length
+      : null;
+
+  // Loose-stool streak: walk most-recent → oldest until a non-loose day
+  // breaks the chain. A day with no GI data is treated as a break.
+  let loose_streak = 0;
+  for (let i = series.length - 1; i >= 0; i--) {
+    const g = series[i]!;
+    if (!isLooseDay(g)) break;
+    loose_streak += 1;
+  }
+
+  return {
+    days_with_data: withData.length,
+    count_avg,
+    bristol_mode,
+    oil_days,
+    urgency_days,
+    blood_days,
+    pert_coverage,
+    loose_streak,
+  };
+}
+
+function isLooseDay(g: GiDay): boolean {
+  if (g.bristol !== null && g.bristol >= LOOSE_BRISTOL) return true;
+  if (g.count !== null && g.count >= LOOSE_COUNT) return true;
+  if (g.oil) return true;
+  return false;
+}
+
+function mode(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const counts = new Map<number, number>();
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+  let best: number | null = null;
+  let bestCount = -1;
+  for (const [v, c] of counts) {
+    if (c > bestCount) {
+      best = v;
+      bestCount = c;
+    }
+  }
+  return best;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+function parseIsoDate(iso: string): Date {
+  // Use UTC noon to avoid DST edge cases shifting the date.
+  return new Date(iso + "T12:00:00.000Z");
+}
+
+function isoFromDate(d: Date): string {
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/tests/unit/gi-trends-calc.test.ts
+++ b/tests/unit/gi-trends-calc.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildGiSeries,
+  projectGiDay,
+  summariseGiSeries,
+} from "~/lib/calculations/gi-trends";
+import type { DailyEntry } from "~/types/clinical";
+
+function entry(date: string, overrides: Partial<DailyEntry> = {}): DailyEntry {
+  return {
+    date,
+    entered_at: `${date}T07:00:00Z`,
+    entered_by: "hulin",
+    created_at: `${date}T07:00:00Z`,
+    updated_at: `${date}T07:00:00Z`,
+    ...overrides,
+  };
+}
+
+describe("projectGiDay", () => {
+  it("prefers stool_count over diarrhoea_count", () => {
+    const g = projectGiDay(
+      entry("2026-05-01", { stool_count: 2, diarrhoea_count: 5 }),
+    );
+    expect(g.count).toBe(2);
+  });
+
+  it("falls back to diarrhoea_count when stool_count is undefined", () => {
+    const g = projectGiDay(entry("2026-05-01", { diarrhoea_count: 4 }));
+    expect(g.count).toBe(4);
+  });
+
+  it("merges stool_oil and legacy steatorrhoea into a single oil flag", () => {
+    expect(projectGiDay(entry("2026-05-01", { stool_oil: true })).oil).toBe(true);
+    expect(projectGiDay(entry("2026-05-01", { steatorrhoea: true })).oil).toBe(
+      true,
+    );
+    expect(projectGiDay(entry("2026-05-01")).oil).toBe(false);
+  });
+});
+
+describe("buildGiSeries", () => {
+  it("emits oldest-to-newest with placeholder rows for missing days", () => {
+    const series = buildGiSeries(
+      [entry("2026-05-01", { stool_count: 3 })],
+      "2026-05-03",
+      3,
+    );
+    expect(series.map((g) => g.date)).toEqual([
+      "2026-05-01",
+      "2026-05-02",
+      "2026-05-03",
+    ]);
+    expect(series[0]?.count).toBe(3);
+    expect(series[1]?.count).toBe(null);
+    expect(series[2]?.count).toBe(null);
+  });
+});
+
+describe("summariseGiSeries", () => {
+  function buildAndSummarise(rows: DailyEntry[], todayISO: string, days: number) {
+    return summariseGiSeries(buildGiSeries(rows, todayISO, days));
+  }
+
+  it("counts days with any GI signal", () => {
+    const s = buildAndSummarise(
+      [
+        entry("2026-05-01", { stool_count: 2 }),
+        entry("2026-05-02"), // no signal
+        entry("2026-05-03", { stool_oil: true }),
+      ],
+      "2026-05-03",
+      3,
+    );
+    expect(s.days_with_data).toBe(2);
+  });
+
+  it("computes count_avg only over days with a number", () => {
+    const s = buildAndSummarise(
+      [
+        entry("2026-05-01", { stool_count: 2 }),
+        entry("2026-05-02", { stool_count: 4 }),
+        entry("2026-05-03"), // skipped
+      ],
+      "2026-05-03",
+      3,
+    );
+    expect(s.count_avg).toBe(3);
+  });
+
+  it("returns null count_avg when no days had a count", () => {
+    const s = buildAndSummarise(
+      [entry("2026-05-01", { stool_oil: true })],
+      "2026-05-01",
+      1,
+    );
+    expect(s.count_avg).toBe(null);
+  });
+
+  it("returns the predominant Bristol type as the mode", () => {
+    const s = buildAndSummarise(
+      [
+        entry("2026-05-01", { stool_bristol: 4 }),
+        entry("2026-05-02", { stool_bristol: 4 }),
+        entry("2026-05-03", { stool_bristol: 6 }),
+      ],
+      "2026-05-03",
+      3,
+    );
+    expect(s.bristol_mode).toBe(4);
+  });
+
+  it("computes PERT coverage ignoring no-fatty-meal days", () => {
+    const s = buildAndSummarise(
+      [
+        entry("2026-05-01", { pert_with_meals_today: "all" }),
+        entry("2026-05-02", { pert_with_meals_today: "some" }),
+        entry("2026-05-03", { pert_with_meals_today: "na" }), // excluded
+      ],
+      "2026-05-03",
+      3,
+    );
+    expect(s.pert_coverage).toBe(0.5);
+  });
+
+  it("returns null pert_coverage when no eligible days", () => {
+    const s = buildAndSummarise(
+      [entry("2026-05-01", { pert_with_meals_today: "na" })],
+      "2026-05-01",
+      1,
+    );
+    expect(s.pert_coverage).toBe(null);
+  });
+
+  it("counts a loose streak from the most recent day backwards", () => {
+    const s = buildAndSummarise(
+      [
+        entry("2026-05-01", { stool_bristol: 4 }),       // not loose
+        entry("2026-05-02", { stool_bristol: 6 }),       // loose
+        entry("2026-05-03", { stool_count: 5 }),         // loose by count
+        entry("2026-05-04", { stool_oil: true }),        // loose by oil
+      ],
+      "2026-05-04",
+      4,
+    );
+    expect(s.loose_streak).toBe(3);
+  });
+
+  it("breaks the loose streak on a missing day", () => {
+    const s = buildAndSummarise(
+      [
+        entry("2026-05-01", { stool_bristol: 6 }),
+        entry("2026-05-02", { stool_bristol: 7 }),
+        // 2026-05-03 has no entry — counts as a break
+        entry("2026-05-04", { stool_bristol: 6 }),
+      ],
+      "2026-05-04",
+      4,
+    );
+    expect(s.loose_streak).toBe(1);
+  });
+
+  it("counts oil / urgency / blood days independently", () => {
+    const s = buildAndSummarise(
+      [
+        entry("2026-05-01", { stool_oil: true, stool_urgency: true }),
+        entry("2026-05-02", { stool_blood: true }),
+        entry("2026-05-03"),
+      ],
+      "2026-05-03",
+      3,
+    );
+    expect(s.oil_days).toBe(1);
+    expect(s.urgency_days).toBe(1);
+    expect(s.blood_days).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an analytical **Digestion trends** section to `/nutrition` that surfaces the new GI fields shipped with #153 — Bristol form, BM count, PERT coverage, oil/urgency/blood days, and a current loose-stool streak.

The section is hidden until at least one day in the 28-day window carries any GI signal, so it stays quiet for users who haven't started filling stool fields yet.

## What it shows

- **Four summary tiles (7d window):** BMs/day average · predominant Bristol type · PERT coverage rate · oil-film day count. Each tile flips to a warn tone when its threshold is crossed (count ≥ 4, Bristol ≤ 2 or ≥ 6, PERT < 70 %, oil ≥ 2 days).
- **28-day Bristol stool-form trend chart** (recharts `TrendChart`), domain pinned to 1–7 with a footnote spelling out the normal band 3–5.
- **7-day BM-count sparkline** plus a current loose-streak readout ("Loose 3 days running").
- **Flag row** (urgency / blood days) — only renders when something is flagged.

Bilingual zh-CN + en throughout.

## Implementation

- `src/lib/calculations/gi-trends.ts` — pure `projectGiDay` / `buildGiSeries` / `summariseGiSeries`. Prefers `stool_count` over `diarrhoea_count` for back-compat with rows captured pre-#153; merges `stool_oil` and the legacy `steatorrhoea` boolean into one oil flag; PERT coverage excludes `"na"` (no fatty meals) days from the denominator.
- `src/components/nutrition/gi-trends-section.tsx` — UI. Uses the existing `TrendChart` and `Sparkline` primitives, no new charting infrastructure.
- `src/app/nutrition/page.tsx` — renders the new section after `WeeklySummary`.

## Architectural alignment

- **No new top-level patient screen.** The section lives inside `/nutrition`, which CLAUDE.md categorises as a desktop-first analytical surface. The AI Dietician already owns end-to-end input → output per its updated role.md (#153).
- **Pure calculators, no Dexie dependency** in the calc module — trivially testable, no fakeIndexedDB needed.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no warnings or errors
- [x] `pnpm test` — **828/828 pass** (13 new tests in `tests/unit/gi-trends-calc.test.ts` covering field preference, oil-flag merge, placeholder days, count averaging, Bristol mode, PERT coverage with `na` exclusion, loose-streak walking with day-gap break, and urgency/blood/oil-day independence)
- [ ] Manual smoke: log a few days of stool data via the daily wizard, confirm tiles populate, chart shows Bristol points, sparkline reflects counts, and the section disappears when entries are removed
- [ ] Manual smoke: confirm Vercel preview renders correctly on mobile widths (the recharts container is `ResponsiveContainer` so it should reflow)

## Out of scope

- Push notifications on cadence days — deferred until the cadence engine has run for a couple of weeks and we're sure the in-feed surfacing tone is right.
- Option C threaded persona UI — substrate ships with #153, presentation layer still deferred.

https://claude.ai/code/session_01UZu1c3M2RX5zi4G2nSZuCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZu1c3M2RX5zi4G2nSZuCr)_