### PR TITLE
refactor(auth): unify password sign-in/sign-up behind shared helper

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
+import { submitPasswordAuth } from "~/lib/supabase/auth";
 import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
 import { Alert } from "~/components/ui/alert";
@@ -32,32 +33,17 @@ function LoginForm() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const supabase = getSupabaseBrowser();
-    if (!supabase) return;
+    if (!getSupabaseBrowser()) return;
     setLoading(true);
     setError(null);
     setInfo(null);
     try {
-      if (mode === "signin") {
-        const { error } = await supabase.auth.signInWithPassword({
-          email,
-          password,
-        });
-        if (error) throw error;
+      const result = await submitPasswordAuth(mode, email, password);
+      if (result.status === "signed-in") {
         router.replace(next);
         router.refresh();
         return;
       }
-      const { data, error } = await supabase.auth.signUp({ email, password });
-      if (error) throw error;
-      // If Supabase returned an active session, sign-up + sign-in happened in
-      // one go (email confirmation off). Skip the re-entry step.
-      if (data.session) {
-        router.replace(next);
-        router.refresh();
-        return;
-      }
-      // Otherwise email confirmation is on; dad needs to check his inbox.
       setInfo(t("welcomeAuth.createdConfirm"));
       setMode("signin");
     } catch (err: unknown) {

--- a/src/components/assessment/pillar-card.tsx
+++ b/src/components/assessment/pillar-card.tsx
@@ -19,9 +19,7 @@ export function PillarRing({
       ? "text-[var(--ok)]"
       : score >= 50
         ? "text-[var(--sand-2)]"
-        : score >= 30
-          ? "text-[var(--warn)]"
-          : "text-[var(--warn)]";
+        : "text-[var(--warn)]";
   return (
     <div className="relative" style={{ width: size, height: size }}>
       <svg width={size} height={size} className="-rotate-90">

--- a/src/components/auth/inline-sign-in.tsx
+++ b/src/components/auth/inline-sign-in.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
+import { submitPasswordAuth } from "~/lib/supabase/auth";
 import { useL } from "~/hooks/use-translate";
 import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
@@ -71,30 +72,16 @@ export function InlineSignIn({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const supabase = getSupabaseBrowser();
-    if (!supabase) return;
+    if (!getSupabaseBrowser()) return;
     setLoading(true);
     setError(null);
     setInfo(null);
     try {
-      if (mode === "signin") {
-        const { error } = await supabase.auth.signInWithPassword({
-          email,
-          password,
-        });
-        if (error) throw error;
+      const result = await submitPasswordAuth(mode, email, password);
+      if (result.status === "signed-in") {
         await onAuthed?.();
         return;
       }
-      const { data, error } = await supabase.auth.signUp({ email, password });
-      if (error) throw error;
-      if (data.session) {
-        await onAuthed?.();
-        return;
-      }
-      // Email confirmation is on; user has to click the link before
-      // we can proceed. Bounce them to sign-in mode and tell them
-      // what's happening.
       setInfo(
         L(
           "Account created — check your email to confirm, then sign in.",

--- a/src/components/auth/welcome-auth-modal.tsx
+++ b/src/components/auth/welcome-auth-modal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { X } from "lucide-react";
 import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
+import { submitPasswordAuth } from "~/lib/supabase/auth";
 import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
 import { useT } from "~/hooks/use-translate";
@@ -54,33 +55,18 @@ export function WelcomeAuthModal() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const supabase = getSupabaseBrowser();
-    if (!supabase) return;
+    if (!getSupabaseBrowser()) return;
     setLoading(true);
     setError(null);
     setInfo(null);
     try {
-      if (mode === "signin") {
-        const { error } = await supabase.auth.signInWithPassword({
-          email,
-          password,
-        });
-        if (error) throw error;
+      const result = await submitPasswordAuth(mode, email, password);
+      if (result.status === "signed-in") {
         localStorage.setItem(SEEN_KEY, nowISO());
         setOpen(false);
         router.refresh();
         return;
       }
-      const { data, error } = await supabase.auth.signUp({ email, password });
-      if (error) throw error;
-      // If Supabase returned a session, confirm-email was off — we're in.
-      if (data.session) {
-        localStorage.setItem(SEEN_KEY, nowISO());
-        setOpen(false);
-        router.refresh();
-        return;
-      }
-      // Otherwise email confirmation is on; tell dad to check his inbox.
       setInfo(t("welcomeAuth.createdConfirm"));
       setMode("signin");
     } catch (err: unknown) {

--- a/src/lib/supabase/auth.ts
+++ b/src/lib/supabase/auth.ts
@@ -1,0 +1,40 @@
+import { getSupabaseBrowser } from "~/lib/supabase/client";
+
+// Outcome of a password sign-in or sign-up. `signed-in` means a session
+// is now active and the caller can advance the UI. `confirmation-required`
+// means sign-up succeeded but Supabase has email confirmation enabled —
+// the user has to click the link in their inbox before they can sign in.
+export type AuthOutcome =
+  | { status: "signed-in" }
+  | { status: "confirmation-required" };
+
+export type AuthMode = "signin" | "signup";
+
+// Shared sign-in / sign-up entry point used by every auth surface
+// (welcome modal, inline panel, /login page). Throws on Supabase errors
+// so callers can surface them via their own error UI.
+export async function submitPasswordAuth(
+  mode: AuthMode,
+  email: string,
+  password: string,
+): Promise<AuthOutcome> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) throw new Error("Supabase is not configured");
+
+  if (mode === "signin") {
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) throw error;
+    return { status: "signed-in" };
+  }
+
+  const { data, error } = await supabase.auth.signUp({ email, password });
+  if (error) throw error;
+  // If Supabase returned a session, email confirmation was off — we're in.
+  // Otherwise the user has to confirm via email before signing in.
+  return data.session
+    ? { status: "signed-in" }
+    : { status: "confirmation-required" };
+}

--- a/tests/unit/supabase-auth.test.ts
+++ b/tests/unit/supabase-auth.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Lock in the discriminated-union contract of submitPasswordAuth() —
+// the helper unifies sign-in and sign-up across the welcome modal,
+// inline auth panel, and /login page. If this contract drifts, every
+// caller's success path breaks silently.
+
+const signInWithPasswordMock = vi.fn();
+const signUpMock = vi.fn();
+const supabaseClient = {
+  auth: {
+    signInWithPassword: signInWithPasswordMock,
+    signUp: signUpMock,
+  },
+};
+
+vi.mock("~/lib/supabase/client", () => ({
+  getSupabaseBrowser: () => supabaseClient,
+}));
+
+beforeEach(() => {
+  signInWithPasswordMock.mockReset();
+  signUpMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("submitPasswordAuth", () => {
+  it("returns signed-in on successful sign-in", async () => {
+    signInWithPasswordMock.mockResolvedValue({ error: null });
+    const { submitPasswordAuth } = await import("~/lib/supabase/auth");
+    const result = await submitPasswordAuth("signin", "a@b.co", "secret");
+    expect(result).toEqual({ status: "signed-in" });
+    expect(signInWithPasswordMock).toHaveBeenCalledWith({
+      email: "a@b.co",
+      password: "secret",
+    });
+  });
+
+  it("throws when sign-in errors", async () => {
+    signInWithPasswordMock.mockResolvedValue({
+      error: new Error("bad credentials"),
+    });
+    const { submitPasswordAuth } = await import("~/lib/supabase/auth");
+    await expect(
+      submitPasswordAuth("signin", "a@b.co", "wrong"),
+    ).rejects.toThrow("bad credentials");
+  });
+
+  it("returns signed-in on sign-up that yields a session", async () => {
+    signUpMock.mockResolvedValue({
+      data: { session: { access_token: "x" } },
+      error: null,
+    });
+    const { submitPasswordAuth } = await import("~/lib/supabase/auth");
+    const result = await submitPasswordAuth("signup", "a@b.co", "secret");
+    expect(result).toEqual({ status: "signed-in" });
+  });
+
+  it("returns confirmation-required on sign-up without a session", async () => {
+    signUpMock.mockResolvedValue({ data: { session: null }, error: null });
+    const { submitPasswordAuth } = await import("~/lib/supabase/auth");
+    const result = await submitPasswordAuth("signup", "a@b.co", "secret");
+    expect(result).toEqual({ status: "confirmation-required" });
+  });
+
+  it("throws when sign-up errors", async () => {
+    signUpMock.mockResolvedValue({
+      data: { session: null },
+      error: new Error("email taken"),
+    });
+    const { submitPasswordAuth } = await import("~/lib/supabase/auth");
+    await expect(
+      submitPasswordAuth("signup", "a@b.co", "secret"),
+    ).rejects.toThrow("email taken");
+  });
+});


### PR DESCRIPTION
## Summary

- Three near-identical Supabase password-auth flows (welcome modal, inline panel, `/login`) consolidated behind `submitPasswordAuth()` in `src/lib/supabase/auth.ts`
- Helper returns a discriminated union (`signed-in` vs `confirmation-required`) so each surface keeps its own post-success behaviour without re-implementing the auth call
- Drop dead ternary branch in `pillar-card.tsx` where `score >= 30` and the below-30 fallback both resolved to the same `--warn` colour
- New 5-test contract lock-in for the helper covers signin success/error, signup with active session, signup pending confirmation, signup error

Net 43 LOC removed across the three call sites; helper is ~40 LOC.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 963/963 passing (was 958, +5 for the new helper contract)
- [ ] Manual smoke: sign in via welcome modal, inline panel, and `/login` page
- [ ] Manual smoke: sign-up flow with email confirmation enabled in Supabase

https://claude.ai/code/session_01TtWFAbAq6qHaA7AFxegrgJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtWFAbAq6qHaA7AFxegrgJ)_