### PR TITLE
fix(nutrition): direct rear-camera capture for meal photo ingest

### DIFF
--- a/src/components/nutrition/meal-ingest.tsx
+++ b/src/components/nutrition/meal-ingest.tsx
@@ -3,7 +3,15 @@
 import { useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Camera, Loader2, Sparkles, Type, Mic, MicOff } from "lucide-react";
+import {
+  Camera,
+  ImagePlus,
+  Loader2,
+  Sparkles,
+  Type,
+  Mic,
+  MicOff,
+} from "lucide-react";
 import { prepareImageForVision } from "~/lib/ingest/image";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
 import {
@@ -57,7 +65,8 @@ export function MealIngest({
     onTranscribed: (chunk) =>
       setText((cur) => (cur ? `${cur} ${chunk}` : chunk)),
   });
-  const fileRef = useRef<HTMLInputElement>(null);
+  const cameraRef = useRef<HTMLInputElement>(null);
+  const libraryRef = useRef<HTMLInputElement>(null);
 
   async function handleFile(file: File) {
     setBusy(true);
@@ -123,19 +132,41 @@ export function MealIngest({
                   variant="primary"
                   size="md"
                   disabled={busy}
-                  onClick={() => fileRef.current?.click()}
+                  onClick={() => cameraRef.current?.click()}
                 >
                   {busy ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
                   ) : (
                     <Camera className="h-4 w-4" />
                   )}
-                  {locale === "zh" ? "拍照 / 选图" : "Take or pick photo"}
+                  {locale === "zh" ? "拍照" : "Take photo"}
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="md"
+                  disabled={busy}
+                  onClick={() => libraryRef.current?.click()}
+                >
+                  <ImagePlus className="h-4 w-4" />
+                  {locale === "zh" ? "从相册选择" : "Pick photo"}
                 </Button>
               </div>
             </div>
+            {/* Two inputs: capture=environment routes directly to the rear camera; the second has no capture so the OS shows the library picker. */}
             <input
-              ref={fileRef}
+              ref={cameraRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              hidden
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) void handleFile(f);
+                e.target.value = "";
+              }}
+            />
+            <input
+              ref={libraryRef}
               type="file"
               accept="image/*"
               hidden


### PR DESCRIPTION
## Summary
- The Photo tab in `MealIngest` routed every tap through a single capture-less `<input type="file">`, which resolves to the OS library picker on Hu Lin's device — there was no way to take a meal photo without first saving it via the system Camera app and re-importing.
- Split the affordance into two buttons backed by separate hidden inputs: **Take photo** with `capture="environment"` (direct rear-camera) and **Pick photo** (existing library flow). Both feed the same `handleFile` codepath, so the parsed-meal preview logic is unchanged.

Closes #195.

## Test plan
- [ ] On iOS Safari, tapping **Take photo / 拍照** opens the rear camera directly, not the library.
- [ ] On Android Chrome and the Capacitor/TWA wrapper, **Take photo** opens the camera; **Pick photo / 从相册选择** opens the gallery.
- [ ] After capture from either path, parse → preview → save still works end-to-end and produces a `photoDataUrl` thumbnail on the timeline.
- [ ] No regression in the Text tab (typed entry + voice memo).

https://claude.ai/code/session_01UcqS8esNmk7D6QLiVm9t4N

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcqS8esNmk7D6QLiVm9t4N)_