### PR TITLE
ci: make Claude respond to @claude mentions on issues + PRs

### DIFF
--- a/.github/workflows/claude-on-mention.yml
+++ b/.github/workflows/claude-on-mention.yml
@@ -1,0 +1,35 @@
+name: Claude Code on @claude mention
+
+# Catches `@claude` mentions in issue + PR-review-comment bodies and
+# starts a Claude Code session scoped to that thread. Pairs with the
+# project-board trigger workflow (which posts the @claude comment on
+# behalf of a card moving to "In Progress") and with humans typing
+# `@claude do X` directly on issues.
+#
+# One-time setup:
+#   1. Install the official Claude GitHub App on this repo:
+#        https://github.com/apps/claude
+#   2. Add `ANTHROPIC_API_KEY` as a repo secret (Settings → Secrets →
+#      Actions). Key is from console.anthropic.com.
+#
+# Without those two pieces the workflow is a no-op (App can't post,
+# action can't authenticate). With them, every @claude mention starts
+# a fresh session that reads .claude/CLAUDE.md and the issue/PR body
+# for context.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-on-mention.yml
+++ b/.github/workflows/claude-on-mention.yml
@@ -9,13 +9,18 @@ name: Claude Code on @claude mention
 # One-time setup:
 #   1. Install the official Claude GitHub App on this repo:
 #        https://github.com/apps/claude
-#   2. Add `ANTHROPIC_API_KEY` as a repo secret (Settings → Secrets →
-#      Actions). Key is from console.anthropic.com.
+#   2. Generate a long-lived OAuth token tied to your Claude
+#      subscription (Pro / Max / Team / Enterprise):
+#        $ claude setup-token
+#      Copy the token IMMEDIATELY — it's printed once and not saved.
+#   3. Add `CLAUDE_CODE_OAUTH_TOKEN` as a repo secret (Settings →
+#      Secrets → Actions). Token is valid for ~1 year; rotate by
+#      re-running `claude setup-token` and overwriting the secret.
 #
-# Without those two pieces the workflow is a no-op (App can't post,
-# action can't authenticate). With them, every @claude mention starts
-# a fresh session that reads .claude/CLAUDE.md and the issue/PR body
-# for context.
+# Why subscription token over `ANTHROPIC_API_KEY`: usage counts
+# against the existing Pro/Max quota instead of pay-per-token billing.
+# If the subscription is downgraded or the token expires, the workflow
+# fails loudly — switch back to `anthropic_api_key:` if needed.
 
 on:
   issue_comment:
@@ -32,4 +37,4 @@ jobs:
     steps:
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/project-board-claude-trigger.yml
+++ b/.github/workflows/project-board-claude-trigger.yml
@@ -67,6 +67,13 @@ jobs:
       - name: Post @claude trigger comment
         uses: actions/github-script@v7
         with:
+          # Post via Thomas's PAT so the comment author is `flytonewyork`,
+          # not `github-actions[bot]`. The Claude Code GitHub App ignores
+          # bot-authored `@claude` mentions as a loop-prevention default,
+          # which silently swallowed this trigger before. PAT only needs
+          # `issues: write` on this repo; it's stored as a repo secret
+          # `PAT_FOR_CLAUDE_TRIGGER` so it's revokable independently.
+          github-token: ${{ secrets.PAT_FOR_CLAUDE_TRIGGER }}
           script: |
             await github.rest.issues.createComment({
               owner: '${{ steps.resolve.outputs.repo_owner }}',


### PR DESCRIPTION
## Summary

Make Claude actually respond to `@claude` mentions on issues and PRs. Three missing pieces, all fixed here:

1. **No consumer workflow.** Nothing in `.github/workflows/` ran `anthropics/claude-code-action`, so `@claude` mentions hit a void.
2. **Trigger comment author was `github-actions[bot]`.** Bot-authored mentions are typically filtered.
3. **Now uses subscription auth, not API key.** Usage counts against your Claude Pro/Max quota, not pay-per-token.

## Changes

- **`.github/workflows/claude-on-mention.yml`** (new): listens on `issue_comment.created` + `pull_request_review_comment.created`, filters for `@claude`, runs `anthropics/claude-code-action@v1` with `CLAUDE_CODE_OAUTH_TOKEN`.
- **`.github/workflows/project-board-claude-trigger.yml`** (modified): post via `PAT_FOR_CLAUDE_TRIGGER` so the comment author is `flytonewyork`, not `github-actions[bot]`.

## You need to do all four before merge does anything useful

1. **Install the Claude GitHub App** on `flytonewyork/medicai`: https://github.com/apps/claude — *(done ✓)*
2. **Generate a subscription OAuth token:**
   ```bash
   claude setup-token
   ```
   Copy the token immediately — it's printed once.
3. **Add repo secrets** (Settings → Secrets and variables → Actions):
   - `CLAUDE_CODE_OAUTH_TOKEN` — the token from step 2
   - `PAT_FOR_CLAUDE_TRIGGER` — fine-scoped PAT with `issues: write` on `flytonewyork/medicai` only
4. *(Optional, after verifying)* delete the `ANTHROPIC_API_KEY` secret.

## Test plan

- [ ] Comment `@claude do this` on issue #165 — expect response within ~30s
- [ ] Drag any Todo card → In Progress on the "save dads life" board — expect bot to post trigger as `flytonewyork`, then Claude responds
- [ ] Confirm Vercel preview deploys cleanly

## Token rotation

`CLAUDE_CODE_OAUTH_TOKEN` is valid ~1 year. To rotate: re-run `claude setup-token`, overwrite the secret. If it expires the workflow fails loudly — that's the right failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4DZxFQnbjrdo29aW8aJre