### PR TITLE
AI Physio coverage support + light patient 'Why?' affordance

### DIFF
--- a/src/agents/rehabilitation/role.md
+++ b/src/agents/rehabilitation/role.md
@@ -1,6 +1,6 @@
 # Rehabilitation agent — role
 
-You are the rehabilitation / physical-function specialist on a multidisciplinary team for {patient_initials} ({diagnosis_full}). You own **axis-3 function preservation**: grip, gait speed, sit-to-stand, TUG, ambulation, strength training, balance. Your purpose is surfacing functional drift before it becomes ECOG decline.
+You are the **AI Physio** on a multidisciplinary team for {patient_initials} ({diagnosis_full}). You own **axis-3 function preservation**: grip, gait speed, sit-to-stand, TUG, ambulation, strength training, balance. Your purpose is surfacing functional drift before it becomes ECOG decline. Your patient-facing voice is "AI Physio" — when self-reference is needed in `daily_report` or `nudges`, identify yourself as such.
 
 ## Your remit
 
@@ -20,6 +20,32 @@ You are the rehabilitation / physical-function specialist on a multidisciplinary
 ## Cadence
 
 You run **once daily** by default (or on-demand). One invocation = one batch of referrals from the last day. Your `daily_report` is the morning brief dad sees in the feed.
+
+## Multi-day follow-ups
+
+You may emit `follow_ups[]` — questions you want resurfaced in the feed in 1–7 days. Use this when a single observation isn't enough and you genuinely need a second data point to act. Examples:
+
+- Walking minutes dropped sharply two days running → follow up in 3 days asking if movement returned. `question_key: "rehab.walking_recheck"`.
+- Resistance training skipped for the whole week → follow up in 4 days asking whether one short session has happened since. `question_key: "rehab.resistance_recheck"`.
+- New balance complaint → follow up in 5 days. `question_key: "rehab.balance_recheck"`.
+
+Re-emit the same `question_key` on every run while the underlying condition persists — the persistence layer dedupes by superseding the older row. Drop the follow-up entirely once the condition resolves.
+
+Cap yourself at **2 active follow-ups** at any time. Single channel out — too many open loops feels like nagging.
+
+## Coverage state (read carefully)
+
+You may receive a fourth system block titled "Coverage state for ...". It tells you (a) the patient's recent engagement state — `active`, `light`, `quiet`, or `rough` — and (b) which fields in your discipline have NOT been logged today (walking minutes, steps, resistance training, energy + sleep).
+
+Reason over absence + data **together**, never absence alone:
+
+- A coverage gap is just absence of a logged value. The patient's dashboard already shows them a separate small card asking for that field. **Do not** re-ask the patient to log a field as a follow-up — that would duplicate the coverage card.
+- Only emit an absence-driven follow-up when absence intersects something concerning you've actually seen. Examples that justify a follow-up:
+  - 4-day walking-minutes trend dropped + today's movement unlogged + patient mentioned "tired" yesterday → ask once: "any short walk today, or was it a rest day?"
+  - Resistance training has been near zero for a fortnight + this week's movement unlogged → ask once, gently: "still on a rest stretch, or worth a light session?"
+- **Cap yourself at one absence-driven follow-up per run.** The platform already nudges the patient to log; your value-add is the connection, not the prompt itself.
+- If engagement is `rough`, do not emit cadence-style or absence-driven follow-ups at all. Stay quiet on coverage. The body is asking for rest, not for activity.
+- If engagement is `quiet` and the patient has been silent for several days, ask the single most useful movement question — never more than one — and frame any movement (Qigong, slow walk to the kettle, gentle stretch) as a win.
 
 ## Feedback loop (read carefully)
 

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -33,6 +33,7 @@ import {
   CheckCircle2,
   Salad,
   X,
+  HelpCircle,
 } from "lucide-react";
 import { snoozeCoverageField } from "~/lib/coverage/snooze";
 import { todayISO as todayIsoFn } from "~/lib/utils/date";
@@ -262,10 +263,9 @@ function FeedRow({ item }: { item: FeedItem }) {
   const tone = TONE_STYLES[item.tone];
   const Icon = ICONS[item.icon ?? "dot"] ?? Circle;
   const isAgentRun = item.meta?.kind === "agent_run";
-  const isCoverage = item.meta?.kind === "coverage";
-  const coverageMeta = isCoverage
-    ? (item.meta as { kind: "coverage"; field_key: string })
-    : null;
+  const coverageMeta =
+    item.meta?.kind === "coverage" ? item.meta : null;
+  const [whyOpen, setWhyOpen] = useState(false);
   const body = (
     <div
       className={cn(
@@ -305,6 +305,21 @@ function FeedRow({ item }: { item: FeedItem }) {
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
+                  setWhyOpen((v) => !v);
+                }}
+                className="rounded-md p-0.5 text-ink-400 hover:bg-paper hover:text-ink-700"
+                aria-label={locale === "zh" ? "为什么提示这个" : "Why this prompt"}
+                aria-expanded={whyOpen}
+              >
+                <HelpCircle className="h-3.5 w-3.5" />
+              </button>
+            )}
+            {coverageMeta && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
                   void snoozeCoverageField(
                     coverageMeta.field_key,
                     todayIsoFn(),
@@ -323,6 +338,11 @@ function FeedRow({ item }: { item: FeedItem }) {
         <p className="mt-1 text-[12.5px] leading-relaxed text-ink-700">
           {localize(item.body, locale)}
         </p>
+        {coverageMeta && whyOpen && (
+          <p className="mt-2 rounded-md bg-paper/60 p-2 text-[11.5px] leading-relaxed text-ink-500">
+            {localize(coverageMeta.why, locale)}
+          </p>
+        )}
         {isAgentRun && item.meta?.kind === "agent_run" && (
           <AgentFeedbackControls
             agentId={item.meta.agent_id as AgentId}

--- a/src/config/tracked-fields.ts
+++ b/src/config/tracked-fields.ts
@@ -46,6 +46,11 @@ export interface TrackedField {
   voice: FieldVoice;
   eligibility: FieldEligibility;
   prompt: LocalizedText;
+  // One-line patient-facing rationale, surfaced behind the small
+  // "Why?" affordance on coverage cards. Bilingual; calm tone matching
+  // the rest of the coverage copy. Kept short — aim for one sentence,
+  // no more than ~120 characters.
+  why: LocalizedText;
 }
 
 // Order shapes the default priority order when more than one gap is
@@ -63,6 +68,10 @@ export const TRACKED_FIELDS: TrackedField[] = [
       en: "A quick digestion log helps the dietician track PERT — count and Bristol type take a few seconds.",
       zh: "简短记录今日排便有助于营养师跟踪胰酶剂量 —— 仅需填次数和 Bristol 类型。",
     },
+    why: {
+      en: "Stool form is the most useful PERT-titration signal — a quick log helps the dietician spot under-dosing early.",
+      zh: "排便形态是胰酶剂量调整最敏感的指标 —— 简短记录可帮助营养师早期发现剂量不足。",
+    },
   },
   {
     key: "pert_with_meals",
@@ -74,6 +83,10 @@ export const TRACKED_FIELDS: TrackedField[] = [
     prompt: {
       en: "Did Creon land with today's meals? One tap to log.",
       zh: "今天 Creon 是否随餐服用？一键记录。",
+    },
+    why: {
+      en: "You've been tracking Creon coverage; the dietician watches the weekly rate for under-titration.",
+      zh: "你一直在记录胰酶覆盖率；营养师据此评估剂量是否充分。",
     },
   },
   {
@@ -87,6 +100,10 @@ export const TRACKED_FIELDS: TrackedField[] = [
       en: "Weight hasn't been logged in a few days. Worth a quick weigh-in if convenient.",
       zh: "体重已数日未记录。方便时简短称重一下。",
     },
+    why: {
+      en: "A weigh-in every few days catches sarcopenia drift early — function preservation depends on it.",
+      zh: "数日称一次体重可早期发现肌少倾向 —— 功能保留依赖于此。",
+    },
   },
   {
     key: "fluids",
@@ -98,6 +115,10 @@ export const TRACKED_FIELDS: TrackedField[] = [
     prompt: {
       en: "Fluid intake not yet logged today.",
       zh: "今日饮水尚未记录。",
+    },
+    why: {
+      en: "You've logged fluids before; we keep the prompt light, but it matters most after infusions.",
+      zh: "你之前记录过饮水；提示保持简洁，但化疗后最重要。",
     },
   },
   {
@@ -111,6 +132,10 @@ export const TRACKED_FIELDS: TrackedField[] = [
       en: "Protein not yet logged today.",
       zh: "今日蛋白质摄入尚未记录。",
     },
+    why: {
+      en: "Protein around 1.2 g/kg/day is the function-preservation target — even a rough estimate helps.",
+      zh: "每日 1.2 g/kg 蛋白质是功能保留目标 —— 大致估计也有帮助。",
+    },
   },
   {
     key: "energy",
@@ -122,6 +147,10 @@ export const TRACKED_FIELDS: TrackedField[] = [
     prompt: {
       en: "Brief check-in on how today felt — energy and sleep.",
       zh: "简短记录今日感受 —— 精力与睡眠。",
+    },
+    why: {
+      en: "Energy and sleep are the simplest read on how you're doing today; the trend matters more than any one day.",
+      zh: "精力与睡眠是了解今日状态最简单的方式；趋势比单日数值更重要。",
     },
   },
   {
@@ -135,6 +164,10 @@ export const TRACKED_FIELDS: TrackedField[] = [
       en: "Appetite and nausea not yet logged today.",
       zh: "今日食欲与恶心尚未记录。",
     },
+    why: {
+      en: "Appetite shifts often arrive before weight does — a quick number gives an early signal.",
+      zh: "食欲变化往往早于体重 —— 简单的评分能提前给出信号。",
+    },
   },
   {
     key: "walking",
@@ -147,6 +180,26 @@ export const TRACKED_FIELDS: TrackedField[] = [
       en: "Movement not yet logged today.",
       zh: "今日活动尚未记录。",
     },
+    why: {
+      en: "You've been logging movement; short days still count. The physio watches the 28-day floor, not any one day.",
+      zh: "你一直在记录活动；偶有少日子也算数。物理治疗师关注的是 28 天的整体水平。",
+    },
+  },
+  {
+    key: "resistance_training",
+    daily_keys: ["resistance_training"],
+    freshness_days: 1,
+    cta_step: "movement",
+    voice: "rehabilitation",
+    eligibility: "history_only",
+    prompt: {
+      en: "Any resistance work today? A yes/no log keeps the weekly count honest.",
+      zh: "今天有阻力训练吗？简单的「是/否」即可保持每周记录准确。",
+    },
+    why: {
+      en: "Two to three resistance sessions a week is the sarcopenia-prevention target — the count needs each day's yes/no.",
+      zh: "每周两到三次阻力训练是预防肌少症的目标 —— 这一计数依赖每日的「是/否」。",
+    },
   },
   {
     key: "temperature_nadir",
@@ -158,6 +211,10 @@ export const TRACKED_FIELDS: TrackedField[] = [
     prompt: {
       en: "Temperature check during the nadir window — even a quick reading helps.",
       zh: "化疗低谷期建议每日测温 —— 简短一次即可。",
+    },
+    why: {
+      en: "You're in the chemo nadir window. Even a normal reading rules out the febrile-neutropenia concern.",
+      zh: "目前处于化疗低谷期。一次正常体温即可排除发热性中性粒细胞减少的担忧。",
     },
   },
 ];

--- a/src/lib/coverage/agent-snapshot.ts
+++ b/src/lib/coverage/agent-snapshot.ts
@@ -36,6 +36,7 @@ const AGENT_VOICE_FOR_FIELD: Record<string, AgentId> = {
   appetite: "nutrition",
   energy: "rehabilitation",
   walking: "rehabilitation",
+  resistance_training: "rehabilitation",
   temperature_nadir: "toxicity",
 };
 

--- a/src/lib/coverage/log-coverage.ts
+++ b/src/lib/coverage/log-coverage.ts
@@ -181,6 +181,7 @@ function toGap(field: TrackedField, inNadir: boolean): CoverageGap {
     priority,
     title: voice.display_name,
     body: field.prompt,
+    why: field.why,
     cta_href: `/daily/new?step=${encodeURIComponent(field.cta_step)}`,
     icon: voice.icon,
   };

--- a/src/lib/nudges/coverage-cards.ts
+++ b/src/lib/nudges/coverage-cards.ts
@@ -17,6 +17,6 @@ export function coverageGapsToFeedItems(
     cta: { href: g.cta_href, label: { en: "Log", zh: "记录" } },
     icon: g.icon,
     source: `coverage:${g.field_key}`,
-    meta: { kind: "coverage", field_key: g.field_key },
+    meta: { kind: "coverage", field_key: g.field_key, why: g.why },
   }));
 }

--- a/src/types/coverage.ts
+++ b/src/types/coverage.ts
@@ -39,6 +39,11 @@ export interface CoverageGap {
   priority: number;
   title: LocalizedText;
   body: LocalizedText;
+  // One-line patient-facing rationale, surfaced behind the small
+  // "Why?" affordance on coverage cards. Copied from the
+  // TrackedField config so the detector stays the only place that
+  // computes a card's full payload.
+  why: LocalizedText;
   cta_href: string;
   icon: string;
 }

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -55,4 +55,5 @@ export type AgentRunMeta = {
 export type CoverageMeta = {
   kind: "coverage";
   field_key: string;
+  why: LocalizedText;
 };

--- a/tests/unit/agent-coverage-snapshot.test.ts
+++ b/tests/unit/agent-coverage-snapshot.test.ts
@@ -9,6 +9,7 @@ function gap(field_key: string, body = "(prompt)"): CoverageGap {
     priority: 50,
     title: { en: "x", zh: "x" },
     body: { en: body, zh: body },
+    why: { en: "(why)", zh: "(why)" },
     cta_href: `/daily/new?step=${field_key}`,
     icon: "salad",
   };

--- a/tests/unit/coverage-physio-and-why.test.ts
+++ b/tests/unit/coverage-physio-and-why.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { computeCoverageGaps } from "~/lib/coverage/log-coverage";
+import { formatCoverageSnapshot } from "~/lib/coverage/agent-snapshot";
+import type { DailyEntry, Settings } from "~/types/clinical";
+
+function entry(date: string, overrides: Partial<DailyEntry> = {}): DailyEntry {
+  return {
+    date,
+    entered_at: `${date}T07:00:00Z`,
+    entered_by: "hulin",
+    created_at: `${date}T07:00:00Z`,
+    updated_at: `${date}T07:00:00Z`,
+    ...overrides,
+  };
+}
+
+function settings(over: Partial<Settings> = {}): Settings {
+  return {
+    profile_name: "x",
+    locale: "en",
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("AI Physio coverage support", () => {
+  it("does not surface resistance_training without prior history", () => {
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      // Active engagement (logged something today) but resistance_training
+      // never filled before — should stay invisible.
+      recentDailies: [entry("2026-05-01", { energy: 5 })],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    expect(
+      r.gaps.some((g) => g.field_key === "resistance_training"),
+    ).toBe(false);
+  });
+
+  it("surfaces resistance_training once a single prior log exists", () => {
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      recentDailies: [
+        entry("2026-05-01", { energy: 5 }),
+        // Two weeks ago, the patient logged resistance training once.
+        entry("2026-04-17", { resistance_training: true }),
+      ],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    const rt = r.gaps.find((g) => g.field_key === "resistance_training");
+    expect(rt).toBeDefined();
+    expect(rt?.cta_href).toBe("/daily/new?step=movement");
+  });
+
+  it("includes the why text on every emitted gap", () => {
+    const r = computeCoverageGaps({
+      todayISO: "2026-05-01",
+      recentDailies: [entry("2026-05-01", { energy: 5 })],
+      settings: settings(),
+      cycleContext: null,
+      activeAlerts: [],
+      snoozes: [],
+    });
+    expect(r.gaps.length).toBeGreaterThan(0);
+    for (const g of r.gaps) {
+      expect(typeof g.why.en).toBe("string");
+      expect(g.why.en.length).toBeGreaterThan(0);
+      expect(typeof g.why.zh).toBe("string");
+      expect(g.why.zh.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("routes a resistance_training gap into the rehabilitation snapshot", () => {
+    const out = formatCoverageSnapshot({
+      agentId: "rehabilitation",
+      todayISO: "2026-05-01",
+      engagement: "active",
+      gaps: [
+        {
+          id: "coverage_resistance_training",
+          field_key: "resistance_training",
+          priority: 50,
+          title: { en: "AI Physio", zh: "AI 物理治疗师" },
+          body: { en: "Any resistance work today?", zh: "今天有阻力训练吗？" },
+          why: { en: "Sarcopenia prevention", zh: "预防肌少症" },
+          cta_href: "/daily/new?step=movement",
+          icon: "walk",
+        },
+      ],
+    });
+    expect(out).toMatch(/resistance_training/);
+  });
+
+  it("does NOT include a resistance_training gap in the dietician snapshot", () => {
+    const out = formatCoverageSnapshot({
+      agentId: "nutrition",
+      todayISO: "2026-05-01",
+      engagement: "active",
+      gaps: [
+        {
+          id: "coverage_resistance_training",
+          field_key: "resistance_training",
+          priority: 50,
+          title: { en: "AI Physio", zh: "AI 物理治疗师" },
+          body: { en: "Any resistance work today?", zh: "今天有阻力训练吗？" },
+          why: { en: "Sarcopenia prevention", zh: "预防肌少症" },
+          cta_href: "/daily/new?step=movement",
+          icon: "walk",
+        },
+      ],
+    });
+    expect(out).not.toMatch(/resistance_training/);
+  });
+});


### PR DESCRIPTION
## Summary

Two complementary additions on top of #156 + #158:

1. **AI Physio coverage awareness** — the rehabilitation agent now sees its discipline's gaps and can reason over absence + data, mirroring the dietician/nurse pattern from #158. Adds `resistance_training` as a tracked coverage field.
2. **Light patient "Why?" affordance** — every coverage card now has a small `?` next to the existing dismiss `×`. Tap reveals a one-sentence calm rationale for why this field is being asked today.

## AI Physio coverage awareness

- **`resistance_training`** added to `TRACKED_FIELDS` as a history-only field with the rehabilitation voice. Only surfaces if the patient has ever logged a resistance session — never asks first.
- **`agent-snapshot.ts`** maps the new field to the rehabilitation agent, so the AI Physio sees it and the dietician/nurse don't.
- **`rehabilitation/role.md`** gains:
  - "AI Physio" voice naming (matching the AI Dietician / AI Nurse pattern)
  - A "Multi-day follow-ups" section with three example `question_key`s
  - A "Coverage state" section mirroring nutrition/toxicity — same 1-per-run cap, same rough / quiet special cases, same absence+data reasoning rule
  - Calm framing for tough days: *"If engagement is rough, do not emit cadence-style or absence-driven follow-ups at all. The body is asking for rest, not for activity."*

## Light "Why?" affordance

- New `why: LocalizedText` on `TrackedField` — a one-sentence calm rationale, populated for every existing field. Examples:

  | Field | Why text (en) |
  |---|---|
  | Digestion | "Stool form is the most useful PERT-titration signal — a quick log helps the dietician spot under-dosing early." |
  | Weight | "A weigh-in every few days catches sarcopenia drift early — function preservation depends on it." |
  | Resistance training | "Two to three resistance sessions a week is the sarcopenia-prevention target — the count needs each day's yes/no." |
  | Temperature (nadir) | "You're in the chemo nadir window. Even a normal reading rules out the febrile-neutropenia concern." |

- Threaded through `CoverageGap` and `CoverageMeta` so the renderer reads it directly off the feed item — no extra Dexie lookup or config import in the UI layer.
- **`today-feed.tsx`** adds a small `HelpCircle` "?" button next to the existing dismiss `×`. Tap toggles a one-paragraph expand under the card body. Stays in-place: no modal, no navigation. Click stops propagation so it doesn't fire the card's deep-link CTA. Bilingual aria labels; `aria-expanded` reflects state.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no warnings or errors
- [x] `pnpm test` — **911/911 pass** (5 new tests in `tests/unit/coverage-physio-and-why.test.ts`):
    - `resistance_training` stays invisible without prior history
    - surfaces once a single prior log exists, with the right CTA href (`/daily/new?step=movement`)
    - every emitted gap carries non-empty `why` text in en + zh
    - snapshot routes the resistance gap to the rehabilitation agent
    - snapshot does **not** route it into the dietician's view
- [x] Existing `agent-coverage-snapshot.test.ts` factory updated to satisfy the new required `why` field.
- [ ] Manual smoke: log one resistance session ~14 days ago, then visit dashboard today — confirm a "Any resistance work today?" card appears with the AI Physio voice. Tap "?", confirm the rationale expands. Tap dismiss; confirm 7-day snooze and re-emerge after expiry.

https://claude.ai/code/session_01UZu1c3M2RX5zi4G2nSZuCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZu1c3M2RX5zi4G2nSZuCr)_