### PR TITLE
fix(ux): button disabled states, fever bounds, next-clinic hiding bug

### DIFF
--- a/src/components/dashboard/next-clinic-card.tsx
+++ b/src/components/dashboard/next-clinic-card.tsx
@@ -27,22 +27,23 @@ export function NextClinicCard() {
     [],
   );
 
+  // ScheduleCard already shows today + tomorrow appointments. Skip those
+  // so the dashboard doesn't surface the same appointment twice — but
+  // still surface the *next* clinic after that window so a planned
+  // 2-week consult isn't invisible whenever a chemo / blood-test clinic
+  // happens to fall in the same 48 hours.
   const next = useMemo(() => {
     if (!appointments) return null;
+    const startToday = new Date();
+    startToday.setHours(0, 0, 0, 0);
+    const endTomorrow = startToday.getTime() + 2 * 24 * 60 * 60 * 1000;
     return nextAppointment(appointments, {
+      from: endTomorrow,
       excludeStatuses: ["cancelled", "missed"],
     });
   }, [appointments]);
 
   if (!next) return null;
-  // ScheduleCard already shows today + tomorrow appointments. Suppress this
-  // dedicated card when the next clinic is already in that window so the
-  // dashboard doesn't surface the same appointment twice.
-  const startToday = new Date();
-  startToday.setHours(0, 0, 0, 0);
-  const endTomorrow = startToday.getTime() + 2 * 24 * 60 * 60 * 1000;
-  const nextStart = new Date(next.starts_at).getTime();
-  if (Number.isFinite(nextStart) && nextStart < endTomorrow) return null;
 
   const when = new Date(next.starts_at);
   const dateLabel = isToday(when)

--- a/src/components/dashboard/quick-checkin-card.tsx
+++ b/src/components/dashboard/quick-checkin-card.tsx
@@ -367,9 +367,12 @@ function FeverRow({
           type="number"
           inputMode="decimal"
           step="0.1"
+          min={35}
+          max={43}
           value={temp}
           onChange={(e) => onTempChange(e.target.value)}
           placeholder="°C"
+          aria-label={locale === "zh" ? "体温 ℃" : "Temperature °C"}
           className="h-11 w-24 rounded-md border border-ink-200 bg-paper-2 px-3 text-base tabular-nums"
         />
       )}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,17 +9,23 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: Size;
 }
 
+// Every variant carries `disabled:opacity-50` + `disabled:hover:*` overrides
+// so disabled states read as inert across the whole button vocabulary —
+// previously only `primary` showed any visual change when disabled, leaving
+// secondary / ghost / danger / tide buttons looking fully active even after
+// `disabled` was applied (cursor change alone doesn't reach screen-reader
+// users or carry from a touch device).
 const variantCls: Record<Variant, string> = {
   primary:
-    "bg-ink-900 text-paper hover:bg-ink-700 disabled:opacity-50",
+    "bg-ink-900 text-paper hover:bg-ink-700 disabled:opacity-50 disabled:hover:bg-ink-900",
   secondary:
-    "border border-ink-200 bg-paper-2 text-ink-900 hover:border-ink-300",
+    "border border-ink-200 bg-paper-2 text-ink-900 hover:border-ink-300 disabled:opacity-50 disabled:hover:border-ink-200",
   ghost:
-    "text-ink-500 hover:bg-ink-100/60",
+    "text-ink-500 hover:bg-ink-100/60 disabled:opacity-50 disabled:hover:bg-transparent",
   danger:
-    "bg-[var(--warn)] text-white hover:opacity-90",
+    "bg-[var(--warn)] text-white hover:opacity-90 disabled:opacity-50 disabled:hover:opacity-50",
   tide:
-    "bg-[var(--tide-2)] text-paper hover:brightness-110",
+    "bg-[var(--tide-2)] text-paper hover:brightness-110 disabled:opacity-50 disabled:hover:brightness-100",
 };
 
 // Heights are deliberate WCAG AA tap-target tiers:


### PR DESCRIPTION
## Summary

Audited the dashboard, daily wizard, and log/diary capture flows for friction, dead UI, and stuck states. Three concrete fixes landed; the rest of the surfaces audited (TodayFeed timeout, ChangeSignals mark-as-done, RecentlyAccepted dismiss, EmergencyCard, ScheduleCard label) turned out to be already-handled correctly on closer reading.

### Fixes

- **Button disabled state across all variants** (`src/components/ui/button.tsx`)
  Only the `primary` variant carried `disabled:opacity-50`. `secondary`, `ghost`, `danger`, and `tide` buttons stayed at full opacity when `disabled` was applied — `cursor:not-allowed` alone doesn't reach screen-reader users or carry from a touch device, so disabled controls (medication-prompts dismiss, daily wizard back/skip, etc.) silently looked active. Added the dimmed state + `disabled:hover:*` overrides to every variant so the inert state is consistent.

- **Fever temp input bounds** (`src/components/dashboard/quick-checkin-card.tsx`)
  The quick-check-in fever field was an unbounded `type=number`, so `-5` or `1000` were valid entries. Added `min={35}` / `max={43}` and an `aria-label` so the field announces purpose to assistive tech.

- **NextClinicCard hiding the wrong appointment** (`src/components/dashboard/next-clinic-card.tsx`)
  When the *nearest* clinic appointment fell inside the today/tomorrow window (which `ScheduleCard` already covers), the card hid itself entirely — even when there was a planned consult two weeks out that the patient should have been able to see. The card was treating "next clinic exists in 48h window" as "no card needed" rather than "skip that one and show the one after." Now filters at the query layer with `from: endTomorrow`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1009 / 1009 passing
- [ ] Visual smoke: trigger a disabled `secondary` / `ghost` / `tide` button (e.g. wizard `Skip` while loading) and confirm it dims
- [ ] Visual smoke: book two clinic appointments — one tomorrow, one in two weeks — and confirm the dashboard shows the schedule card *and* the NextClinicCard for the +14d consult
- [ ] Manual: enter a fever temp on quick check-in and confirm browser rejects values outside 35–43°C

https://claude.ai/code/session_01VPrT82x8aAqifR26MqB6jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPrT82x8aAqifR26MqB6jk)_