### PR TITLE
ci: switch board trigger to issues.labeled (projects_v2_item not a valid repo workflow trigger)

### DIFF
--- a/.github/workflows/project-board-claude-trigger.yml
+++ b/.github/workflows/project-board-claude-trigger.yml
@@ -1,25 +1,32 @@
 name: Project board trigger Claude on In Progress
 
-# When a project-board card on the "save dads life" project moves to
-# the "In Progress" status, post an @claude mention on the linked
-# issue. The Claude Code GitHub App picks up the mention and starts a
-# new session scoped to that issue.
+# When you want Claude to pick up an issue, label it `status:in-progress`.
+# This workflow posts an @claude mention on the issue, which the
+# Claude Code GitHub App picks up and starts a fresh session for.
 #
-# Why this workflow exists: the GitHub MCP server doesn't expose
-# Projects v2 webhooks to Claude sessions directly. So we bridge:
-# project status change -> issue comment -> @claude trigger.
+# Why a label trigger and not a project-board trigger:
+# `projects_v2_item` events ARE webhooks, but GitHub Actions does NOT
+# accept them as `on:` keys for repository-level workflows — only for
+# organization-level workflows in the org's `.github` repo. Since the
+# "save dads life" project is user-owned, we bridge via a label.
 #
-# Caveat: `projects_v2_item` events fire at the user / org level. If
-# the project is later moved to an org that doesn't include this
-# repo, this workflow stops firing silently. The workflow_dispatch
-# trigger below lets us test the comment path manually with an
-# explicit issue number.
+# Two paths to fire this:
+#   1. Apply the `status:in-progress` label on the issue manually
+#      (one click in the Issues tab — it auto-creates the label on
+#      first use).
+#   2. Run this workflow manually from the Actions tab with an issue
+#      number — useful if you don't want to label.
+#
+# If you want to keep the project board as the single source of
+# truth, GitHub Projects v2 has a built-in workflow "Status field ->
+# label sync" that you'd need to set up separately on the project
+# itself (Settings -> Workflows). Once configured, dragging the card
+# to "In Progress" applies the label automatically, which fires this
+# workflow.
 
 on:
-  projects_v2_item:
-    types: [edited]
-  # Manual fallback for testing — pass an issue number, the comment
-  # gets posted as if the card had just moved to In Progress.
+  issues:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -35,79 +42,50 @@ jobs:
   trigger-claude:
     runs-on: ubuntu-latest
     # Run on:
-    #  (a) manual workflow_dispatch — always
-    #  (b) projects_v2_item.edited where Status changed TO "In Progress"
-    #      and the linked content is an Issue
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'projects_v2_item' && github.event.changes.field_value.field_name == 'Status' && github.event.changes.field_value.to.name == 'In Progress' && github.event.projects_v2_item.content_type == 'Issue') }}
+    #   (a) workflow_dispatch — always, with the user-supplied issue number
+    #   (b) issues.labeled — only when the new label is `status:in-progress`
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && github.event.label.name == 'status:in-progress') }}
     steps:
-      - name: Resolve issue context
+      - name: Resolve issue number
         id: resolve
         uses: actions/github-script@v7
         env:
           EVENT_NAME: ${{ github.event_name }}
           MANUAL_ISSUE_NUMBER: ${{ inputs.issue_number }}
+          LABELED_ISSUE_NUMBER: ${{ github.event.issue.number }}
         with:
           script: |
             const eventName = process.env.EVENT_NAME;
+            let n;
             if (eventName === 'workflow_dispatch') {
-              const n = parseInt(process.env.MANUAL_ISSUE_NUMBER, 10);
-              if (!Number.isFinite(n)) {
-                core.setFailed('issue_number input is required');
-                return;
-              }
-              core.setOutput('issue_number', String(n));
-              core.setOutput('repo_owner', context.repo.owner);
-              core.setOutput('repo_name', context.repo.repo);
+              n = parseInt(process.env.MANUAL_ISSUE_NUMBER, 10);
+            } else {
+              n = parseInt(process.env.LABELED_ISSUE_NUMBER, 10);
+            }
+            if (!Number.isFinite(n)) {
+              core.setFailed('Could not resolve issue number');
               return;
             }
-            // projects_v2_item path: resolve via graphql node id.
-            const nodeId = context.payload.projects_v2_item?.content_node_id;
-            if (!nodeId) {
-              core.setFailed('No content_node_id in payload');
-              return;
-            }
-            const res = await github.graphql(
-              `query($id: ID!) {
-                node(id: $id) {
-                  ... on Issue {
-                    number
-                    repository { name owner { login } }
-                  }
-                }
-              }`,
-              { id: nodeId },
-            );
-            const issue = res.node;
-            if (!issue || !issue.number) {
-              core.setFailed('Could not resolve issue from node ' + nodeId);
-              return;
-            }
-            core.setOutput('issue_number', String(issue.number));
-            core.setOutput('repo_owner', issue.repository.owner.login);
-            core.setOutput('repo_name', issue.repository.name);
+            core.setOutput('issue_number', String(n));
 
       - name: Post @claude trigger comment
         uses: actions/github-script@v7
         env:
           ISSUE_NUMBER: ${{ steps.resolve.outputs.issue_number }}
-          REPO_OWNER: ${{ steps.resolve.outputs.repo_owner }}
-          REPO_NAME: ${{ steps.resolve.outputs.repo_name }}
         with:
           script: |
             const issueNumber = parseInt(process.env.ISSUE_NUMBER, 10);
-            const owner = process.env.REPO_OWNER;
-            const repo = process.env.REPO_NAME;
             const body = [
-              '@claude this card moved to **In Progress** on the project board.',
+              '@claude this issue was marked **In Progress** — picking it up.',
               '',
-              'Please pick it up: read the issue body for full context, plan the work, and ship.',
+              'Please read the issue body for full context, plan the work, and ship.',
               'If anything is ambiguous or needs Thomas / Hu Lin input, comment instead of guessing.',
               '',
               '_Posted automatically by `.github/workflows/project-board-claude-trigger.yml`._',
             ].join('\n');
             await github.rest.issues.createComment({
-              owner,
-              repo,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               issue_number: issueNumber,
               body,
             });


### PR DESCRIPTION
## Summary

Fix the workflow rejected by GitHub Actions:
> `Invalid workflow file: ...#L1 (Line: 19, Col: 3): Unexpected value 'projects_v2_item'`

`projects_v2_item` is a real webhook event but **isn't** accepted as an `on:` key for repository-level workflows — only for organization-level workflows in an org's `.github` repo. The "save dads life" project is user-owned, so the bridge has to go through a label.

## New trigger model

- **`issues.labeled`** filtered to label `status:in-progress` — apply the label, the @claude comment posts.
- **`workflow_dispatch`** with an issue number — manual fallback.

## Path to "drag to In Progress = wakes Claude"

If you want the project-board drag to remain the primary UX (instead of labeling), Projects v2 has a built-in **status → label** sync workflow you'd configure on the project itself (project Settings → Workflows → "Status changed to In Progress applies label X"). Once enabled, dragging a card to In Progress applies `status:in-progress`, which fires this workflow. Documented in the workflow header.

## Test plan

- [ ] Actions tab → "Project board trigger Claude on In Progress" → **Run workflow** → enter any issue number → confirm an `@claude` comment appears
- [ ] Apply the `status:in-progress` label to any issue → confirm the same comment appears
- [ ] Optionally configure the Projects v2 status-to-label sync to test the drag path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4DZxFQnbjrdo29aW8aJre

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4DZxFQnbjrdo29aW8aJre)_