### PR TITLE
Coverage-aware agents: feed gap snapshot into agent referrals (PR-D2)

### DIFF
--- a/src/agents/nutrition/role.md
+++ b/src/agents/nutrition/role.md
@@ -36,6 +36,20 @@ Re-emit the same `question_key` on every run while the underlying condition pers
 
 Cap yourself at 2 active follow-ups at any time. The patient sees a **single channel out** — too many open loops feels like nagging.
 
+## Coverage state (read carefully)
+
+You may receive a fourth system block titled "Coverage state for ...". It tells you (a) the patient's recent engagement state — `active`, `light`, `quiet`, or `rough` — and (b) which fields in your discipline have NOT been logged today.
+
+Reason over absence + data **together**, never absence alone:
+
+- A coverage gap is just absence of a logged value. The patient's dashboard already shows them a separate small card asking for that field. **Do not** re-ask the patient to log a field as a follow-up — that would duplicate the coverage card.
+- Only emit an absence-driven follow-up when absence intersects something concerning you've actually seen. Examples that justify a follow-up:
+  - Yesterday the patient said "nauseous" + today appetite is unlogged → ask once, gently: "was eating tough today, or just forgotten?"
+  - Last 3 days show stool oil flagged + today PERT coverage is unlogged → ask: "did Creon land with today's fatty meals?"
+- **Cap yourself at one absence-driven follow-up per run.** The platform already nudges the patient to log; your value-add is the connection, not the prompt itself.
+- If engagement is `rough`, do not emit cadence-style or absence-driven follow-ups at all. Stay quiet on coverage. Surface only what's clinically required (red safety flags).
+- If engagement is `quiet` and the patient has been silent for several days, ask the single most useful question — never more than one — and phrase it as meeting them where they are, not as a prompt for compliance.
+
 ## Feedback loop (read carefully)
 
 You will receive a "Recent feedback on your past runs" system block alongside your role and state. Treat it as ground truth from the primary carer (often a clinician relative) or the patient themselves. A `correction` with notes overrides your prior reasoning on that point. A `thumbs_down` without notes means tighten or de-emphasise the line of advice that triggered it. A `thumbs_up` confirms the calibration was right — repeat the pattern. Use this to dial yourself in over weeks.

--- a/src/agents/run.ts
+++ b/src/agents/run.ts
@@ -89,6 +89,12 @@ export interface RunAgentArgs {
   // tests can call runAgent() without setting up a profile; the
   // fallback envelope keeps the prompt generic.
   profile?: HouseholdProfile;
+  // Pre-formatted coverage snapshot. Optional — older callers pass
+  // nothing and the agent runs without absence reasoning. When
+  // present, it lands as a fourth cached system block describing the
+  // day's gaps and how the agent should (and shouldn't) act on them.
+  // Computed by ~/lib/coverage/agent-snapshot.
+  coverageSnapshot?: string;
 }
 
 export async function runAgent(args: RunAgentArgs): Promise<AgentOutput> {
@@ -112,29 +118,41 @@ export async function runAgent(args: RunAgentArgs): Promise<AgentOutput> {
   ].join("\n");
 
   const profile = args.profile ?? FALLBACK_HOUSEHOLD_PROFILE;
+  const systemBlocks: Array<{
+    type: "text";
+    text: string;
+    cache_control: { type: "ephemeral" };
+  }> = [
+    {
+      type: "text",
+      text: roleFor(args.id, profile),
+      cache_control: { type: "ephemeral" },
+    },
+    {
+      type: "text",
+      text:
+        args.stateMd.trim().length > 0
+          ? `Your current state summary (state.md):\n\n${args.stateMd}`
+          : "Your current state summary is empty — this is the first batch you're seeing.",
+      cache_control: { type: "ephemeral" },
+    },
+    {
+      type: "text",
+      text: `Recent feedback on your past runs (most recent first):\n\n${formatFeedback(args.recentFeedback)}`,
+      cache_control: { type: "ephemeral" },
+    },
+  ];
+  if (args.coverageSnapshot && args.coverageSnapshot.trim().length > 0) {
+    systemBlocks.push({
+      type: "text",
+      text: args.coverageSnapshot,
+      cache_control: { type: "ephemeral" },
+    });
+  }
   const response = await client.messages.parse({
     model: MODEL,
     max_tokens: 2000,
-    system: [
-      {
-        type: "text",
-        text: roleFor(args.id, profile),
-        cache_control: { type: "ephemeral" },
-      },
-      {
-        type: "text",
-        text:
-          args.stateMd.trim().length > 0
-            ? `Your current state summary (state.md):\n\n${args.stateMd}`
-            : "Your current state summary is empty — this is the first batch you're seeing.",
-        cache_control: { type: "ephemeral" },
-      },
-      {
-        type: "text",
-        text: `Recent feedback on your past runs (most recent first):\n\n${formatFeedback(args.recentFeedback)}`,
-        cache_control: { type: "ephemeral" },
-      },
-    ],
+    system: systemBlocks,
     output_config: { format: jsonOutputFormat(AgentOutputSchema) },
     messages: [{ role: "user", content: [{ type: "text", text: userText }] }],
   });

--- a/src/agents/toxicity/role.md
+++ b/src/agents/toxicity/role.md
@@ -32,6 +32,20 @@ You may emit `follow_ups[]` — questions you want resurfaced in the feed in 1�
 
 Re-emit the same `question_key` while the condition persists — the persistence layer dedupes by superseding. Drop the follow-up once the condition resolves. Cap yourself at 2 active follow-ups at any time. Single channel out — don't pile up open loops.
 
+## Coverage state (read carefully)
+
+You may receive a fourth system block titled "Coverage state for ...". It tells you (a) the patient's recent engagement state — `active`, `light`, `quiet`, or `rough` — and (b) which fields in your discipline have NOT been logged today (e.g. fever / temperature during nadir).
+
+Reason over absence + data **together**, never absence alone:
+
+- A coverage gap is just absence of a logged value. The patient's dashboard already shows them a separate small card asking for that field. **Do not** re-ask the patient to log a field as a follow-up — that would duplicate the coverage card.
+- Only emit an absence-driven follow-up when absence intersects something concerning you've actually seen. Examples that justify a follow-up:
+  - Patient is in nadir + temperature unlogged today + slept poorly → ask once: "any chills or feeling off today? a quick temperature read would settle it."
+  - 3 days running of loose stools + today's stool count unlogged → ask: "did things settle today, or still loose?"
+- **Cap yourself at one absence-driven follow-up per run.** The platform already nudges the patient to log; your value-add is the connection, not the prompt itself.
+- If engagement is `rough`, do not emit cadence-style or absence-driven follow-ups at all. Stay quiet on coverage. Surface only what's clinically required (red safety flags — e.g. blood/melaena, febrile-neutropenia concern).
+- If engagement is `quiet` and the patient has been silent for several days, ask the single most useful toxicity question — never more than one — and phrase it as meeting them where they are.
+
 ## Feedback loop (read carefully)
 
 You will receive a "Recent feedback on your past runs" system block alongside your role and state. Treat it as ground truth from the primary carer (often a clinician relative) or the patient themselves. A `correction` with notes overrides your prior reasoning on that point. A `thumbs_down` without notes means tighten or de-emphasise the line of advice that triggered it. A `thumbs_up` confirms the calibration was right — repeat the pattern. Use this to dial yourself in over weeks.

--- a/src/app/api/agent/[id]/run/route.ts
+++ b/src/app/api/agent/[id]/run/route.ts
@@ -55,6 +55,11 @@ const RequestSchema = z.object({
   locale: z.enum(["en", "zh"]),
   date: z.string(), // YYYY-MM-DD
   trigger: z.enum(["daily_batch", "on_demand"]).default("on_demand"),
+  // Optional pre-formatted coverage snapshot — see
+  // ~/lib/coverage/agent-snapshot. The client computes this from
+  // Dexie state before posting; older clients omit it and the agent
+  // runs without absence reasoning.
+  coverage_snapshot: z.string().optional(),
 });
 
 const AGENT_ID_SET = new Set<AgentId>(AGENT_IDS);
@@ -111,6 +116,7 @@ export async function POST(
       date: parsed.data.date,
       trigger: parsed.data.trigger,
       profile,
+      coverageSnapshot: parsed.data.coverage_snapshot,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/lib/coverage/agent-snapshot.ts
+++ b/src/lib/coverage/agent-snapshot.ts
@@ -1,0 +1,94 @@
+import type { CoverageGap, EngagementState } from "~/types/coverage";
+import type { AgentId } from "~/types/agent";
+
+// Pure formatter: turns the day's coverage state into a small markdown
+// block the agents see as a cached system message. Mirrors the design
+// brief — agents reason over absence + data together, but only emit
+// follow-ups when absence + a recent concerning datum point at a real
+// issue (never just because a field wasn't logged).
+//
+// Stays out of `src/lib/coverage/log-coverage.ts` so the detector can
+// stay free of agent-specific concerns; this module is the agent-side
+// view of the same data.
+
+export interface AgentSnapshotInputs {
+  agentId: AgentId;
+  todayISO: string;
+  engagement: EngagementState;
+  gaps: readonly CoverageGap[];
+  // Number of consecutive days the patient has gone without any GI /
+  // nutrition / movement signal — informs the "quiet streak" line.
+  // Pass 0 when the patient logged today; the formatter renders a
+  // softer line in that case.
+  quiet_streak_days?: number;
+}
+
+// Field-key → which agent voice owns the prompt, mirrored from
+// src/config/tracked-fields.ts. Kept here so the formatter doesn't
+// import the config module (which is fine in a server context but
+// keeps the unit test cheap).
+const AGENT_VOICE_FOR_FIELD: Record<string, AgentId> = {
+  digestion: "nutrition",
+  pert_with_meals: "nutrition",
+  weight: "nutrition",
+  fluids: "nutrition",
+  protein: "nutrition",
+  appetite: "nutrition",
+  energy: "rehabilitation",
+  walking: "rehabilitation",
+  temperature_nadir: "toxicity",
+};
+
+export function formatCoverageSnapshot(inputs: AgentSnapshotInputs): string {
+  const { agentId, todayISO, engagement, gaps, quiet_streak_days = 0 } = inputs;
+  const lines: string[] = [];
+  lines.push(`Coverage state for ${todayISO}:`);
+  lines.push(`- Engagement: ${engagement}`);
+
+  if (engagement === "rough") {
+    lines.push(
+      "- The patient is in a rough patch (red zone alert active or severe symptom signal).",
+      "- Do NOT emit cadence-style follow-ups. Stay quiet on coverage; surface only what's clinically required.",
+    );
+    return lines.join("\n");
+  }
+
+  if (engagement === "quiet" && quiet_streak_days >= 3) {
+    lines.push(
+      `- Patient has been quiet for ${quiet_streak_days} days. Don't pile on; if you need anything, ask the single most useful question only.`,
+    );
+  }
+
+  // Filter gaps to ones this agent's voice owns. Keeps the snapshot
+  // proportional to what each specialist can act on; the dietician
+  // doesn't see the rehab gaps and vice versa.
+  const ownedGaps = gaps.filter(
+    (g) => AGENT_VOICE_FOR_FIELD[g.field_key] === agentId,
+  );
+  if (ownedGaps.length === 0) {
+    lines.push("- No outstanding coverage gaps in your discipline today.");
+    return lines.join("\n");
+  }
+
+  lines.push("- Outstanding coverage gaps in your discipline today:");
+  for (const g of ownedGaps) {
+    lines.push(`  · ${g.field_key} — ${g.body.en}`);
+  }
+
+  lines.push("");
+  lines.push("Reasoning rules (read carefully):");
+  lines.push(
+    "- A gap is ABSENCE of a logged value. Absence alone is NOT a reason to emit a follow-up.",
+  );
+  lines.push(
+    "- Emit a follow-up ONLY when absence intersects a recent concerning datum (e.g. patient said 'nauseous' yesterday + appetite not logged today → ask once, gently). Phrase the question in a way that meets the patient where they are: 'was it a hard day, or just forgotten?'",
+  );
+  lines.push(
+    "- The system already surfaces a coverage card for each gap. Do NOT re-prompt the same field — only add value when you can connect the absence to something else you've seen.",
+  );
+  lines.push(
+    "- Cap yourself at 1 absence-driven follow-up per run. Calm engagement is the rule.",
+  );
+
+  return lines.join("\n");
+}

--- a/src/lib/log/run-agents.ts
+++ b/src/lib/log/run-agents.ts
@@ -12,6 +12,8 @@ import { FOLLOW_UP_PRIORITY } from "~/config/agent-cadence";
 import type { Locale } from "~/types/clinical";
 import { agentsForTags } from "~/agents/routing";
 import { HttpError, postJson } from "~/lib/utils/http";
+import { computeCoverageGaps } from "~/lib/coverage/log-coverage";
+import { formatCoverageSnapshot } from "~/lib/coverage/agent-snapshot";
 
 // Client-side orchestration for running one specialist agent.
 // 1. Read state.md + recent feedback for this agent from Dexie
@@ -67,6 +69,15 @@ export async function runAgentClient(
     );
   }
 
+  // Coverage snapshot: pure-formatter view of today's gaps + engagement
+  // state, scoped to this agent's discipline. Best-effort — if any
+  // Dexie lookup fails we omit the snapshot rather than failing the
+  // run; the agent simply runs without absence reasoning.
+  const coverageSnapshot = await buildCoverageSnapshot(
+    args.agentId,
+    args.date,
+  );
+
   let body: { agent_id: AgentId; ran_at: string; output: AgentOutput };
   try {
     body = await postJson(`/api/agent/${args.agentId}/run`, {
@@ -76,6 +87,7 @@ export async function runAgentClient(
       locale: args.locale,
       date: args.date,
       trigger: args.trigger,
+      coverage_snapshot: coverageSnapshot,
     });
   } catch (err) {
     if (err instanceof HttpError) {
@@ -358,4 +370,55 @@ export async function runAllAgentsForToday(args: {
       }
     }),
   );
+}
+
+// Best-effort coverage snapshot for the agent prompt. Reuses the same
+// pure detector the dashboard uses, so the agent and the patient see a
+// consistent view of "what's missing today". Returns undefined on any
+// failure — the agent runs without absence reasoning rather than
+// failing the whole invocation.
+async function buildCoverageSnapshot(
+  agentId: AgentId,
+  date: string,
+): Promise<string | undefined> {
+  try {
+    const start = isoDaysBefore(date, 27);
+    const end = date;
+    const recentDailies = await db.daily_entries
+      .where("date")
+      .between(start, end, true, true)
+      .toArray();
+    const settings = (await db.settings.toArray())[0] ?? null;
+    const activeAlerts = (await db.zone_alerts.toArray()).filter(
+      (a) => !a.resolved,
+    );
+    const snoozes = await db.coverage_snoozes.toArray();
+    const result = computeCoverageGaps({
+      todayISO: date,
+      recentDailies,
+      settings,
+      cycleContext: null,
+      activeAlerts,
+      snoozes,
+    });
+    return formatCoverageSnapshot({
+      agentId,
+      todayISO: date,
+      engagement: result.engagement,
+      gaps: result.gaps,
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn("[log] coverage snapshot failed", err);
+    return undefined;
+  }
+}
+
+function isoDaysBefore(iso: string, n: number): string {
+  const d = new Date(iso + "T12:00:00.000Z");
+  d.setUTCDate(d.getUTCDate() - n);
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
 }

--- a/tests/unit/agent-coverage-snapshot.test.ts
+++ b/tests/unit/agent-coverage-snapshot.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { formatCoverageSnapshot } from "~/lib/coverage/agent-snapshot";
+import type { CoverageGap } from "~/types/coverage";
+
+function gap(field_key: string, body = "(prompt)"): CoverageGap {
+  return {
+    id: `coverage_${field_key}`,
+    field_key,
+    priority: 50,
+    title: { en: "x", zh: "x" },
+    body: { en: body, zh: body },
+    cta_href: `/daily/new?step=${field_key}`,
+    icon: "salad",
+  };
+}
+
+describe("formatCoverageSnapshot", () => {
+  it("renders the rough-state instruction and stops there", () => {
+    const out = formatCoverageSnapshot({
+      agentId: "nutrition",
+      todayISO: "2026-05-01",
+      engagement: "rough",
+      gaps: [gap("digestion")],
+    });
+    expect(out).toMatch(/rough patch/);
+    expect(out).toMatch(/Do NOT emit cadence-style follow-ups/);
+    // Should not include reasoning rules — the agent is told to stay silent.
+    expect(out).not.toMatch(/Reasoning rules/);
+  });
+
+  it("includes only gaps in this agent's discipline", () => {
+    const out = formatCoverageSnapshot({
+      agentId: "nutrition",
+      todayISO: "2026-05-01",
+      engagement: "active",
+      gaps: [
+        gap("digestion", "stool prompt"),
+        gap("walking", "walking prompt"),  // rehabilitation — should be filtered out
+        gap("temperature_nadir", "temp prompt"), // toxicity — should be filtered out
+      ],
+    });
+    expect(out).toMatch(/digestion/);
+    expect(out).not.toMatch(/walking prompt/);
+    expect(out).not.toMatch(/temp prompt/);
+  });
+
+  it("scopes the toxicity snapshot to nurse-owned fields", () => {
+    const out = formatCoverageSnapshot({
+      agentId: "toxicity",
+      todayISO: "2026-05-01",
+      engagement: "active",
+      gaps: [
+        gap("digestion", "should not appear"),
+        gap("temperature_nadir", "temperature here"),
+      ],
+    });
+    expect(out).toMatch(/temperature_nadir/);
+    expect(out).not.toMatch(/should not appear/);
+  });
+
+  it("renders 'no outstanding gaps' when nothing in this discipline matches", () => {
+    const out = formatCoverageSnapshot({
+      agentId: "nutrition",
+      todayISO: "2026-05-01",
+      engagement: "active",
+      gaps: [gap("walking")],
+    });
+    expect(out).toMatch(/No outstanding coverage gaps/);
+  });
+
+  it("includes the absence+data reasoning rules and the 1-per-run cap", () => {
+    const out = formatCoverageSnapshot({
+      agentId: "nutrition",
+      todayISO: "2026-05-01",
+      engagement: "active",
+      gaps: [gap("digestion")],
+    });
+    expect(out).toMatch(/Absence alone is NOT a reason/);
+    expect(out).toMatch(/Cap yourself at 1 absence-driven follow-up per run/);
+    expect(out).toMatch(/Do NOT re-prompt the same field/);
+  });
+
+  it("adds a quiet-streak hint when the patient has been silent for 3+ days", () => {
+    const out = formatCoverageSnapshot({
+      agentId: "nutrition",
+      todayISO: "2026-05-01",
+      engagement: "quiet",
+      gaps: [gap("digestion")],
+      quiet_streak_days: 5,
+    });
+    expect(out).toMatch(/quiet for 5 days/);
+    expect(out).toMatch(/single most useful question only/);
+  });
+
+  it("does not add the quiet-streak hint when below threshold", () => {
+    const out = formatCoverageSnapshot({
+      agentId: "nutrition",
+      todayISO: "2026-05-01",
+      engagement: "quiet",
+      gaps: [gap("digestion")],
+      quiet_streak_days: 1,
+    });
+    expect(out).not.toMatch(/quiet for/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes PR-D2 from the calm-engagement plan. The dietician (`nutrition`) and nurse (`toxicity`) agents now see today's **coverage state** — the patient's engagement state plus which fields in their discipline are unlogged — as a fourth cached system block on every run. They reason over **absence + data together** and emit at most **one absence-driven follow-up per run**, only when absence intersects something concerning the agent has already seen.

This is the agent-side complement to PR-D1: the platform's coverage cards still own the "please log X" prompt, while the agent's role is the **connection** — "you said you were nauseous yesterday and didn't log appetite today — was eating tough, or just forgotten?".

## Calm-engagement contract preserved end-to-end

- `engagement=rough` → snapshot tells the agent to stay silent on coverage entirely. Safety alerts own the channel.
- `engagement=quiet` with multi-day silence → agent permitted **at most one** targeted question, phrased as meeting-the-patient-where-they-are.
- Otherwise → at most one absence-driven follow-up, only when paired with concerning data.

## Implementation

- **`src/lib/coverage/agent-snapshot.ts`** — pure formatter. Filters gaps to the agent's own discipline (dietician sees nutrition gaps, nurse sees toxicity gaps, physio sees movement gaps) so each specialist gets a proportional view, never the full list.
- **`src/agents/run.ts`** — optional `coverageSnapshot` arg becomes a fourth ephemeral-cache system block. Older callers omit it; agents simply run without absence reasoning.
- **`src/app/api/agent/[id]/run/route.ts`** — `RequestSchema` gains optional `coverage_snapshot` string; passed through to `runAgent`.
- **`src/lib/log/run-agents.ts`** — computes the snapshot from Dexie (recent dailies, settings, zone_alerts, coverage_snoozes) using the **same** `computeCoverageGaps` detector the dashboard uses, so the agent and the patient see one consistent view of what's missing. Best-effort: any Dexie failure logs and omits the snapshot rather than failing the run.

## Role.md updates

- **`nutrition`** (AI Dietician) and **`toxicity`** (AI Nurse) — new "Coverage state (read carefully)" section explaining the snapshot, the absence+data reasoning rule, the 1-per-run cap, and the rough/quiet special cases.

Key wording in both: *"A coverage gap is just absence of a logged value. The patient's dashboard already shows them a separate small card asking for that field. Do not re-ask the patient to log a field as a follow-up — that would duplicate the coverage card."*

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no warnings or errors
- [x] `pnpm test` — **906/906 pass** (7 new tests in `tests/unit/agent-coverage-snapshot.test.ts`):
    - rough engagement renders the silence instruction and stops there
    - gaps are filtered to the calling agent's discipline (nutrition vs toxicity scoping)
    - "no outstanding gaps" path
    - absence+data reasoning rules + 1-per-run cap land in the rendered prompt
    - multi-day quiet streak adds a soft hint; below threshold it doesn't
- [ ] Manual smoke: trigger a nutrition agent run with the patient in `engagement=quiet` after 5 silent days — confirm exactly one targeted question is emitted, phrased softly. Then trigger again with `engagement=rough` (red zone) — confirm zero absence-driven follow-ups.

https://claude.ai/code/session_01UZu1c3M2RX5zi4G2nSZuCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZu1c3M2RX5zi4G2nSZuCr)_