### PR TITLE
Coverage engine: calm gap detector for daily logging

### DIFF
--- a/src/components/daily/daily-wizard.tsx
+++ b/src/components/daily/daily-wizard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useLiveQuery } from "dexie-react-hooks";
 import Link from "next/link";
 import { db, now } from "~/lib/db/dexie";
@@ -192,6 +192,8 @@ export function DailyWizard({ entryId, date }: Props) {
   const locale = useLocale();
   const t = useT();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const initialStep = searchParams?.get("step") as CatId | null;
   const enteredBy = useUIStore((s) => s.enteredBy);
 
   const existing = useLiveQuery(
@@ -255,6 +257,26 @@ export function DailyWizard({ entryId, date }: Props) {
     if (!inChemoWindow || existing) return;
     setPicked((p) => (p.includes("symptoms") ? p : [...p, "symptoms"]));
   }, [inChemoWindow, existing]);
+
+  // Coverage cards (and any future deep link) can land the patient
+  // on the wizard with `?step=digestion` (or any other CatId). When
+  // that's the case we pre-pick that one category and jump straight
+  // into stepping mode — keeps the calm-engagement contract by
+  // skipping the picker screen for a single targeted task. Runs once
+  // on mount; the patient can still add other steps from the review
+  // screen afterwards.
+  useEffect(() => {
+    if (!initialStep) return;
+    if (existing) return;
+    const valid = CATS.some((c) => c.id === initialStep);
+    if (!valid) return;
+    setPicked([initialStep]);
+    setCursor(0);
+    setPhase("stepping");
+    // We intentionally fire once on mount; subsequent renders shouldn't
+    // re-trigger the jump after the patient navigates within the wizard.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function patch<K extends keyof DailyEntry>(k: K, v: DailyEntry[K] | undefined) {
     setDraft((d) => {

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -31,7 +31,11 @@ import {
   Check,
   Circle,
   CheckCircle2,
+  Salad,
+  X,
 } from "lucide-react";
+import { snoozeCoverageField } from "~/lib/coverage/snooze";
+import { todayISO as todayIsoFn } from "~/lib/utils/date";
 
 // Bumped when the narrative prompt or shape changes so that stale
 // payloads in localStorage are ignored without forcing a manual clear.
@@ -52,6 +56,7 @@ const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   clock: Clock,
   user: User,
   pulse: Sparkles,
+  salad: Salad,
   dot: Circle,
 };
 
@@ -257,6 +262,10 @@ function FeedRow({ item }: { item: FeedItem }) {
   const tone = TONE_STYLES[item.tone];
   const Icon = ICONS[item.icon ?? "dot"] ?? Circle;
   const isAgentRun = item.meta?.kind === "agent_run";
+  const isCoverage = item.meta?.kind === "coverage";
+  const coverageMeta = isCoverage
+    ? (item.meta as { kind: "coverage"; field_key: string })
+    : null;
   const body = (
     <div
       className={cn(
@@ -277,18 +286,39 @@ function FeedRow({ item }: { item: FeedItem }) {
           <div className="text-[13.5px] font-semibold text-ink-900">
             {localize(item.title, locale)}
           </div>
-          <span
-            className={cn(
-              "mono shrink-0 text-[9.5px] uppercase tracking-[0.12em]",
-              item.tone === "warning"
-                ? "text-[var(--warn)]"
-                : item.tone === "positive"
-                  ? "text-[var(--ok)]"
-                  : "text-ink-400",
+          <div className="flex items-center gap-1.5">
+            <span
+              className={cn(
+                "mono shrink-0 text-[9.5px] uppercase tracking-[0.12em]",
+                item.tone === "warning"
+                  ? "text-[var(--warn)]"
+                  : item.tone === "positive"
+                    ? "text-[var(--ok)]"
+                    : "text-ink-400",
+              )}
+            >
+              {categoryLabel(item.category, locale)}
+            </span>
+            {coverageMeta && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  void snoozeCoverageField(
+                    coverageMeta.field_key,
+                    todayIsoFn(),
+                  );
+                }}
+                className="rounded-md p-0.5 text-ink-400 hover:bg-paper hover:text-ink-700"
+                aria-label={
+                  locale === "zh" ? "暂时收起" : "Dismiss"
+                }
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
             )}
-          >
-            {categoryLabel(item.category, locale)}
-          </span>
+          </div>
         </div>
         <p className="mt-1 text-[12.5px] leading-relaxed text-ink-700">
           {localize(item.body, locale)}
@@ -303,7 +333,9 @@ function FeedRow({ item }: { item: FeedItem }) {
     </div>
   );
   // Agent-run cards never wrap in a Link — the embedded feedback controls
-  // need their own click surface.
+  // need their own click surface. Coverage cards do wrap in a Link but
+  // the dismiss button stops propagation to keep the X click out of the
+  // navigation event.
   if (item.cta && !isAgentRun) {
     return (
       <Link href={item.cta.href} className="block">
@@ -328,6 +360,7 @@ function categoryLabel(
     trend: { en: "Trend", zh: "趋势" },
     encouragement: { en: "Going well", zh: "进展良好" },
     nutrition: { en: "Nutrition", zh: "营养" },
+    coverage: { en: "Log", zh: "记录" },
     memory: { en: "Memory", zh: "回忆" },
     invitation: { en: "Gathering", zh: "聚会" },
   };

--- a/src/config/tracked-fields.ts
+++ b/src/config/tracked-fields.ts
@@ -1,0 +1,163 @@
+import type { DailyEntry } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
+
+// Curated list of fields the coverage engine watches. Each entry is a
+// pure record — no Dexie reads, no UI side effects — that the engine
+// joins against recent dailies, settings, and the cycle context to
+// compute whether to surface a coverage card today.
+//
+// Calm-engagement rules live alongside the field:
+//   - `freshness_days`     how many days an entry counts as "fresh".
+//                          1 = today only; 7 = current week, etc.
+//   - `cta_step`           wizard step to deep-link into. Routes to
+//                          /daily/new?step=<cta_step>.
+//   - `voice`              which AI voice owns this prompt — drives
+//                          card title and icon via AGENT_VOICES.
+//   - `eligibility`        when the engine is allowed to surface it:
+//                            "default"          always-eligible core fields
+//                            "tracked_symptoms" only if listed in
+//                                                settings.tracked_symptoms
+//                            "history_only"     only if the field has
+//                                                been filled at least
+//                                                once in the last 60 d
+//                            "nadir_only"       only when the patient is
+//                                                in the chemo nadir window
+//
+// The "don't pull on strings that aren't there" rule from the design
+// brief: anything outside `default` is suppressed unless its specific
+// eligibility check passes.
+
+export type FieldEligibility =
+  | "default"
+  | "tracked_symptoms"
+  | "history_only"
+  | "nadir_only";
+
+export type FieldVoice = "nutrition" | "toxicity" | "rehabilitation";
+
+export interface TrackedField {
+  key: string;
+  // The DailyEntry column(s) we read to decide if it's been logged.
+  // Multiple keys mean "any of these counts as logged" — e.g. the
+  // digestion card resolves on either stool_count or stool_bristol.
+  daily_keys: ReadonlyArray<keyof DailyEntry>;
+  freshness_days: number;
+  cta_step: string;
+  voice: FieldVoice;
+  eligibility: FieldEligibility;
+  prompt: LocalizedText;
+}
+
+// Order shapes the default priority order when more than one gap is
+// eligible after engagement-state filtering. The list is intentionally
+// short — coverage prompts are rationed.
+export const TRACKED_FIELDS: TrackedField[] = [
+  {
+    key: "digestion",
+    daily_keys: ["stool_count", "stool_bristol"],
+    freshness_days: 1,
+    cta_step: "digestion",
+    voice: "nutrition",
+    eligibility: "default",
+    prompt: {
+      en: "A quick digestion log helps the dietician track PERT — count and Bristol type take a few seconds.",
+      zh: "简短记录今日排便有助于营养师跟踪胰酶剂量 —— 仅需填次数和 Bristol 类型。",
+    },
+  },
+  {
+    key: "pert_with_meals",
+    daily_keys: ["pert_with_meals_today"],
+    freshness_days: 1,
+    cta_step: "digestion",
+    voice: "nutrition",
+    eligibility: "history_only",
+    prompt: {
+      en: "Did Creon land with today's meals? One tap to log.",
+      zh: "今天 Creon 是否随餐服用？一键记录。",
+    },
+  },
+  {
+    key: "weight",
+    daily_keys: ["weight_kg"],
+    freshness_days: 3,
+    cta_step: "weight",
+    voice: "nutrition",
+    eligibility: "default",
+    prompt: {
+      en: "Weight hasn't been logged in a few days. Worth a quick weigh-in if convenient.",
+      zh: "体重已数日未记录。方便时简短称重一下。",
+    },
+  },
+  {
+    key: "fluids",
+    daily_keys: ["fluids_ml"],
+    freshness_days: 1,
+    cta_step: "food",
+    voice: "nutrition",
+    eligibility: "history_only",
+    prompt: {
+      en: "Fluid intake not yet logged today.",
+      zh: "今日饮水尚未记录。",
+    },
+  },
+  {
+    key: "protein",
+    daily_keys: ["protein_grams"],
+    freshness_days: 1,
+    cta_step: "food",
+    voice: "nutrition",
+    eligibility: "history_only",
+    prompt: {
+      en: "Protein not yet logged today.",
+      zh: "今日蛋白质摄入尚未记录。",
+    },
+  },
+  {
+    key: "energy",
+    daily_keys: ["energy", "sleep_quality"],
+    freshness_days: 1,
+    cta_step: "feelings",
+    voice: "rehabilitation",
+    eligibility: "default",
+    prompt: {
+      en: "Brief check-in on how today felt — energy and sleep.",
+      zh: "简短记录今日感受 —— 精力与睡眠。",
+    },
+  },
+  {
+    key: "appetite",
+    daily_keys: ["appetite", "nausea"],
+    freshness_days: 1,
+    cta_step: "feelings",
+    voice: "nutrition",
+    eligibility: "history_only",
+    prompt: {
+      en: "Appetite and nausea not yet logged today.",
+      zh: "今日食欲与恶心尚未记录。",
+    },
+  },
+  {
+    key: "walking",
+    daily_keys: ["walking_minutes", "steps"],
+    freshness_days: 1,
+    cta_step: "movement",
+    voice: "rehabilitation",
+    eligibility: "history_only",
+    prompt: {
+      en: "Movement not yet logged today.",
+      zh: "今日活动尚未记录。",
+    },
+  },
+  {
+    key: "temperature_nadir",
+    daily_keys: ["fever", "fever_temp"],
+    freshness_days: 1,
+    cta_step: "symptoms",
+    voice: "toxicity",
+    eligibility: "nadir_only",
+    prompt: {
+      en: "Temperature check during the nadir window — even a quick reading helps.",
+      zh: "化疗低谷期建议每日测温 —— 简短一次即可。",
+    },
+  },
+];

--- a/src/hooks/use-today-feed.ts
+++ b/src/hooks/use-today-feed.ts
@@ -31,6 +31,7 @@ export function useTodayFeed({
   const alerts = useLiveQuery(() => db.zone_alerts.toArray());
   const cycles = useLiveQuery(() => latestTreatmentCycles(1));
   const agentRuns = useLiveQuery(() => latestAgentRuns(40));
+  const coverageSnoozes = useLiveQuery(() => db.coverage_snoozes.toArray());
 
   return useMemo(() => {
     const s = settings ?? null;
@@ -76,6 +77,17 @@ export function useTodayFeed({
       cycleContext: ctx,
       weather,
       agentRuns: agentRuns ?? [],
+      coverageSnoozes: coverageSnoozes ?? [],
     });
-  }, [settings, dailies, labs, tasks, alerts, cycles, weather, agentRuns]);
+  }, [
+    settings,
+    dailies,
+    labs,
+    tasks,
+    alerts,
+    cycles,
+    weather,
+    agentRuns,
+    coverageSnoozes,
+  ]);
 }

--- a/src/lib/coverage/engagement-state.ts
+++ b/src/lib/coverage/engagement-state.ts
@@ -1,0 +1,141 @@
+import type { DailyEntry, ZoneAlert } from "~/types/clinical";
+import type { EngagementState } from "~/types/coverage";
+
+// Calm-engagement classifier. Patient's recent logging behaviour
+// scaled to one of four states; the coverage engine uses this to cap
+// outreach so the app doesn't nag during a rough patch.
+//
+// Rules (in priority order — first match wins):
+//   1. Any unresolved red zone alert today → rough.
+//      Safety owns the channel that day.
+//   2. Last 2 days carry severe symptom signal (fatigue ≥ 7 OR
+//      anorexia ≥ 7 OR pain_worst ≥ 7 OR explicit fever) → rough.
+//   3. Logged something today → active.
+//   4. Logged on at least 2 of the last 7 days → light.
+//   5. Otherwise → quiet (silence over a couple of days).
+//
+// "Logged something" = any DailyEntry row exists for that date with
+// at least one tracked field populated. We don't try to infer mood
+// from row presence alone — an empty row counts as not logged.
+
+export interface EngagementStateInputs {
+  todayISO: string;
+  recentDailies: readonly DailyEntry[]; // any order; module sorts defensively
+  activeAlerts: readonly ZoneAlert[];
+}
+
+const ROUGH_LOOKBACK_DAYS = 2;
+const LIGHT_MIN_DAYS = 2;
+const SEVERE_SYMPTOM_THRESHOLD = 7;
+
+export function classifyEngagement(
+  inputs: EngagementStateInputs,
+): EngagementState {
+  const { todayISO, recentDailies, activeAlerts } = inputs;
+
+  if (
+    activeAlerts.some(
+      (a) => !a.resolved && a.zone === "red",
+    )
+  ) {
+    return "rough";
+  }
+
+  const sortedDesc = [...recentDailies].sort((a, b) =>
+    b.date.localeCompare(a.date),
+  );
+
+  // Look at the most-recent ROUGH_LOOKBACK_DAYS days for severe symptom signals.
+  const roughWindow = sortedDesc.filter((d) =>
+    daysBetween(d.date, todayISO) <= ROUGH_LOOKBACK_DAYS - 1 &&
+    daysBetween(d.date, todayISO) >= 0,
+  );
+  if (roughWindow.some(isSevereDay)) return "rough";
+
+  if (sortedDesc.some((d) => d.date === todayISO && hasAnySignal(d))) {
+    return "active";
+  }
+
+  // Last 7 days, excluding today.
+  const recentSeven = sortedDesc.filter((d) => {
+    const delta = daysBetween(d.date, todayISO);
+    return delta > 0 && delta <= 7;
+  });
+  const loggedDates = new Set(
+    recentSeven.filter(hasAnySignal).map((d) => d.date),
+  );
+  if (loggedDates.size >= LIGHT_MIN_DAYS) return "light";
+
+  return "quiet";
+}
+
+// "Has any signal" mirrors the DailyEntry's optional-field design — we
+// look across the broad set of inputs that count as a real log. Pure
+// metadata fields (entered_by, created_at, ...) don't count.
+function hasAnySignal(d: DailyEntry): boolean {
+  return (
+    typeof d.energy === "number" ||
+    typeof d.sleep_quality === "number" ||
+    typeof d.appetite === "number" ||
+    typeof d.nausea === "number" ||
+    typeof d.weight_kg === "number" ||
+    typeof d.steps === "number" ||
+    typeof d.protein_grams === "number" ||
+    typeof d.fluids_ml === "number" ||
+    typeof d.walking_minutes === "number" ||
+    typeof d.stool_count === "number" ||
+    typeof d.stool_bristol === "number" ||
+    d.stool_oil === true ||
+    d.stool_blood === true ||
+    d.stool_urgency === true ||
+    d.pert_with_meals_today !== undefined ||
+    d.fever === true ||
+    d.practice_morning_completed === true ||
+    d.practice_evening_completed === true ||
+    (typeof d.reflection === "string" && d.reflection.trim().length > 0)
+  );
+}
+
+function isSevereDay(d: DailyEntry): boolean {
+  if (d.fever === true) return true;
+  if (
+    typeof d.fatigue === "number" &&
+    d.fatigue >= SEVERE_SYMPTOM_THRESHOLD
+  )
+    return true;
+  if (
+    typeof d.anorexia === "number" &&
+    d.anorexia >= SEVERE_SYMPTOM_THRESHOLD
+  )
+    return true;
+  if (
+    typeof d.pain_worst === "number" &&
+    d.pain_worst >= SEVERE_SYMPTOM_THRESHOLD
+  )
+    return true;
+  return false;
+}
+
+// Whole-day delta between two ISO YYYY-MM-DD strings.
+function daysBetween(aISO: string, bISO: string): number {
+  const a = Date.parse(aISO + "T12:00:00.000Z");
+  const b = Date.parse(bISO + "T12:00:00.000Z");
+  if (Number.isNaN(a) || Number.isNaN(b)) return 0;
+  return Math.round((b - a) / (24 * 3600 * 1000));
+}
+
+// Daily cap on coverage prompts surfaced today, by engagement state.
+// Designed to feel responsive when the patient is engaged, and quiet
+// when they're not.
+export function coverageCapForState(state: EngagementState): number {
+  switch (state) {
+    case "active":
+      return 3;
+    case "light":
+      return 2;
+    case "quiet":
+      return 1;
+    case "rough":
+      return 0;
+  }
+}

--- a/src/lib/coverage/log-coverage.ts
+++ b/src/lib/coverage/log-coverage.ts
@@ -1,0 +1,196 @@
+import type {
+  CoverageGap,
+  CoverageSnoozeRow,
+  EngagementState,
+} from "~/types/coverage";
+import type { DailyEntry, Settings, ZoneAlert } from "~/types/clinical";
+import type { CycleContext } from "~/types/treatment";
+import {
+  TRACKED_FIELDS,
+  type TrackedField,
+} from "~/config/tracked-fields";
+import {
+  AGENT_VOICES,
+  type AgentVoice,
+} from "~/config/agent-cadence";
+import {
+  classifyEngagement,
+  coverageCapForState,
+} from "./engagement-state";
+
+// Pure gap detector. Walks TRACKED_FIELDS, drops anything ineligible
+// (eligibility check + snooze + already-logged-this-window), then
+// caps to the engagement state's daily quota. Calm by default — never
+// surfaces fields the patient has never touched (history_only) and
+// never surfaces ANY coverage card during a rough patch.
+
+export interface CoverageInputs {
+  todayISO: string;
+  // Last ~28 days of entries — we only need 60d for history checks
+  // and 7d for engagement, but the 28d window already loaded by the
+  // dashboard is plenty.
+  recentDailies: readonly DailyEntry[];
+  settings: Settings | null;
+  cycleContext: CycleContext | null;
+  activeAlerts: readonly ZoneAlert[];
+  // Active snoozes — rows whose snoozed_until is still in the future.
+  // The composer reads from Dexie and passes them in; this module
+  // stays pure.
+  snoozes: readonly CoverageSnoozeRow[];
+}
+
+export interface CoverageResult {
+  engagement: EngagementState;
+  gaps: CoverageGap[];
+}
+
+const HISTORY_LOOKBACK_DAYS = 60;
+const DEFAULT_PRIORITY = 50;
+const NADIR_PRIORITY = 40;
+
+export function computeCoverageGaps(
+  inputs: CoverageInputs,
+): CoverageResult {
+  const engagement = classifyEngagement({
+    todayISO: inputs.todayISO,
+    recentDailies: inputs.recentDailies,
+    activeAlerts: inputs.activeAlerts,
+  });
+  const cap = coverageCapForState(engagement);
+  if (cap === 0) return { engagement, gaps: [] };
+
+  const todayEntry =
+    inputs.recentDailies.find((d) => d.date === inputs.todayISO) ?? null;
+  const trackedSymptoms = inputs.settings?.tracked_symptoms ?? [];
+  const snoozedFields = activeSnoozeKeys(inputs.snoozes, inputs.todayISO);
+  const inNadir = inputs.cycleContext?.phase?.key === "nadir";
+
+  const candidates: CoverageGap[] = [];
+  for (const field of TRACKED_FIELDS) {
+    if (snoozedFields.has(field.key)) continue;
+    if (
+      !isEligible({
+        field,
+        trackedSymptoms,
+        recentDailies: inputs.recentDailies,
+        inNadir,
+        todayISO: inputs.todayISO,
+      })
+    )
+      continue;
+    if (isFreshlyLogged(field, inputs.recentDailies, todayEntry, inputs.todayISO))
+      continue;
+
+    candidates.push(toGap(field, inNadir));
+    if (candidates.length >= cap) break;
+  }
+
+  return { engagement, gaps: candidates };
+}
+
+function activeSnoozeKeys(
+  snoozes: readonly CoverageSnoozeRow[],
+  todayISO: string,
+): Set<string> {
+  const out = new Set<string>();
+  for (const s of snoozes) {
+    if (s.snoozed_until > todayISO) out.add(s.field_key);
+  }
+  return out;
+}
+
+interface EligibilityArgs {
+  field: TrackedField;
+  trackedSymptoms: readonly string[];
+  recentDailies: readonly DailyEntry[];
+  inNadir: boolean;
+  todayISO: string;
+}
+
+function isEligible(args: EligibilityArgs): boolean {
+  switch (args.field.eligibility) {
+    case "default":
+      return true;
+    case "tracked_symptoms":
+      return args.trackedSymptoms.includes(args.field.key);
+    case "history_only":
+      return hasHistoryWithin(
+        args.field,
+        args.recentDailies,
+        args.todayISO,
+        HISTORY_LOOKBACK_DAYS,
+      );
+    case "nadir_only":
+      return args.inNadir;
+  }
+}
+
+function hasHistoryWithin(
+  field: TrackedField,
+  dailies: readonly DailyEntry[],
+  todayISO: string,
+  windowDays: number,
+): boolean {
+  const cutoff = isoDaysBefore(todayISO, windowDays);
+  for (const d of dailies) {
+    if (d.date < cutoff || d.date > todayISO) continue;
+    if (anyFieldFilled(d, field.daily_keys)) return true;
+  }
+  return false;
+}
+
+function isFreshlyLogged(
+  field: TrackedField,
+  dailies: readonly DailyEntry[],
+  todayEntry: DailyEntry | null,
+  todayISO: string,
+): boolean {
+  if (field.freshness_days === 1) {
+    return todayEntry !== null && anyFieldFilled(todayEntry, field.daily_keys);
+  }
+  const cutoff = isoDaysBefore(todayISO, field.freshness_days - 1);
+  for (const d of dailies) {
+    if (d.date < cutoff || d.date > todayISO) continue;
+    if (anyFieldFilled(d, field.daily_keys)) return true;
+  }
+  return false;
+}
+
+function anyFieldFilled(
+  d: DailyEntry,
+  keys: ReadonlyArray<keyof DailyEntry>,
+): boolean {
+  for (const k of keys) {
+    const v = d[k];
+    if (v === undefined || v === null) continue;
+    if (typeof v === "string" && v.trim() === "") continue;
+    return true;
+  }
+  return false;
+}
+
+function toGap(field: TrackedField, inNadir: boolean): CoverageGap {
+  const voice: AgentVoice = AGENT_VOICES[field.voice];
+  const priority =
+    field.eligibility === "nadir_only" && inNadir
+      ? NADIR_PRIORITY
+      : DEFAULT_PRIORITY;
+  return {
+    id: `coverage_${field.key}`,
+    field_key: field.key,
+    priority,
+    title: voice.display_name,
+    body: field.prompt,
+    cta_href: `/daily/new?step=${encodeURIComponent(field.cta_step)}`,
+    icon: voice.icon,
+  };
+}
+
+function isoDaysBefore(iso: string, n: number): string {
+  const d = new Date(iso + "T12:00:00.000Z");
+  d.setUTCDate(d.getUTCDate() - n);
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/src/lib/coverage/snooze.ts
+++ b/src/lib/coverage/snooze.ts
@@ -1,0 +1,39 @@
+import { db, now } from "~/lib/db/dexie";
+import { TRACKED_FIELDS } from "~/config/tracked-fields";
+
+// Snooze durations per tracked-field freshness band. The brief was
+// "3d daily / 7d weekly / 14d fortnightly" — we map each tracked
+// field's freshness window onto one of those buckets so the dismiss
+// behaviour always feels proportionate.
+function snoozeDaysFor(fieldKey: string): number {
+  const f = TRACKED_FIELDS.find((tf) => tf.key === fieldKey);
+  if (!f) return 3;
+  if (f.freshness_days <= 1) return 3;
+  if (f.freshness_days <= 7) return 7;
+  return 14;
+}
+
+// Record a dismiss. Creates one new row per dismiss (history is
+// preserved for audit / future engagement-aware tuning); the detector
+// only cares about the most recent unexpired row per field_key.
+export async function snoozeCoverageField(
+  fieldKey: string,
+  todayISO: string,
+): Promise<void> {
+  const days = snoozeDaysFor(fieldKey);
+  const until = isoDaysAfter(todayISO, days);
+  await db.coverage_snoozes.add({
+    field_key: fieldKey,
+    snoozed_at: now(),
+    snoozed_until: until,
+  });
+}
+
+function isoDaysAfter(iso: string, n: number): string {
+  const d = new Date(iso + "T12:00:00.000Z");
+  d.setUTCDate(d.getUTCDate() + n);
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -59,6 +59,7 @@ import type {
 } from "~/types/nutrition";
 import type { HouseholdProfile as HouseholdProfileRow } from "~/types/household-profile";
 import type { VoiceMemo } from "~/types/voice-memo";
+import type { CoverageSnoozeRow } from "~/types/coverage";
 
 export class AnchorDB extends Dexie {
   daily_entries!: Table<DailyEntry, number>;
@@ -127,6 +128,12 @@ export class AnchorDB extends Dexie {
   // labels that supervise axis-attribution priors and calibration audit.
   provisional_signals!: Table<ProvisionalSignalRow, string>;
   signal_labels!: Table<SignalLabelRow, string>;
+  // v25: Coverage-engine snoozes. Patient's dismiss action on a
+  // coverage card writes a row here; the engine reads the table on
+  // every feed compose and suppresses the matching field_key until
+  // snoozed_until expires. Calm-engagement complement to the
+  // detector itself.
+  coverage_snoozes!: Table<CoverageSnoozeRow, number>;
 
   constructor() {
     super("anchor_db");
@@ -410,6 +417,16 @@ export class AnchorDB extends Dexie {
         "&id, detector_id, metric_id, status, created_at, expires_at",
       signal_labels:
         "&id, signal_id, visit_date, label, applied_at",
+    });
+    // v25: Coverage-engine snoozes. One row per dismissed coverage
+    // prompt; `snoozed_until` is an ISO YYYY-MM-DD that the detector
+    // compares against today on every feed compose. Indexed on
+    // field_key so the active-snooze query is O(unique fields), and
+    // on snoozed_until so the periodic prune ("drop expired rows")
+    // stays cheap.
+    this.version(25).stores({
+      coverage_snoozes:
+        "++id, field_key, snoozed_until, snoozed_at",
     });
   }
 }

--- a/src/lib/nudges/compose.ts
+++ b/src/lib/nudges/compose.ts
@@ -9,6 +9,7 @@ import type { CycleContext, NudgeTemplate } from "~/types/treatment";
 import type { CurrentWeather } from "~/lib/weather/open-meteo";
 import type { FeedItem } from "~/types/feed";
 import type { AgentFollowUpRow, AgentRunRow } from "~/types/agent";
+import type { CoverageSnoozeRow } from "~/types/coverage";
 import { computeTrendNudges } from "./trend-nudges";
 import { computeWeatherNudges } from "./weather-nudges";
 import { computeNutritionNudges } from "./nutrition-nudges";
@@ -18,6 +19,8 @@ import { agentRunsToFeedItems } from "./agent-runs";
 import { resurfaceFollowUps } from "./follow-up-resurface";
 import { computeCadencePrompts } from "./cadence-prompts";
 import { computeGiTileNudges } from "./gi-tile-nudges";
+import { computeCoverageGaps } from "~/lib/coverage/log-coverage";
+import { coverageGapsToFeedItems } from "./coverage-cards";
 import { getActiveTaskInstances } from "~/lib/tasks/engine";
 
 export interface ComposeInputs {
@@ -34,6 +37,9 @@ export interface ComposeInputs {
   // filters by `due_at <= today` and ranks them. Pass an empty array
   // if the caller has no follow-up state yet.
   followUps?: AgentFollowUpRow[];
+  // Active coverage-prompt snoozes. Pass all rows from the
+  // coverage_snoozes table; the engine filters expired ones.
+  coverageSnoozes?: CoverageSnoozeRow[];
 }
 
 export function composeTodayFeed(inputs: ComposeInputs): FeedItem[] {
@@ -144,6 +150,22 @@ export function composeTodayFeed(inputs: ComposeInputs): FeedItem[] {
       activeAlerts: inputs.activeAlerts,
     }),
   );
+
+  // ── 9. Coverage prompts (calm gap detector) ────────────────────────
+  // Reaches out only as far as the patient's recent engagement allows
+  // — full quota when active today, smaller when light, one when
+  // quiet, none at all during a rough patch. Cards are dismissible
+  // (snooze stored in coverage_snoozes); the engine respects active
+  // snoozes here.
+  const coverage = computeCoverageGaps({
+    todayISO: inputs.todayISO,
+    recentDailies: inputs.recentDailies,
+    settings: inputs.settings,
+    cycleContext: inputs.cycleContext,
+    activeAlerts: inputs.activeAlerts,
+    snoozes: inputs.coverageSnoozes ?? [],
+  });
+  feed.push(...coverageGapsToFeedItems(coverage.gaps));
 
   // ── Dedupe + sort + cap ────────────────────────────────────────────
   const seen = new Set<string>();

--- a/src/lib/nudges/coverage-cards.ts
+++ b/src/lib/nudges/coverage-cards.ts
@@ -1,0 +1,22 @@
+import type { FeedItem } from "~/types/feed";
+import type { CoverageGap } from "~/types/coverage";
+
+// Convert detector gaps to feed items. Stays a thin shim because the
+// gap shape is already feed-friendly — keeps the coverage detector
+// independent of the FeedItem type so it stays trivially testable.
+export function coverageGapsToFeedItems(
+  gaps: readonly CoverageGap[],
+): FeedItem[] {
+  return gaps.map((g) => ({
+    id: g.id,
+    priority: g.priority,
+    category: "coverage",
+    tone: "info",
+    title: g.title,
+    body: g.body,
+    cta: { href: g.cta_href, label: { en: "Log", zh: "记录" } },
+    icon: g.icon,
+    source: `coverage:${g.field_key}`,
+    meta: { kind: "coverage", field_key: g.field_key },
+  }));
+}

--- a/src/types/coverage.ts
+++ b/src/types/coverage.ts
@@ -1,0 +1,44 @@
+import type { LocalizedText } from "./localized";
+
+// Local-first record of a coverage prompt the patient dismissed. Read
+// by the coverage engine on every feed compose to decide whether to
+// re-surface the same gap. Auto-expires when `snoozed_until` <=
+// today; a stale dismiss is treated as no dismiss.
+export interface CoverageSnoozeRow {
+  id?: number;
+  // Stable identifier for the field whose card was dismissed
+  // (e.g. `digestion`, `weight`, `practice_morning`). Matches
+  // `TrackedField.key` in src/config/tracked-fields.
+  field_key: string;
+  snoozed_at: string;
+  snoozed_until: string; // ISO YYYY-MM-DD
+}
+
+// Patient's recent logging behaviour. The coverage engine modulates
+// outreach against this so the app stays calm when the patient is
+// rough or quiet. Classifier lives in
+// src/lib/coverage/engagement-state.ts.
+export type EngagementState =
+  // Logged something today.
+  | "active"
+  // Logged at least once in the last 7 days but not today.
+  | "light"
+  // Nothing in 3+ days.
+  | "quiet"
+  // Red zone alert active OR fatigue/pain/anorexia high in last 2 days.
+  | "rough";
+
+// One detected gap. Rendered as a coverage feed card with a deep-link
+// CTA into the right wizard step. The feed composer handles dedup
+// against `id` and applies the engagement-aware cap.
+export interface CoverageGap {
+  id: string;
+  field_key: string;
+  // Lower number = higher rank. Engine emits 50 by default; cycle-
+  // mandated gaps (temperature in nadir) push to 40.
+  priority: number;
+  title: LocalizedText;
+  body: LocalizedText;
+  cta_href: string;
+  icon: string;
+}

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -16,6 +16,11 @@ export type FeedCategory =
   // physical signal) and `trend` (statistical drift) — these carry
   // dietitian-grade recommendations with explicit citations.
   | "nutrition"
+  // Coverage-engine prompts: a curated, dismissible nudge that the
+  // patient hasn't logged a particular field today / this week. Calm
+  // by design — capped per day by engagement state, suppressed
+  // entirely during a rough patch. See src/lib/coverage.
+  | "coverage"
   // Legacy-module categories. `memory` resurfaces anniversary items at
   // low priority; `invitation` carries orchestrator event suggestions
   // (slice 15). Both are always lower-priority than clinical items.
@@ -36,12 +41,18 @@ export interface FeedItem {
   source?: string;
   // Optional structured meta for sources that need to thread state back
   // to the renderer (e.g. agent_run cards rendering thumbs/correction
-  // controls). Discriminated by `kind`.
-  meta?: AgentRunMeta;
+  // controls, coverage cards rendering a dismiss button). Discriminated
+  // by `kind`.
+  meta?: AgentRunMeta | CoverageMeta;
 }
 
 export type AgentRunMeta = {
   kind: "agent_run";
   agent_id: string;
   run_id: number;
+};
+
+export type CoverageMeta = {
+  kind: "coverage";
+  field_key: string;
 };

--- a/tests/unit/coverage-engine.test.ts
+++ b/tests/unit/coverage-engine.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from "vitest";
+import { computeCoverageGaps } from "~/lib/coverage/log-coverage";
+import {
+  classifyEngagement,
+  coverageCapForState,
+} from "~/lib/coverage/engagement-state";
+import type {
+  DailyEntry,
+  Settings,
+  ZoneAlert,
+} from "~/types/clinical";
+import type { CoverageSnoozeRow } from "~/types/coverage";
+
+function entry(date: string, overrides: Partial<DailyEntry> = {}): DailyEntry {
+  return {
+    date,
+    entered_at: `${date}T07:00:00Z`,
+    entered_by: "hulin",
+    created_at: `${date}T07:00:00Z`,
+    updated_at: `${date}T07:00:00Z`,
+    ...overrides,
+  };
+}
+
+function alert(zone: ZoneAlert["zone"]): ZoneAlert {
+  return {
+    rule_id: "x",
+    rule_name: "x",
+    zone,
+    category: "toxicity",
+    triggered_at: "2026-05-01T07:00:00Z",
+    resolved: false,
+    acknowledged: false,
+    recommendation: "",
+    recommendation_zh: "",
+    suggested_levers: [],
+    created_at: "2026-05-01T07:00:00Z",
+    updated_at: "2026-05-01T07:00:00Z",
+  };
+}
+
+describe("classifyEngagement", () => {
+  it("returns rough when a red zone alert is active", () => {
+    const state = classifyEngagement({
+      todayISO: "2026-05-01",
+      recentDailies: [entry("2026-05-01", { stool_count: 2 })],
+      activeAlerts: [alert("red")],
+    });
+    expect(state).toBe("rough");
+  });
+
+  it("returns rough on severe symptom signal in last 2 days", () => {
+    const state = classifyEngagement({
+      todayISO: "2026-05-01",
+      recentDailies: [entry("2026-04-30", { fatigue: 8 })],
+      activeAlerts: [],
+    });
+    expect(state).toBe("rough");
+  });
+
+  it("returns active when today has any signal", () => {
+    const state = classifyEngagement({
+      todayISO: "2026-05-01",
+      recentDailies: [entry("2026-05-01", { stool_count: 1 })],
+      activeAlerts: [],
+    });
+    expect(state).toBe("active");
+  });
+
+  it("returns light with 2+ days logged in past 7 (excluding today)", () => {
+    const state = classifyEngagement({
+      todayISO: "2026-05-01",
+      recentDailies: [
+        entry("2026-04-29", { weight_kg: 65 }),
+        entry("2026-04-28", { protein_grams: 60 }),
+      ],
+      activeAlerts: [],
+    });
+    expect(state).toBe("light");
+  });
+
+  it("returns quiet with no signal in last 7 days", () => {
+    const state = classifyEngagement({
+      todayISO: "2026-05-01",
+      recentDailies: [],
+      activeAlerts: [],
+    });
+    expect(state).toBe("quiet");
+  });
+});
+
+describe("coverageCapForState", () => {
+  it("scales cap per state", () => {
+    expect(coverageCapForState("active")).toBe(3);
+    expect(coverageCapForState("light")).toBe(2);
+    expect(coverageCapForState("quiet")).toBe(1);
+    expect(coverageCapForState("rough")).toBe(0);
+  });
+});
+
+describe("computeCoverageGaps", () => {
+  function settings(over: Partial<Settings> = {}): Settings {
+    return {
+      profile_name: "x",
+      locale: "en",
+      created_at: "2026-04-01T00:00:00Z",
+      updated_at: "2026-04-01T00:00:00Z",
+      ...over,
+    };
+  }
+
+  it("returns no gaps and engagement=rough when red zone is active", () => {
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      recentDailies: [],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [alert("red")],
+      snoozes: [],
+    });
+    expect(r.engagement).toBe("rough");
+    expect(r.gaps).toEqual([]);
+  });
+
+  it("does not surface history_only fields the patient has never filled", () => {
+    // Active engagement (logged today) but no prior weight/fluid/protein
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      recentDailies: [entry("2026-05-01", { energy: 5 })],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    expect(r.engagement).toBe("active");
+    // `digestion` is default-eligible so it CAN appear; history_only fields
+    // (fluids, protein, walking, appetite, pert) should not.
+    const keys = r.gaps.map((g) => g.field_key);
+    expect(keys).not.toContain("fluids");
+    expect(keys).not.toContain("protein");
+    expect(keys).not.toContain("walking");
+    expect(keys).not.toContain("appetite");
+    expect(keys).not.toContain("pert_with_meals");
+  });
+
+  it("surfaces history_only fields once a prior entry shows history", () => {
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      // Today's entry deliberately fills `energy` (so the patient is
+      // engagement=active and the `energy` field is fresh) but leaves
+      // protein blank. A protein entry 5 days ago provides history.
+      recentDailies: [
+        entry("2026-05-01", { energy: 5 }),
+        entry("2026-04-26", { protein_grams: 60 }),
+      ],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    const keys = r.gaps.map((g) => g.field_key);
+    expect(keys).toContain("protein");
+  });
+
+  it("respects the daily cap from engagement state", () => {
+    // Quiet state → cap 1. Even if many gaps qualify, only 1 surfaces.
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      // History across multiple history_only fields, but no recent log
+      // → engagement=quiet.
+      recentDailies: [
+        entry("2026-04-15", {
+          protein_grams: 60,
+          fluids_ml: 1500,
+          walking_minutes: 20,
+          appetite: 5,
+        }),
+      ],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    expect(r.engagement).toBe("quiet");
+    expect(r.gaps).toHaveLength(1);
+  });
+
+  it("hides a field while its snooze is active", () => {
+    const snooze: CoverageSnoozeRow = {
+      field_key: "digestion",
+      snoozed_at: "2026-05-01T07:00:00Z",
+      snoozed_until: "2026-05-04",
+    };
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      recentDailies: [entry("2026-05-01", { energy: 5 })],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [snooze],
+    });
+    expect(r.gaps.some((g) => g.field_key === "digestion")).toBe(false);
+  });
+
+  it("re-surfaces the field after the snooze expires", () => {
+    const snooze: CoverageSnoozeRow = {
+      field_key: "digestion",
+      snoozed_at: "2026-04-28T07:00:00Z",
+      snoozed_until: "2026-04-30",
+    };
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      recentDailies: [entry("2026-05-01", { energy: 5 })],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [snooze],
+    });
+    expect(r.gaps.some((g) => g.field_key === "digestion")).toBe(true);
+  });
+
+  it("emits a coverage card with a deep-link CTA into the right step", () => {
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      recentDailies: [entry("2026-05-01", { energy: 5 })],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    const dig = r.gaps.find((g) => g.field_key === "digestion");
+    expect(dig?.cta_href).toBe("/daily/new?step=digestion");
+  });
+
+  it("does not re-prompt a field that was already logged today", () => {
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      recentDailies: [
+        entry("2026-05-01", { stool_count: 2, energy: 5 }),
+      ],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    expect(r.gaps.some((g) => g.field_key === "digestion")).toBe(false);
+    expect(r.gaps.some((g) => g.field_key === "energy")).toBe(false);
+  });
+
+  it("keeps weight prompt inside the 3-day freshness window", () => {
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      // Logged weight 2 days ago — still fresh, should not re-prompt.
+      recentDailies: [
+        entry("2026-05-01", { energy: 5 }),
+        entry("2026-04-29", { weight_kg: 65 }),
+      ],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    expect(r.gaps.some((g) => g.field_key === "weight")).toBe(false);
+  });
+
+  it("re-prompts weight after the 3-day freshness window expires", () => {
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      // Last weigh-in 5 days ago — outside the 3-day window.
+      recentDailies: [
+        entry("2026-05-01", { energy: 5 }),
+        entry("2026-04-26", { weight_kg: 65 }),
+      ],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    expect(r.gaps.some((g) => g.field_key === "weight")).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes the "what hasn't been logged yet?" gap that none of the
existing surfaces (zone alerts, trend nudges, agent reports,
follow-ups, GI tile nudges) covered. Cards surface only as far as
the patient's recent engagement allows — full quota when active,
smaller when light, one when quiet, and zero during a rough patch.

Calm-engagement contract
- Engagement classifier (active / light / quiet / rough) drives a
  per-day cap of 3 / 2 / 1 / 0 coverage prompts.
- "Don't pull on strings that aren't there": a tracked field is
  surfaced only if it's in `default` core, listed in
  `settings.tracked_symptoms`, has been filled at least once in the
  last 60 days, or is mandated for the current cycle phase
  (temperature in nadir).
- Dismiss snoozes the field for 3 / 7 / 14 days based on its
  freshness band; expired snoozes auto-reactivate.
- Card vanishes the moment the field is logged — Dexie liveQuery in
  use-today-feed.ts means the next render strips the gap with no
  reload or interstitial.

What's tracked (curated, in `src/config/tracked-fields.ts`)
- digestion (stool count + Bristol)            — default
- pert_with_meals                              — history-only
- weight                                       — default, 3-day window
- fluids / protein / appetite / walking         — history-only
- energy + sleep                                — default
- temperature                                   — nadir-only

Architecture
- `src/lib/coverage/log-coverage.ts` — pure detector. No Dexie
  reads; the composer passes recent dailies, settings, cycle
  context, active alerts, and active snoozes in.
- `src/lib/coverage/engagement-state.ts` — classifier + cap helper.
- `src/lib/coverage/snooze.ts` — Dexie writer for the dismiss path.
- `src/lib/nudges/coverage-cards.ts` — gap-to-FeedItem shim, new
  `coverage` feed category, `CoverageMeta` discriminator on FeedItem.
- `src/lib/nudges/compose.ts` — wires step 9 after the cadence
  prompts; `composeTodayFeed` accepts an optional `coverageSnoozes`
  array that the dashboard hook reads from Dexie.
- `src/lib/db/dexie.ts` — v25 adds the `coverage_snoozes` table
  indexed on `field_key`, `snoozed_until`, `snoozed_at`.

UI
- `today-feed.tsx` adds a small dismiss `X` on coverage cards (event
  stops propagation so the card's CTA isn't fired by the click) and
  records the snooze.
- `daily-wizard.tsx` reads `?step=` and pre-picks that category +
  jumps straight into stepping mode. Coverage card CTAs deep-link
  into the right wizard step (e.g. /daily/new?step=digestion).

Tests (16 new in tests/unit/coverage-engine.test.ts)
- Engagement classifier: red zone, severe symptom, active, light,
  quiet branches.
- Cap helper across all four states.
- Coverage detector: rough → no gaps; history-only fields hidden
  without prior history, surfaced after a single prior fill;
  daily cap respected by engagement state; snooze hides + expires;
  CTA href points at the right wizard step; freshness window
  respected for the 3-day weight prompt; today's logged field is
  not re-prompted.

Full suite 899/899 passing; typecheck and lint clean.

https://claude.ai/code/session_01UZu1c3M2RX5zi4G2nSZuCr