### PR TITLE
refactor(utils): consolidate UTC-stable day-shift helper across 6 sites

### DIFF
--- a/src/components/nutrition/gi-trends-section.tsx
+++ b/src/components/nutrition/gi-trends-section.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
-import { todayISO } from "~/lib/utils/date";
+import { shiftIsoDate, todayISO } from "~/lib/utils/date";
 import { useLocale } from "~/hooks/use-translate";
 import { Card, CardContent } from "~/components/ui/card";
 import { Sparkline } from "~/components/ui/sparkline";
@@ -25,7 +25,7 @@ export function GiTrendsSection() {
   const today = todayISO();
 
   const recent = useLiveQuery(async () => {
-    const start = isoDaysAgo(LONG_WINDOW - 1);
+    const start = shiftIsoDate(today, -(LONG_WINDOW - 1));
     return db.daily_entries.where("date").between(start, today, true, true).toArray();
   }, [today]);
 
@@ -233,11 +233,3 @@ function bristolLabel(n: number, locale: string): string {
   return `${n} · ${arr[n] ?? ""}`;
 }
 
-function isoDaysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
-}

--- a/src/lib/calculations/gi-trends.ts
+++ b/src/lib/calculations/gi-trends.ts
@@ -1,4 +1,5 @@
 import type { DailyEntry } from "~/types/clinical";
+import { shiftIsoDate } from "~/lib/utils/date";
 
 // Pure trend calculators for the GI / digestive surface. Take a slice
 // of daily_entries (chronological order doesn't matter — the helpers
@@ -92,11 +93,8 @@ export function buildGiSeries(
   for (const e of entries) byDate.set(e.date, projectGiDay(e));
 
   const out: GiDay[] = [];
-  const today = parseIsoDate(todayISO);
   for (let i = days - 1; i >= 0; i--) {
-    const d = new Date(today);
-    d.setUTCDate(d.getUTCDate() - i);
-    const iso = isoFromDate(d);
+    const iso = shiftIsoDate(todayISO, -i);
     out.push(
       byDate.get(iso) ?? {
         date: iso,
@@ -186,16 +184,4 @@ function mode(values: number[]): number | null {
 
 function round1(n: number): number {
   return Math.round(n * 10) / 10;
-}
-
-function parseIsoDate(iso: string): Date {
-  // Use UTC noon to avoid DST edge cases shifting the date.
-  return new Date(iso + "T12:00:00.000Z");
-}
-
-function isoFromDate(d: Date): string {
-  const yyyy = d.getUTCFullYear();
-  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(d.getUTCDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
 }

--- a/src/lib/coverage/log-coverage.ts
+++ b/src/lib/coverage/log-coverage.ts
@@ -13,6 +13,7 @@ import {
   AGENT_VOICES,
   type AgentVoice,
 } from "~/config/agent-cadence";
+import { shiftIsoDate } from "~/lib/utils/date";
 import {
   classifyEngagement,
   coverageCapForState,
@@ -131,7 +132,7 @@ function hasHistoryWithin(
   todayISO: string,
   windowDays: number,
 ): boolean {
-  const cutoff = isoDaysBefore(todayISO, windowDays);
+  const cutoff = shiftIsoDate(todayISO, -windowDays);
   for (const d of dailies) {
     if (d.date < cutoff || d.date > todayISO) continue;
     if (anyFieldFilled(d, field.daily_keys)) return true;
@@ -148,7 +149,7 @@ function isFreshlyLogged(
   if (field.freshness_days === 1) {
     return todayEntry !== null && anyFieldFilled(todayEntry, field.daily_keys);
   }
-  const cutoff = isoDaysBefore(todayISO, field.freshness_days - 1);
+  const cutoff = shiftIsoDate(todayISO, -(field.freshness_days - 1));
   for (const d of dailies) {
     if (d.date < cutoff || d.date > todayISO) continue;
     if (anyFieldFilled(d, field.daily_keys)) return true;
@@ -187,11 +188,3 @@ function toGap(field: TrackedField, inNadir: boolean): CoverageGap {
   };
 }
 
-function isoDaysBefore(iso: string, n: number): string {
-  const d = new Date(iso + "T12:00:00.000Z");
-  d.setUTCDate(d.getUTCDate() - n);
-  const yyyy = d.getUTCFullYear();
-  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(d.getUTCDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
-}

--- a/src/lib/coverage/snooze.ts
+++ b/src/lib/coverage/snooze.ts
@@ -1,5 +1,6 @@
 import { db, now } from "~/lib/db/dexie";
 import { TRACKED_FIELDS } from "~/config/tracked-fields";
+import { shiftIsoDate } from "~/lib/utils/date";
 
 // Snooze durations per tracked-field freshness band. The brief was
 // "3d daily / 7d weekly / 14d fortnightly" — we map each tracked
@@ -21,19 +22,10 @@ export async function snoozeCoverageField(
   todayISO: string,
 ): Promise<void> {
   const days = snoozeDaysFor(fieldKey);
-  const until = isoDaysAfter(todayISO, days);
+  const until = shiftIsoDate(todayISO, days);
   await db.coverage_snoozes.add({
     field_key: fieldKey,
     snoozed_at: now(),
     snoozed_until: until,
   });
-}
-
-function isoDaysAfter(iso: string, n: number): string {
-  const d = new Date(iso + "T12:00:00.000Z");
-  d.setUTCDate(d.getUTCDate() + n);
-  const yyyy = d.getUTCFullYear();
-  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(d.getUTCDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
 }

--- a/src/lib/log/run-agents.ts
+++ b/src/lib/log/run-agents.ts
@@ -14,6 +14,7 @@ import { agentsForTags } from "~/agents/routing";
 import { HttpError, postJson } from "~/lib/utils/http";
 import { computeCoverageGaps } from "~/lib/coverage/log-coverage";
 import { formatCoverageSnapshot } from "~/lib/coverage/agent-snapshot";
+import { shiftIsoDate } from "~/lib/utils/date";
 
 // Client-side orchestration for running one specialist agent.
 // 1. Read state.md + recent feedback for this agent from Dexie
@@ -382,7 +383,7 @@ async function buildCoverageSnapshot(
   date: string,
 ): Promise<string | undefined> {
   try {
-    const start = isoDaysBefore(date, 27);
+    const start = shiftIsoDate(date, -27);
     const end = date;
     const recentDailies = await db.daily_entries
       .where("date")
@@ -414,11 +415,3 @@ async function buildCoverageSnapshot(
   }
 }
 
-function isoDaysBefore(iso: string, n: number): string {
-  const d = new Date(iso + "T12:00:00.000Z");
-  d.setUTCDate(d.getUTCDate() - n);
-  const yyyy = d.getUTCFullYear();
-  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(d.getUTCDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
-}

--- a/src/lib/treatment/calendar-sync.ts
+++ b/src/lib/treatment/calendar-sync.ts
@@ -15,7 +15,7 @@
 
 import { db, now } from "~/lib/db/dexie";
 import { PROTOCOL_BY_ID } from "~/config/protocols";
-import { formatLocalDateISO, formatHHMM } from "~/lib/utils/date";
+import { formatLocalDateISO, formatHHMM, shiftIsoDate } from "~/lib/utils/date";
 import type { Appointment } from "~/types/appointment";
 import type { Protocol, TreatmentCycle } from "~/types/treatment";
 import type { LocalizedText } from "~/types/treatment";
@@ -46,13 +46,7 @@ function addDaysISO(isoDate: string, days: number, startTime = "09:00"): string 
   // `isoDate` is an ISO date like "2026-05-13" (or "2026-05-13T…"); we
   // want start_date + (days) at `startTime` local — we just write an
   // offset-free ISO so downstream consumers render in the user's tz.
-  const dayStr = isoDate.slice(0, 10);
-  const [y, m, d] = dayStr.split("-").map(Number);
-  if (!y || !m || !d) return isoDate;
-  const base = new Date(Date.UTC(y, m - 1, d));
-  base.setUTCDate(base.getUTCDate() + days);
-  const iso = base.toISOString().slice(0, 10);
-  return `${iso}T${startTime}:00`;
+  return `${shiftIsoDate(isoDate, days)}T${startTime}:00`;
 }
 
 function localizedEn(text: LocalizedText | string | undefined): string {

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -118,6 +118,18 @@ export function shiftIsoDays(iso: string, days: number): string {
   return d.toISOString();
 }
 
+// Shift a YYYY-MM-DD calendar date by N days using UTC arithmetic.
+// Anchored at noon UTC so DST and ±12h timezone offsets can't flip the day.
+// Use this for any day-keyed math that must stay stable regardless of the
+// caller's local clock — coverage windows, agent log lookbacks, GI series
+// scaffolding. For local-zone diary/dashboard math (where the user's wall
+// clock is the truth) use `shiftDateISO` instead.
+export function shiftIsoDate(date: string, days: number): string {
+  const d = new Date(`${date.slice(0, 10)}T12:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+}
+
 // BCP-47 language tag for the patient's locale. Centralised so the zh-CN /
 // en-AU mapping isn't repeated across every component that calls
 // toLocaleDateString / toLocaleTimeString.

--- a/tests/unit/date-utils.test.ts
+++ b/tests/unit/date-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { shiftIsoDate, shiftIsoDays } from "~/lib/utils/date";
+
+describe("shiftIsoDate", () => {
+  it("shifts forward and back without flipping calendar days", () => {
+    expect(shiftIsoDate("2026-05-04", 1)).toBe("2026-05-05");
+    expect(shiftIsoDate("2026-05-04", -1)).toBe("2026-05-03");
+    expect(shiftIsoDate("2026-05-04", 0)).toBe("2026-05-04");
+  });
+
+  it("handles month and year boundaries", () => {
+    expect(shiftIsoDate("2026-01-31", 1)).toBe("2026-02-01");
+    expect(shiftIsoDate("2026-12-31", 1)).toBe("2027-01-01");
+    expect(shiftIsoDate("2026-03-01", -1)).toBe("2026-02-28");
+  });
+
+  it("crosses leap-day correctly", () => {
+    expect(shiftIsoDate("2024-02-28", 1)).toBe("2024-02-29");
+    expect(shiftIsoDate("2024-03-01", -1)).toBe("2024-02-29");
+  });
+
+  it("is stable across DST spring-forward (Australia, October)", () => {
+    // AEST→AEDT happens early October; the noon-UTC anchor must keep
+    // the calendar day intact regardless of the runner's local zone.
+    expect(shiftIsoDate("2026-10-04", 1)).toBe("2026-10-05");
+    expect(shiftIsoDate("2026-10-05", -1)).toBe("2026-10-04");
+  });
+
+  it("accepts an ISO datetime and only uses its date portion", () => {
+    expect(shiftIsoDate("2026-05-04T23:00:00Z", 1)).toBe("2026-05-05");
+    expect(shiftIsoDate("2026-05-04T01:00:00+10:00", -1)).toBe("2026-05-03");
+  });
+});
+
+describe("shiftIsoDays", () => {
+  it("preserves the time-of-day component while shifting UTC days", () => {
+    expect(shiftIsoDays("2026-05-04T13:30:00.000Z", 1)).toBe(
+      "2026-05-05T13:30:00.000Z",
+    );
+    expect(shiftIsoDays("2026-05-04T13:30:00.000Z", -7)).toBe(
+      "2026-04-27T13:30:00.000Z",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Five separate files reinvented the same UTC-noon-anchored "shift a YYYY-MM-DD by N days" helper, plus `treatment/calendar-sync.ts:addDaysISO` did the same math by hand before appending a time component. Each carried its own `padStart(2, "0")` formatting boilerplate.

`~/lib/utils/date.ts` already exposed `shiftDateISO` (local-zone) and `shiftIsoDays` (UTC, full timestamp, preserves time-of-day), but had no UTC-stable variant for the YYYY-MM-DD → YYYY-MM-DD case. Adds `shiftIsoDate(date, days)` and replaces all six call sites with it.

**Sites consolidated:**
- `src/lib/coverage/log-coverage.ts` — `isoDaysBefore` deleted
- `src/lib/coverage/snooze.ts` — `isoDaysAfter` deleted
- `src/lib/log/run-agents.ts` — `isoDaysBefore` deleted
- `src/lib/calculations/gi-trends.ts` — `parseIsoDate` + `isoFromDate` deleted, `buildGiSeries` loop simplified
- `src/components/nutrition/gi-trends-section.tsx` — `isoDaysAgo` deleted
- `src/lib/treatment/calendar-sync.ts:addDaysISO` — body collapsed to one line

Net diff: **−63 / +25 lines** plus a focused unit test that locks in DST + month/year/leap-day correctness.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test --run` — 964/964 green (107 files), including the new `date-utils.test.ts` covering month/year boundaries, leap day, AEDT spring-forward, and ISO-datetime inputs
- [x] No clinical thresholds, zone rules, or schema fields touched — pure structural refactor
- [ ] CI green on PR (smoke-test in browser before promote-to-ready)

## Why this matters

Pure code-debt cleanup. The duplicated helpers had each drifted slightly (one used `getUTCDate`, one `getDate`, one anchored at noon, one didn't), so day-keyed math in coverage / agents / GI series wasn't guaranteed to agree under DST or zone shifts. One helper, one test, one source of truth.

https://claude.ai/code/session_01BZSvkADMUhyoGnFGEVkozh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZSvkADMUhyoGnFGEVkozh)_