### PR TITLE
refactor: dedupe time, household, and streak helpers

### DIFF
--- a/src/app/api/agent/[id]/run/route.ts
+++ b/src/app/api/agent/[id]/run/route.ts
@@ -12,6 +12,7 @@ import { runAgent } from "~/agents/run";
 import { readJsonBody } from "~/lib/anthropic/route-helpers";
 import { requireSession } from "~/lib/auth/require-session";
 import { loadHouseholdProfile } from "~/lib/household/profile";
+import { nowISO } from "~/lib/utils/date";
 
 export const runtime = "nodejs";
 // Specialist agents chew through referrals + state and emit up to 2k tokens
@@ -122,7 +123,7 @@ export async function POST(
 
   return NextResponse.json({
     agent_id: id,
-    ran_at: new Date().toISOString(),
+    ran_at: nowISO(),
     referral_count: parsed.data.referrals.length,
     trigger: parsed.data.trigger,
     output,

--- a/src/app/api/ai/parse-meal/route.ts
+++ b/src/app/api/ai/parse-meal/route.ts
@@ -6,8 +6,10 @@ import {
   readJsonBody,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
-import { getSupabaseServer } from "~/lib/supabase/server";
-import { loadHouseholdProfile } from "~/lib/household/profile";
+import {
+  getOptionalHouseholdId,
+  loadHouseholdProfile,
+} from "~/lib/household/profile";
 import {
   ParsedMealSchema,
   buildNutritionSystem,
@@ -55,27 +57,8 @@ export async function POST(req: Request) {
 
   // Local-first: this route is called from /nutrition meal-ingest AND
   // from the voice-memo apply step (macro fill on parsed meals). Both
-  // surfaces work pre-sign-in per middleware.ts. Best-effort household
-  // lookup so the prompt can still personalise when a session exists;
-  // falls back to FALLBACK_HOUSEHOLD_PROFILE otherwise.
-  let householdId: string | null = null;
-  try {
-    const sb = getSupabaseServer();
-    if (sb) {
-      const { data } = await sb.auth.getUser();
-      if (data?.user) {
-        const { data: membership } = await sb
-          .from("household_memberships")
-          .select("household_id")
-          .eq("user_id", data.user.id)
-          .maybeSingle();
-        householdId = (membership?.household_id as string | undefined) ?? null;
-      }
-    }
-  } catch {
-    // unauthenticated — use the fallback profile
-  }
-  const profile = await loadHouseholdProfile(householdId);
+  // surfaces work pre-sign-in per middleware.ts.
+  const profile = await loadHouseholdProfile(await getOptionalHouseholdId());
   const localeNote =
     body.locale === "zh"
       ? "Reply in English keys, but populate name_zh for every item."

--- a/src/app/api/ai/parse-voice-memo/route.ts
+++ b/src/app/api/ai/parse-voice-memo/route.ts
@@ -5,8 +5,10 @@ import {
   readJsonBody,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
-import { getSupabaseServer } from "~/lib/supabase/server";
-import { loadHouseholdProfile } from "~/lib/household/profile";
+import {
+  getOptionalHouseholdId,
+  loadHouseholdProfile,
+} from "~/lib/household/profile";
 import { wrapUserInput } from "~/lib/anthropic/wrap-user-input";
 import {
   VoiceMemoParseSchema,
@@ -72,24 +74,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "transcript required" }, { status: 400 });
   }
 
-  let householdId: string | null = null;
-  try {
-    const sb = getSupabaseServer();
-    if (sb) {
-      const { data } = await sb.auth.getUser();
-      if (data?.user) {
-        const { data: membership } = await sb
-          .from("household_memberships")
-          .select("household_id")
-          .eq("user_id", data.user.id)
-          .maybeSingle();
-        householdId = (membership?.household_id as string | undefined) ?? null;
-      }
-    }
-  } catch {
-    // unauthenticated or schema mismatch — use the fallback profile
-  }
-  const profile = await loadHouseholdProfile(householdId);
+  const profile = await loadHouseholdProfile(await getOptionalHouseholdId());
   const localeNote =
     body.locale === "zh"
       ? "The transcript is Mandarin. Translate before extracting."

--- a/src/app/care-team/page.tsx
+++ b/src/app/care-team/page.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
+import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
 import { PageHeader, SectionHeader } from "~/components/ui/page-header";
 import { Card } from "~/components/ui/card";
@@ -231,15 +231,15 @@ function ContactForm({
   const [followUp, setFollowUp] = useState(editing?.follow_up_needed ?? false);
 
   const save = async () => {
-    const nowISO = new Date().toISOString();
+    const at = now();
     const payload: CareTeamContact = {
       date,
       kind,
       with_who: withWho || undefined,
       notes: notes || undefined,
       follow_up_needed: followUp,
-      created_at: editing?.created_at ?? nowISO,
-      updated_at: nowISO,
+      created_at: editing?.created_at ?? at,
+      updated_at: at,
     };
     if (editing?.id) {
       await db.care_team_contacts.update(editing.id, payload);

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -221,12 +221,12 @@ export default function LogPage() {
     // longer the source of truth — the memo is.
     try {
       const logId = (await db.log_events.add({
-        at: new Date().toISOString(),
+        at: now(),
         input: {
           text: text.trim(),
           tags: Array.from(tags),
           locale,
-          at: new Date().toISOString(),
+          at: now(),
         },
       })) as number;
       await db.voice_memos.update(memoId, {

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
+import { db, now } from "~/lib/db/dexie";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { useSettings } from "~/hooks/use-settings";
 import { PageHeader } from "~/components/ui/page-header";
@@ -62,7 +62,7 @@ export default function ReportsPage() {
           db.zone_alerts.toArray(),
         ]);
       const bundle = {
-        exported_at: new Date().toISOString(),
+        exported_at: now(),
         schema_version: 1,
         settings: settingsRows,
         daily_entries: dailies,
@@ -87,8 +87,8 @@ export default function ReportsPage() {
       const existing = settingsRows[0];
       if (existing?.id) {
         await db.settings.update(existing.id, {
-          last_exported_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
+          last_exported_at: now(),
+          updated_at: now(),
         });
       }
     } finally {

--- a/src/components/auth/welcome-auth-modal.tsx
+++ b/src/components/auth/welcome-auth-modal.tsx
@@ -7,6 +7,7 @@ import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client"
 import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
 import { useT } from "~/hooks/use-translate";
+import { nowISO } from "~/lib/utils/date";
 
 const SEEN_KEY = "anchor.welcomeSeenAt";
 
@@ -47,7 +48,7 @@ export function WelcomeAuthModal() {
   }, [open]);
 
   function close() {
-    localStorage.setItem(SEEN_KEY, new Date().toISOString());
+    localStorage.setItem(SEEN_KEY, nowISO());
     setOpen(false);
   }
 
@@ -65,7 +66,7 @@ export function WelcomeAuthModal() {
           password,
         });
         if (error) throw error;
-        localStorage.setItem(SEEN_KEY, new Date().toISOString());
+        localStorage.setItem(SEEN_KEY, nowISO());
         setOpen(false);
         router.refresh();
         return;
@@ -74,7 +75,7 @@ export function WelcomeAuthModal() {
       if (error) throw error;
       // If Supabase returned a session, confirm-email was off — we're in.
       if (data.session) {
-        localStorage.setItem(SEEN_KEY, new Date().toISOString());
+        localStorage.setItem(SEEN_KEY, nowISO());
         setOpen(false);
         router.refresh();
         return;

--- a/src/components/dashboard/change-signals-card.tsx
+++ b/src/components/dashboard/change-signals-card.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useLiveQuery } from "dexie-react-hooks";
-import { db } from "~/lib/db/dexie";
+import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
 import { useSettings } from "~/hooks/use-settings";
 import { Card } from "~/components/ui/card";
@@ -85,7 +85,7 @@ export function ChangeSignalsCard() {
     if (!dailies || !fortnightlies || !labs || !cycles || !careTeamContacts) {
       return;
     }
-    const asOf = new Date().toISOString();
+    const asOf = now();
     const inputs = {
       as_of: asOf,
       settings: settings ?? null,

--- a/src/components/dashboard/sync-prompt-card.tsx
+++ b/src/components/dashboard/sync-prompt-card.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useLiveQuery } from "dexie-react-hooks";
 import { CloudOff, X } from "lucide-react";
-import { db } from "~/lib/db/dexie";
+import { db, now } from "~/lib/db/dexie";
 import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
 import { useT } from "~/hooks/use-translate";
 
@@ -54,7 +54,7 @@ export function SyncPromptCard() {
   if (!entryCount || entryCount < 1) return null;
 
   function handleDismiss() {
-    localStorage.setItem(DISMISS_KEY, new Date().toISOString());
+    localStorage.setItem(DISMISS_KEY, now());
     setDismissed(true);
   }
 

--- a/src/components/family/quick-note.tsx
+++ b/src/components/family/quick-note.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { db } from "~/lib/db/dexie";
+import { db, now } from "~/lib/db/dexie";
 import { useLocale } from "~/hooks/use-translate";
 import { useUIStore } from "~/stores/ui-store";
 import { tagInput } from "~/lib/log/tag";
@@ -31,7 +31,7 @@ export function QuickNote() {
     setError(null);
     try {
       const tags = tagInput(body);
-      const at = new Date().toISOString();
+      const at = now();
       const { getCachedUserId } = await import("~/lib/supabase/current-user");
       const uid = getCachedUserId();
       await db.log_events.add({

--- a/src/hooks/use-household-presence.ts
+++ b/src/hooks/use-household-presence.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { RealtimeChannel } from "@supabase/supabase-js";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
+import { nowISO } from "~/lib/utils/date";
 import { useHousehold } from "./use-household";
 
 // Ephemeral presence: which household members have Anchor open right
@@ -45,7 +46,7 @@ export function useHouseholdPresence(surface: string): {
       user_id: profile.id,
       display_name: profile.display_name || "",
       surface,
-      joined_at: new Date().toISOString(),
+      joined_at: nowISO(),
     };
 
     channel = sb

--- a/src/hooks/use-voice-transcription.ts
+++ b/src/hooks/use-voice-transcription.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { db } from "~/lib/db/dexie";
+import { db, now } from "~/lib/db/dexie";
 import { persistVoiceMemo } from "~/lib/voice-memo/persist";
 import { uploadVoiceMemoAudio } from "~/lib/voice-memo/cloud";
 import { parseVoiceMemo } from "~/lib/voice-memo/parse";
@@ -303,7 +303,7 @@ export function useVoiceTranscription(
                 void db.voice_memos
                   .update(memoId, {
                     transcript: running,
-                    updated_at: new Date().toISOString(),
+                    updated_at: now(),
                   })
                   .catch(() => {
                     // already handled — best effort
@@ -318,7 +318,7 @@ export function useVoiceTranscription(
             try {
               await db.voice_memos.update(memoId, {
                 transcript: text,
-                updated_at: new Date().toISOString(),
+                updated_at: now(),
               });
             } catch (err) {
               // eslint-disable-next-line no-console

--- a/src/lib/calendar/ics-export.ts
+++ b/src/lib/calendar/ics-export.ts
@@ -1,4 +1,5 @@
 import type { Appointment } from "~/types/appointment";
+import { nowISO } from "~/lib/utils/date";
 
 // Serialise the patient's Anchor schedule as RFC 5545 iCalendar text. The
 // output is a one-shot snapshot — Anchor is local-first and appointments
@@ -110,7 +111,7 @@ export function appointmentsToIcs(
   appointments: readonly Appointment[],
   opts: { calendarName?: string } = {},
 ): string {
-  const dtstamp = formatUtc(new Date().toISOString());
+  const dtstamp = formatUtc(nowISO());
   const lines: string[] = [
     "BEGIN:VCALENDAR",
     "VERSION:2.0",

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -416,6 +416,6 @@ export class AnchorDB extends Dexie {
 
 export const db = new AnchorDB();
 
-export function now(): string {
-  return new Date().toISOString();
-}
+// Historical alias for nowISO(). Kept for callers that already import
+// `now` alongside `db` from this module — see ~/lib/utils/date.
+export { nowISO as now } from "~/lib/utils/date";

--- a/src/lib/household/profile.ts
+++ b/src/lib/household/profile.ts
@@ -28,6 +28,28 @@ const FIELDS = [
   "updated_at",
 ].join(", ");
 
+// Best-effort household lookup for routes that work pre-sign-in (per
+// middleware.ts: parse-meal, parse-voice-memo, etc). Never throws —
+// returns null on no session, no Supabase config, or schema error so
+// callers fall through to FALLBACK_HOUSEHOLD_PROFILE. Routes that
+// _require_ a session should use requireSession() instead.
+export async function getOptionalHouseholdId(): Promise<string | null> {
+  try {
+    const sb = getSupabaseServer();
+    if (!sb) return null;
+    const { data } = await sb.auth.getUser();
+    if (!data?.user) return null;
+    const { data: membership } = await sb
+      .from("household_memberships")
+      .select("household_id")
+      .eq("user_id", data.user.id)
+      .maybeSingle();
+    return (membership?.household_id as string | undefined) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function loadHouseholdProfile(
   household_id: string | null,
 ): Promise<HouseholdProfile> {

--- a/src/lib/legacy/biographer.ts
+++ b/src/lib/legacy/biographer.ts
@@ -5,6 +5,7 @@ import type {
 } from "~/types/legacy";
 import type { EnteredBy } from "~/types/clinical";
 import type { FeedItem } from "~/types/feed";
+import { nowISO } from "~/lib/utils/date";
 
 // Biographer — deterministic layer.
 //
@@ -245,7 +246,7 @@ export function recomputeOutlineCoverage(
       linked_entries: matching
         .map((e) => e.id ?? 0)
         .filter((id) => id > 0),
-      updated_at: new Date().toISOString(),
+      updated_at: nowISO(),
     };
   });
 }

--- a/src/lib/legacy/export.ts
+++ b/src/lib/legacy/export.ts
@@ -8,6 +8,7 @@ import type {
   ProfilePrompt,
 } from "~/types/legacy";
 import type { TimelineMedia } from "~/types/timeline";
+import { nowISO } from "~/lib/utils/date";
 
 // Encrypted legacy export bundle.
 //
@@ -133,7 +134,7 @@ export function buildManifest(
 
   return {
     version: 1,
-    exported_at: input.now_iso ?? new Date().toISOString(),
+    exported_at: input.now_iso ?? nowISO(),
     bundle_version: BUNDLE_VERSION,
     consent,
     includes,

--- a/src/lib/legacy/prompts-seed.ts
+++ b/src/lib/legacy/prompts-seed.ts
@@ -1,5 +1,6 @@
 import type { ProfilePrompt, PromptSource } from "~/types/legacy";
 import type { LocalizedText } from "~/types/localized";
+import { nowISO } from "~/lib/utils/date";
 
 // Seeded bilingual prompt library. ~120 prompts across seven evidence-
 // based frameworks plus a deliberate lightness band.
@@ -638,11 +639,11 @@ export async function seedProfilePrompts(
     profile_prompts: import("dexie").Table<ProfilePrompt, number>;
   },
 ): Promise<number> {
-  const now = new Date().toISOString();
+  const at = nowISO();
   const rows = PROMPTS_SEED.map<ProfilePrompt>((p) => ({
     ...p,
-    created_at: now,
-    updated_at: now,
+    created_at: at,
+    updated_at: at,
   }));
   await db.profile_prompts.bulkAdd(rows);
   return rows.length;

--- a/src/lib/push/server.ts
+++ b/src/lib/push/server.ts
@@ -1,5 +1,6 @@
 import webpush from "web-push";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { nowISO } from "~/lib/utils/date";
 
 // Server-side push helpers. VAPID keys live as Vercel env vars:
 //   VAPID_PUBLIC_KEY  (base64-url, also exposed to the client via
@@ -111,7 +112,7 @@ export async function sendPushToUser(
       sent += 1;
       await serviceRole
         .from("push_subscriptions")
-        .update({ last_pushed_at: new Date().toISOString() })
+        .update({ last_pushed_at: nowISO() })
         .eq("id", sub.id);
     } else if (res.status === 404 || res.status === 410) {
       // Endpoint gone — drop the row so it doesn't linger.

--- a/src/lib/rules/zone-rules.ts
+++ b/src/lib/rules/zone-rules.ts
@@ -27,62 +27,63 @@ function gripDeclinePct(s: ClinicalSnapshot): number | null {
 const latestAlbumin = (s: ClinicalSnapshot): number | undefined =>
   s.recentLabs[s.recentLabs.length - 1]?.albumin;
 
-// Count how many of the last `windowDays` daily entries (most recent
-// first) reported loose stools — Bristol ≥ 6 OR raw count above the
-// yellow threshold OR explicit steatorrhoea/oil flag. Used by the
-// "persistent loose stools" rule below; PERT under-titration usually
-// shows up as 3+ days running rather than a single bad day.
-function loosStoolDayStreak(s: ClinicalSnapshot, windowDays: number): number {
-  const recent = [...s.recentDailies]
-    .sort((a, b) => b.date.localeCompare(a.date))
-    .slice(0, windowDays);
-  let streak = 0;
-  for (const d of recent) {
-    const looseByBristol =
-      typeof d.stool_bristol === "number" &&
-      d.stool_bristol >= GI.loose_stool_bristol_min;
-    const looseByCount =
-      typeof d.stool_count === "number" &&
-      d.stool_count >= GI.stool_count_yellow;
-    const looseByDiarrhoeaCount =
-      typeof d.diarrhoea_count === "number" &&
-      d.diarrhoea_count >= GI.stool_count_yellow;
-    const looseByOil = d.stool_oil === true || d.steatorrhoea === true;
-    if (looseByBristol || looseByCount || looseByDiarrhoeaCount || looseByOil) {
-      streak += 1;
-    } else if (streak > 0) {
-      // Break the streak on the first non-loose day; we want consecutive
-      // recent days, not "any 3 of the last 5".
-      break;
-    }
-  }
-  return streak;
-}
+const FN = thresholds.function;
+const PSY = thresholds.psychological;
+const NUT = thresholds.nutrition;
+const DIS = thresholds.disease;
+const GI = thresholds.gi;
 
-function constipationDayStreak(
+// Count consecutive most-recent daily entries that match `predicate`,
+// up to `windowDays`. Streak ends at the first non-matching day — we
+// want "3 days running", not "3 of the last 5". Used for both loose-
+// stool persistence (PERT under-titration signal) and constipation
+// runs; the predicate carries the clinical definition.
+function consecutiveDayStreak(
   s: ClinicalSnapshot,
   windowDays: number,
+  predicate: (d: ClinicalSnapshot["recentDailies"][number]) => boolean,
 ): number {
   const recent = [...s.recentDailies]
     .sort((a, b) => b.date.localeCompare(a.date))
     .slice(0, windowDays);
   let streak = 0;
   for (const d of recent) {
-    const constipated =
-      (typeof d.stool_bristol === "number" &&
-        d.stool_bristol <= GI.constipation_bristol_max) ||
-      (typeof d.stool_count === "number" && d.stool_count === 0);
-    if (constipated) streak += 1;
+    if (predicate(d)) streak += 1;
     else if (streak > 0) break;
   }
   return streak;
 }
 
-const FN = thresholds.function;
-const PSY = thresholds.psychological;
-const NUT = thresholds.nutrition;
-const DIS = thresholds.disease;
-const GI = thresholds.gi;
+const isLooseStoolDay = (
+  d: ClinicalSnapshot["recentDailies"][number],
+): boolean => {
+  const looseByBristol =
+    typeof d.stool_bristol === "number" &&
+    d.stool_bristol >= GI.loose_stool_bristol_min;
+  const looseByCount =
+    typeof d.stool_count === "number" &&
+    d.stool_count >= GI.stool_count_yellow;
+  const looseByDiarrhoeaCount =
+    typeof d.diarrhoea_count === "number" &&
+    d.diarrhoea_count >= GI.stool_count_yellow;
+  const looseByOil = d.stool_oil === true || d.steatorrhoea === true;
+  return looseByBristol || looseByCount || looseByDiarrhoeaCount || looseByOil;
+};
+
+const isConstipationDay = (
+  d: ClinicalSnapshot["recentDailies"][number],
+): boolean =>
+  (typeof d.stool_bristol === "number" &&
+    d.stool_bristol <= GI.constipation_bristol_max) ||
+  (typeof d.stool_count === "number" && d.stool_count === 0);
+
+const loosStoolDayStreak = (s: ClinicalSnapshot, windowDays: number): number =>
+  consecutiveDayStreak(s, windowDays, isLooseStoolDay);
+
+const constipationDayStreak = (
+  s: ClinicalSnapshot,
+  windowDays: number,
+): number => consecutiveDayStreak(s, windowDays, isConstipationDay);
 
 const MS_PER_DAY = 24 * 3600 * 1000;
 

--- a/src/lib/state/detectors/events.ts
+++ b/src/lib/state/detectors/events.ts
@@ -4,7 +4,7 @@
 // marks as done writes one row here. The attribution layer consumes this
 // log to answer "was this signal's resolution preceded by any of the
 // suggested actions?" — the core loop of the app.
-import { db } from "~/lib/db/dexie";
+import { db, now } from "~/lib/db/dexie";
 import type {
   ChangeSignalRow,
   SignalEventKind,
@@ -34,7 +34,7 @@ export async function logSignalEvent(
     action_ref_id: input.action_ref_id,
     action_kind: input.action_kind,
     note: input.note,
-    created_at: input.at ?? new Date().toISOString(),
+    created_at: input.at ?? now(),
   };
   return (await db.signal_events.add(row)) as number;
 }

--- a/src/lib/state/detectors/persistence.ts
+++ b/src/lib/state/detectors/persistence.ts
@@ -2,7 +2,7 @@
 // detector orchestration stays pure and the consumer (UI, background job)
 // handles IO. Writes to signal_events on every lifecycle transition so the
 // attribution layer (slice 4) can walk the timeline.
-import { db } from "~/lib/db/dexie";
+import { db, now } from "~/lib/db/dexie";
 import { latestChangeSignals } from "~/lib/db/queries";
 import type { ChangeSignalRow, SignalEventKind } from "~/types/clinical";
 import { evaluateDetectors, reconcileSignals } from ".";
@@ -114,11 +114,11 @@ export async function setSignalStatus(
   status: SignalStatus,
   note?: string,
 ): Promise<void> {
-  const nowISO = new Date().toISOString();
+  const at = now();
   await db.change_signals.update(id, {
     status,
     resolved_at:
-      status === "resolved" || status === "dismissed" ? nowISO : undefined,
+      status === "resolved" || status === "dismissed" ? at : undefined,
     note,
   });
   const kind = statusToEventKind(status);
@@ -127,7 +127,7 @@ export async function setSignalStatus(
       signal_id: id,
       kind,
       note,
-      at: nowISO,
+      at,
     });
   }
 }

--- a/src/lib/supabase/households.ts
+++ b/src/lib/supabase/households.ts
@@ -1,4 +1,5 @@
 import { getSupabaseBrowser } from "./client";
+import { nowISO } from "~/lib/utils/date";
 import type {
   Household,
   HouseholdInvite,
@@ -353,7 +354,7 @@ export async function revokeInvite(inviteId: string): Promise<void> {
   if (!sb) return;
   const { error } = await sb
     .from("household_invites")
-    .update({ revoked_at: new Date().toISOString() })
+    .update({ revoked_at: nowISO() })
     .eq("id", inviteId);
   if (error) throw error;
 }

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -1,4 +1,5 @@
 import { getSupabaseBrowser } from "~/lib/supabase/client";
+import { nowISO } from "~/lib/utils/date";
 import { getCachedHouseholdId, refreshHouseholdId } from "./household-context";
 import type { SyncedTable } from "./tables";
 
@@ -71,7 +72,7 @@ async function processQueue(): Promise<void> {
               data: op.data,
               deleted: false,
               household_id: householdId,
-              updated_at: new Date().toISOString(),
+              updated_at: nowISO(),
             },
             { onConflict: "table_name,local_id" },
           );
@@ -81,7 +82,7 @@ async function processQueue(): Promise<void> {
             .from("cloud_rows")
             .update({
               deleted: true,
-              updated_at: new Date().toISOString(),
+              updated_at: nowISO(),
             })
             .eq("table_name", op.table)
             .eq("local_id", op.local_id)

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -10,6 +10,14 @@ export function todayISO(): string {
   return `${yyyy}-${mm}-${dd}`;
 }
 
+// Current instant as a UTC ISO string. The de-facto wire format for
+// `created_at`/`updated_at`/`at` columns and any timestamp written
+// through Dexie or Supabase. Centralised so a future move to a clock
+// abstraction (or fixed-clock testing) only touches one site.
+export function nowISO(): string {
+  return new Date().toISOString();
+}
+
 // Return the YYYY-MM-DD prefix of any ISO datetime string. Used widely for
 // keying dailies/meals/appointments by calendar date.
 export function isoDatePart(iso: string): string {

--- a/src/lib/weather/open-meteo.ts
+++ b/src/lib/weather/open-meteo.ts
@@ -1,3 +1,5 @@
+import { nowISO } from "~/lib/utils/date";
+
 // Open-Meteo — free, keyless, CORS-enabled weather + geocoding.
 // We send only city name (to geocode) and lat/lon (to forecast). Nothing
 // identifying about the patient leaves the device.
@@ -97,7 +99,7 @@ export async function fetchCurrentWeather({
   const min_temp_c_24h = next24.length ? Math.min(...next24) : t;
   const max_temp_c_24h = next24.length ? Math.max(...next24) : t;
   return {
-    fetched_at: new Date().toISOString(),
+    fetched_at: nowISO(),
     city,
     latitude,
     longitude,


### PR DESCRIPTION
## Summary

Three focused DRY passes, scoped to land cleanly without behaviour change.

- **`nowISO()` helper.** New `nowISO()` in `src/lib/utils/date.ts` is now the canonical UTC ISO timestamp source. 28 inline `new Date().toISOString()` call sites across components, hooks, API routes, and lib modules now go through it. The pre-existing `now()` in `src/lib/db/dexie.ts` (used by 56 files) is preserved as a re-export so callers keep working but share one implementation.
- **`getOptionalHouseholdId()`.** `parse-meal` and `parse-voice-memo` each inlined the same 15-line `try { sb.auth.getUser(); household_memberships lookup } catch {}` for their pre-sign-in fallback path. Extracted to `src/lib/household/profile.ts` — the two routes now do `loadHouseholdProfile(await getOptionalHouseholdId())`.
- **`consecutiveDayStreak()`.** `loosStoolDayStreak` and `constipationDayStreak` in `src/lib/rules/zone-rules.ts` had identical sort/slice/loop algorithms. Extracted to one `consecutiveDayStreak(snapshot, window, predicate)` plus named `isLooseStoolDay` / `isConstipationDay` predicates. The clinical definitions now live where they belong.

Notes on what was deliberately **not** done from the survey:

- 1,200+ `locale === "zh"` ternaries — too sweeping for a single PR.
- Mega-page splits (memos detail, onboarding wizard, daily wizard) — high blast radius, needs UX review.
- `AnthropicGate` / `JsonBodyResult` "consolidation" — the field names (`client`, `body`, `value`) are semantically meaningful; collapsing to a single `Result<T>` would force renames at every call site for no readability gain.
- Blanket `slice(0, 10)` → `isoDatePart()` rewrite — marginal clarity gain over churn.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 98 files / 883 tests pass
- [ ] Smoke-check the two refactored API routes (`/api/ai/parse-meal`, `/api/ai/parse-voice-memo`) on a local dev server signed-in and signed-out
- [ ] Confirm zone-rules engine still emits the same alerts for the persistent-loose-stool and constipation fixtures

https://claude.ai/code/session_01Rxg5qvRZPXj1zy4uadDoi9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rxg5qvRZPXj1zy4uadDoi9)_