### PR TITLE
fix(ux): trim dashboard friction, dead code, and stuck UI states

### DIFF
--- a/src/app/diary/page.tsx
+++ b/src/app/diary/page.tsx
@@ -6,22 +6,14 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { format, parseISO } from "date-fns";
 import {
   Mic,
-  MicOff,
   Loader2,
   FlaskConical,
   ClipboardList,
   Sparkles,
   CalendarDays,
-  CheckCircle2,
-  X,
-  Undo2,
-  ChevronRight,
 } from "lucide-react";
 import { useLocale } from "~/hooks/use-translate";
-import { useUIStore } from "~/stores/ui-store";
-import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
 import { syncPendingVoiceMemoAudio } from "~/lib/voice-memo/cloud";
-import { undoAppliedPatch } from "~/lib/voice-memo/apply";
 import { db } from "~/lib/db/dexie";
 import { buildDiaryDays, type DiaryDay } from "~/lib/diary/build";
 import { todayISO } from "~/lib/utils/date";
@@ -31,9 +23,7 @@ import { PageHeader } from "~/components/ui/page-header";
 import { Alert } from "~/components/ui/alert";
 import { EmptyState } from "~/components/ui/empty-state";
 import { VoiceMemoCard } from "~/components/diary/voice-memo-card";
-import { cn } from "~/lib/utils/cn";
 import type { AgentRunRow } from "~/types/agent";
-import type { AppliedPatch, VoiceMemo } from "~/types/voice-memo";
 
 // /diary — the patient's daily timeline. One section per day, newest
 // first, combining:
@@ -51,7 +41,6 @@ const WINDOW_DAYS_DEFAULT = 14;
 
 export default function DiaryPage() {
   const locale = useLocale();
-  const enteredBy = useUIStore((s) => s.enteredBy);
 
   // useLiveQuery on each table keeps the diary fresh as new rows land
   // — recording a memo, opening /daily, syncing labs all reflect here
@@ -189,113 +178,6 @@ export default function DiaryPage() {
         </ol>
       )}
     </div>
-  );
-}
-
-function RecorderCard({
-  voice,
-  locale,
-}: {
-  voice: ReturnType<typeof useVoiceTranscription>;
-  locale: "en" | "zh";
-}) {
-  if (!voice) {
-    return (
-      <Alert variant="info" role="status">
-        {locale === "zh"
-          ? "此浏览器不支持录音。请使用 iOS Safari 或最新 Chrome。"
-          : "This browser can't record audio. Use Safari on iOS or current Chrome."}
-      </Alert>
-    );
-  }
-
-  const recording = voice.status === "recording";
-  const transcribing = voice.status === "transcribing";
-
-  return (
-    <Card className="p-5">
-      <div className="flex items-center gap-4">
-        <button
-          type="button"
-          onClick={() => {
-            if (recording) voice.stop();
-            else void voice.start();
-          }}
-          disabled={transcribing}
-          aria-label={
-            recording
-              ? locale === "zh" ? "停止录音" : "Stop recording"
-              : locale === "zh" ? "开始录音" : "Start recording"
-          }
-          aria-pressed={recording}
-          className={cn(
-            "relative flex h-16 w-16 items-center justify-center rounded-full shadow-md transition-all",
-            recording
-              ? "bg-[var(--warn,#d97706)] text-white"
-              : "bg-ink-900 text-paper hover:scale-105",
-            transcribing && "opacity-60",
-          )}
-        >
-          {recording && (
-            <span className="absolute inset-0 animate-ping rounded-full bg-[var(--warn,#d97706)]/40" />
-          )}
-          {transcribing ? (
-            <Loader2 className="relative h-6 w-6 animate-spin" />
-          ) : recording ? (
-            <MicOff className="relative h-6 w-6" />
-          ) : (
-            <Mic className="relative h-6 w-6" />
-          )}
-        </button>
-        <div className="min-w-0 flex-1">
-          <div className="text-[14px] font-medium text-ink-900">
-            {recording
-              ? locale === "zh" ? "正在录音" : "Recording"
-              : transcribing
-                ? locale === "zh" ? "正在识别…" : "Transcribing…"
-                : locale === "zh" ? "今天怎么样？" : "How's today?"}
-          </div>
-          <div className="text-[12px] text-ink-500">
-            {recording
-              ? locale === "zh"
-                ? "把要记的事说一遍，再轻点停止。"
-                : "Say what you want to remember, then tap stop."
-              : transcribing
-                ? locale === "zh"
-                  ? "录音已结束，正在生成文字。"
-                  : "Recording done, transcribing."
-                : locale === "zh"
-                  ? "轻点录音，AI 会保存录音并整理文字。"
-                  : "Tap to record. We keep the audio and the transcript."}
-          </div>
-        </div>
-      </div>
-      {!recording && !transcribing && (
-        <div className="mt-3 rounded-md border border-ink-100 bg-paper-2/40 px-3 py-2 text-[11.5px] leading-relaxed text-ink-500">
-          <span className="text-ink-700 font-medium">
-            {locale === "zh" ? "可以聊：" : "Try mentioning: "}
-          </span>
-          {locale === "zh"
-            ? "睡眠、精力、症状、饮食、活动、家人、化验或扫描结果。"
-            : "sleep, energy, symptoms, food, activity, family, scan or lab results."}
-        </div>
-      )}
-      {transcribing && voice.liveText && (
-        <div className="mt-3 rounded-md bg-paper-2/60 px-3 py-2 text-[13px] leading-relaxed text-ink-900">
-          <span className="text-ink-500 text-[10.5px] uppercase tracking-wider">
-            {locale === "zh" ? "正在识别" : "Live"}
-          </span>
-          <p className="mt-1 whitespace-pre-wrap">{voice.liveText}</p>
-        </div>
-      )}
-      {voice.error && (
-        <Alert variant="warn" role="alert" className="mt-3">
-          {locale === "zh"
-            ? `录音出错：${voice.error}`
-            : `Voice error: ${voice.error}`}
-        </Alert>
-      )}
-    </Card>
   );
 }
 
@@ -449,214 +331,3 @@ function buildDailySummary(
   return parts.join(" · ");
 }
 
-// Inline preview that follows the recorder. Drives the post-record UX:
-// transcribing → showing applied patches with Undo → showing a Review
-// CTA when the parse came back medium/low confidence and nothing
-// auto-applied. Dismissible — the patient closes it when they're done.
-function RecentMemoCard({
-  memoId,
-  locale,
-  onDismiss,
-}: {
-  memoId: number;
-  locale: "en" | "zh";
-  onDismiss: () => void;
-}) {
-  const memo = useLiveQuery<VoiceMemo | undefined>(
-    () => db.voice_memos.get(memoId) as Promise<VoiceMemo | undefined>,
-    [memoId],
-  );
-  if (!memo) return null;
-
-  const parsed = memo.parsed_fields;
-  const liveApplied = (parsed?.applied_patches ?? []).filter(
-    (p) => !p.undone_at,
-  );
-  const transcribing = !memo.transcript.trim();
-  const parsing = Boolean(memo.transcript.trim()) && !parsed;
-
-  let body: React.ReactNode;
-  if (transcribing) {
-    body = (
-      <span className="inline-flex items-center gap-1.5 text-[12px] text-ink-500">
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        {locale === "zh" ? "正在识别…" : "Transcribing…"}
-      </span>
-    );
-  } else if (parsing) {
-    body = (
-      <span className="inline-flex items-center gap-1.5 text-[12px] text-ink-500">
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        {locale === "zh" ? "AI 正在解读…" : "Claude reading the memo…"}
-      </span>
-    );
-  } else if (liveApplied.length > 0) {
-    body = (
-      <AppliedSummary
-        memoId={memoId}
-        patches={liveApplied}
-        locale={locale}
-      />
-    );
-  } else if (parsed && parsed.confidence !== "high") {
-    body = (
-      <Link
-        href={`/memos/${memoId}`}
-        className="inline-flex items-center gap-1 text-[12.5px] font-medium text-[var(--tide-2)] hover:underline"
-      >
-        {locale === "zh"
-          ? `识别可信度：${parsed.confidence === "medium" ? "中" : "低"} — 审核并保存`
-          : `Confidence: ${parsed.confidence} — review and save`}
-        <ChevronRight className="h-3.5 w-3.5" aria-hidden />
-      </Link>
-    );
-  } else {
-    body = (
-      <span className="text-[12px] text-ink-500">
-        {locale === "zh"
-          ? "AI 没有从这段录音里抽出可登入的内容。"
-          : "Claude didn't pull anything loggable from this memo."}
-      </span>
-    );
-  }
-
-  const followUps = (parsed?.follow_up_questions ?? []).slice(0, 2);
-
-  return (
-    <Card className="p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="text-[10.5px] font-medium uppercase tracking-wider text-ink-400">
-            {locale === "zh" ? "刚才的录音" : "Just recorded"}
-          </div>
-          <div className="mt-1.5">{body}</div>
-        </div>
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label={locale === "zh" ? "关闭" : "Dismiss"}
-          className="-mr-1 -mt-1 flex h-7 w-7 items-center justify-center rounded-full text-ink-400 hover:text-ink-700"
-        >
-          <X className="h-3.5 w-3.5" aria-hidden />
-        </button>
-      </div>
-      {followUps.length > 0 && (
-        <div className="mt-3 border-t border-ink-100 pt-3">
-          <div className="text-[10.5px] font-medium uppercase tracking-wider text-[var(--tide-2)]">
-            {locale === "zh" ? "AI 想问" : "From your AI nurse"}
-          </div>
-          <ul className="mt-1.5 space-y-1">
-            {followUps.map((q, i) => (
-              <li
-                key={i}
-                className="text-[12.5px] italic text-ink-700"
-              >
-                {q}
-              </li>
-            ))}
-          </ul>
-          <p className="mt-1 text-[10.5px] text-ink-400">
-            {locale === "zh"
-              ? "想回答的话，再录一段就行。"
-              : "Want to answer? Just record again — Claude will read it."}
-          </p>
-        </div>
-      )}
-    </Card>
-  );
-}
-
-function AppliedSummary({
-  memoId,
-  patches,
-  locale,
-}: {
-  memoId: number;
-  patches: AppliedPatch[];
-  locale: "en" | "zh";
-}) {
-  const [busy, setBusy] = useState<number | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  async function onUndo(index: number) {
-    setBusy(index);
-    setError(null);
-    const r = await undoAppliedPatch(memoId, index);
-    setBusy(null);
-    if (!r.ok) setError(r.error ?? "Undo failed");
-  }
-
-  return (
-    <div className="space-y-2">
-      <div className="inline-flex items-center gap-1.5 text-[12px] font-medium text-emerald-700">
-        <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
-        {locale === "zh"
-          ? `已保存 ${patches.length} 项`
-          : `Saved ${patches.length} item${patches.length === 1 ? "" : "s"}`}
-      </div>
-      <ul className="space-y-1.5">
-        {patches.map((p, i) => (
-          <li
-            key={`${p.applied_at}-${i}`}
-            className="flex items-start justify-between gap-3 rounded-md border border-ink-100 px-3 py-2"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="text-[12px] font-medium text-ink-900">
-                {tableLabel(p.table, locale)}
-              </div>
-              <div className="text-[11.5px] text-ink-700">
-                {summariseFields(p.fields)}
-              </div>
-            </div>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => onUndo(i)}
-              disabled={busy === i}
-            >
-              {busy === i ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Undo2 className="h-3.5 w-3.5" />
-              )}
-              {locale === "zh" ? "撤销" : "Undo"}
-            </Button>
-          </li>
-        ))}
-      </ul>
-      <Link
-        href={`/memos/${memoId}`}
-        className="inline-flex items-center gap-1 text-[11.5px] text-ink-500 hover:text-ink-900 hover:underline"
-      >
-        {locale === "zh" ? "查看详情" : "Open memo"}
-        <ChevronRight className="h-3 w-3" aria-hidden />
-      </Link>
-      {error && (
-        <p className="text-[11.5px] text-[var(--warn)]">{error}</p>
-      )}
-    </div>
-  );
-}
-
-function tableLabel(
-  table: AppliedPatch["table"],
-  locale: "en" | "zh",
-): string {
-  if (locale === "zh") {
-    if (table === "daily_entries") return "日常表";
-    if (table === "life_events") return "门诊记录";
-    return "预约";
-  }
-  if (table === "daily_entries") return "Daily form";
-  if (table === "life_events") return "Clinic visit";
-  return "Appointment";
-}
-
-function summariseFields(
-  fields: AppliedPatch["fields"],
-): string {
-  return Object.entries(fields)
-    .slice(0, 4)
-    .map(([k, v]) => `${k}: ${v}`)
-    .join(" · ");
-}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { db, now } from "~/lib/db/dexie";
@@ -30,6 +30,18 @@ export default function SettingsPage() {
       locale: "en",
     },
   });
+
+  // Local "just saved" flag rather than `formState.isSubmitSuccessful`,
+  // which stays true until the next submission and reads as a permanent
+  // confirmation. Auto-clears after a few seconds so the message is a
+  // genuine acknowledgement, not stale chrome.
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  useEffect(() => {
+    if (savedAt === null) return;
+    const id = setTimeout(() => setSavedAt(null), 4000);
+    return () => clearTimeout(id);
+  }, [savedAt]);
 
   useEffect(() => {
     if (current) {
@@ -65,35 +77,47 @@ export default function SettingsPage() {
   }, [current, reset]);
 
   async function onSubmit(values: SettingsInput) {
-    // If home_city changed or lat/lon missing, re-geocode.
-    const needsGeocode =
-      values.home_city &&
-      (values.home_city !== current?.home_city ||
-        typeof values.home_lat !== "number" ||
-        typeof values.home_lon !== "number");
-    if (needsGeocode && values.home_city) {
-      try {
-        const { geocodeCity } = await import("~/lib/weather/open-meteo");
-        const geo = await geocodeCity(values.home_city);
-        if (geo) {
-          values.home_lat = geo.latitude;
-          values.home_lon = geo.longitude;
-          values.home_timezone = geo.timezone;
+    setSaveError(null);
+    try {
+      // If home_city changed or lat/lon missing, re-geocode.
+      const needsGeocode =
+        values.home_city &&
+        (values.home_city !== current?.home_city ||
+          typeof values.home_lat !== "number" ||
+          typeof values.home_lon !== "number");
+      if (needsGeocode && values.home_city) {
+        try {
+          const { geocodeCity } = await import("~/lib/weather/open-meteo");
+          const geo = await geocodeCity(values.home_city);
+          if (geo) {
+            values.home_lat = geo.latitude;
+            values.home_lon = geo.longitude;
+            values.home_timezone = geo.timezone;
+          }
+        } catch {
+          // non-fatal
         }
-      } catch {
-        // non-fatal
       }
+      if (current?.id) {
+        await db.settings.update(current.id, { ...values, updated_at: now() });
+      } else {
+        await db.settings.add({
+          ...values,
+          created_at: now(),
+          updated_at: now(),
+        });
+      }
+      setLocale(values.locale);
+      setSavedAt(Date.now());
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[settings] save failed", err);
+      setSaveError(
+        locale === "zh"
+          ? "保存失败，请再试一次。"
+          : "Couldn't save — please try again.",
+      );
     }
-    if (current?.id) {
-      await db.settings.update(current.id, { ...values, updated_at: now() });
-    } else {
-      await db.settings.add({
-        ...values,
-        created_at: now(),
-        updated_at: now(),
-      });
-    }
-    setLocale(values.locale);
   }
 
   return (
@@ -204,12 +228,19 @@ export default function SettingsPage() {
           </Field>
         </section>
 
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <Button type="submit" disabled={formState.isSubmitting}>
             {formState.isSubmitting ? t("common.saving") : t("common.save")}
           </Button>
-          {formState.isSubmitSuccessful && (
-            <span className="text-xs text-ink-500">{t("common.saved")}</span>
+          {savedAt !== null && (
+            <span className="text-xs text-[var(--ok)]">
+              {t("common.saved")}
+            </span>
+          )}
+          {saveError && (
+            <span role="alert" className="text-xs text-[var(--warn)]">
+              {saveError}
+            </span>
           )}
         </div>
       </form>

--- a/src/components/dashboard/pillar-tiles.tsx
+++ b/src/components/dashboard/pillar-tiles.tsx
@@ -414,7 +414,7 @@ export function PillarTiles() {
       key: "practice",
       node: (
         <Link
-          href={`/daily/new?date=${todayISO}`}
+          href="/practices"
           className="a-card flex min-h-[140px] flex-col gap-2 p-4 text-left transition-colors hover:border-ink-300"
         >
           <div className="flex items-center justify-between">
@@ -454,7 +454,7 @@ export function PillarTiles() {
       key: "protein",
       node: (
         <Link
-          href={`/daily/new?date=${todayISO}`}
+          href="/nutrition/log"
           className="a-card flex min-h-[140px] flex-col gap-2 p-4 text-left transition-colors hover:border-ink-300"
         >
           <div className="flex items-center justify-between">

--- a/src/components/dashboard/quick-checkin-card.tsx
+++ b/src/components/dashboard/quick-checkin-card.tsx
@@ -11,7 +11,8 @@ import { runEngineAndPersist } from "~/lib/rules/engine";
 import { Card } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils/cn";
-import { Check, Thermometer } from "lucide-react";
+import { Check, Thermometer, Pencil } from "lucide-react";
+import type { DailyEntry } from "~/types/clinical";
 
 const SCALES = [
   {
@@ -68,21 +69,21 @@ export function QuickCheckinCard() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [justSaved, setJustSaved] = useState(false);
 
-  // After save, the live query picks up `existing` and would normally
-  // unmount the card. We keep a "Saved" acknowledgement visible for
-  // ~6s so the patient has time to read the confirmation and tap the
-  // "Add detail" link if they want to. After that the card cleans
-  // itself up automatically (existing-row path returns null). Without
-  // this timer the saved banner stays on the dashboard for the rest
-  // of the session; with too short a timer (was 2.5s) the patient
-  // misses the chance to add detail.
+  // After save, the live query picks up `existing` and switches the
+  // card to its compact "Saved today" summary. We don't auto-hide
+  // anymore — silence on the dashboard after a check-in left users
+  // wondering whether the save took. The compact summary stays until
+  // tomorrow's date rolls over (or the entry is edited from the
+  // full log), and the Full-log link gives a one-tap path to amend.
   useEffect(() => {
     if (!justSaved) return;
     const id = setTimeout(() => setJustSaved(false), 6000);
     return () => clearTimeout(id);
   }, [justSaved]);
 
-  if (existing && !justSaved) return null;
+  if (existing && !justSaved) {
+    return <SavedTodaySummary entry={existing} />;
+  }
 
   async function save() {
     setSaving(true);
@@ -373,5 +374,92 @@ function FeverRow({
         />
       )}
     </div>
+  );
+}
+
+// Compact "checked in today" acknowledgement. Replaces the previous
+// behaviour of vanishing once the entry was saved — that left the
+// dashboard silent on the question patients/carers ask first
+// ("did I already do this?"). Shows the values that were saved with a
+// one-tap path back into the full daily wizard for amendments.
+function SavedTodaySummary({ entry }: { entry: DailyEntry }) {
+  const locale = useLocale();
+  const items: Array<{ label: string; value: string; tone?: "warn" }> = [];
+  if (typeof entry.energy === "number") {
+    items.push({
+      label: locale === "zh" ? "精力" : "Energy",
+      value: `${entry.energy}/10`,
+    });
+  }
+  if (typeof entry.pain_current === "number") {
+    items.push({
+      label: locale === "zh" ? "疼痛" : "Pain",
+      value: `${entry.pain_current}/10`,
+    });
+  }
+  if (typeof entry.nausea === "number") {
+    items.push({
+      label: locale === "zh" ? "恶心" : "Nausea",
+      value: `${entry.nausea}/10`,
+    });
+  }
+  if (entry.fever) {
+    items.push({
+      label: locale === "zh" ? "发热" : "Fever",
+      value:
+        typeof entry.fever_temp === "number"
+          ? `${entry.fever_temp.toFixed(1)} °C`
+          : locale === "zh" ? "是" : "yes",
+      tone: "warn",
+    });
+  }
+  return (
+    <Card className="p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <div
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
+            style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
+          >
+            <Check className="h-4 w-4" strokeWidth={3} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[13px] font-semibold text-ink-900">
+              {locale === "zh" ? "今日已记录" : "Checked in today"}
+            </div>
+            {items.length > 0 ? (
+              <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[12px] text-ink-700">
+                {items.map((it) => (
+                  <span
+                    key={it.label}
+                    className={cn(
+                      "tabular-nums",
+                      it.tone === "warn" && "text-[var(--warn)] font-medium",
+                    )}
+                  >
+                    <span className="text-ink-500">{it.label}</span>{" "}
+                    {it.value}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-0.5 text-[12px] text-ink-500">
+                {locale === "zh"
+                  ? "可以打开完整日志补充。"
+                  : "Open the full log to add detail."}
+              </p>
+            )}
+          </div>
+        </div>
+        <Link
+          href="/daily/new"
+          aria-label={locale === "zh" ? "编辑或补充今日记录" : "Edit today's check-in"}
+          className="inline-flex shrink-0 items-center gap-1 rounded-md border border-ink-200 px-2 py-1 text-[11px] text-ink-700 hover:border-[var(--tide-2)] hover:text-[var(--tide-2)]"
+        >
+          <Pencil className="h-3 w-3" />
+          {locale === "zh" ? "补充" : "Edit"}
+        </Link>
+      </div>
+    </Card>
   );
 }

--- a/src/components/dashboard/sync-prompt-card.tsx
+++ b/src/components/dashboard/sync-prompt-card.tsx
@@ -7,6 +7,7 @@ import { CloudOff, X } from "lucide-react";
 import { db, now } from "~/lib/db/dexie";
 import { getSupabaseBrowser, isSupabaseConfigured } from "~/lib/supabase/client";
 import { useT } from "~/hooks/use-translate";
+import { Card, CardContent } from "~/components/ui/card";
 
 const DISMISS_KEY = "anchor.syncPromptDismissedAt";
 
@@ -59,28 +60,34 @@ export function SyncPromptCard() {
   }
 
   return (
-    <div className="flex items-start gap-3 rounded-md border border-ink-200 bg-paper-2/70 px-4 py-3">
-      <CloudOff className="mt-0.5 h-4 w-4 shrink-0 text-ink-500" aria-hidden />
-      <div className="flex-1 space-y-1 text-sm">
-        <p className="font-medium text-ink-800">{t("syncPrompt.title")}</p>
-        <p className="text-ink-600">{t("syncPrompt.body")}</p>
-        <div className="pt-1">
-          <Link
-            href="/login"
-            className="inline-flex items-center rounded-md border border-ink-300 bg-paper px-3 py-1.5 text-xs font-medium text-ink-800 hover:border-ink-400 hover:bg-paper-2"
-          >
-            {t("syncPrompt.cta")}
-          </Link>
+    <Card>
+      <CardContent className="flex items-start gap-3 pt-4">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-ink-100 text-ink-500">
+          <CloudOff className="h-4 w-4" aria-hidden />
         </div>
-      </div>
-      <button
-        type="button"
-        onClick={handleDismiss}
-        aria-label={t("syncPrompt.dismiss")}
-        className="shrink-0 rounded p-1 text-ink-400 hover:text-ink-700"
-      >
-        <X className="h-4 w-4" aria-hidden />
-      </button>
-    </div>
+        <div className="flex-1 space-y-1">
+          <p className="text-[13px] font-semibold text-ink-900">
+            {t("syncPrompt.title")}
+          </p>
+          <p className="text-[11.5px] text-ink-500">{t("syncPrompt.body")}</p>
+          <div className="pt-1">
+            <Link
+              href="/login"
+              className="inline-flex items-center rounded-md border border-ink-300 bg-paper px-3 py-1.5 text-xs font-medium text-ink-800 hover:border-ink-400 hover:bg-paper-2"
+            >
+              {t("syncPrompt.cta")}
+            </Link>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label={t("syncPrompt.dismiss")}
+          className="-mr-1 -mt-1 shrink-0 rounded p-1 text-ink-400 hover:text-ink-700"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary

A targeted UX pass on the patient surface — the dashboard, the diary, the
two settings flows that are most often touched. Each fix removes
something the user otherwise had to ignore, work around, or wonder
about.

### Dashboard / Quick check-in
- **Persistent "checked in today" summary** replaces the 6s-and-vanish
  acknowledgement. After save the card briefly celebrates ("Saved for
  today"), then settles into a compact pill with the saved values
  (energy, pain, nausea, fever) and a one-tap **Edit** path into the
  full wizard. Prior behaviour left the dashboard silent on the
  question patients/carers ask first: *"did I already do this?"*
- **Pillar tiles point at the right destination.** The "Practice today"
  tile now opens `/practices` (where practices are managed) instead of
  the daily wizard. The protein-gap tile opens `/nutrition/log` (the
  canonical meal-log path) rather than the daily wizard.
- **Sync-prompt card uses the shared Card primitive** so it visually
  matches its dashboard siblings instead of rendering as a thinner,
  flatter strip.

### Settings
- **Save state no longer sticks**. `formState.isSubmitSuccessful` was
  permanent until the next submission, so "Saved" sat on the page
  forever. A local timestamp drives a 4s acknowledgement.
- **Save errors surface inline** instead of failing silently — the
  Dexie write was wrapped in a try/catch but errors were never shown.

### Diary page
- **Removed 329 lines of dead code.** `RecorderCard`, `RecentMemoCard`,
  `AppliedSummary` and their helpers were defined but never rendered —
  the page's only CTA links to `/log` for capture. Imports + the
  unused `enteredBy` came along for the ride.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (958 / 958)
- [x] `pnpm build`
- [ ] Manual: tap Save on quick check-in → see celebratory card → see
  values pill after 6s → tap Edit → land on `/daily/new`
- [ ] Manual: open Settings → Save → "Saved" disappears after 4s
- [ ] Manual: tap practice tile on dashboard → land on `/practices`
- [ ] Manual: tap protein-gap tile on dashboard → land on
  `/nutrition/log`

https://claude.ai/code/session_01VRdf2Tuqs9zEFjeKaEzaP9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRdf2Tuqs9zEFjeKaEzaP9)_