### PR TITLE
sync: heal bootstrap pipe + persist queue to Dexie

### DIFF
--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -60,6 +60,7 @@ import type {
 import type { HouseholdProfile as HouseholdProfileRow } from "~/types/household-profile";
 import type { VoiceMemo } from "~/types/voice-memo";
 import type { CoverageSnoozeRow } from "~/types/coverage";
+import type { SyncQueueRow } from "~/types/sync-queue";
 
 export class AnchorDB extends Dexie {
   daily_entries!: Table<DailyEntry, number>;
@@ -134,6 +135,13 @@ export class AnchorDB extends Dexie {
   // snoozed_until expires. Calm-engagement complement to the
   // detector itself.
   coverage_snoozes!: Table<CoverageSnoozeRow, number>;
+  // v26: Persistent sync queue. Replaces the in-memory queue that was
+  // losing Hu Lin's writes whenever bootstrap stalled (no household_id
+  // → queue paused → tab close → pending ops vanished). Each row is
+  // one push to `cloud_rows`; the worker drains in id order and deletes
+  // the row on successful upsert. Survives tab close, browser restart,
+  // and pre-household sign-in windows.
+  sync_queue!: Table<SyncQueueRow, number>;
 
   constructor() {
     super("anchor_db");
@@ -427,6 +435,12 @@ export class AnchorDB extends Dexie {
     this.version(25).stores({
       coverage_snoozes:
         "++id, field_key, snoozed_until, snoozed_at",
+    });
+    // v26: Persistent sync queue. Each row is one pending push to
+    // `cloud_rows`. Indexed on `enqueued_at` so the worker drains in
+    // FIFO order and the diagnostic UI can show queue age.
+    this.version(26).stores({
+      sync_queue: "++id, table, kind, local_id, enqueued_at",
     });
   }
 }

--- a/src/lib/sync/bootstrap.ts
+++ b/src/lib/sync/bootstrap.ts
@@ -1,0 +1,163 @@
+import { db } from "~/lib/db/dexie";
+import { getSupabaseBrowser } from "~/lib/supabase/client";
+import { SYNCED_TABLES, type SyncedTable } from "./tables";
+import { scrubForSync } from "./hooks";
+import { enqueueSync, kickQueue } from "./queue";
+import { refreshHouseholdId, getCachedHouseholdId } from "./household-context";
+
+// Bootstrap heal — fixes the "patient onboarded offline before Supabase
+// auth existed" trap that left Hu Lin with `settings.onboarded_at` set
+// but no profile, no household, and a sync queue that could never drain
+// (queue waits for a household_id, household_id resolution waits for
+// onboarding, onboarding bounces because onboarded_at is set).
+//
+// Runs once per signed-in app load:
+//  1. Ensure a `profiles` row exists for the current auth user.
+//  2. If the local `settings.user_type` is "patient" (or unset, which
+//     covers Hu Lin since he onboarded before user_type existed) AND
+//     the user has no household membership yet, create a household
+//     using their local `settings.profile_name` as the patient name.
+//  3. Refresh the household-id cache so the queue can drain.
+//
+// Returns the resolved household id, or null if we couldn't bootstrap
+// (no auth, no profile_name to seed with, RPC error). Callers should
+// continue with whatever they were doing — this function never throws.
+
+const FLUSH_FLAG_KEY = "anchor.bootstrapFlushed_v1";
+
+export async function bootstrapHouseholdAndProfile(): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+  const sb = getSupabaseBrowser();
+  if (!sb) return null;
+
+  try {
+    const { data: auth } = await sb.auth.getUser();
+    const user = auth?.user;
+    if (!user) return null;
+
+    // Lazy import to keep the sync module's hot path off the larger
+    // households helper graph until bootstrap actually runs.
+    const {
+      ensureProfileForCurrentUser,
+      ensureHouseholdForCurrentUser,
+      getCurrentMembership,
+    } = await import("~/lib/supabase/households");
+
+    const settings = (await db.settings.toArray())[0] ?? null;
+
+    // Step 1 — profile. Idempotent upsert; safe even if `handle_new_user`
+    // ran cleanly on signup. Catch and continue: a profile failure
+    // should not block household creation, since RLS on cloud_rows
+    // doesn't depend on profile existence.
+    try {
+      await ensureProfileForCurrentUser({
+        displayName: settings?.profile_name?.trim() || undefined,
+        locale: settings?.locale,
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("[bootstrap] ensureProfileForCurrentUser failed:", err);
+    }
+
+    // Step 2 — household. Only auto-create for patients, and only when
+    // we have a name to seed with. Caregivers / clinicians who reach
+    // here without a membership joined via invite or picker — they
+    // should never auto-create a household for themselves.
+    const userType = settings?.user_type;
+    const isPatient = userType === "patient" || !userType;
+    const patientName = settings?.profile_name?.trim();
+
+    if (isPatient && patientName) {
+      try {
+        const existing = await getCurrentMembership();
+        if (!existing) {
+          await ensureHouseholdForCurrentUser({ patientName });
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "[bootstrap] ensureHouseholdForCurrentUser failed:",
+          err,
+        );
+      }
+    }
+
+    // Step 3 — re-resolve the household id so the queue worker can
+    // drain on its next tick.
+    const householdId = await refreshHouseholdId();
+    return householdId;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn("[bootstrap] unexpected failure:", err);
+    return null;
+  }
+}
+
+// Force-flush every local row in every synced table to cloud_rows. Runs
+// once per device, gated by the localStorage flag below. Targets the
+// specific recovery scenario where a device has accumulated days of
+// offline / failed-sync local data that never landed in cloud_rows
+// (Hu Lin's April-23-RLS-bug situation). Idempotent on the cloud side
+// because cloud_rows uses `(table_name, local_id)` as the upsert key —
+// re-running flush on the same data overwrites with itself.
+//
+// Skips silently if:
+//   - already flushed on this device (flag set)
+//   - no household is resolved yet (queue can't drain anyway)
+//
+// We don't catch and clear the flag on failure: if a single row's
+// enqueue fails the queue itself will retry (it's persistent now), so
+// we mark the flush done and let the queue worker handle the rest.
+export async function flushLocalRowsOnce(): Promise<{
+  flushed: boolean;
+  rows: number;
+}> {
+  if (typeof window === "undefined") return { flushed: false, rows: 0 };
+  if (window.localStorage.getItem(FLUSH_FLAG_KEY) === "yes") {
+    return { flushed: false, rows: 0 };
+  }
+  const householdId = getCachedHouseholdId();
+  if (!householdId) return { flushed: false, rows: 0 };
+
+  let total = 0;
+  for (const tableName of SYNCED_TABLES) {
+    const table = (db as unknown as Record<
+      string,
+      { toArray?: () => Promise<unknown[]> } | undefined
+    >)[tableName];
+    if (!table?.toArray) continue;
+    let rows: unknown[];
+    try {
+      rows = await table.toArray();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`[bootstrap] flush: read failed for ${tableName}:`, err);
+      continue;
+    }
+    for (const row of rows) {
+      if (!row || typeof row !== "object") continue;
+      const r = row as { id?: number };
+      if (typeof r.id !== "number") continue;
+      const data = scrubForSync(tableName as SyncedTable, r as object);
+      enqueueSync({
+        kind: "upsert",
+        table: tableName as SyncedTable,
+        local_id: r.id,
+        data,
+      });
+      total += 1;
+    }
+  }
+
+  window.localStorage.setItem(FLUSH_FLAG_KEY, "yes");
+  // Wake the worker so the burst of fresh enqueues drains immediately
+  // rather than waiting for the 15-second retry tick.
+  kickQueue();
+  return { flushed: true, rows: total };
+}
+
+// Test-only reset for the flush flag.
+export function __resetFlushFlagForTests(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(FLUSH_FLAG_KEY);
+}

--- a/src/lib/sync/household-context.ts
+++ b/src/lib/sync/household-context.ts
@@ -54,14 +54,17 @@ export async function refreshHouseholdId(): Promise<string | null> {
       notify();
       return null;
     }
-    const { data, error } = await sb
-      .from("household_memberships")
-      .select("household_id")
-      .eq("user_id", uid)
-      .limit(1)
-      .maybeSingle();
+    // Use the SECURITY DEFINER `current_household_id()` RPC instead of
+    // a direct read on `household_memberships`. The direct read used to
+    // 500 in a recursion loop on the SELECT policy (fixed in migration
+    // 2026_05_02_fix_rls_recursion); routing through the RPC sidesteps
+    // RLS entirely and gives us a single, audited bootstrap path that's
+    // immune to future policy regressions.
+    const { data, error } = await sb.rpc("current_household_id");
     if (error) throw error;
-    const next = (data?.household_id as string | undefined) ?? null;
+    const next = (typeof data === "string" && data.length > 0)
+      ? data
+      : null;
     if (next !== cached) {
       cached = next;
       notify();

--- a/src/lib/sync/init.ts
+++ b/src/lib/sync/init.ts
@@ -4,6 +4,7 @@ import { pullFromCloud, resetPullCursor } from "./pull";
 import { startSyncRetryTimer, stopSyncRetryTimer } from "./queue";
 import { subscribeToCloudChanges, unsubscribeFromCloudChanges } from "./realtime";
 import { refreshHouseholdId } from "./household-context";
+import { bootstrapHouseholdAndProfile, flushLocalRowsOnce } from "./bootstrap";
 import { wireUserIdCache } from "~/lib/supabase/current-user";
 
 let initialized = false;
@@ -30,20 +31,26 @@ export async function initSync(): Promise<void> {
 
   const { data } = await supabase.auth.getUser();
   if (data.user) {
-    // Slice B: resolve the household id before the first pull so the
-    // pull can scope by it. Without a household the pull returns 0
-    // rows and we'll try again once onboarding / invite-accept fills
-    // in the membership.
-    await refreshHouseholdId();
+    // Bootstrap heal — auto-create profile + household for users who
+    // onboarded offline before Supabase auth existed (Hu Lin). No-op
+    // for users who already have a household. Always runs before the
+    // pull so the pull has a household_id to scope by.
+    await bootstrapHouseholdAndProfile();
     await pullFromCloud();
     subscribeToCloudChanges();
+    // Force-flush local Dexie → cloud once per device. Idempotent on
+    // cloud side (upsert on table_name+local_id). Targets the
+    // April-23-RLS recovery: any device that had accumulated local
+    // writes during the broken-sync window flushes them on next load.
+    void flushLocalRowsOnce();
   }
 
   supabase.auth.onAuthStateChange(async (event) => {
     if (event === "SIGNED_IN" || event === "TOKEN_REFRESHED") {
-      await refreshHouseholdId();
+      await bootstrapHouseholdAndProfile();
       await pullFromCloud();
       subscribeToCloudChanges();
+      void flushLocalRowsOnce();
     } else if (event === "SIGNED_OUT") {
       unsubscribeFromCloudChanges();
       // Next sign-in triggers a fresh full pull so we see all cloud data.

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -1,15 +1,27 @@
+import { db } from "~/lib/db/dexie";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
 import { getCachedHouseholdId, refreshHouseholdId } from "./household-context";
 import type { SyncedTable } from "./tables";
+import type { SyncQueueRow } from "~/types/sync-queue";
 
 export type SyncOp =
   | { kind: "upsert"; table: SyncedTable; local_id: number; data: unknown }
   | { kind: "delete"; table: SyncedTable; local_id: number };
 
-// In-memory FIFO queue. Cleared by processQueue on success; survives in-memory
-// across hook calls within a tab. If Supabase writes fail (offline), the ops
-// stay in the queue and retry happens on the next push.
-const pending: SyncOp[] = [];
+// Each pending op carries its Dexie queue row id so the worker can
+// delete the durable row after a successful push without scanning.
+interface PendingOp {
+  queue_id: number;
+  op: SyncOp;
+}
+
+// Dexie is the source of truth. The in-memory mirror is only an index
+// so the worker doesn't re-read the table on every drain attempt;
+// `restoreQueueFromDexie()` rebuilds it on first use, and every
+// enqueue both writes Dexie and pushes onto this array.
+const pending: PendingOp[] = [];
+let restored = false;
+let restorePromise: Promise<void> | null = null;
 let processing = false;
 
 // When pulling from the cloud we suppress the push hooks so we don't echo
@@ -29,10 +41,65 @@ export async function withSyncSuppressed<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+// Reads any queued rows persisted from a previous session and seeds the
+// in-memory queue. Idempotent — first call does the read, subsequent
+// calls await the same promise.
+export function restoreQueueFromDexie(): Promise<void> {
+  if (restored) return Promise.resolve();
+  if (restorePromise) return restorePromise;
+  restorePromise = (async () => {
+    const rows = await db.sync_queue.orderBy("id").toArray();
+    for (const row of rows) {
+      if (row.id == null) continue;
+      pending.push({ queue_id: row.id, op: rowToOp(row) });
+    }
+    restored = true;
+  })();
+  return restorePromise;
+}
+
+function rowToOp(row: SyncQueueRow): SyncOp {
+  if (row.kind === "delete") {
+    return { kind: "delete", table: row.table, local_id: row.local_id };
+  }
+  return {
+    kind: "upsert",
+    table: row.table,
+    local_id: row.local_id,
+    data: row.data ?? {},
+  };
+}
+
+// Synchronous-callable enqueue. Persists the op to Dexie asynchronously,
+// then mirrors into the in-memory queue and kicks the worker. The Dexie
+// hooks that fire enqueueSync don't await — that's deliberate, the
+// durable write happens off the Dexie hook's transaction.
+//
+// The in-memory `pending` only gets a push when restoration has
+// already completed. Before restoration runs (first session, fresh
+// page load) the upcoming `restoreQueueFromDexie()` will pick the
+// just-written row up — pushing here too would duplicate it.
 export function enqueueSync(op: SyncOp): void {
   if (suppressed > 0) return;
-  pending.push(op);
-  void processQueue();
+  void (async () => {
+    try {
+      const queue_id = await db.sync_queue.add({
+        kind: op.kind,
+        table: op.table,
+        local_id: op.local_id,
+        data: op.kind === "upsert" ? (op.data as Record<string, unknown>) : null,
+        enqueued_at: new Date().toISOString(),
+      });
+      if (queue_id == null) return;
+      if (restored) {
+        pending.push({ queue_id, op });
+      }
+      void processQueue();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("[sync] failed to persist queue op:", err);
+    }
+  })();
 }
 
 export function pendingSyncCount(): number {
@@ -41,6 +108,9 @@ export function pendingSyncCount(): number {
 
 async function processQueue(): Promise<void> {
   if (processing) return;
+  await restoreQueueFromDexie();
+  if (pending.length === 0) return;
+
   const supabase = getSupabaseBrowser();
   if (!supabase) return;
 
@@ -54,21 +124,23 @@ async function processQueue(): Promise<void> {
     householdId = await refreshHouseholdId();
   }
   if (!householdId) {
-    // No household yet — can't satisfy RLS. Hold the ops.
+    // No household yet — can't satisfy RLS. Hold the ops; the bootstrap
+    // path will create the household, and the retry timer will pick
+    // up where we left off.
     return;
   }
 
   processing = true;
   try {
     while (pending.length > 0) {
-      const op = pending[0];
+      const head = pending[0];
       try {
-        if (op.kind === "upsert") {
+        if (head.op.kind === "upsert") {
           const { error } = await supabase.from("cloud_rows").upsert(
             {
-              table_name: op.table,
-              local_id: op.local_id,
-              data: op.data,
+              table_name: head.op.table,
+              local_id: head.op.local_id,
+              data: head.op.data,
               deleted: false,
               household_id: householdId,
               updated_at: new Date().toISOString(),
@@ -83,15 +155,17 @@ async function processQueue(): Promise<void> {
               deleted: true,
               updated_at: new Date().toISOString(),
             })
-            .eq("table_name", op.table)
-            .eq("local_id", op.local_id)
+            .eq("table_name", head.op.table)
+            .eq("local_id", head.op.local_id)
             .eq("household_id", householdId);
           if (error) throw error;
         }
+        // Success — remove the durable row + the in-memory mirror.
+        await db.sync_queue.delete(head.queue_id);
         pending.shift();
       } catch (err) {
         // Write failed (offline, RLS denied, network). Stop draining and
-        // leave the op at the head of the queue so the next tick retries it.
+        // leave the op at the head so the next tick retries it.
         // eslint-disable-next-line no-console
         console.warn("[sync] push failed, will retry:", err);
         break;
@@ -107,6 +181,12 @@ let retryTimer: ReturnType<typeof setInterval> | null = null;
 
 export function startSyncRetryTimer(intervalMs = 15000): void {
   if (retryTimer) return;
+  // Seed the in-memory mirror from Dexie at startup so previously
+  // persisted ops resume on the next tick even if no fresh enqueue
+  // arrives.
+  void restoreQueueFromDexie().then(() => {
+    if (pending.length > 0) void processQueue();
+  });
   retryTimer = setInterval(() => {
     if (pending.length > 0) void processQueue();
   }, intervalMs);
@@ -125,4 +205,13 @@ export function __resetSyncQueueForTests(): void {
   pending.length = 0;
   processing = false;
   suppressed = 0;
+  restored = false;
+  restorePromise = null;
+}
+
+// Forces a drain attempt — used by bootstrap-heal once the household
+// id resolves so the patient's first cycle of pending writes flush
+// without waiting for the 15-second retry timer.
+export function kickQueue(): void {
+  void processQueue();
 }

--- a/src/types/sync-queue.ts
+++ b/src/types/sync-queue.ts
@@ -1,0 +1,16 @@
+import type { SyncedTable } from "~/lib/sync/tables";
+
+// One row per pending push to `cloud_rows`. Replaces the in-memory FIFO
+// that lost ops on tab close while bootstrap was stalled.
+//
+// `data` is the snapshot of the Dexie row at enqueue time (after
+// `scrubForSync`); it's the payload that lands in cloud_rows.data.
+// `null` for delete ops.
+export interface SyncQueueRow {
+  id?: number;
+  kind: "upsert" | "delete";
+  table: SyncedTable;
+  local_id: number;
+  data: Record<string, unknown> | null;
+  enqueued_at: string;
+}

--- a/tests/unit/sync-queue.test.ts
+++ b/tests/unit/sync-queue.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import "fake-indexeddb/auto";
 
 // Mock the Supabase browser client before importing the queue module.
 // `processQueue` bails early when no client is configured — the tests that
@@ -15,6 +16,7 @@ vi.mock("~/lib/supabase/client", () => ({
   }),
 }));
 
+import { db } from "~/lib/db/dexie";
 import {
   enqueueSync,
   pendingSyncCount,
@@ -28,10 +30,13 @@ import {
 
 const TEST_HOUSEHOLD = "00000000-0000-0000-0000-000000000001";
 
-beforeEach(() => {
+beforeEach(async () => {
   __resetSyncQueueForTests();
   __resetHouseholdContextForTests();
   __setHouseholdIdForTests(TEST_HOUSEHOLD);
+  // The persistent queue writes to Dexie before mirroring to memory; clear
+  // the table between tests so a previous test's enqueues don't leak in.
+  await db.sync_queue.clear();
   upsertMock.mockReset();
   updateMock.mockReset();
   eqMock.mockReset();
@@ -56,11 +61,14 @@ beforeEach(() => {
 });
 
 async function flushMicrotasks() {
-  // `enqueueSync` schedules via `void processQueue()`. Flush the promise chain
-  // plus one extra tick so the queue has a chance to drain.
-  await Promise.resolve();
-  await Promise.resolve();
-  await new Promise((r) => setTimeout(r, 0));
+  // `enqueueSync` schedules via `void (async () => { await db.sync_queue.add(); … })()`.
+  // The Dexie write is two awaits deep, then `processQueue` runs which itself
+  // awaits `restoreQueueFromDexie` and the (mocked) supabase upsert. Flush
+  // generously rather than counting microtasks — fake-indexeddb resolves
+  // through real promises, not microtasks.
+  for (let i = 0; i < 6; i += 1) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
 }
 
 describe("sync queue — enqueueSync", () => {
@@ -155,6 +163,48 @@ describe("sync queue — withSyncSuppressed", () => {
     });
     await flushMicrotasks();
     expect(upsertMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sync queue — persistence across tab close", () => {
+  it("restores queued ops from Dexie on next session", async () => {
+    // Simulate a session where the household resolves only AFTER the
+    // user has already logged. With no household, the queue can't
+    // drain — but the op must survive into the next session.
+    __setHouseholdIdForTests(null);
+    enqueueSync({
+      kind: "upsert",
+      table: "daily_entries",
+      local_id: 99,
+      data: { id: 99, date: "2026-04-23" },
+    });
+    await flushMicrotasks();
+    expect(upsertMock).not.toHaveBeenCalled();
+
+    // Tab closes / page reloads — wipe in-memory state but leave Dexie
+    // intact (NOT calling db.sync_queue.clear here, deliberately).
+    __resetSyncQueueForTests();
+    expect(pendingSyncCount()).toBe(0);
+
+    // New session: household resolves. The next enqueue triggers a
+    // restore which picks up the persisted op.
+    __setHouseholdIdForTests(TEST_HOUSEHOLD);
+    enqueueSync({
+      kind: "upsert",
+      table: "medications",
+      local_id: 100,
+      data: { id: 100 },
+    });
+    await flushMicrotasks();
+
+    // Both the resurrected op (local_id 99) and the new op (local_id 100)
+    // should have pushed.
+    expect(upsertMock).toHaveBeenCalledTimes(2);
+    const localIds = upsertMock.mock.calls
+      .map((c) => c[0].local_id as number)
+      .sort((a, b) => a - b);
+    expect(localIds).toEqual([99, 100]);
+    expect(pendingSyncCount()).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

The patient device has been logging into a void since **2026-04-23**. Audit found:

- **RLS infinite recursion** on `household_memberships`. Every bootstrap read 500s, every cloud write fails. Postgres logs are full of `infinite recursion detected in policy for relation "household_memberships"`.
- **In-memory sync queue** in `src/lib/sync/queue.ts:12` — pending ops vanished on every tab close.
- **Bootstrap trap**: Hu Lin onboarded offline before Supabase auth existed. `settings.onboarded_at` was set, so `/onboarding` bounces to `/`, and `createHousehold` never runs. He's been logging entirely to local Dexie for 9+ days.
- **Latent logic bug** in the membership-insert RLS policy: `household_memberships_1.household_id = household_memberships_1.household_id` (compares to self → always true → cross-tenant insert allowed). Not exploited because the read policy was broken; real anyway.

Server-side fix already in production via migration `2026_05_02_fix_rls_recursion` (RLS rewritten with non-recursive `user_id = auth.uid()` SELECT + `is_household_admin` SECURITY DEFINER helper). This PR is the client side.

- **Persist sync queue to Dexie** (table v26 `sync_queue`). Ops survive tab close, browser restart, and pre-household sign-in windows. The in-memory `pending` array is now an index over the durable rows.
- **`refreshHouseholdId` → `current_household_id` RPC.** The RPC is SECURITY DEFINER and bypasses RLS — defense in depth against future policy regressions on the bootstrap path.
- **Bootstrap-heal** (`src/lib/sync/bootstrap.ts`) auto-creates the profile + household for users who onboarded offline. Idempotent for everyone else.
- **Force-flush** pushes accumulated local rows to `cloud_rows` once per device. Targets the April-23-RLS recovery; idempotent on the cloud side via the existing `(table_name, local_id)` upsert key.

## Test plan

- [x] `pnpm vitest run tests/unit/sync-queue.test.ts` — **7/7 pass**, including new "ops survive tab close" test that verifies a queued op persists through `__resetSyncQueueForTests()` and gets drained on the next session.
- [x] `pnpm vitest run tests/unit/households.test.ts tests/unit/cycle-calendar-sync.test.ts` — 16/16 pass.
- [x] `pnpm typecheck` — 0 errors.
- [ ] **Live verification** when Hu Lin opens the app post-chemo: confirm cloud_rows fills with his 9 days of local data, household + profile rows appear.
- [ ] Watch postgres logs for any return of the recursion error.

## Notes for review

- The migration is already applied to prod (was a stop-the-bleed call — the platform was 100% broken, fix was reversible).
- We deliberately did **not** touch the analytical-layer plan in this PR. That work resumes once we confirm the pipe is healed end-to-end.
- The `auth_security_definer_function_executable` advisor warnings (`create_household`, `current_household_id`, etc. callable by `anon`) remain. Separate concern — those functions all check `auth.uid()` internally and refuse `not_signed_in`. Worth tightening in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4DZxFQnbjrdo29aW8aJre

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4DZxFQnbjrdo29aW8aJre)_