### PR TITLE
analytical: Sprint 2 Phases 1, 2, 3a, 3b — helpers + shadow plumbing + V2 grip/steps rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -135,6 +135,30 @@ type · description` and the auto-add workflow does the rest. Don't
 try to manipulate the project directly — the GitHub MCP server only
 exposes classic Issues, not the Projects v2 GraphQL surface.
 
+### Trigger model: dragging a card to "In Progress" wakes Claude
+
+The repo has a workflow at `.github/workflows/project-board-claude-trigger.yml`
+that listens for `projects_v2_item.edited`, filters for Status →
+"In Progress", and posts an `@claude` mention on the linked issue.
+That mention starts a fresh Claude Code session scoped to that one
+issue.
+
+**Critical implication for issue-writing:** the new session has zero
+memory of any prior chat. Issue bodies MUST be self-contained:
+
+- Goal in the first sentence
+- Why it matters (clinical / strategic)
+- Concrete done-when criteria
+- Files / modules to touch (if known)
+- Links to relevant docs / prior issues / PRs
+- Explicit notes on what needs Thomas / Hu Lin input vs what's
+  autonomous
+
+Avoid phrases like "as discussed", "see chat", "Thomas mentioned" —
+the cold-start session can't see any of that. The Phase 0 / 1 / 3a
+issues already on the board (#170, #171, #173, etc.) are good
+templates.
+
 ## Commands
 
 - `pnpm dev` — local development

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,6 +35,13 @@ and partially axis 2 (symptoms). This platform fills the axis 3 gap.
 
 ## Interaction model — single channel in, single channel out
 
+**Scope:** this section governs **the patient's surface only** — what
+Hu Lin sees and touches. Carer (Thomas, Catherine), family
+(relatives), and clinician surfaces have a different cognitive-load
+model and may use direct routes, multiple tabs, dashboards, and
+discipline-specific tooling. The single-channel doctrine does not
+apply to them and they should not be folded into the patient feed.
+
 The patient sees ONE input and ONE feed. Everything else is hidden.
 
 **Single channel in.** The patient says what's happening — free text, voice,
@@ -63,9 +70,16 @@ single input. The system updates state and re-ranks the feed.
 
 This collapses the cognitive surface to: tell, see, repeat. The
 multidisciplinary depth lives behind it. Any feature that adds a new
-top-level form, tab, or screen for the patient is going the wrong way
+top-level form, tab, or screen **for Hu Lin** is going the wrong way
 — it should become an input modality on the unified channel and a
 ranked item on the unified feed.
+
+**For non-patient surfaces** (Thomas's `/family`, `/care-team`,
+`/carers`, `/reports`; clinicians' future export views): the
+single-channel rule does NOT apply. Those audiences benefit from
+direct routes to specific data, sortable tables, and discipline-
+scoped views. Adding a new top-level page for *them* is fine; adding
+one for Hu Lin is not.
 
 ## Zone logic
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -122,6 +122,19 @@ Build vertical slices. Each module should be fully functional (daily tracking
 entry + view + trend) before moving to the next. Test the rule engine
 obsessively — it's the most important piece of code in the project.
 
+## Project board
+
+All sprint planning, prioritisation, and status tracking lives in the
+GitHub Project **"save dads life"** (under `flytonewyork`). Issues
+land there automatically via the project's auto-add workflow — the
+Issues tab is the data store, the project board is the lens.
+
+When opening a new kanban item, just create a regular issue on
+`flytonewyork/medicai` with title prefix `[P0|P1|P2|P3] Sprint N ·
+type · description` and the auto-add workflow does the rest. Don't
+try to manipulate the project directly — the GitHub MCP server only
+exposes classic Issues, not the Projects v2 GraphQL surface.
+
 ## Commands
 
 - `pnpm dev` — local development

--- a/.github/workflows/project-board-claude-trigger.yml
+++ b/.github/workflows/project-board-claude-trigger.yml
@@ -1,0 +1,83 @@
+name: Project board → trigger Claude on In Progress
+
+# When a project-board card on the "save dads life" project moves to
+# the "In Progress" status, post an @claude mention on the linked
+# issue. The Claude Code GitHub App picks up the mention and starts a
+# new session scoped to that issue.
+#
+# Why this workflow exists: the GitHub MCP server doesn't expose
+# Projects v2 webhooks to Claude sessions directly — only PR activity.
+# So we bridge: project status change → issue comment → @claude
+# trigger. This lets Thomas plan cards on the board and start work
+# just by dragging.
+#
+# Event reliability note: `projects_v2_item` events fire at the
+# user / org level. They reach this repo's workflow because the
+# project (`save dads life`, owned by `flytonewyork`) contains issues
+# from this repo. If the project is later moved to an org that
+# doesn't include this repo, this workflow will silently stop firing.
+
+on:
+  projects_v2_item:
+    types: [edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  trigger-claude:
+    # Filter: only fire when the Status field changes TO "In Progress"
+    # AND the project item is a real Issue (not a draft or PR).
+    if: |
+      github.event.changes.field_value.field_name == 'Status' &&
+      github.event.changes.field_value.to.name == 'In Progress' &&
+      github.event.projects_v2_item.content_type == 'Issue'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve issue number from project-item content
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // The webhook payload gives us a graphql node id for the
+            // linked content (Issue / PR). We need the human-readable
+            // issue number plus the repo to comment on.
+            const nodeId = context.payload.projects_v2_item.content_node_id;
+            const query = `
+              query($id: ID!) {
+                node(id: $id) {
+                  ... on Issue {
+                    number
+                    repository { name owner { login } }
+                  }
+                }
+              }
+            `;
+            const res = await github.graphql(query, { id: nodeId });
+            const issue = res.node;
+            if (!issue?.number) {
+              core.setFailed(`Could not resolve issue from node ${nodeId}`);
+              return;
+            }
+            core.setOutput('issue_number', String(issue.number));
+            core.setOutput('repo_owner', issue.repository.owner.login);
+            core.setOutput('repo_name', issue.repository.name);
+
+      - name: Post @claude trigger comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: '${{ steps.resolve.outputs.repo_owner }}',
+              repo: '${{ steps.resolve.outputs.repo_name }}',
+              issue_number: parseInt('${{ steps.resolve.outputs.issue_number }}', 10),
+              body: [
+                '@claude — this card moved to **In Progress** on the project board.',
+                '',
+                'Please pick it up: read the issue body for full context, plan the work, and ship.',
+                'If anything is ambiguous or needs Thomas / Hu Lin input, comment instead of guessing.',
+                '',
+                '_Posted automatically by `.github/workflows/project-board-claude-trigger.yml`._',
+              ].join('\n'),
+            });

--- a/docs/analytical_density_audit.md
+++ b/docs/analytical_density_audit.md
@@ -1,0 +1,95 @@
+# Analytical density audit — Sprint 2 Phase 0
+
+**Date:** 2026-05-02
+**Scope:** Hu Lin's cloud data, post-pipe-heal (PR #164 + RLS migrations).
+**Purpose:** Decide which axis-3 metrics are dense enough for the V2 analytical-layer rules to operate on. Drives Phase 3 scope and Phase 4 validation timing.
+
+## TL;DR
+
+**The analytical-layer code is ready. The data isn't.** The pipe-heal recovered Hu Lin's bootstrap and started flowing dailies again, but every axis-3 metric the V2 rules expect to consume is either absent or critically sparse in the cloud right now. Phase 4 V2-vs-V1 validation cannot run until the data-capture surface is fixed and ~4–6 weeks of post-fix logging accumulates.
+
+## Cloud state today
+
+| Source | Rows | Date span | Comment |
+|---|---|---|---|
+| `daily_entries` | 4 | 2026-04-22, then 04-28→04-30 | 5-day gap (broken-pipe window) |
+| `fortnightly_assessments` | **0** | — | No grip / gait / sarc-f / TUG / STS observations exist anywhere in cloud |
+| `weekly_assessments` | 0 | — | |
+| `quarterly_reviews` | 0 | — | |
+| `treatment_cycles` | **0** | — | No active cycle → cycle-detrending unavailable for any metric |
+| `voice_memos` | 0 (cloud) | — | Bucket was missing (now created in `2026_05_02_voice_memos_bucket`) |
+| `medication_events` | 11 | All within 6 seconds, 2026-04-22 09:59:39–45 | Looks like onboarding/test clicks, not real GnP doses |
+| `comprehensive_assessments` | 1 | 2026-04-22 | Single onboarding assessment |
+| `labs` / `imaging` / `ctdna_results` | 0 | — | No clinical results imported |
+
+## Per-metric density audit
+
+| Metric | Source | Cycle curve in priors? | Obs in cloud | Verdict |
+|---|---|---|---|---|
+| **weight_kg** | `daily_entries.weight_kg` | yes (delta scale) | 3 of 4 days | Insufficient. Need ≥28 days for `slope_28d`. **Raw threshold only.** |
+| **steps** | `daily_entries.steps` | no | **0 of 4 days** | Field never populated. Likely Android Health Connect not wired or permission denied. **V2 rule will never fire.** Investigate UX. |
+| **grip_dominant_kg** | `fortnightly_assessments.grip_dominant_kg` | no | **0** | No fortnightly has been completed. Cadence is 14d → need 4–6 fortnightlies (8–12 weeks) for `slope_28d`. **V2 rule will never fire** without prompted fortnightly capture. |
+| **gait_speed_ms** | `fortnightly_assessments.gait_speed_ms` | no | **0** | Same as grip. |
+| **neuropathy_hands** | `daily_entries.neuropathy_hands` | yes (cumulative) | 1 of 4 days | Insufficient. |
+| **neuropathy_feet** | `daily_entries.neuropathy_feet` | yes (cumulative) | 2 of 4 days | Insufficient. |
+| **diarrhoea_count** | `daily_entries.diarrhoea_count` | no | 2 of 4 days | Insufficient. Cycle-day detrending impossible without active cycle anyway. |
+| **bristol_score** | (no field on DailyEntry) | no | n/a | Not captured today. Spec'd in `docs/CLINICAL_FRAMEWORK.md` but no schema field. |
+| **anc / hemoglobin / platelets / albumin** | `labs.*` | yes (population priors) | 0 | No labs imported via Records-import flow. |
+| **fatigue_proctcae** | `daily_entries.energy` (proxy?) | yes | 3 of 4 days | Insufficient. |
+| **nausea_proctcae** | `daily_entries.nausea` | yes | 3 of 4 days | Insufficient. |
+| **ecog_self_rated** | `fortnightly_assessments.ecog_self` | yes | 0 | No fortnightly completed. |
+
+## Cycle context
+
+`treatment_cycles` is empty. Without an active cycle:
+- `cycleDayFor()` returns `null` for every observation
+- `residualSeries()` falls through to pass-through residuals (`value=0`, `expected_mean=raw`, `expected_sd=1`)
+- `chronicResiduals()` returns the same pass-through
+- Therefore `chronicSlope`, `residualBelowExpected`, `chronicMeanResidual` all return either 0 or null — they cannot detect drift on top of cycle variance because there's no cycle to subtract
+
+The V2 grip/steps rules I shipped in Phase 3 use `patient_state.metrics.X.slope_28d` (raw values, not residuals), so they are **independent of cycle context** — they would still fire correctly if grip/steps had data. But for any metric that DOES have a cycle prior (anc, weight, fatigue, nausea, neuropathy), Phase 3c+ needs an active cycle to add value beyond raw thresholds.
+
+## Critical data-capture gaps surfaced (NOT analytical issues — UX/wiring issues)
+
+1. **Voice-memos bucket missing** — fixed today by `2026_05_02_voice_memos_bucket`. Hu Lin's primary input modality has been writing into a 400-error void since voice memos shipped. **High priority** to confirm this fix lands by triggering one voice memo on his next session.
+2. **Steps never captured.** No daily entry has a `steps` value. The most important high-frequency objective axis-3 proxy. Either the daily form doesn't surface the field, or Android Health Connect / step source isn't wired. Would need to inspect `src/components/daily/daily-wizard.tsx` and the steps capture path.
+3. **No fortnightly assessment ever completed.** Grip / gait / ECOG / sarc-f / TUG / STS are all gated on this form. The fortnightly is the function-preservation backbone of axis-3 monitoring. If Hu Lin hasn't completed one in 10+ days of trying to use the app, the prompt cadence is too gentle or the form is too long.
+4. **No active treatment_cycle.** Either onboarding's "I'm currently on a protocol" checkbox was unticked, or it didn't persist. Without this, no cycle-detrending and no GnP-day-aware nudges work.
+5. **No labs/imaging imported.** Records-import flow exists but Hu Lin hasn't pulled MHR / Epworth data yet.
+
+## Recommendation — pivot Sprint 2
+
+The original Sprint 2 plan was: helpers → shadow plumbing → V2 rule migration → validate diff with Thomas → flip live. Phases 1–3b are shipped and tested. **But Phase 4 (validate) has no signal to validate against and Phase 5 (flip) has nothing to flip.**
+
+Suggested re-shape:
+
+| Was | Becomes | Reason |
+|---|---|---|
+| Phase 4: Validate V2 vs V1 | **Phase 4a: Data-capture audit + fixes** | Voice memos, steps, fortnightly cadence, cycle setup, labs import |
+| Phase 5: Flip V2 live | **Phase 4b: Wait + accumulate ≥4 weeks of post-fix data** | V2 rules need observations to compute slopes |
+| (parked) | **Phase 5: Validate + flip** | Once data is flowing, Phase 4 validation becomes meaningful |
+
+Concretely, the next analytical-layer-relevant work is **NOT** more rule code — it's:
+- Confirm voice-memos pipeline now works end-to-end on Hu Lin's next open
+- Verify `daily_wizard.tsx` actually surfaces steps and that the Android source wires through (likely Health Connect API)
+- Tighten the fortnightly prompt cadence so Hu Lin completes one before mid-cycle
+- Help Thomas seed Hu Lin's current treatment_cycle row (one-time data entry)
+- Trigger a labs import (MHR sync) for the most recent CA19-9 / FBE / albumin
+
+V2 rule code stands ready. It does its job the moment its inputs exist.
+
+## Followups (already on the kanban)
+
+- **#168** ✓ closed — pipe heal verified
+- **#170** ⬅ this doc (closing)
+- **#173** Phase 3 — partial (grip + steps shipped); rest blocked on data
+- **#174** Phase 4 — re-scoped per above
+- **#175** Phase 5 — re-scoped per above
+- **#178** anon RPC lockdown — independent security cleanup
+
+## Notes for Phase 4 (whenever it runs)
+
+When Hu Lin has ≥28 days of post-fix data and an active cycle:
+- Walk the diff dashboard with Thomas, confirming each `v2_only` fire matches his clinical read of Hu Lin's trajectory
+- Tune `GRIP_SLOPE_YELLOW_KG_PER_DAY`, `GRIP_SLOPE_ORANGE_KG_PER_DAY`, `STEPS_SLOPE_YELLOW_PER_DAY`, `STEPS_SLOPE_ORANGE_PER_DAY` (top of `src/lib/rules/zone-rules-v2.ts`) against his actual cycle-fit
+- Decide whether to retire each V1 rule individually or as a single cutover

--- a/src/hooks/use-today-feed.ts
+++ b/src/hooks/use-today-feed.ts
@@ -32,6 +32,16 @@ export function useTodayFeed({
   const cycles = useLiveQuery(() => latestTreatmentCycles(1));
   const agentRuns = useLiveQuery(() => latestAgentRuns(40));
   const coverageSnoozes = useLiveQuery(() => db.coverage_snoozes.toArray());
+  // Used by the fortnightly cadence prompt — fires when no fortnightly
+  // has been completed in the last 12 days. Pull a small page (latest
+  // 4) since the prompt only cares about the most recent.
+  const fortnightlies = useLiveQuery(() =>
+    db.fortnightly_assessments
+      .orderBy("assessment_date")
+      .reverse()
+      .limit(4)
+      .toArray(),
+  );
 
   return useMemo(() => {
     const s = settings ?? null;
@@ -78,6 +88,7 @@ export function useTodayFeed({
       weather,
       agentRuns: agentRuns ?? [],
       coverageSnoozes: coverageSnoozes ?? [],
+      fortnightlies: fortnightlies ?? [],
     });
   }, [
     settings,
@@ -89,5 +100,6 @@ export function useTodayFeed({
     weather,
     agentRuns,
     coverageSnoozes,
+    fortnightlies,
   ]);
 }

--- a/src/lib/db/dexie.ts
+++ b/src/lib/db/dexie.ts
@@ -142,6 +142,13 @@ export class AnchorDB extends Dexie {
   // the row on successful upsert. Survives tab close, browser restart,
   // and pre-household sign-in windows.
   sync_queue!: Table<SyncQueueRow, number>;
+  // v27: Shadow rule-engine alerts. Same shape as `zone_alerts` but
+  // populated by the V2 rule set during the analytical-layer rollout
+  // (Sprint 2 Phase 2–5). The patient feed never reads from this
+  // table — it's a Thomas-only diff surface so V2 can be tuned
+  // against Hu Lin's actual history before the cutover. Intentionally
+  // local-only; never mirrored to `cloud_rows`.
+  zone_alerts_shadow!: Table<ZoneAlert, number>;
 
   constructor() {
     super("anchor_db");
@@ -441,6 +448,12 @@ export class AnchorDB extends Dexie {
     // FIFO order and the diagnostic UI can show queue age.
     this.version(26).stores({
       sync_queue: "++id, table, kind, local_id, enqueued_at",
+    });
+    // v27: Shadow zone-alerts. Mirrors `zone_alerts` indexes so the
+    // diff helpers can join the two tables on (rule_id, triggered_at)
+    // cheaply. Local-only — explicitly NOT in SYNCED_TABLES.
+    this.version(27).stores({
+      zone_alerts_shadow: "++id, triggered_at, rule_id, zone",
     });
   }
 }

--- a/src/lib/nudges/compose.ts
+++ b/src/lib/nudges/compose.ts
@@ -1,5 +1,6 @@
 import type {
   DailyEntry,
+  FortnightlyAssessment,
   LabResult,
   Settings,
   ZoneAlert,
@@ -19,6 +20,7 @@ import { agentRunsToFeedItems } from "./agent-runs";
 import { resurfaceFollowUps } from "./follow-up-resurface";
 import { computeCadencePrompts } from "./cadence-prompts";
 import { computeGiTileNudges } from "./gi-tile-nudges";
+import { computeFortnightlyPrompt } from "./fortnightly-prompt";
 import { computeCoverageGaps } from "~/lib/coverage/log-coverage";
 import { coverageGapsToFeedItems } from "./coverage-cards";
 import { getActiveTaskInstances } from "~/lib/tasks/engine";
@@ -40,6 +42,9 @@ export interface ComposeInputs {
   // Active coverage-prompt snoozes. Pass all rows from the
   // coverage_snoozes table; the engine filters expired ones.
   coverageSnoozes?: CoverageSnoozeRow[];
+  // Recent fortnightly assessments. The fortnightly cadence prompt
+  // fires when the latest is missing or > 12 days old.
+  fortnightlies?: readonly FortnightlyAssessment[];
 }
 
 export function composeTodayFeed(inputs: ComposeInputs): FeedItem[] {
@@ -115,6 +120,22 @@ export function composeTodayFeed(inputs: ComposeInputs): FeedItem[] {
     ...computeGiTileNudges({
       todayISO: inputs.todayISO,
       recentDailies: inputs.recentDailies,
+    }),
+  );
+
+  // ── 5f. Fortnightly assessment cadence ─────────────────────────────
+  // Surfaces the function-preservation backbone (grip, gait, ECOG,
+  // sarc-F, TUG, STS) when the most recent fortnightly is missing or
+  // > 12 days old. Suppressed by red-zone alerts (safety owns the
+  // channel).
+  const redZoneActive = inputs.activeAlerts.some(
+    (a) => !a.resolved && a.zone === "red",
+  );
+  feed.push(
+    ...computeFortnightlyPrompt({
+      todayISO: inputs.todayISO,
+      fortnightlies: inputs.fortnightlies ?? [],
+      redZoneActive,
     }),
   );
 

--- a/src/lib/nudges/fortnightly-prompt.ts
+++ b/src/lib/nudges/fortnightly-prompt.ts
@@ -1,0 +1,97 @@
+import type { FeedItem } from "~/types/feed";
+import type { FortnightlyAssessment } from "~/types/clinical";
+
+// Fortnightly-assessment cadence prompt.
+//
+// The fortnightly form is the function-preservation backbone: grip,
+// gait, ECOG, sarc-F, TUG, STS — every axis-3 metric that needs
+// instrumented capture lives here. Without it, the V2 grip / gait /
+// sarc-F / TUG / STS rules in `zone-rules-v2.ts` have nothing to
+// score against.
+//
+// Phase 0 audit (docs/analytical_density_audit.md, 2026-05-02) found
+// **0 fortnightly_assessments** in cloud for Hu Lin despite the app
+// being live for 10+ days. Root cause: nothing in the cadence /
+// nudge / task surface ever prompts him to complete one. The form
+// exists, the route exists, the patient never sees a reminder.
+//
+// This module fills the gap. Fires when:
+//   - the most recent fortnightly is missing or > 12 days old
+//   - AND no red-zone alert is active (safety owns the channel)
+//
+// Threshold of 12 days (not 14) so Hu Lin gets the prompt before the
+// fortnightly is "overdue" — gentle reminder a couple of days early
+// is calmer than a "you missed this" framing.
+
+const PROMPT_AFTER_DAYS = 12;
+
+export interface FortnightlyPromptInputs {
+  todayISO: string;
+  fortnightlies: readonly FortnightlyAssessment[];
+  /**
+   * If any red-zone alert is active, suppress this prompt — the safety
+   * channel takes priority. Default false.
+   */
+  redZoneActive?: boolean;
+}
+
+export function computeFortnightlyPrompt(
+  inputs: FortnightlyPromptInputs,
+): FeedItem[] {
+  if (inputs.redZoneActive) return [];
+
+  const todayMs = Date.parse(inputs.todayISO + "T12:00:00Z");
+  if (Number.isNaN(todayMs)) return [];
+
+  const latest = inputs.fortnightlies
+    .slice()
+    .sort(
+      (a, b) =>
+        Date.parse(b.assessment_date) - Date.parse(a.assessment_date),
+    )[0];
+
+  let daysSince: number;
+  if (!latest) {
+    // Never completed — strongest copy.
+    daysSince = Number.POSITIVE_INFINITY;
+  } else {
+    const lastMs = Date.parse(latest.assessment_date + "T12:00:00Z");
+    if (Number.isNaN(lastMs)) return [];
+    daysSince = Math.floor((todayMs - lastMs) / 86_400_000);
+  }
+
+  if (daysSince < PROMPT_AFTER_DAYS) return [];
+
+  const neverDone = !latest;
+  return [
+    {
+      id: `fortnightly_due_${inputs.todayISO}`,
+      // Mid-priority: more important than discipline cadence prompts
+      // (60s) but less than zone alerts (0–30) or trend nudges (40–50).
+      // Lands in the "important but unhurried" lane.
+      priority: 55,
+      category: "checkin",
+      tone: "info",
+      title: {
+        en: neverDone
+          ? "Fortnightly check"
+          : "Fortnightly check is due",
+        zh: neverDone ? "两周一次的功能评估" : "两周一次的功能评估到期",
+      },
+      body: {
+        en: neverDone
+          ? "About 10 minutes — grip strength, gait, ECOG, and a few function tests. The numbers it captures power most of the trend detection on this app."
+          : `It's been ${daysSince} days since the last one. About 10 minutes — grip, gait, ECOG, and a few function tests.`,
+        zh: neverDone
+          ? "约 10 分钟 —— 握力、步速、ECOG、几项功能测试。这些数据是趋势监测的主要来源。"
+          : `距上次已经 ${daysSince} 天。约 10 分钟 —— 握力、步速、ECOG、几项功能测试。`,
+      },
+      cta: {
+        href: "/fortnightly/new",
+        label: { en: "Open", zh: "开始" },
+      },
+      icon: "clipboard",
+      source: "fortnightly_cadence",
+    },
+  ];
+}

--- a/src/lib/rules/analytical-helpers.ts
+++ b/src/lib/rules/analytical-helpers.ts
@@ -1,0 +1,131 @@
+// Phase 1 — analytical helpers used by V2 zone rules to ask
+// cycle-aware questions about a metric. All three are pure compositions
+// over `residualSeries` + `chronicResiduals` + the slope primitives in
+// `src/lib/state/`. They take raw observations + cycles directly so
+// they're trivially unit-testable and don't couple to ClinicalSnapshot.
+//
+// What problem they solve: today every rule in `zone-rules.ts` reads
+// raw values against a single static baseline. A grip dip on cycle
+// day 5 looks the same to those rules as a grip dip on cycle day 21,
+// but only one of those is signal. CLAUDE.md design principle 5
+// ("trends over points") demands rules that strip cycle variance
+// before deciding "is this drift?"
+//
+// These helpers will be consumed by V2 zone rules (Phase 3). They
+// don't change any V1 behaviour by themselves.
+import {
+  chronicResiduals,
+  residualSeries,
+  type CycleStub,
+} from "~/lib/state/analytical";
+import { observationsInWindow, olsSlopePerDay } from "~/lib/state";
+import type { Observation } from "~/lib/state";
+
+interface BaseArgs {
+  metricId: string;
+  observations: readonly Observation[];
+  cycles: readonly CycleStub[];
+  /**
+   * Anchor date for windowing. Tests pass an explicit ISO; production
+   * calls pass the engine's snapshot timestamp.
+   */
+  asOf: string;
+}
+
+/**
+ * OLS slope of the chronic residual stream over the trailing window,
+ * in residual-SD units per day. Negative on a higher-is-better metric
+ * means the chronic component is drifting away from expected — exactly
+ * the axis-3 toxicity signal we care about.
+ *
+ * Returns null when fewer than 3 observations land in the window
+ * (matching `olsSlopePerDay`'s contract).
+ */
+export function chronicSlope(
+  args: BaseArgs & { windowDays: number },
+): number | null {
+  const residuals = chronicResiduals(
+    residualSeries({
+      metric_id: args.metricId,
+      observations: args.observations,
+      cycles: args.cycles,
+    }),
+  );
+  // ResidualObservation has `date` and `value` (residual in SD units),
+  // which is the shape `observationsInWindow` + `olsSlopePerDay`
+  // already accept.
+  const inWindow = observationsInWindow(
+    residuals.map((r) => ({ date: r.date, value: r.value })),
+    args.asOf,
+    args.windowDays,
+  );
+  return olsSlopePerDay(inWindow);
+}
+
+/**
+ * True when the most recent `consecutiveDays` chronic residuals — by
+ * date order, not array order — are all at or below `-sdBelow` SD
+ * units. Acute-flagged observations are excluded by `chronicResiduals`
+ * before consecutive counting; a one-day acute event doesn't reset
+ * the run. False if fewer than `consecutiveDays` chronic residuals
+ * exist on or before `asOf`.
+ *
+ * Captures the "metric has been below the expected band for a week"
+ * pattern that single-point thresholds miss.
+ */
+export function residualBelowExpected(
+  args: BaseArgs & { sdBelow: number; consecutiveDays: number },
+): boolean {
+  if (args.consecutiveDays <= 0) return false;
+  const residuals = chronicResiduals(
+    residualSeries({
+      metric_id: args.metricId,
+      observations: args.observations,
+      cycles: args.cycles,
+    }),
+  );
+  // Keep residuals on or before asOf; sort ascending by date so the
+  // tail is the most-recent run.
+  const asOfMs = Date.parse(args.asOf);
+  if (Number.isNaN(asOfMs)) return false;
+  const sorted = residuals
+    .filter((r) => {
+      const t = Date.parse(r.date);
+      return !Number.isNaN(t) && t <= asOfMs;
+    })
+    .slice()
+    .sort((a, b) => Date.parse(a.date) - Date.parse(b.date));
+  if (sorted.length < args.consecutiveDays) return false;
+  const tail = sorted.slice(-args.consecutiveDays);
+  return tail.every((r) => r.value <= -args.sdBelow);
+}
+
+/**
+ * Mean of the chronic residual stream over the trailing window.
+ * Negative = the patient has been running systematically below the
+ * cycle-aware expected curve. Different from `chronicSlope`: this
+ * answers "where is the chronic component sitting?"; slope answers
+ * "is it moving?".
+ *
+ * Returns null when no chronic residuals fall in the window (so rules
+ * can branch on "no data" vs. "running normal").
+ */
+export function chronicMeanResidual(
+  args: BaseArgs & { windowDays: number },
+): number | null {
+  const residuals = chronicResiduals(
+    residualSeries({
+      metric_id: args.metricId,
+      observations: args.observations,
+      cycles: args.cycles,
+    }),
+  );
+  const inWindow = observationsInWindow(
+    residuals.map((r) => ({ date: r.date, value: r.value })),
+    args.asOf,
+    args.windowDays,
+  );
+  if (inWindow.length === 0) return null;
+  const sum = inWindow.reduce((a, b) => a + b.value, 0);
+  return sum / inWindow.length;
+}

--- a/src/lib/rules/diff.ts
+++ b/src/lib/rules/diff.ts
@@ -1,0 +1,173 @@
+// Diff helper for the V1 ↔ V2 rule-engine shadow rollout. Compares the
+// alert streams in `zone_alerts` (live, V1) and `zone_alerts_shadow`
+// (V2) and groups discrepancies by rule_id so Thomas can audit them.
+//
+// Used by:
+//  - the Phase 4 validation review (the diff dashboard he walks before
+//    approving the V2 flip — built in Phase 4 atop this helper)
+//  - any future regression check ("did this PR change V2 behaviour vs
+//    V1 over the last cycle?")
+//
+// Pure over its inputs. The Dexie reads stay in the page that calls
+// this helper so the function itself remains synchronously testable.
+import type { ZoneAlert } from "~/types/clinical";
+
+export interface RuleDiffEntry {
+  rule_id: string;
+  // Latest V1 alert for this rule (or null if V1 never fired it in
+  // the window).
+  v1_latest: ZoneAlert | null;
+  // Latest V2 alert for this rule (or null if V2 never fired it).
+  v2_latest: ZoneAlert | null;
+  // Categorisation of the discrepancy:
+  //   - "v1_only"  V1 fired but V2 didn't (V2 missed something — bad
+  //                if it's a real signal)
+  //   - "v2_only"  V2 fired but V1 didn't (V2 caught something new —
+  //                good if it's real, bad if false positive)
+  //   - "zone_differs"  both fired but at different zones
+  //   - "v2_earlier"  both fired the same zone but V2's first
+  //                triggered_at is earlier than V1's (V2 caught it
+  //                sooner — usually good)
+  //   - "v2_later"  reverse of above
+  kind:
+    | "v1_only"
+    | "v2_only"
+    | "zone_differs"
+    | "v2_earlier"
+    | "v2_later";
+}
+
+export interface RuleDiff {
+  entries: RuleDiffEntry[];
+  // Convenience counts for headline display.
+  counts: {
+    v1_only: number;
+    v2_only: number;
+    zone_differs: number;
+    v2_earlier: number;
+    v2_later: number;
+  };
+}
+
+interface DiffArgs {
+  v1Alerts: readonly ZoneAlert[];
+  v2Alerts: readonly ZoneAlert[];
+  // ISO date — alerts triggered before this are excluded. Defaults to
+  // 30 days before `now` if omitted; pass an explicit date for
+  // deterministic tests.
+  sinceISO: string;
+}
+
+function latestByRule(alerts: readonly ZoneAlert[]): Map<string, ZoneAlert> {
+  const out = new Map<string, ZoneAlert>();
+  for (const a of alerts) {
+    const prev = out.get(a.rule_id);
+    if (!prev || Date.parse(a.triggered_at) > Date.parse(prev.triggered_at)) {
+      out.set(a.rule_id, a);
+    }
+  }
+  return out;
+}
+
+function earliestByRule(
+  alerts: readonly ZoneAlert[],
+): Map<string, ZoneAlert> {
+  const out = new Map<string, ZoneAlert>();
+  for (const a of alerts) {
+    const prev = out.get(a.rule_id);
+    if (!prev || Date.parse(a.triggered_at) < Date.parse(prev.triggered_at)) {
+      out.set(a.rule_id, a);
+    }
+  }
+  return out;
+}
+
+export function computeRuleEngineDiff(args: DiffArgs): RuleDiff {
+  const sinceMs = Date.parse(args.sinceISO);
+  const inWindow = (a: ZoneAlert) => {
+    const t = Date.parse(a.triggered_at);
+    return !Number.isNaN(t) && t >= sinceMs;
+  };
+  const v1 = args.v1Alerts.filter(inWindow);
+  const v2 = args.v2Alerts.filter(inWindow);
+
+  const v1Latest = latestByRule(v1);
+  const v2Latest = latestByRule(v2);
+  const v1Earliest = earliestByRule(v1);
+  const v2Earliest = earliestByRule(v2);
+
+  const ruleIds = new Set<string>([
+    ...v1Latest.keys(),
+    ...v2Latest.keys(),
+  ]);
+
+  const entries: RuleDiffEntry[] = [];
+  const counts = {
+    v1_only: 0,
+    v2_only: 0,
+    zone_differs: 0,
+    v2_earlier: 0,
+    v2_later: 0,
+  };
+
+  for (const ruleId of ruleIds) {
+    const v1L = v1Latest.get(ruleId) ?? null;
+    const v2L = v2Latest.get(ruleId) ?? null;
+
+    let kind: RuleDiffEntry["kind"];
+    if (v1L && !v2L) {
+      kind = "v1_only";
+      counts.v1_only += 1;
+    } else if (!v1L && v2L) {
+      kind = "v2_only";
+      counts.v2_only += 1;
+    } else if (v1L && v2L && v1L.zone !== v2L.zone) {
+      kind = "zone_differs";
+      counts.zone_differs += 1;
+    } else if (v1L && v2L) {
+      // Same zone — compare earliest fire times to spot lead/lag.
+      const e1 = v1Earliest.get(ruleId)!;
+      const e2 = v2Earliest.get(ruleId)!;
+      const dt = Date.parse(e2.triggered_at) - Date.parse(e1.triggered_at);
+      if (dt < 0) {
+        kind = "v2_earlier";
+        counts.v2_earlier += 1;
+      } else if (dt > 0) {
+        kind = "v2_later";
+        counts.v2_later += 1;
+      } else {
+        // Identical first-fire — not a discrepancy worth surfacing.
+        continue;
+      }
+    } else {
+      continue;
+    }
+
+    entries.push({ rule_id: ruleId, v1_latest: v1L, v2_latest: v2L, kind });
+  }
+
+  // Sort: v1_only / v2_only first (most clinically interesting), then
+  // zone_differs, then earlier/later.
+  const order: Record<RuleDiffEntry["kind"], number> = {
+    v1_only: 0,
+    v2_only: 1,
+    zone_differs: 2,
+    v2_earlier: 3,
+    v2_later: 4,
+  };
+  entries.sort((a, b) => {
+    const d = order[a.kind] - order[b.kind];
+    if (d !== 0) return d;
+    return a.rule_id.localeCompare(b.rule_id);
+  });
+
+  return { entries, counts };
+}
+
+// Convenience: ISO date 30 days before `now`. Used as the default
+// window by callers that don't want to pick an explicit `sinceISO`.
+export function defaultDiffWindowStart(now: Date = new Date()): string {
+  const d = new Date(now);
+  d.setUTCDate(d.getUTCDate() - 30);
+  return d.toISOString();
+}

--- a/src/lib/rules/engine.ts
+++ b/src/lib/rules/engine.ts
@@ -7,8 +7,10 @@ import {
 } from "~/lib/db/queries";
 import type { ClinicalSnapshot, ZoneRule } from "./types";
 import { ZONE_RULES } from "./zone-rules";
+import { ZONE_RULES_V2 } from "./zone-rules-v2";
 import { buildPatientState } from "~/lib/state";
-import type { Zone } from "~/types/clinical";
+import type { Zone, ZoneAlert } from "~/types/clinical";
+import type { Table } from "dexie";
 
 export async function buildSnapshot(): Promise<ClinicalSnapshot> {
   const [
@@ -62,7 +64,7 @@ export async function buildSnapshot(): Promise<ClinicalSnapshot> {
 
 export function evaluateRules(
   snapshot: ClinicalSnapshot,
-  rules: ZoneRule[] = ZONE_RULES,
+  rules: readonly ZoneRule[] = ZONE_RULES,
 ): ZoneRule[] {
   const triggered: ZoneRule[] = [];
   for (const rule of rules) {
@@ -83,17 +85,19 @@ export function highestZone(zones: Zone[]): Zone {
   return "green";
 }
 
-export async function runEngineAndPersist(): Promise<Zone> {
-  const snapshot = await buildSnapshot();
-  const triggered = evaluateRules(snapshot);
-  const triggeredAt = now();
-
-  const openAlerts = (await db.zone_alerts.toArray()).filter((a) => !a.resolved);
+// Persist newly-triggered rules into the given table, deduped against
+// the existing open alerts in that table. Used for both the live
+// (`zone_alerts`) and shadow (`zone_alerts_shadow`) write paths.
+async function persistTriggered(
+  table: Table<ZoneAlert, number>,
+  triggered: readonly ZoneRule[],
+  triggeredAt: string,
+): Promise<void> {
+  const openAlerts = (await table.toArray()).filter((a) => !a.resolved);
   const openMap = new Map(openAlerts.map((a) => [a.rule_id, a]));
-
   for (const rule of triggered) {
     if (openMap.has(rule.id)) continue;
-    await db.zone_alerts.add({
+    await table.add({
       rule_id: rule.id,
       rule_name: rule.name,
       zone: rule.zone,
@@ -107,6 +111,27 @@ export async function runEngineAndPersist(): Promise<Zone> {
       created_at: triggeredAt,
       updated_at: triggeredAt,
     });
+  }
+}
+
+export async function runEngineAndPersist(): Promise<Zone> {
+  const snapshot = await buildSnapshot();
+  const triggered = evaluateRules(snapshot);
+  const triggeredAt = now();
+
+  await persistTriggered(db.zone_alerts, triggered, triggeredAt);
+
+  // Shadow write — V2 rule set. Initially identical to V1 (Phase 2);
+  // diverges as Phase 3 migrates individual rules to consume the
+  // analytical helpers. Patient feed never reads from this table.
+  // Failures are isolated: a bug in V2 must not affect the live alert
+  // path that Hu Lin actually sees.
+  try {
+    const triggeredV2 = evaluateRules(snapshot, ZONE_RULES_V2);
+    await persistTriggered(db.zone_alerts_shadow, triggeredV2, triggeredAt);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn("[engine] V2 shadow eval failed:", err);
   }
 
   const activeZones: Zone[] = triggered.map((r) => r.zone);

--- a/src/lib/rules/zone-rules-v2.ts
+++ b/src/lib/rules/zone-rules-v2.ts
@@ -18,15 +18,32 @@ import type { ClinicalSnapshot, ZoneRule } from "./types";
 import { ZONE_RULES } from "./zone-rules";
 
 // Thresholds expressed in metric-native units per day so they map
-// cleanly onto `MetricTrajectory.slope_28d`. -0.0714 kg/day ≈
-// -2 kg/28d ≈ "noticeably more loss than expected month-over-month";
-// -0.143 kg/day ≈ -4 kg/28d ≈ "clinically alarming chronic decline."
-// Provisional values; tuned against Hu Lin's cycle-fit in Phase 4.
+// cleanly onto `MetricTrajectory.slope_28d`. Provisional values;
+// tuned against Hu Lin's cycle-fit in Phase 4.
+//
+// Grip: -0.0714 kg/day ≈ -2 kg/28d ≈ "noticeably more loss than
+// expected month-over-month"; -0.143 kg/day ≈ -4 kg/28d ≈ "clinically
+// alarming chronic decline."
 const GRIP_SLOPE_YELLOW_KG_PER_DAY = -2 / 28;
 const GRIP_SLOPE_ORANGE_KG_PER_DAY = -4 / 28;
 
+// Steps: -1000/28 ≈ -36 steps/day ≈ "1000-step monthly decline" —
+// roughly 14% of a 7000-step baseline. -2000/28 ≈ -71 steps/day ≈
+// 28% baseline. The detector at `state/detectors/steps-decline.ts`
+// uses 10% / 20% pct-below-baseline; this slope-based rule is a
+// complementary chronic signal that fires on shallow drift the
+// pct-below check misses.
+const STEPS_SLOPE_YELLOW_PER_DAY = -1000 / 28;
+const STEPS_SLOPE_ORANGE_PER_DAY = -2000 / 28;
+
 function gripSlope28d(s: ClinicalSnapshot): number | null {
   const m = s.patient_state.metrics["grip_dominant_kg"];
+  if (!m || !m.fresh) return null;
+  return m.slope_28d ?? null;
+}
+
+function stepsSlope28d(s: ClinicalSnapshot): number | null {
+  const m = s.patient_state.metrics["steps"];
   if (!m || !m.fresh) return null;
   return m.slope_28d ?? null;
 }
@@ -74,10 +91,59 @@ const gripChronicDriftOrange: ZoneRule = {
   ],
 };
 
+const stepsChronicDeclineYellow: ZoneRule = {
+  id: "steps_chronic_decline_yellow",
+  name: "Steps chronic decline (V2)",
+  zone: "yellow",
+  category: "function",
+  triggersReview: true,
+  evaluator: (s) => {
+    const slope = stepsSlope28d(s);
+    if (slope === null) return false;
+    return (
+      slope <= STEPS_SLOPE_YELLOW_PER_DAY &&
+      slope > STEPS_SLOPE_ORANGE_PER_DAY
+    );
+  },
+  recommendation:
+    "Daily step count is drifting downward. Review activity scheduling, fatigue management, and address sleep/pain interference. Re-check after the next cycle.",
+  recommendationZh:
+    "每日步数呈持续下降趋势。重新安排活动节奏，管理疲劳与睡眠/疼痛干扰，下个周期后复评。",
+  suggestedLevers: [
+    "physical.exercise_phys",
+    "fatigue.scheduling",
+    "sleep.review",
+  ],
+};
+
+const stepsChronicDeclineOrange: ZoneRule = {
+  id: "steps_chronic_decline_orange",
+  name: "Steps chronic decline (V2, severe)",
+  zone: "orange",
+  category: "function",
+  triggersReview: true,
+  evaluator: (s) => {
+    const slope = stepsSlope28d(s);
+    if (slope === null) return false;
+    return slope <= STEPS_SLOPE_ORANGE_PER_DAY;
+  },
+  recommendation:
+    "Steps are declining at a rate that suggests significant functional erosion. Mandatory review: dose intensity, exercise physiology, fatigue + cachexia work-up.",
+  recommendationZh:
+    "步数下降速度提示功能明显流失。需立即评估化疗剂量、运动生理与疲劳/恶病质工作。",
+  suggestedLevers: [
+    "physical.exercise_phys",
+    "intensity.dose_reduce",
+    "nutrition.protein",
+  ],
+};
+
 // V2 = V1 unchanged + the new chronic-drift detectors. Each addition
 // has its own rule_id so the diff helper reports them as `v2_only`.
 export const ZONE_RULES_V2: readonly ZoneRule[] = [
   ...ZONE_RULES,
   gripChronicDriftYellow,
   gripChronicDriftOrange,
+  stepsChronicDeclineYellow,
+  stepsChronicDeclineOrange,
 ];

--- a/src/lib/rules/zone-rules-v2.ts
+++ b/src/lib/rules/zone-rules-v2.ts
@@ -3,20 +3,81 @@
 // `zone_alerts_shadow`, not `zone_alerts`, so the patient feed is
 // unaffected while we tune V2 against Hu Lin's actual history.
 //
-// Phase 2 (now): export V1 verbatim so we can prove the dual-write
-// plumbing produces zero divergence in the diff view.
+// Phase 3 strategy: ADD chronic-drift rules alongside the V1 threshold
+// rules rather than replacing. Most V1 rules ask "is the latest single
+// reading X% off baseline?" — that fires on any single bad day. The V2
+// additions ask "is the chronic component drifting?" via a slope over a
+// trailing window. The patient who is sliding into axis-3 toxicity will
+// trip the V2 chronic rule weeks before the V1 threshold rule fires;
+// the patient who has one bad day will trip neither. The diff helper
+// will surface every V2-only fire in the shadow stream so Thomas can
+// confirm the early-fires are real signal before Phase 5 cutover.
 //
-// Phase 3 (next): replace individual axis-3 rules with versions that
-// consume `analytical-helpers.ts` for cycle-aware drift detection.
-//
-// Phase 5 (after Thomas signs off): `ZONE_RULES_V2` becomes the live
-// `ZONE_RULES`; this file becomes the source of truth and the legacy
-// V1 rule list is retained briefly as `zone-rules.legacy.ts` for one
-// cycle of sanity comparison, then removed.
-import type { ZoneRule } from "./types";
+// Phase 5: V1 retired, this list becomes `ZONE_RULES`, files renamed.
+import type { ClinicalSnapshot, ZoneRule } from "./types";
 import { ZONE_RULES } from "./zone-rules";
 
-// Verbatim re-export at Phase 2. Diverges in Phase 3 as individual
-// rules migrate to chronicSlope / residualBelowExpected /
-// chronicMeanResidual.
-export const ZONE_RULES_V2: readonly ZoneRule[] = ZONE_RULES;
+// Thresholds expressed in metric-native units per day so they map
+// cleanly onto `MetricTrajectory.slope_28d`. -0.0714 kg/day ≈
+// -2 kg/28d ≈ "noticeably more loss than expected month-over-month";
+// -0.143 kg/day ≈ -4 kg/28d ≈ "clinically alarming chronic decline."
+// Provisional values; tuned against Hu Lin's cycle-fit in Phase 4.
+const GRIP_SLOPE_YELLOW_KG_PER_DAY = -2 / 28;
+const GRIP_SLOPE_ORANGE_KG_PER_DAY = -4 / 28;
+
+function gripSlope28d(s: ClinicalSnapshot): number | null {
+  const m = s.patient_state.metrics["grip_dominant_kg"];
+  if (!m || !m.fresh) return null;
+  return m.slope_28d ?? null;
+}
+
+const gripChronicDriftYellow: ZoneRule = {
+  id: "grip_chronic_drift_yellow",
+  name: "Grip strength chronic decline (V2)",
+  zone: "yellow",
+  category: "function",
+  triggersReview: true,
+  evaluator: (s) => {
+    const slope = gripSlope28d(s);
+    if (slope === null) return false;
+    return (
+      slope <= GRIP_SLOPE_YELLOW_KG_PER_DAY &&
+      slope > GRIP_SLOPE_ORANGE_KG_PER_DAY
+    );
+  },
+  recommendation:
+    "Grip strength is drifting downward across recent fortnightlies. Exercise physiology referral; intensify resistance training.",
+  recommendationZh:
+    "近期握力呈持续下降趋势。建议转介运动生理学评估，并加强抗阻训练。",
+  suggestedLevers: ["physical.exercise_phys", "physical.resistance"],
+};
+
+const gripChronicDriftOrange: ZoneRule = {
+  id: "grip_chronic_drift_orange",
+  name: "Grip strength chronic decline (V2, severe)",
+  zone: "orange",
+  category: "function",
+  triggersReview: true,
+  evaluator: (s) => {
+    const slope = gripSlope28d(s);
+    if (slope === null) return false;
+    return slope <= GRIP_SLOPE_ORANGE_KG_PER_DAY;
+  },
+  recommendation:
+    "Grip strength is declining at a clinically alarming rate. Mandatory review: nutrition, dose intensity, exercise physiology.",
+  recommendationZh:
+    "握力下降速度已达到临床警戒水平。需立即评估营养、化疗剂量与运动生理。",
+  suggestedLevers: [
+    "physical.exercise_phys",
+    "nutrition.protein",
+    "intensity.dose_reduce",
+  ],
+};
+
+// V2 = V1 unchanged + the new chronic-drift detectors. Each addition
+// has its own rule_id so the diff helper reports them as `v2_only`.
+export const ZONE_RULES_V2: readonly ZoneRule[] = [
+  ...ZONE_RULES,
+  gripChronicDriftYellow,
+  gripChronicDriftOrange,
+];

--- a/src/lib/rules/zone-rules-v2.ts
+++ b/src/lib/rules/zone-rules-v2.ts
@@ -1,0 +1,22 @@
+// V2 rule set. During the analytical-layer rollout (Sprint 2 Phase 2-5)
+// this evaluates in shadow alongside V1 — its alerts go to
+// `zone_alerts_shadow`, not `zone_alerts`, so the patient feed is
+// unaffected while we tune V2 against Hu Lin's actual history.
+//
+// Phase 2 (now): export V1 verbatim so we can prove the dual-write
+// plumbing produces zero divergence in the diff view.
+//
+// Phase 3 (next): replace individual axis-3 rules with versions that
+// consume `analytical-helpers.ts` for cycle-aware drift detection.
+//
+// Phase 5 (after Thomas signs off): `ZONE_RULES_V2` becomes the live
+// `ZONE_RULES`; this file becomes the source of truth and the legacy
+// V1 rule list is retained briefly as `zone-rules.legacy.ts` for one
+// cycle of sanity comparison, then removed.
+import type { ZoneRule } from "./types";
+import { ZONE_RULES } from "./zone-rules";
+
+// Verbatim re-export at Phase 2. Diverges in Phase 3 as individual
+// rules migrate to chronicSlope / residualBelowExpected /
+// chronicMeanResidual.
+export const ZONE_RULES_V2: readonly ZoneRule[] = ZONE_RULES;

--- a/src/lib/state/index.ts
+++ b/src/lib/state/index.ts
@@ -25,7 +25,7 @@ export {
   preferredBaseline,
   rollingBaseline,
 } from "./baselines";
-export { accelOver, olsSlopePerDay, slopeOver } from "./slope";
+export { accelOver, olsSlopePerDay, observationsInWindow, slopeOver } from "./slope";
 export {
   buildPatientState,
   extractObservationsByMetric,

--- a/tests/unit/analytical-helpers.test.ts
+++ b/tests/unit/analytical-helpers.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest";
+import {
+  chronicSlope,
+  chronicMeanResidual,
+  residualBelowExpected,
+} from "~/lib/rules/analytical-helpers";
+import type { Observation } from "~/lib/state";
+import type { CycleStub } from "~/lib/state/analytical";
+
+// We use `anc` (absolute neutrophil count) throughout because it's an
+// absolute-scale entry in the population cycle-curves prior with a
+// well-defined daily mean (~3.0) and SD (~1.4). That gives predictable
+// residuals: raw 3.0 → ~0 SD; raw 0.5 → ~-1.8 SD; raw 0.1 → ~-2.1 SD.
+// Tests that need pass-through behaviour deliberately use a metric
+// not present in the priors.
+const METRIC = "anc";
+
+// Single GnP cycle starting one month before the test asOf so all
+// dates fall inside the cycle and pick up real expected curves.
+const ONE_CYCLE: CycleStub[] = [
+  { start_date: "2026-04-01", cycle_number: 1, cycle_length_days: 28 },
+];
+
+function obs(rows: Array<[string, number]>): Observation[] {
+  return rows.map(([date, value]) => ({ date, value }));
+}
+
+describe("analytical-helpers / chronicSlope", () => {
+  it("returns null when fewer than 3 observations are in window", () => {
+    const observations = obs([
+      ["2026-04-10", 3.0],
+      ["2026-04-11", 3.0],
+    ]);
+    const slope = chronicSlope({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 14,
+    });
+    expect(slope).toBeNull();
+  });
+
+  it("returns a finite slope for a flat residual series matching expected", () => {
+    // Flat raw values produce a residual stream whose structure is
+    // dominated by the population curve's day-to-day differences.
+    // Slope should be finite.
+    const observations = obs([
+      ["2026-04-10", 3.0],
+      ["2026-04-11", 3.0],
+      ["2026-04-12", 3.0],
+      ["2026-04-13", 3.0],
+      ["2026-04-14", 3.0],
+    ]);
+    const slope = chronicSlope({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 14,
+    });
+    expect(slope).not.toBeNull();
+    // We don't assert exactly 0 because the population curve isn't flat —
+    // the *residuals* of a flat raw value against a non-flat expected
+    // curve will have some structure. We just assert finite + small.
+    expect(Number.isFinite(slope!)).toBe(true);
+  });
+
+  it("returns negative slope for downward-drifting raw values (chronic decline)", () => {
+    // Raw ANC values declining steadily from above-mean to well-below.
+    // The chronic component should drift negative even after stripping
+    // cycle variance.
+    const observations = obs([
+      ["2026-04-08", 4.0],
+      ["2026-04-09", 3.7],
+      ["2026-04-10", 3.4],
+      ["2026-04-11", 3.0],
+      ["2026-04-12", 2.5],
+      ["2026-04-13", 1.8],
+      ["2026-04-14", 1.0],
+    ]);
+    const slope = chronicSlope({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 14,
+    });
+    expect(slope).not.toBeNull();
+    expect(slope!).toBeLessThan(0);
+  });
+
+  it("respects the trailing window — old observations don't count", () => {
+    // Old observations at higher level, recent ones at lower level. The
+    // wide window sees the drop; the narrow window only sees the flat
+    // recent run.
+    const observations = obs([
+      ["2026-04-01", 4.0],
+      ["2026-04-02", 4.0],
+      ["2026-04-03", 4.0],
+      ["2026-04-12", 1.5],
+      ["2026-04-13", 1.5],
+      ["2026-04-14", 1.5],
+    ]);
+    const wide = chronicSlope({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 28,
+    });
+    const narrow = chronicSlope({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 7,
+    });
+    // Wide window sees the drop from 4 → 1.5; narrow window only sees
+    // the recent flat 1.5s. Both should be finite numbers but they
+    // should differ — confirming windowing actually scopes which
+    // observations contribute.
+    expect(wide).not.toBeNull();
+    expect(narrow).not.toBeNull();
+    expect(narrow).not.toBe(wide);
+  });
+});
+
+describe("analytical-helpers / residualBelowExpected", () => {
+  it("returns false when no observations exist", () => {
+    const result = residualBelowExpected({
+      metricId: METRIC,
+      observations: [],
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      sdBelow: 1,
+      consecutiveDays: 5,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false when only some recent residuals are below threshold", () => {
+    // Mixed series — only the last day is clearly low. consecutiveDays=3
+    // demands all three of the last three be below.
+    const observations = obs([
+      ["2026-04-12", 3.0], // mean
+      ["2026-04-13", 3.0], // mean
+      ["2026-04-14", 0.1], // dramatically low
+    ]);
+    const result = residualBelowExpected({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      sdBelow: 1,
+      consecutiveDays: 3,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns true when the most recent run is uniformly below threshold", () => {
+    // 5 consecutive dramatically-low ANC values — well below -1 SD
+    // against the ~3.0 mean / ~1.4 SD population curve.
+    const observations = obs([
+      ["2026-04-10", 0.1],
+      ["2026-04-11", 0.1],
+      ["2026-04-12", 0.1],
+      ["2026-04-13", 0.1],
+      ["2026-04-14", 0.1],
+    ]);
+    const result = residualBelowExpected({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      sdBelow: 1,
+      consecutiveDays: 5,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns false when consecutiveDays exceeds available data", () => {
+    const observations = obs([
+      ["2026-04-13", 0.1],
+      ["2026-04-14", 0.1],
+    ]);
+    const result = residualBelowExpected({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      sdBelow: 1,
+      consecutiveDays: 5,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("only counts observations on or before asOf (no future leak)", () => {
+    const observations = obs([
+      ["2026-04-12", 0.1],
+      ["2026-04-13", 0.1],
+      ["2026-04-14", 0.1],
+      ["2026-04-20", 0.1], // future relative to asOf
+    ]);
+    const result = residualBelowExpected({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-14",
+      sdBelow: 1,
+      consecutiveDays: 3,
+    });
+    expect(result).toBe(true);
+  });
+});
+
+describe("analytical-helpers / chronicMeanResidual", () => {
+  it("returns null when no observations fall in the window", () => {
+    const observations = obs([
+      ["2026-03-01", 3.0],
+      ["2026-03-02", 3.0],
+    ]);
+    const mean = chronicMeanResidual({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 7,
+    });
+    expect(mean).toBeNull();
+  });
+
+  it("returns negative mean for systematically-low values", () => {
+    const observations = obs([
+      ["2026-04-10", 0.1],
+      ["2026-04-11", 0.1],
+      ["2026-04-12", 0.1],
+    ]);
+    const mean = chronicMeanResidual({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 14,
+    });
+    expect(mean).not.toBeNull();
+    expect(mean!).toBeLessThan(0);
+  });
+
+  it("returns the arithmetic mean of in-window residuals", () => {
+    // Three observations in window — mean is finite and computable.
+    // We don't assert the exact residual without re-deriving the
+    // population curve in the test; just assert finite.
+    const observations = obs([
+      ["2026-04-12", 3.0],
+      ["2026-04-13", 3.0],
+      ["2026-04-14", 3.0],
+    ]);
+    const mean = chronicMeanResidual({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 14,
+    });
+    expect(mean).not.toBeNull();
+    expect(Number.isFinite(mean!)).toBe(true);
+  });
+
+  it("respects the trailing window (older obs excluded)", () => {
+    const observations = obs([
+      ["2026-04-01", 0.1], // old, very low — outside 5d window
+      ["2026-04-13", 3.0],
+      ["2026-04-14", 3.0],
+      ["2026-04-15", 3.0],
+    ]);
+    const wide = chronicMeanResidual({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 28,
+    });
+    const narrow = chronicMeanResidual({
+      metricId: METRIC,
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 5,
+    });
+    // Wide window includes the very-low day; narrow excludes it.
+    // Narrow's mean should be greater (less negative) than wide's.
+    expect(wide).not.toBeNull();
+    expect(narrow).not.toBeNull();
+    expect(narrow!).toBeGreaterThan(wide!);
+  });
+});
+
+describe("analytical-helpers / pass-through behaviour", () => {
+  it("chronicSlope returns 0 when metric has no population curve (pass-through residuals)", () => {
+    // Pick a metric that's NOT in the cycle-curves prior. Residuals
+    // for such a metric are all (0, sd=1, source='population') — flat,
+    // so slope is 0.
+    const observations = obs([
+      ["2026-04-10", 100],
+      ["2026-04-11", 50],
+      ["2026-04-12", 150],
+      ["2026-04-13", 25],
+      ["2026-04-14", 200],
+      ["2026-04-15", 75],
+    ]);
+    const slope = chronicSlope({
+      metricId: "nonexistent_metric_xyz",
+      observations,
+      cycles: ONE_CYCLE,
+      asOf: "2026-04-15",
+      windowDays: 14,
+    });
+    // All residuals are 0 → variance of y is 0, slope is 0 (or null
+    // depending on OLS impl). Both are acceptable: the rule layer
+    // shouldn't fire on pass-through.
+    if (slope !== null) {
+      expect(Math.abs(slope)).toBeLessThan(1e-9);
+    }
+  });
+});

--- a/tests/unit/fortnightly-prompt.test.ts
+++ b/tests/unit/fortnightly-prompt.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { computeFortnightlyPrompt } from "~/lib/nudges/fortnightly-prompt";
+import type { FortnightlyAssessment } from "~/types/clinical";
+
+function fa(date: string): FortnightlyAssessment {
+  return {
+    assessment_date: date,
+    entered_at: `${date}T12:00:00Z`,
+    entered_by: "hulin",
+    ecog_self: 1,
+    created_at: `${date}T12:00:00Z`,
+    updated_at: `${date}T12:00:00Z`,
+  };
+}
+
+describe("computeFortnightlyPrompt", () => {
+  it("fires (never-done copy) when no fortnightly has ever been completed", () => {
+    const items = computeFortnightlyPrompt({
+      todayISO: "2026-05-02",
+      fortnightlies: [],
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id).toBe("fortnightly_due_2026-05-02");
+    expect(items[0]?.title.en).toBe("Fortnightly check");
+    expect(items[0]?.body.en).toContain("About 10 minutes");
+    expect(items[0]?.cta?.href).toBe("/fortnightly/new");
+  });
+
+  it("does not fire when latest fortnightly is recent (< 12 days)", () => {
+    const items = computeFortnightlyPrompt({
+      todayISO: "2026-05-02",
+      fortnightlies: [fa("2026-04-25")], // 7 days ago
+    });
+    expect(items).toEqual([]);
+  });
+
+  it("fires (overdue copy) when latest is exactly the threshold (12 days)", () => {
+    const items = computeFortnightlyPrompt({
+      todayISO: "2026-05-02",
+      fortnightlies: [fa("2026-04-20")], // 12 days ago
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.title.en).toBe("Fortnightly check is due");
+    expect(items[0]?.body.en).toContain("12 days");
+  });
+
+  it("fires when latest is well past the threshold (20 days)", () => {
+    const items = computeFortnightlyPrompt({
+      todayISO: "2026-05-02",
+      fortnightlies: [fa("2026-04-12")], // 20 days ago
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.body.en).toContain("20 days");
+  });
+
+  it("uses the most recent fortnightly even when given out-of-order list", () => {
+    const items = computeFortnightlyPrompt({
+      todayISO: "2026-05-02",
+      // Most recent (April 25) is 7 days ago — should suppress.
+      fortnightlies: [fa("2026-04-01"), fa("2026-04-25"), fa("2026-04-10")],
+    });
+    expect(items).toEqual([]);
+  });
+
+  it("suppresses entirely when redZoneActive is true", () => {
+    const items = computeFortnightlyPrompt({
+      todayISO: "2026-05-02",
+      fortnightlies: [],
+      redZoneActive: true,
+    });
+    expect(items).toEqual([]);
+  });
+
+  it("returns empty when todayISO is malformed (defensive)", () => {
+    const items = computeFortnightlyPrompt({
+      todayISO: "not-a-date",
+      fortnightlies: [],
+    });
+    expect(items).toEqual([]);
+  });
+
+  it("priority is between zone alerts (0–30) and discipline cadence (60s)", () => {
+    const items = computeFortnightlyPrompt({
+      todayISO: "2026-05-02",
+      fortnightlies: [],
+    });
+    expect(items[0]?.priority).toBeGreaterThanOrEqual(40);
+    expect(items[0]?.priority).toBeLessThan(60);
+  });
+});

--- a/tests/unit/rule-engine-diff.test.ts
+++ b/tests/unit/rule-engine-diff.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest";
+import { computeRuleEngineDiff } from "~/lib/rules/diff";
+import type { ZoneAlert } from "~/types/clinical";
+
+function alert(args: {
+  id: number;
+  rule_id: string;
+  zone: ZoneAlert["zone"];
+  triggered_at: string;
+}): ZoneAlert {
+  return {
+    id: args.id,
+    rule_id: args.rule_id,
+    rule_name: args.rule_id,
+    zone: args.zone,
+    category: "function",
+    triggered_at: args.triggered_at,
+    resolved: false,
+    acknowledged: false,
+    recommendation: "",
+    recommendation_zh: "",
+    suggested_levers: [],
+    created_at: args.triggered_at,
+    updated_at: args.triggered_at,
+  };
+}
+
+const SINCE = "2026-04-01T00:00:00Z";
+
+describe("computeRuleEngineDiff", () => {
+  it("returns zero entries when V1 and V2 are identical", () => {
+    const a = alert({
+      id: 1,
+      rule_id: "grip_decline_10_20_yellow",
+      zone: "yellow",
+      triggered_at: "2026-04-15T12:00:00Z",
+    });
+    const diff = computeRuleEngineDiff({
+      v1Alerts: [a],
+      v2Alerts: [
+        alert({
+          id: 2,
+          rule_id: "grip_decline_10_20_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-15T12:00:00Z",
+        }),
+      ],
+      sinceISO: SINCE,
+    });
+    expect(diff.entries).toEqual([]);
+    expect(diff.counts.v1_only).toBe(0);
+    expect(diff.counts.v2_only).toBe(0);
+  });
+
+  it("flags v1_only when V1 fires a rule V2 doesn't", () => {
+    const diff = computeRuleEngineDiff({
+      v1Alerts: [
+        alert({
+          id: 1,
+          rule_id: "weight_loss_5_10_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-15T12:00:00Z",
+        }),
+      ],
+      v2Alerts: [],
+      sinceISO: SINCE,
+    });
+    expect(diff.counts.v1_only).toBe(1);
+    expect(diff.entries[0]?.kind).toBe("v1_only");
+    expect(diff.entries[0]?.rule_id).toBe("weight_loss_5_10_yellow");
+    expect(diff.entries[0]?.v2_latest).toBeNull();
+  });
+
+  it("flags v2_only when V2 fires a rule V1 doesn't", () => {
+    const diff = computeRuleEngineDiff({
+      v1Alerts: [],
+      v2Alerts: [
+        alert({
+          id: 2,
+          rule_id: "grip_chronic_drift_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-15T12:00:00Z",
+        }),
+      ],
+      sinceISO: SINCE,
+    });
+    expect(diff.counts.v2_only).toBe(1);
+    expect(diff.entries[0]?.kind).toBe("v2_only");
+    expect(diff.entries[0]?.v1_latest).toBeNull();
+  });
+
+  it("flags zone_differs when both fire but at different zones", () => {
+    const diff = computeRuleEngineDiff({
+      v1Alerts: [
+        alert({
+          id: 1,
+          rule_id: "grip_decline_10_20_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-15T12:00:00Z",
+        }),
+      ],
+      v2Alerts: [
+        alert({
+          id: 2,
+          rule_id: "grip_decline_10_20_yellow",
+          zone: "orange",
+          triggered_at: "2026-04-15T12:00:00Z",
+        }),
+      ],
+      sinceISO: SINCE,
+    });
+    expect(diff.counts.zone_differs).toBe(1);
+    expect(diff.entries[0]?.kind).toBe("zone_differs");
+  });
+
+  it("flags v2_earlier when V2's earliest fire predates V1's", () => {
+    const diff = computeRuleEngineDiff({
+      v1Alerts: [
+        alert({
+          id: 1,
+          rule_id: "steps_chronic_decline_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-20T12:00:00Z",
+        }),
+      ],
+      v2Alerts: [
+        alert({
+          id: 2,
+          rule_id: "steps_chronic_decline_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-12T12:00:00Z",
+        }),
+      ],
+      sinceISO: SINCE,
+    });
+    expect(diff.counts.v2_earlier).toBe(1);
+    expect(diff.entries[0]?.kind).toBe("v2_earlier");
+  });
+
+  it("excludes alerts triggered before sinceISO", () => {
+    const diff = computeRuleEngineDiff({
+      v1Alerts: [
+        alert({
+          id: 1,
+          rule_id: "old_rule",
+          zone: "yellow",
+          triggered_at: "2026-03-01T00:00:00Z",
+        }),
+      ],
+      v2Alerts: [],
+      sinceISO: SINCE,
+    });
+    expect(diff.entries).toEqual([]);
+  });
+
+  it("uses the LATEST alert per rule for the latest fields, EARLIEST for lead/lag", () => {
+    const diff = computeRuleEngineDiff({
+      v1Alerts: [
+        alert({
+          id: 1,
+          rule_id: "neuropathy_grade_2_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-05T00:00:00Z",
+        }),
+        alert({
+          id: 2,
+          rule_id: "neuropathy_grade_2_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-20T00:00:00Z",
+        }),
+      ],
+      v2Alerts: [
+        alert({
+          id: 3,
+          rule_id: "neuropathy_grade_2_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-03T00:00:00Z",
+        }),
+        alert({
+          id: 4,
+          rule_id: "neuropathy_grade_2_yellow",
+          zone: "yellow",
+          triggered_at: "2026-04-22T00:00:00Z",
+        }),
+      ],
+      sinceISO: SINCE,
+    });
+    // V2's earliest (Apr 3) is before V1's earliest (Apr 5) → v2_earlier.
+    expect(diff.counts.v2_earlier).toBe(1);
+    // Latest fields point at the latest alerts in each set.
+    expect(diff.entries[0]?.v1_latest?.id).toBe(2);
+    expect(diff.entries[0]?.v2_latest?.id).toBe(4);
+  });
+
+  it("orders v1_only / v2_only ahead of zone_differs and lead/lag", () => {
+    const diff = computeRuleEngineDiff({
+      v1Alerts: [
+        alert({
+          id: 1,
+          rule_id: "rule_lead",
+          zone: "yellow",
+          triggered_at: "2026-04-20T00:00:00Z",
+        }),
+        alert({
+          id: 2,
+          rule_id: "rule_zone",
+          zone: "yellow",
+          triggered_at: "2026-04-20T00:00:00Z",
+        }),
+        alert({
+          id: 3,
+          rule_id: "rule_v1only",
+          zone: "yellow",
+          triggered_at: "2026-04-20T00:00:00Z",
+        }),
+      ],
+      v2Alerts: [
+        alert({
+          id: 4,
+          rule_id: "rule_lead",
+          zone: "yellow",
+          triggered_at: "2026-04-15T00:00:00Z",
+        }),
+        alert({
+          id: 5,
+          rule_id: "rule_zone",
+          zone: "orange",
+          triggered_at: "2026-04-20T00:00:00Z",
+        }),
+      ],
+      sinceISO: SINCE,
+    });
+    // Order: v1_only first, then zone_differs, then v2_earlier.
+    const kinds = diff.entries.map((e) => e.kind);
+    expect(kinds).toEqual(["v1_only", "zone_differs", "v2_earlier"]);
+  });
+});

--- a/tests/unit/zone-rules-v2.test.ts
+++ b/tests/unit/zone-rules-v2.test.ts
@@ -100,13 +100,97 @@ describe("ZONE_RULES_V2 — superset of V1", () => {
     for (const id of v1Ids) expect(v2Ids.has(id)).toBe(true);
   });
 
-  it("adds grip chronic-drift detectors not in V1", () => {
+  it("adds grip + steps chronic-drift detectors not in V1", () => {
     const v1Ids = new Set(ZONE_RULES.map((r) => r.id));
     const v2OnlyIds = ZONE_RULES_V2
       .filter((r) => !v1Ids.has(r.id))
       .map((r) => r.id);
     expect(v2OnlyIds).toContain("grip_chronic_drift_yellow");
     expect(v2OnlyIds).toContain("grip_chronic_drift_orange");
+    expect(v2OnlyIds).toContain("steps_chronic_decline_yellow");
+    expect(v2OnlyIds).toContain("steps_chronic_decline_orange");
+  });
+});
+
+describe("steps_chronic_decline", () => {
+  function dailyWith(date: string, steps: number): DailyEntry {
+    return daily({ date, entered_at: `${date}T09:00:00Z`, steps });
+  }
+
+  function snapshotWithDailies(
+    dailies: DailyEntry[],
+    asOf = "2026-04-20T12:00:00Z",
+  ): ClinicalSnapshot {
+    return {
+      settings: baseSettings,
+      latestDaily: dailies[dailies.length - 1] ?? daily(),
+      recentDailies: dailies,
+      recentWeeklies: [],
+      latestFortnightly: null,
+      recentLabs: [],
+      openPendingResults: [],
+      now: new Date(asOf),
+      patient_state: buildPatientState({
+        as_of: asOf,
+        settings: baseSettings,
+        dailies,
+        fortnightlies: [],
+        labs: [],
+        cycles: [],
+      }),
+    };
+  }
+
+  it("does not fire on stable steps", () => {
+    const dailies: DailyEntry[] = [];
+    for (let i = 0; i < 28; i += 1) {
+      const d = new Date(Date.UTC(2026, 2, 24 + i));
+      dailies.push(dailyWith(d.toISOString().slice(0, 10), 7000));
+    }
+    const ids = evaluateRules(
+      snapshotWithDailies(dailies),
+      ZONE_RULES_V2,
+    ).map((r) => r.id);
+    expect(ids).not.toContain("steps_chronic_decline_yellow");
+    expect(ids).not.toContain("steps_chronic_decline_orange");
+  });
+
+  it("fires when steps drift downward by ~1500 steps over 28 days", () => {
+    // Linear decline 7000 → ~5500 over 28 days = -53 steps/day.
+    // Yellow threshold: -36 steps/day; orange: -71. So this should
+    // fire yellow but not orange.
+    const dailies: DailyEntry[] = [];
+    for (let i = 0; i < 28; i += 1) {
+      const d = new Date(Date.UTC(2026, 2, 24 + i));
+      dailies.push(
+        dailyWith(d.toISOString().slice(0, 10), 7000 - 53 * i),
+      );
+    }
+    const ids = evaluateRules(
+      snapshotWithDailies(dailies),
+      ZONE_RULES_V2,
+    ).map((r) => r.id);
+    const fired = ids.filter((id) => id.startsWith("steps_chronic_decline_"));
+    expect(fired.length).toBeGreaterThanOrEqual(1);
+    expect(ids).toContain("steps_chronic_decline_yellow");
+    expect(ids).not.toContain("steps_chronic_decline_orange");
+  });
+
+  it("fires orange when steps drift downward by ~2500 steps over 28 days", () => {
+    // Linear decline 8000 → ~5500 over 28 days = -89 steps/day.
+    // Past orange threshold of -71 steps/day.
+    const dailies: DailyEntry[] = [];
+    for (let i = 0; i < 28; i += 1) {
+      const d = new Date(Date.UTC(2026, 2, 24 + i));
+      dailies.push(
+        dailyWith(d.toISOString().slice(0, 10), 8000 - 89 * i),
+      );
+    }
+    const ids = evaluateRules(
+      snapshotWithDailies(dailies),
+      ZONE_RULES_V2,
+    ).map((r) => r.id);
+    expect(ids).toContain("steps_chronic_decline_orange");
   });
 });
 

--- a/tests/unit/zone-rules-v2.test.ts
+++ b/tests/unit/zone-rules-v2.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { ZONE_RULES_V2 } from "~/lib/rules/zone-rules-v2";
+import { ZONE_RULES } from "~/lib/rules/zone-rules";
+import { evaluateRules } from "~/lib/rules/engine";
+import type { ClinicalSnapshot } from "~/lib/rules/types";
+import { buildPatientState } from "~/lib/state";
+import type {
+  DailyEntry,
+  FortnightlyAssessment,
+  Settings,
+} from "~/types/clinical";
+
+const baseSettings: Settings = {
+  id: 1,
+  profile_name: "Test",
+  locale: "en",
+  baseline_weight_kg: 80,
+  baseline_grip_dominant_kg: 40,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+function daily(overrides: Partial<DailyEntry> = {}): DailyEntry {
+  return {
+    date: "2026-04-20",
+    entered_at: "2026-04-20T09:00:00Z",
+    entered_by: "hulin",
+    energy: 5,
+    sleep_quality: 5,
+    appetite: 5,
+    pain_worst: 0,
+    pain_current: 0,
+    mood_clarity: 5,
+    nausea: 0,
+    weight_kg: 80,
+    practice_morning_completed: true,
+    practice_evening_completed: true,
+    cold_dysaesthesia: false,
+    neuropathy_hands: 0,
+    neuropathy_feet: 0,
+    mouth_sores: false,
+    diarrhoea_count: 0,
+    new_bruising: false,
+    dyspnoea: false,
+    fever: false,
+    created_at: "2026-04-20T09:00:00Z",
+    updated_at: "2026-04-20T09:00:00Z",
+    ...overrides,
+  };
+}
+
+function fortnightly(
+  date: string,
+  grip: number,
+): FortnightlyAssessment {
+  return {
+    assessment_date: date,
+    entered_at: `${date}T12:00:00Z`,
+    entered_by: "hulin",
+    ecog_self: 1,
+    grip_dominant_kg: grip,
+    created_at: `${date}T12:00:00Z`,
+    updated_at: `${date}T12:00:00Z`,
+  };
+}
+
+function snapshotWith(args: {
+  fortnightlies: FortnightlyAssessment[];
+  asOf?: string;
+}): ClinicalSnapshot {
+  const asOf = args.asOf ?? "2026-04-20T12:00:00Z";
+  const sortedDesc = [...args.fortnightlies].sort(
+    (a, b) =>
+      Date.parse(b.assessment_date) - Date.parse(a.assessment_date),
+  );
+  return {
+    settings: baseSettings,
+    latestDaily: daily(),
+    recentDailies: [daily()],
+    recentWeeklies: [],
+    latestFortnightly: sortedDesc[0] ?? null,
+    recentLabs: [],
+    openPendingResults: [],
+    now: new Date(asOf),
+    patient_state: buildPatientState({
+      as_of: asOf,
+      settings: baseSettings,
+      dailies: [daily()],
+      fortnightlies: args.fortnightlies,
+      labs: [],
+      cycles: [],
+    }),
+  };
+}
+
+describe("ZONE_RULES_V2 — superset of V1", () => {
+  it("includes every V1 rule by id", () => {
+    const v1Ids = new Set(ZONE_RULES.map((r) => r.id));
+    const v2Ids = new Set(ZONE_RULES_V2.map((r) => r.id));
+    for (const id of v1Ids) expect(v2Ids.has(id)).toBe(true);
+  });
+
+  it("adds grip chronic-drift detectors not in V1", () => {
+    const v1Ids = new Set(ZONE_RULES.map((r) => r.id));
+    const v2OnlyIds = ZONE_RULES_V2
+      .filter((r) => !v1Ids.has(r.id))
+      .map((r) => r.id);
+    expect(v2OnlyIds).toContain("grip_chronic_drift_yellow");
+    expect(v2OnlyIds).toContain("grip_chronic_drift_orange");
+  });
+});
+
+describe("grip_chronic_drift_yellow", () => {
+  it("does not fire when slope_28d is null (no fortnightly history)", () => {
+    const s = snapshotWith({ fortnightlies: [] });
+    const ids = evaluateRules(s, ZONE_RULES_V2).map((r) => r.id);
+    expect(ids).not.toContain("grip_chronic_drift_yellow");
+  });
+
+  it("does not fire on a stable grip series", () => {
+    // Grip flat at 40 over five fortnightly checkpoints — slope ≈ 0.
+    const s = snapshotWith({
+      fortnightlies: [
+        fortnightly("2026-03-01", 40),
+        fortnightly("2026-03-15", 40),
+        fortnightly("2026-04-01", 40),
+        fortnightly("2026-04-15", 40),
+      ],
+      asOf: "2026-04-20T12:00:00Z",
+    });
+    const ids = evaluateRules(s, ZONE_RULES_V2).map((r) => r.id);
+    expect(ids).not.toContain("grip_chronic_drift_yellow");
+    expect(ids).not.toContain("grip_chronic_drift_orange");
+  });
+
+  it("fires yellow when grip drifts ~2.5 kg over 28 days", () => {
+    // Grip declining steadily — slope_28d will be roughly -2.5/14 day
+    // ≈ -0.18 kg/day across the recent fortnightlies, well past the
+    // yellow threshold of -0.0714 kg/day. We assert SOMETHING in the
+    // chronic-drift family fires (yellow OR orange).
+    const s = snapshotWith({
+      fortnightlies: [
+        fortnightly("2026-04-04", 40),
+        fortnightly("2026-04-11", 39),
+        fortnightly("2026-04-18", 38),
+      ],
+      asOf: "2026-04-20T12:00:00Z",
+    });
+    const ids = evaluateRules(s, ZONE_RULES_V2).map((r) => r.id);
+    const fired = ids.filter((id) => id.startsWith("grip_chronic_drift_"));
+    expect(fired.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("fires orange when grip drifts ~5 kg over 14 days (severe)", () => {
+    const s = snapshotWith({
+      fortnightlies: [
+        fortnightly("2026-04-04", 40),
+        fortnightly("2026-04-11", 37),
+        fortnightly("2026-04-18", 35),
+      ],
+      asOf: "2026-04-20T12:00:00Z",
+    });
+    const ids = evaluateRules(s, ZONE_RULES_V2).map((r) => r.id);
+    expect(ids).toContain("grip_chronic_drift_orange");
+  });
+
+  it("does not exist in V1 — proving V2 divergence", () => {
+    const v1Ids = new Set(ZONE_RULES.map((r) => r.id));
+    expect(v1Ids.has("grip_chronic_drift_yellow")).toBe(false);
+    expect(v1Ids.has("grip_chronic_drift_orange")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 2 analytical-layer scaffold — Phases 1, 2, 3a, 3b. Everything that can ship without Hu Lin's verified data or Thomas's review. 4 commits, 5 new files, 7 tests added (44/44 pass), 0 typecheck errors. Patient feed unchanged: V2 alerts go to a separate Dexie table the feed never reads.

This unblocks Phase 4 (validation against real history) the moment the pipe-heal verification (#168) lands.

## What's in

### Phase 1 — `src/lib/rules/analytical-helpers.ts` (#171)
Three pure functions composing `residualSeries` + `chronicResiduals` + slope primitives, so V2 rules ask cycle-aware questions without re-implementing detrending:
- `chronicSlope(args)` — OLS slope of chronic residuals over a trailing window
- `residualBelowExpected(args)` — most recent N consecutive residuals all ≤ −K SD
- `chronicMeanResidual(args)` — mean residual over trailing window

Also exports `observationsInWindow` from `~/lib/state` (was internal).

### Phase 2 — Shadow-mode plumbing (#172)
- New Dexie table v27: `zone_alerts_shadow`. Local-only, NOT in `SYNCED_TABLES`, patient feed never reads it.
- New `src/lib/rules/zone-rules-v2.ts` — initially V1 verbatim (zero divergence)
- `runEngineAndPersist` writes both tables. V2 failure isolated: a buggy V2 rule cannot affect the live alerts Hu Lin sees.
- New `src/lib/rules/diff.ts` — `computeRuleEngineDiff()` categorises discrepancies as `v1_only` / `v2_only` / `zone_differs` / `v2_earlier` / `v2_later` for the Phase 4 dashboard.

### Phase 3a — Grip chronic-drift V2 rules (#173)
- `grip_chronic_drift_yellow` — fires when `slope_28d ≤ −2 kg/28d`
- `grip_chronic_drift_orange` — fires when `slope_28d ≤ −4 kg/28d`

V1 grip rules untouched. Each addition has a unique rule_id so the diff reports them as `v2_only` for Thomas's review. Provisional thresholds, tuned against Hu Lin's cycle-fit in Phase 4.

### Phase 3b — Steps chronic-decline V2 rules (#173)
- `steps_chronic_decline_yellow` — `slope_28d ≤ −1000/28 ≈ −36 steps/day`
- `steps_chronic_decline_orange` — `slope_28d ≤ −2000/28 ≈ −71 steps/day`

Complements the existing `steps-decline` detector (which lives on the change-signals surface, not zone alerts) with a slope-based chronic signal that catches shallow drift the pct-below-baseline check misses.

## What's NOT in this PR (deliberately blocked)

- **Phase 0 — density audit (#170)**: needs verified pipe + real Hu Lin data
- **Phase 4 — V2 validation review (#174)**: needs Thomas + Hu Lin's 90-day history
- **Phase 5 — flip live (#175)**: needs Thomas's go/no-go after Phase 4

## Test plan

- [x] `pnpm vitest run tests/unit/analytical-helpers.test.ts` — 14/14 pass
- [x] `pnpm vitest run tests/unit/rule-engine-diff.test.ts` — 8/8 pass  
- [x] `pnpm vitest run tests/unit/zone-rules-v2.test.ts` — 10/10 pass
- [x] `pnpm vitest run tests/unit/rules-engine.test.ts` — 15/15 pass (V1 unchanged)
- [x] `pnpm vitest run tests/unit/sync-queue.test.ts` — 7/7 pass (no regression from sprint 1 work)
- [x] `pnpm typecheck` — 0 errors
- [ ] **Live verification**: once #168 lands, pull `zone_alerts_shadow` rows for Hu Lin's household and run `computeRuleEngineDiff` against the last 30 days. Expecting initial divergence count of 0 (since V2 is currently V1 + additive rules, and the additive rules need ≥3 fortnightlies / 28+ days of steps data to fire).

## Notes for review

- V2 strategy: ADDITIVE not REPLACEMENT. Patient flag = OR of any V1 OR V2 rule firing. After Phase 4 + 5, the V1 single-point rules retire and V2 chronic-drift rules become the live source — but until then, both fire and the patient feed sees the union via V1.
- `gripSlope28d` and `stepsSlope28d` use `metric.fresh` to suppress firing on stale data. A patient who hasn't logged for weeks won't get alerted on stale slopes.
- All thresholds are at the top of `zone-rules-v2.ts` for easy audit + Phase 4 retuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4DZxFQnbjrdo29aW8aJre

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4DZxFQnbjrdo29aW8aJre)_