### PR TITLE
chore(workflow): use `in progress` label as Claude trigger

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -140,7 +140,7 @@ only exposes classic Issues, not the Projects v2 GraphQL surface.
 
 ### Trigger model: the LABEL wakes Claude, not the drag
 
-Applying the **`status:in-progress`** label to an issue posts an
+Applying the **`in progress`** label to an issue posts an
 `@claude` mention via the workflow at
 `.github/workflows/project-board-claude-trigger.yml`. The Claude
 Code GitHub App picks up the mention and starts a fresh session
@@ -151,7 +151,7 @@ project board does **NOT** apply the label automatically. GitHub
 Projects v2 doesn't natively sync the Status field to a label. To
 wake Claude on a card, either:
 
-- **Recommended:** apply the `status:in-progress` label directly on
+- **Recommended:** apply the `in progress` label directly on
   the issue (one click in the Issues tab). The board's Status field
   is for visualisation; the label is for automation.
 - **Alternative:** run the "Trigger Claude on issue label" workflow

--- a/.github/ISSUE_TEMPLATE/sprint-task.yml
+++ b/.github/ISSUE_TEMPLATE/sprint-task.yml
@@ -67,7 +67,7 @@ body:
     attributes:
       value: |
         ---
-        **To trigger Claude on this issue:** apply the `status:in-progress` label,
+        **To trigger Claude on this issue:** apply the `in progress` label,
         OR run the "Trigger Claude on issue label" workflow manually from the
         Actions tab with this issue's number. Both fire `@claude` and start a fresh
         session scoped to this issue.

--- a/.github/workflows/project-board-claude-trigger.yml
+++ b/.github/workflows/project-board-claude-trigger.yml
@@ -1,6 +1,6 @@
 name: Trigger Claude on issue label
 
-# Apply the `status:in-progress` label to an issue and this workflow
+# Apply the `in progress` label to an issue and this workflow
 # posts an @claude mention. The Claude Code GitHub App picks up the
 # mention and starts a fresh session scoped to that issue.
 #
@@ -14,7 +14,7 @@ name: Trigger Claude on issue label
 # **Drag-on-board does NOT trigger this workflow** — GitHub Projects
 # v2 doesn't natively sync the Status field to a label. To wake
 # Claude on a card, either:
-#   (a) apply the `status:in-progress` label directly on the issue
+#   (a) apply the `in progress` label directly on the issue
 #       (one click in the Issues tab), or
 #   (b) run this workflow manually from the Actions tab with an
 #       issue number, or
@@ -30,7 +30,7 @@ name: Trigger Claude on issue label
 # fails with `HttpError: Resource not accessible by integration`.
 #
 # Two paths to fire this:
-#   1. Apply the `status:in-progress` label on the issue manually
+#   1. Apply the `in progress` label on the issue manually
 #      (one click in the Issues tab — it auto-creates the label on
 #      first use).
 #   2. Run this workflow manually from the Actions tab with an issue
@@ -68,8 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     # Run on:
     #   (a) workflow_dispatch — always, with the user-supplied issue number
-    #   (b) issues.labeled — only when the new label is `status:in-progress`
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && github.event.label.name == 'status:in-progress') }}
+    #   (b) issues.labeled — only when the new label is `in progress`
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && github.event.label.name == 'in progress') }}
     steps:
       - name: Resolve issue number
         id: resolve


### PR DESCRIPTION
## Summary
- The Claude trigger workflow was looking for `status:in-progress`, but the label Thomas actually applies (and that the project board's "In Progress" column maps to) is `in progress`. Net effect: tagging an issue as in-progress did nothing.
- Switches the trigger to `in progress` so the obvious action wakes Claude. No new label to learn.
- Updated docs (`CLAUDE.md`) and the Sprint task issue template to match.

## Test plan
- [ ] Apply the `in progress` label to a test issue → workflow runs and posts an `@claude ...` comment.
- [ ] Removing/re-adding the label fires the workflow again (acceptable; the comment is idempotent enough).
- [ ] Manual `workflow_dispatch` with an issue number still works.

## Pre-flight check (Thomas)
The `@claude` comment only does anything if the **Claude Code GitHub App** is installed on `flytonewyork/medicai`. If labelling fires the workflow but nothing happens after the bot comment, install/authorise the App at https://github.com/apps/claude.

https://claude.ai/code/session_01UcqS8esNmk7D6QLiVm9t4N

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcqS8esNmk7D6QLiVm9t4N)_