### PR TITLE
refactor: extract getErrorMessage helper + TEXT_FIELD_MAX constant

### DIFF
--- a/src/agents/skills/dispatch.ts
+++ b/src/agents/skills/dispatch.ts
@@ -5,6 +5,7 @@ import { readAppointmentsHandler } from "./handlers/read-appointments";
 import { readCareTeamHandler } from "./handlers/read-care-team";
 import { readDailyHandler } from "./handlers/read-daily";
 import { readLabsHandler } from "./handlers/read-labs";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Dispatcher: maps a tool_use call ("name" + input object) to the matching
 // handler and returns the tool_result payload. Lives alongside the
@@ -50,7 +51,7 @@ export async function dispatchSkill(
     const output = await handler(input);
     return { ok: true, output };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    return { ok: false, error: getErrorMessage(err) };
   }
 }
 

--- a/src/app/api/agent/[id]/run/route.ts
+++ b/src/app/api/agent/[id]/run/route.ts
@@ -13,6 +13,7 @@ import { readJsonBody } from "~/lib/anthropic/route-helpers";
 import { requireSession } from "~/lib/auth/require-session";
 import { loadHouseholdProfile } from "~/lib/household/profile";
 import { nowISO } from "~/lib/utils/date";
+import { getErrorMessage } from "~/lib/utils/error";
 
 export const runtime = "nodejs";
 // Specialist agents chew through referrals + state and emit up to 2k tokens
@@ -120,7 +121,7 @@ export async function POST(
       coverageSnapshot: parsed.data.coverage_snapshot,
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = getErrorMessage(err);
     return NextResponse.json(
       { error: "Agent run failed", message },
       { status: 502 },

--- a/src/app/api/ai/parse-voice-memo/route.ts
+++ b/src/app/api/ai/parse-voice-memo/route.ts
@@ -10,6 +10,7 @@ import {
   loadHouseholdProfile,
 } from "~/lib/household/profile";
 import { wrapUserInput } from "~/lib/anthropic/wrap-user-input";
+import { getErrorMessage } from "~/lib/utils/error";
 import {
   VoiceMemoParseSchema,
   buildVoiceMemoParseSystem,
@@ -152,7 +153,7 @@ export async function POST(req: Request) {
       {
         error:
           "Model response was not valid JSON: " +
-          (err instanceof Error ? err.message : String(err)),
+          (getErrorMessage(err)),
       },
       { status: 502 },
     );

--- a/src/app/api/ai/transcribe/route.ts
+++ b/src/app/api/ai/transcribe/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Voice-memo transcription. Browser records via MediaRecorder, posts
 // the resulting audio blob here as multipart/form-data; we hand it
@@ -98,7 +99,7 @@ export async function POST(req: Request) {
       },
     );
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = getErrorMessage(err);
     return NextResponse.json({ error: message }, { status: 502 });
   }
 

--- a/src/app/api/ingest-ics/route.ts
+++ b/src/app/api/ingest-ics/route.ts
@@ -3,6 +3,7 @@ import { icsEventsToOps, parseIcs } from "~/lib/ingest/ics";
 import { readJsonBody } from "~/lib/anthropic/route-helpers";
 import { requireSession } from "~/lib/auth/require-session";
 import type { IngestDraft } from "~/types/ingest";
+import { getErrorMessage } from "~/lib/utils/error";
 
 export const runtime = "nodejs";
 // ICS import fetches a remote webcal URL server-side (sometimes slow iCloud
@@ -63,7 +64,7 @@ export async function POST(req: Request) {
       raw = await res.text();
       sourceHint = url;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = getErrorMessage(err);
       return NextResponse.json(
         { error: `Couldn't fetch calendar: ${message}` },
         { status: 502 },

--- a/src/app/api/parse-appointment/route.ts
+++ b/src/app/api/parse-appointment/route.ts
@@ -8,6 +8,7 @@ import {
 } from "~/lib/anthropic/route-helpers";
 import { requireSession } from "~/lib/auth/require-session";
 import { wrapUserInputBlock } from "~/lib/anthropic/wrap-user-input";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Server-side vision/text parser for appointment letters, cards, and
 // pasted emails. Accepts either an image (data URL or https URL) or a
@@ -144,7 +145,7 @@ export async function POST(req: Request) {
     }
     return NextResponse.json({ appointment: response.parsed_output });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = getErrorMessage(err);
     return NextResponse.json(
       { error: "Parse failed", message },
       { status: 502 },

--- a/src/app/carers/page.tsx
+++ b/src/app/carers/page.tsx
@@ -29,6 +29,7 @@ import { InviteCarerFlow } from "~/components/invite/invite-carer-flow";
 import { MembersList } from "~/components/invite/members-list";
 import { PendingInvitesList } from "~/components/invite/pending-invites-list";
 import { LocalContactsSection } from "~/components/invite/local-contacts-section";
+import { getErrorMessage } from "~/lib/utils/error";
 import {
   UserPlus,
   Loader2,
@@ -527,7 +528,7 @@ function SessionDiag() {
         }
       } catch (err) {
         lines.push(
-          `diag exception: ${err instanceof Error ? err.message : String(err)}`,
+          `diag exception: ${getErrorMessage(err)}`,
         );
       } finally {
         if (!cancelled) setInfo(lines);

--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -23,6 +23,7 @@ import {
 import { todayISO } from "~/lib/utils/date";
 import { HttpError } from "~/lib/utils/http";
 import { Sparkles, Check, Loader2 } from "lucide-react";
+import { getErrorMessage } from "~/lib/utils/error";
 
 export default function MealIngestPage() {
   const locale = useLocale();
@@ -49,7 +50,7 @@ export default function MealIngestPage() {
       return;
     }
     setSignInRequired(false);
-    setError(e instanceof Error ? e.message : String(e));
+    setError(getErrorMessage(e));
   }
 
   async function onPhoto(file: File) {
@@ -61,7 +62,7 @@ export default function MealIngestPage() {
       const blob = new Blob([Uint8Array.from(atob(p.base64), (c) => c.charCodeAt(0))]);
       setPreview(URL.createObjectURL(blob));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(null);
     }
@@ -119,7 +120,7 @@ export default function MealIngestPage() {
       setEstimate(null);
       setSaved({ proteinAdd });
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(null);
     }

--- a/src/app/ingest/notes/page.tsx
+++ b/src/app/ingest/notes/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "~/lib/ingest/notes-vision";
 import { todayISO } from "~/lib/utils/date";
 import { Sparkles, Check, Loader2 } from "lucide-react";
+import { getErrorMessage } from "~/lib/utils/error";
 
 type DailyPatch = NonNullable<NotesStructure["daily_patch"]>;
 
@@ -46,7 +47,7 @@ export default function NotesIngestPage() {
       const blob = new Blob([Uint8Array.from(atob(p.base64), (c) => c.charCodeAt(0))]);
       setPreview(URL.createObjectURL(blob));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(null);
     }
@@ -60,7 +61,7 @@ export default function NotesIngestPage() {
       const result = await structureNotes({ model, image: prepared });
       setStructured(result);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(null);
     }
@@ -103,7 +104,7 @@ export default function NotesIngestPage() {
       setStructured(null);
       setSaved({ fields: fieldCount });
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(null);
     }

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -33,6 +33,7 @@ import {
   Keyboard,
 } from "lucide-react";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
+import { getErrorMessage } from "~/lib/utils/error";
 
 const TAG_LABELS: Record<LogTag, { en: string; zh: string }> = {
   diet: { en: "diet", zh: "饮食" },
@@ -177,7 +178,7 @@ export default function LogPage() {
       } catch (err) {
         setRun({
           kind: "error",
-          message: err instanceof Error ? err.message : String(err),
+          message: getErrorMessage(err),
         });
       }
       return;
@@ -211,7 +212,7 @@ export default function LogPage() {
     } catch (err) {
       setRun({
         kind: "error",
-        message: err instanceof Error ? err.message : String(err),
+        message: getErrorMessage(err),
       });
       return;
     }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,6 +8,7 @@ import { Field, TextInput } from "~/components/ui/field";
 import { Alert } from "~/components/ui/alert";
 import { PageHeader } from "~/components/ui/page-header";
 import { useT } from "~/hooks/use-translate";
+import { getErrorMessage } from "~/lib/utils/error";
 
 function LoginForm() {
   const t = useT();
@@ -61,7 +62,7 @@ function LoginForm() {
       setInfo(t("welcomeAuth.createdConfirm"));
       setMode("signin");
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/src/app/memos/[id]/page.tsx
+++ b/src/app/memos/[id]/page.tsx
@@ -43,6 +43,7 @@ import type {
 } from "~/types/voice-memo";
 import { cn } from "~/lib/utils/cn";
 import { formatDurationMs } from "~/lib/utils/date";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Memo detail. Shows the full transcript, audio playback, and Claude's
 // structured parse as a PREVIEW FORM the patient confirms before any
@@ -294,7 +295,7 @@ function PlaybackCard({
       try {
         await audioRef.current.play();
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err));
+        setError(getErrorMessage(err));
       }
     }
   }
@@ -501,7 +502,7 @@ function PreviewForm({
       });
       setAppliedRecently(true);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(false);
     }

--- a/src/app/schedule/new/page.tsx
+++ b/src/app/schedule/new/page.tsx
@@ -14,6 +14,7 @@ import type { Appointment } from "~/types/appointment";
 import { Loader2, ImagePlus, Sparkles } from "lucide-react";
 import { todayISO } from "~/lib/utils/date";
 import { postJson } from "~/lib/utils/http";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // One unified "smart entry" surface. The patient can:
 //   1. Paste an email body or free-text ("Chemo Friday 10am with Dr Lee at Epworth")
@@ -150,7 +151,7 @@ function SmartEntry({
       );
       await onParsed(data.appointment);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setBusy(false);
     }

--- a/src/app/treatment/new/page.tsx
+++ b/src/app/treatment/new/page.tsx
@@ -27,6 +27,7 @@ import type {
 } from "~/types/medication";
 import type { Appointment } from "~/types/appointment";
 import { ChevronLeft, ChevronRight, Check } from "lucide-react";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Three-step wizard for setting up a chemo cycle. Replaces the previous
 // one-shot CycleForm so the patient (or carer) can preview every linked
@@ -214,7 +215,7 @@ export default function NewTreatmentCyclePage() {
 
       router.push(`/treatment/${cycleId}?cycle_added=1`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/src/components/assessment/coach-drawer.tsx
+++ b/src/components/assessment/coach-drawer.tsx
@@ -7,6 +7,7 @@ import { useLocale } from "~/hooks/use-translate";
 import { useDefaultAiModel } from "~/hooks/use-settings";
 import { askCoach, type CoachContext, type CoachMessage } from "~/lib/ai/coach";
 import { Sparkles, X, Send, Loader2 } from "lucide-react";
+import { getErrorMessage } from "~/lib/utils/error";
 
 export function CoachDrawer({ context }: { context: CoachContext }) {
   const locale = useLocale();
@@ -34,7 +35,7 @@ export function CoachDrawer({ context }: { context: CoachContext }) {
       });
       setHistory((h) => [...h, { role: "assistant", content: reply }]);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(false);
     }

--- a/src/components/assessment/wizard.tsx
+++ b/src/components/assessment/wizard.tsx
@@ -34,6 +34,7 @@ import {
   Stethoscope,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import { getErrorMessage } from "~/lib/utils/error";
 
 const HELPER_ROLE_ICON = {
   self: User,
@@ -528,7 +529,7 @@ function ReviewView({
         updated_at: now(),
       });
     } catch (e) {
-      setAiError(e instanceof Error ? e.message : String(e));
+      setAiError(getErrorMessage(e));
     } finally {
       setAiBusy(false);
     }

--- a/src/components/auth/inline-sign-in.tsx
+++ b/src/components/auth/inline-sign-in.tsx
@@ -7,6 +7,7 @@ import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
 import { Alert } from "~/components/ui/alert";
 import { Loader2 } from "lucide-react";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Embeddable sign-in / sign-up panel. Same behaviour as
 // /login and the welcome modal, but rendered inline so an onboarding
@@ -103,7 +104,7 @@ export function InlineSignIn({
       );
       setMode("signin");
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/src/components/auth/welcome-auth-modal.tsx
+++ b/src/components/auth/welcome-auth-modal.tsx
@@ -8,6 +8,7 @@ import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
 import { useT } from "~/hooks/use-translate";
 import { nowISO } from "~/lib/utils/date";
+import { getErrorMessage } from "~/lib/utils/error";
 
 const SEEN_KEY = "anchor.welcomeSeenAt";
 
@@ -84,7 +85,7 @@ export function WelcomeAuthModal() {
       setInfo(t("welcomeAuth.createdConfirm"));
       setMode("signin");
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/src/components/diary/voice-memo-card.tsx
+++ b/src/components/diary/voice-memo-card.tsx
@@ -16,6 +16,7 @@ import { resolveVoiceMemoAudioUrl } from "~/lib/voice-memo/cloud";
 import { Card } from "~/components/ui/card";
 import { cn } from "~/lib/utils/cn";
 import { formatDurationMs, formatHHMM } from "~/lib/utils/date";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Diary card for one voice memo. Shows the recorded time, duration,
 // transcript, and an inline play button. Audio is fetched lazily —
@@ -71,7 +72,7 @@ export function VoiceMemoCard({ memo, locale }: VoiceMemoCardProps) {
       audio.src = url;
       await audio.play();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     }
   }
 

--- a/src/components/family/log-for-patient.tsx
+++ b/src/components/family/log-for-patient.tsx
@@ -12,6 +12,7 @@ import { Field, Textarea } from "~/components/ui/field";
 import { Check, MessageSquarePlus, Sparkles } from "lucide-react";
 import { todayISO } from "~/lib/utils/date";
 import { FollowUpsCard } from "~/components/log/follow-ups-card";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Caregiver-flavoured log form on /family. Uses the direct-file path
 // from PR #72 so a short entry like "blood sugar 7.9 this morning"
@@ -42,7 +43,7 @@ export function LogForPatient() {
       setFiled(parsed);
       setText("");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/src/components/family/quick-note.tsx
+++ b/src/components/family/quick-note.tsx
@@ -9,6 +9,7 @@ import { Button } from "~/components/ui/button";
 import { Field, Textarea } from "~/components/ui/field";
 import { Card, CardContent } from "~/components/ui/card";
 import { Send, Check, Loader2 } from "lucide-react";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // One-textarea contribution surface for family members. Writes a
 // `log_events` row tagged (via the existing tagger, or defaulting to
@@ -49,7 +50,7 @@ export function QuickNote() {
       setState("done");
       window.setTimeout(() => setState("idle"), 2500);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
       setState("error");
     }
   }

--- a/src/components/ingest/calendar-subscribe.tsx
+++ b/src/components/ingest/calendar-subscribe.tsx
@@ -10,6 +10,7 @@ import { Field, TextInput, Textarea } from "~/components/ui/field";
 import { Calendar, AlertCircle, Loader2 } from "lucide-react";
 import type { IngestDraft } from "~/types/ingest";
 import { postJson } from "~/lib/utils/http";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Feeds the ICS path through the same preview-diff flow. Accepts
 // either a webcal:// / https:// subscription URL (Apple Calendar,
@@ -60,7 +61,7 @@ export function CalendarSubscribe({
       setUrl("");
       setText("");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setBusy(false);
     }

--- a/src/components/ingest/phone-note.tsx
+++ b/src/components/ingest/phone-note.tsx
@@ -10,6 +10,7 @@ import { Field, Textarea } from "~/components/ui/field";
 import { Mic, MicOff, AlertCircle, Loader2, Phone } from "lucide-react";
 import type { IngestDraft } from "~/types/ingest";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Quick-capture surface for phone-call instructions. The patient (or
 // the carer on the line) types or dictates what they just heard; the
@@ -59,7 +60,7 @@ export function PhoneCallNote({
       onDraft(data.draft);
       setText("");
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setBusy(false);
     }

--- a/src/components/ingest/universal-drop.tsx
+++ b/src/components/ingest/universal-drop.tsx
@@ -10,6 +10,7 @@ import { Button } from "~/components/ui/button";
 import { Field, Textarea } from "~/components/ui/field";
 import { ImagePlus, Loader2, Sparkles, AlertCircle } from "lucide-react";
 import type { IngestDraft, IngestSourceKind } from "~/types/ingest";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Universal entry point. Patient pastes an email body, types a quick
 // note, or snaps a photo (or picks a PDF — converted to image first).
@@ -59,7 +60,7 @@ export function UniversalDrop({
         source: file.type === "application/pdf" ? "pdf" : "photo",
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
       setBusy(false);
     }
   }
@@ -85,7 +86,7 @@ export function UniversalDrop({
       onDraft(data.draft);
       setText("");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setBusy(false);
     }

--- a/src/components/invite/local-contacts-section.tsx
+++ b/src/components/invite/local-contacts-section.tsx
@@ -31,6 +31,7 @@ import {
   CircleAlert,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Local contacts directory — phone numbers, specialties, and notes for
 // people in the patient's external care orbit (oncologist, surgeon, GP,
@@ -243,7 +244,7 @@ export function LocalContactsSection() {
       }
       cancel();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/src/components/nutrition/meal-ingest.tsx
+++ b/src/components/nutrition/meal-ingest.tsx
@@ -26,6 +26,7 @@ import { Alert } from "~/components/ui/alert";
 import { useLocale } from "~/hooks/use-translate";
 import { HttpError } from "~/lib/utils/http";
 import { cn } from "~/lib/utils/cn";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Two-tab ingest. Photo and text both produce the same ParsedMealResult
 // shape, which the parent screen renders into a confirmable preview.
@@ -53,7 +54,7 @@ export function MealIngest({
       return;
     }
     setSignInRequired(false);
-    setError(e instanceof Error ? e.message : String(e));
+    setError(getErrorMessage(e));
   }
   // Click-to-record voice memo. Tap once to record, tap again to stop;
   // the audio uploads to /api/ai/transcribe (Whisper) and the finalised

--- a/src/components/schedule/appointment-form.tsx
+++ b/src/components/schedule/appointment-form.tsx
@@ -16,6 +16,7 @@ import { Field, TextInput, Textarea } from "~/components/ui/field";
 import { PrepEditor } from "~/components/schedule/prep-editor";
 import { toDatetimeLocalInput as toLocalInput } from "~/lib/utils/date";
 import { AttendeeChips } from "~/components/schedule/attendee-chips";
+import { getErrorMessage } from "~/lib/utils/error";
 
 const KINDS: AppointmentKind[] = [
   "clinic",
@@ -143,7 +144,7 @@ export function AppointmentForm({
 
       router.push(`/schedule/${id}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(getErrorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/src/hooks/use-voice-transcription.ts
+++ b/src/hooks/use-voice-transcription.ts
@@ -11,6 +11,7 @@ import {
 } from "~/lib/voice-memo/sse";
 import type { VoiceMemo } from "~/types/voice-memo";
 import type { EnteredBy } from "~/types/clinical";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Click-to-record voice transcription via Whisper. The patient taps
 // once to start, taps again to stop. We record the whole utterance
@@ -311,7 +312,7 @@ export function useVoiceTranscription(
               }
             });
           } catch (err) {
-            transcribeError = err instanceof Error ? err.message : String(err);
+            transcribeError = getErrorMessage(err);
           }
 
           if (memoId !== null && text) {
@@ -363,7 +364,7 @@ export function useVoiceTranscription(
         }
       }, maxDurationMs);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = getErrorMessage(err);
       setError(message);
       setStatus("error");
       cleanup();

--- a/src/lib/anthropic/route-helpers.ts
+++ b/src/lib/anthropic/route-helpers.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
+import { getErrorMessage } from "~/lib/utils/error";
 
 export { DEFAULT_AI_MODEL } from "./model";
 
@@ -55,7 +56,7 @@ export async function withAnthropicErrorBoundary<T>(
   try {
     return { value: await work() };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = getErrorMessage(err);
     return {
       error: NextResponse.json({ error: message }, { status: 502 }),
     };

--- a/src/lib/ingest/bulk.ts
+++ b/src/lib/ingest/bulk.ts
@@ -12,6 +12,7 @@ import {
 } from "./save";
 import { db, now } from "~/lib/db/dexie";
 import type { IngestedDocument } from "~/types/clinical";
+import { getErrorMessage } from "~/lib/utils/error";
 
 export type BulkItemStatus =
   | "queued"
@@ -94,7 +95,7 @@ export async function processBulkItemOcr(
       status: "parsing",
     });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = getErrorMessage(err);
     await db.ingested_documents.update(docId, {
       status: "error",
       error_message: msg,
@@ -147,7 +148,7 @@ export async function parseBulkItem(
   } catch (err) {
     mutate(item.id, {
       status: "parse_failed",
-      error: err instanceof Error ? err.message : String(err),
+      error: getErrorMessage(err),
     });
   }
 }
@@ -183,7 +184,7 @@ export async function processBulkItemVision(
   try {
     prepared = await prepareImageForVision(item.file);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = getErrorMessage(err);
     await db.ingested_documents.update(docId, {
       status: "error",
       error_message: msg,
@@ -212,7 +213,7 @@ export async function processBulkItemVision(
       progress: undefined,
     });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = getErrorMessage(err);
     await db.ingested_documents.update(docId, {
       status: "error",
       error_message: msg,
@@ -280,7 +281,7 @@ export async function processBulkItemDocx(
       progress: undefined,
     });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = getErrorMessage(err);
     await db.ingested_documents.update(docId, {
       status: "error",
       error_message: msg,
@@ -304,7 +305,7 @@ export async function saveBulkItem(
   } catch (err) {
     mutate(item.id, {
       status: "parse_failed",
-      error: err instanceof Error ? err.message : String(err),
+      error: getErrorMessage(err),
     });
   }
 }

--- a/src/lib/ingest/operations.ts
+++ b/src/lib/ingest/operations.ts
@@ -18,6 +18,7 @@ import type {
 import type { Medication } from "~/types/medication";
 import type { PatientTask } from "~/types/task";
 import type { TreatmentCycle } from "~/types/treatment";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Row-level provenance the caller can attach to every row written by an
 // IngestDraft. Copied onto each add_* op's data before insert unless the
@@ -253,7 +254,7 @@ export async function applyIngestOp(
     return {
       op,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: getErrorMessage(err),
     };
   }
 }

--- a/src/lib/log/run-agents.ts
+++ b/src/lib/log/run-agents.ts
@@ -14,6 +14,7 @@ import { agentsForTags } from "~/agents/routing";
 import { HttpError, postJson } from "~/lib/utils/http";
 import { computeCoverageGaps } from "~/lib/coverage/log-coverage";
 import { formatCoverageSnapshot } from "~/lib/coverage/agent-snapshot";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Client-side orchestration for running one specialist agent.
 // 1. Read state.md + recent feedback for this agent from Dexie
@@ -365,7 +366,7 @@ export async function runAllAgentsForToday(args: {
         return {
           id,
           runId: null,
-          error: err instanceof Error ? err.message : String(err),
+          error: getErrorMessage(err),
         };
       }
     }),

--- a/src/lib/push/server.ts
+++ b/src/lib/push/server.ts
@@ -1,6 +1,7 @@
 import webpush from "web-push";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { nowISO } from "~/lib/utils/date";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Server-side push helpers. VAPID keys live as Vercel env vars:
 //   VAPID_PUBLIC_KEY  (base64-url, also exposed to the client via
@@ -84,7 +85,7 @@ export async function sendPush(
       (err as { statusCode?: number })?.statusCode ??
       (err as { status?: number })?.status ??
       500;
-    const message = err instanceof Error ? err.message : String(err);
+    const message = getErrorMessage(err);
     return { ok: false, status: statusCode, error: message };
   }
 }

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,0 +1,12 @@
+// Extract a human-readable message from an `unknown` thrown value. Centralised
+// so the `err instanceof Error ? err.message : String(err)` ternary doesn't
+// have to be re-derived at every catch site (it had reached 50+ copies before
+// this helper landed).
+//
+// Strict-mode catch parameters are typed `unknown`, so callers cannot just
+// reach for `.message` directly — using this helper keeps the surface honest
+// without losing the string fallback for things like thrown strings or
+// objects from older libraries.
+export function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/lib/validators/schemas.ts
+++ b/src/lib/validators/schemas.ts
@@ -2,6 +2,12 @@ import { z } from "zod";
 
 const scale0to10 = z.number().min(0).max(10);
 
+// Soft cap for free-text fields (reflections, weekly notes, questions for the
+// oncologist). Stops a runaway paste from blowing up downstream payloads while
+// still leaving room for a discursive entry. Centralised so adjusting the cap
+// is one edit, not a search-and-replace.
+const TEXT_FIELD_MAX = 4000;
+
 // `entered_by` is the household member who logged the entry. The full
 // EnteredBy type in ~/types/clinical also includes "clinician" and
 // "jonalyn", but those identities don't enter data through the wizard,
@@ -47,7 +53,7 @@ export const dailyEntrySchema = z.object({
   abdominal_pain: scale0to10.optional(),
   taste_changes: z.number().min(0).max(5).optional(),
   steatorrhoea: z.boolean().optional(),
-  reflection: z.string().max(4000).optional(),
+  reflection: z.string().max(TEXT_FIELD_MAX).optional(),
   reflection_lang: z.enum(["en", "zh"]).optional(),
   protein_grams: z.number().min(0).max(500).optional(),
   meals_count: z.number().int().min(0).max(10).optional(),
@@ -156,9 +162,9 @@ export const weeklyAssessmentSchema = z.object({
   cognitive_stillness: z.number().min(1).max(5),
   social_practice_integrity: z.number().min(1).max(5),
   energy_trend: z.enum(["improving", "stable", "declining"]).optional(),
-  concerns: z.string().max(4000).optional(),
-  questions_for_oncologist: z.string().max(4000).optional(),
-  week_summary: z.string().max(4000).optional(),
+  concerns: z.string().max(TEXT_FIELD_MAX).optional(),
+  questions_for_oncologist: z.string().max(TEXT_FIELD_MAX).optional(),
+  week_summary: z.string().max(TEXT_FIELD_MAX).optional(),
 });
 
 export type WeeklyAssessmentInput = z.infer<typeof weeklyAssessmentSchema>;

--- a/src/lib/voice-memo/apply.ts
+++ b/src/lib/voice-memo/apply.ts
@@ -12,6 +12,7 @@ import type {
   VoiceMemoParsedFields,
 } from "~/types/voice-memo";
 import { localDayISO } from "~/lib/utils/date";
+import { getErrorMessage } from "~/lib/utils/error";
 import {
   extractNumericValue,
   findAppointmentForClinicVisit,
@@ -960,7 +961,7 @@ export async function undoAppliedPatch(
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: getErrorMessage(err),
     };
   }
 

--- a/src/lib/voice-memo/parse.ts
+++ b/src/lib/voice-memo/parse.ts
@@ -2,6 +2,7 @@ import { db, now } from "~/lib/db/dexie";
 import { postJson } from "~/lib/utils/http";
 import type { VoiceMemoParsedFields } from "~/types/voice-memo";
 import { applyMemoPatches } from "./apply";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Slice 3 → ship: Claude reads every memo end-to-end and returns a
 // structured picture of it (daily-tracking fields, clinic visits,
@@ -77,7 +78,7 @@ export interface ParseAttempt {
 }
 
 function humaniseParseError(err: unknown): string {
-  const raw = err instanceof Error ? err.message : String(err);
+  const raw = getErrorMessage(err);
   // postJson wraps server bodies as `HTTP 502: {"error":"..."}` —
   // unwrap so the patient-facing message is the actual cause.
   const match = raw.match(/HTTP \d+:\s*(.+)/);

--- a/src/lib/voice-memo/retranscribe.ts
+++ b/src/lib/voice-memo/retranscribe.ts
@@ -1,6 +1,7 @@
 import { db, now } from "~/lib/db/dexie";
 import { parseVoiceMemo } from "./parse";
 import { parseSseStream, readTranscriptionFrame } from "./sse";
+import { getErrorMessage } from "~/lib/utils/error";
 
 // Retry transcription for a memo whose first attempt failed
 // (env-var glitch, network blip, OpenAI 5xx). Uses the audio Blob
@@ -46,7 +47,7 @@ export async function retranscribeVoiceMemo(memoId: number): Promise<{
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: getErrorMessage(err),
     };
   }
   if (!res.ok) {


### PR DESCRIPTION
## Summary

Targeted code-debt cleanup focused on **genuine** duplication, not stylistic churn.

- **`getErrorMessage(err: unknown)` helper** at `src/lib/utils/error.ts` replaces the `err instanceof Error ? err.message : String(err)` ternary that had grown to **49 catch sites** across components, API routes, and lib code. Behaviour is byte-for-byte identical; the win is one place to adjust if we ever want to log/redact/normalise thrown values.
- **`TEXT_FIELD_MAX = 4000` constant** in `validators/schemas.ts` keeps the soft cap on `reflection`, `concerns`, `questions_for_oncologist`, and `week_summary` in lockstep instead of being four scattered magic numbers.

## Deliberately out of scope

The survey turned up three other candidates I rejected during execution:

1. **Window-size constants** (`.slice(-7)`, `.slice(-3)` in `use-metrics.ts`, `trend-nudges.ts`, `zone-rules.ts`). The call sites already have clear local naming (`last7`, `last7Weights`) and contextual comments. A `WINDOW_7_DAYS` constant would add indirection without adding clarity.
2. **Sharing `ROLLING_WINDOW_DAYS = 7`** between `steps-decline.ts` and `social-isolation.ts`. Only **two** sites today. Per CLAUDE.md ("Three similar lines is better than a premature abstraction"), worth revisiting if a third detector lands with the same window.
3. **`useAsyncState` hook** around `useState(false)` + `useState<string|null>(null)`. Premature abstraction over two trivial hooks; CLAUDE.md doctrine again.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — no warnings or errors
- [x] `pnpm test` — 958/958 unit tests pass across 106 files
- [ ] Spot-check at runtime that an error path (e.g. failed sign-in) still shows the right message in the UI

## Files changed

- `src/lib/utils/error.ts` — new helper (12 lines)
- `src/lib/validators/schemas.ts` — extract `TEXT_FIELD_MAX`
- 36 other files — mechanical replacement (1–2 line diff each)

https://claude.ai/code/session_0177MFW9qgU6GQTC7CbwiJdh

---
_Generated by [Claude Code](https://claude.ai/code/session_0177MFW9qgU6GQTC7CbwiJdh)_