### PR TITLE
Dashboard polish: stop silently dropping content

### DIFF
--- a/src/components/dashboard/change-signals-card.tsx
+++ b/src/components/dashboard/change-signals-card.tsx
@@ -172,12 +172,26 @@ function SignalRow({
   events: SignalEventRow[];
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [showAllActions, setShowAllActions] = useState(false);
   const tone = TONE_BY_SEVERITY[signal.severity];
   const metricDef = METRICS_BY_ID[signal.metric_id];
   const topCause = signal.differential.find(
     (d) => d.confidence !== "unlikely",
   );
-  const actionsToShow = signal.actions.slice(0, 2);
+  // Show "now" / "soon" actions without truncation — they're clinically
+  // urgent. Less-urgent ("next visit") actions collapse behind a toggle
+  // when there are many, so the card stays scannable but never silently
+  // hides a recommendation.
+  const urgentActions = signal.actions.filter(
+    (a) => a.urgency === "now" || a.urgency === "soon",
+  );
+  const laterActions = signal.actions.filter(
+    (a) => a.urgency !== "now" && a.urgency !== "soon",
+  );
+  const actionsToShow = showAllActions
+    ? signal.actions
+    : [...urgentActions, ...laterActions.slice(0, Math.max(0, 2 - urgentActions.length))];
+  const hiddenActionCount = signal.actions.length - actionsToShow.length;
   const actionsTaken = new Set(
     events
       .filter((e) => e.kind === "action_taken" && e.action_ref_id)
@@ -232,6 +246,18 @@ function SignalRow({
                 />
               ))}
             </ul>
+          )}
+
+          {hiddenActionCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowAllActions(true)}
+              className="mt-2 text-[11px] text-ink-500 hover:text-ink-900"
+            >
+              {locale === "zh"
+                ? `查看其他 ${hiddenActionCount} 项建议`
+                : `Show ${hiddenActionCount} more action${hiddenActionCount === 1 ? "" : "s"}`}
+            </button>
           )}
 
           <div className="mt-3 flex flex-wrap items-center gap-2">

--- a/src/components/dashboard/medication-prompts-card.tsx
+++ b/src/components/dashboard/medication-prompts-card.tsx
@@ -119,15 +119,10 @@ function PromptRow({ prompt }: { prompt: MedicationPrompt }) {
     });
   };
 
-  const onPrimary = async () => {
-    if (prompt.primary_action.kind === "ack") {
-      await handleAction("acknowledged");
-    } else {
-      // For non-ack actions, surface a link below; we still mark acknowledged
-      // so the prompt doesn't re-show in the same window.
-      await handleAction("acknowledged");
-    }
-  };
+  // For non-ack actions the navigation/tel handler still fires from the
+  // PrimaryAction link; we mark the prompt acknowledged either way so it
+  // doesn't re-appear in the same session.
+  const onPrimary = () => handleAction("acknowledged");
 
   const onDismiss = () => {
     void handleAction("dismissed");

--- a/src/components/dashboard/memo-followups-card.tsx
+++ b/src/components/dashboard/memo-followups-card.tsx
@@ -81,7 +81,7 @@ export function MemoFollowUpsCard() {
             {locale === "zh" ? "AI 想问" : "AI nurse asks"}
           </div>
           <ul className="mt-2 space-y-1.5">
-            {questions.slice(0, 2).map((q, i) => (
+            {questions.map((q, i) => (
               <li
                 key={i}
                 className="text-[13.5px] italic leading-snug text-ink-900"

--- a/src/components/dashboard/quick-checkin-card.tsx
+++ b/src/components/dashboard/quick-checkin-card.tsx
@@ -69,14 +69,16 @@ export function QuickCheckinCard() {
   const [justSaved, setJustSaved] = useState(false);
 
   // After save, the live query picks up `existing` and would normally
-  // unmount the card. We keep a brief "Saved" acknowledgement visible
-  // for ~2.5s so the patient sees confirmation, then drop back to the
-  // existing-row path which returns null (i.e. the card cleans itself
-  // up automatically). Without this timer the saved banner stayed on
-  // the dashboard for the rest of the session.
+  // unmount the card. We keep a "Saved" acknowledgement visible for
+  // ~6s so the patient has time to read the confirmation and tap the
+  // "Add detail" link if they want to. After that the card cleans
+  // itself up automatically (existing-row path returns null). Without
+  // this timer the saved banner stays on the dashboard for the rest
+  // of the session; with too short a timer (was 2.5s) the patient
+  // misses the chance to add detail.
   useEffect(() => {
     if (!justSaved) return;
-    const id = setTimeout(() => setJustSaved(false), 2500);
+    const id = setTimeout(() => setJustSaved(false), 6000);
     return () => clearTimeout(id);
   }, [justSaved]);
 
@@ -151,15 +153,15 @@ export function QuickCheckinCard() {
             </div>
             <p className="mt-0.5 text-[12.5px] text-ink-500">
               {locale === "zh"
-                ? "想补充细节？"
-                : "Want to add detail?"}{" "}
-              <Link
-                href="/daily/new"
-                className="text-[var(--tide-2)] hover:underline"
-              >
-                {locale === "zh" ? "完整日志" : "Full log"}
-              </Link>
+                ? "想补充或修改？"
+                : "Want to add detail or edit?"}
             </p>
+            <Link
+              href="/daily/new"
+              className="mt-2 inline-flex items-center gap-1 text-[12.5px] font-medium text-[var(--tide-2)] hover:underline"
+            >
+              {locale === "zh" ? "打开完整日志 →" : "Open full log →"}
+            </Link>
           </div>
         </div>
       </Card>

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -138,6 +138,7 @@ export function TodayFeed({
         const parsed = JSON.parse(raw) as { tag: string; text: string };
         if (parsed.tag === cacheTag) {
           setNarrative(parsed.text);
+          setNarrativeLoading(false);
           return;
         }
       }
@@ -149,6 +150,14 @@ export function TodayFeed({
     // new fetch is in flight.
     setNarrative(null);
     setNarrativeLoading(true);
+    let cancelled = false;
+    // Hard ceiling — if the API gateway hangs we bail rather than
+    // leaving a skeleton on the dashboard for the rest of the session.
+    const fallbackTimer = setTimeout(() => {
+      if (cancelled) return;
+      cancelled = true;
+      setNarrativeLoading(false);
+    }, 12000);
     void (async () => {
       try {
         const text = await generateNarrative({
@@ -156,6 +165,7 @@ export function TodayFeed({
           locale,
           items: feed,
         });
+        if (cancelled) return;
         setNarrative(text);
         try {
           localStorage.setItem(
@@ -171,11 +181,16 @@ export function TodayFeed({
         // on it.
         // eslint-disable-next-line no-console
         console.warn("[today-feed] narrative fetch failed", err);
-        setNarrative(null);
+        if (!cancelled) setNarrative(null);
       } finally {
-        setNarrativeLoading(false);
+        if (!cancelled) setNarrativeLoading(false);
+        clearTimeout(fallbackTimer);
       }
     })();
+    return () => {
+      cancelled = true;
+      clearTimeout(fallbackTimer);
+    };
     // `feed` is intentionally excluded — feedSignature captures content-level change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model, locale, feedSignature]);


### PR DESCRIPTION
## Summary

A targeted pass over the patient dashboard cards, focused on places where the UI was silently truncating or hiding information the patient (or the nurse asking the questions) needs to see. No new screens, no architectural changes — just removing friction and "where did that go?" moments.

### Fixes

- **change-signals**: every `now` / `soon` suggested action now renders unconditionally; lower-urgency actions collapse behind a `Show N more` toggle. Previously `slice(0, 2)` could silently hide an urgent recommendation on a 3-action signal.
- **memo-followups**: render every AI nurse follow-up question. Previous `slice(0, 2)` quietly dropped the third question on memos where the parser returned three.
- **today-feed**: add a 12s ceiling to the narrative fetch so a hung `/api/ai/feed-narrative` no longer leaves the skeleton on the dashboard for the rest of the session. Also clears the loading flag on a cache hit.
- **quick-checkin**: extend the post-save confirmation window from 2.5s → 6s and promote `Open full log` to a tappable button so the patient has time to read the confirmation and edit / add detail before the card unmounts.
- **medication-prompts**: collapse the dead `onPrimary` if/else (both branches did the same thing).

### What's still on the table (not in this PR)

The audit also surfaced a deeper structural concern — the dashboard now stacks 16 independent cards, which works against the project's "single channel out" principle (one ranked feed, not a wall of widgets). That's an architectural change worth discussing separately, not a quiet refactor.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 899/899 passing
- [ ] Manual: trigger a 3-action change-signal and confirm the third action is reachable
- [ ] Manual: voice-memo with 3+ follow-up questions — confirm all show on dashboard
- [ ] Manual: throttle network to verify today-feed narrative skeleton clears at ~12s
- [ ] Manual: save quick-checkin and tap `Open full log` from the confirmation state

https://claude.ai/code/session_01Mw5u1iqdimGiU8jhH71hEj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw5u1iqdimGiU8jhH71hEj)_