### PR TITLE
Anchor Phase 1: foundation + Eligibility Engine v0 (Layer 2)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,0 +1,40 @@
+# Subagents
+
+Fresh-context subagents Claude Code can spawn from the parent session.
+One file per agent. Format: Markdown with YAML frontmatter.
+
+## Frontmatter contract
+
+```yaml
+---
+name: trial-monitor              # invoked as @trial-monitor
+description: One sentence on when to use this agent.
+tools:                           # explicit allow-list — anything not listed
+  - Read                         # is denied. Never include Write/Edit/Bash
+  - mcp__clinicaltrials__*       # in any agent that touches external data.
+  - mcp__biomcp__*
+model: sonnet                    # optional override
+---
+
+Body is the system prompt the subagent runs with.
+```
+
+## Cold-start rule
+
+A subagent is a cold session — it sees its own frontmatter + the prompt
+the parent passes, and **nothing else** from the parent's context.
+Brief it like a colleague who just walked into the room: state the
+goal, the inputs to read, the output shape, and the constraints.
+
+## Phase 1 inhabitants
+
+- `trial-monitor.md` — runs the shortlist daily, returns a delta vs the
+  prior run snapshot. Read-only allow-list, no write/edit/bash.
+
+## Outbound-comms invariant
+
+No subagent in this repo wires a tool whose name implies outbound
+communication (`*send*`, `*post*`, `*publish*`, `*draft_send*`,
+`gmail_send`, `twilio*`, `mcp__*__send_*`). The PreToolUse hook in
+`.claude/hooks/block-outbound-comms.sh` is the second-line failsafe; the
+first line is **not listing those tools in `tools:` at all**.

--- a/.claude/agents/trial-monitor.md
+++ b/.claude/agents/trial-monitor.md
@@ -1,0 +1,104 @@
+---
+name: trial-monitor
+description: Run the Anchor shortlist against ClinicalTrials.gov + BioMCP and return a delta vs the prior run snapshot. Read-only — no writes, no edits, no shell. Invoke daily, or on demand when the operator wants a recruitment-status check on the seven shortlisted trials.
+tools:
+  - Read
+  - mcp__clinicaltrials__search_studies
+  - mcp__clinicaltrials__get_study
+  - mcp__clinicaltrials__list_studies
+  - mcp__clinicaltrials__study_metadata
+  - mcp__biomcp__search
+  - mcp__biomcp__article_search
+  - mcp__biomcp__article_details
+  - mcp__biomcp__trial_search
+  - mcp__biomcp__trial_details
+  - mcp__biomcp__variant_search
+  - mcp__biomcp__variant_details
+---
+
+You are the **trial-monitor** subagent for Anchor.
+
+## What you do
+
+For each NCT in `src/eligibility/shortlist.yaml`, query its current
+state on ClinicalTrials.gov (via the `clinicaltrials` MCP) and surface
+deltas vs the prior monitor snapshot at
+`.claude/local/last-monitor-run.json` (gitignored — may not exist on
+first run, in which case treat every record as "new").
+
+Then ask BioMCP (`biomcp` MCP tools) for any new RASolute 302 / KRAS-on
+inhibitor / daraxonrasib (RMC-6236) / MTAP-deletion-PDAC literature
+posted since the prior run. Surface deltas only.
+
+## What you return
+
+A single Markdown report with the following sections:
+
+1. **Shortlist deltas** — per NCT: status (Recruiting / Active /
+   Suspended / Terminated / Completed), AU site changes, eligibility
+   amendments, principal-investigator changes, last-update date.
+   Highlight `[CLOSURE]`, `[NEW SITE]`, `[ELIGIBILITY CHANGED]`.
+2. **New trials matching the bridge profile** — surfaced via a
+   `clinicaltrials` search for `pancreatic cancer + KRAS-mutant` ∩
+   `Australia` ∩ Status:Recruiting. Mark as `[NEW TRIAL]`. Operator
+   decides whether to add to the shortlist.
+3. **Literature signals** — papers, conference abstracts, regulatory
+   announcements relevant to RMC-6236, RASolute 302, MTAP-deletion
+   PDAC, or KRAS-on inhibitor class effects. From BioMCP only.
+4. **Operative-variable update** — any concrete signal about the AU
+   EAP timeline for RMC-6236. Pull from press releases, ASCO/AACR/ESMO
+   abstracts, or the trial's own status field. If nothing new: say so
+   in one line.
+
+## Constraints (hard)
+
+- **Never write.** You have Read and the read-only MCP tools listed
+  above. You cannot create, modify, or delete any file. The PreToolUse
+  hook in `.claude/hooks/block-outbound-comms.sh` is a second-line
+  failsafe; the first line is your `tools:` allow-list above.
+- **Never communicate outbound.** No emails, no posts, no drafts. The
+  report is for the operator's eyes only.
+- **Never invent.** If a field is unavailable from the MCP query,
+  return `unknown` and tag `[VERIFY]`. Do not guess.
+- **Cite every claim.** Each delta must reference its NCT ID + a
+  ClinicalTrials.gov field name (e.g. `OverallStatus`, `LastUpdatePostDate`)
+  or a BioMCP record ID + URL.
+
+## Inputs you can rely on
+
+- `src/eligibility/shortlist.yaml` — the seven NCTs (one or more may be
+  `nct_id: TBD` for the Epworth Jreissati actives until the operator
+  fills them in).
+- `.claude/local/last-monitor-run.json` — the prior run's snapshot,
+  or absent on first run.
+
+## Output format example
+
+```
+## Shortlist deltas (2026-05-08 vs 2026-05-01)
+
+### NCT06625320 — RASolute 302 EAP (RMC-6236)
+- OverallStatus: Recruiting (unchanged)
+- LastUpdatePostDate: 2026-04-29
+- AU sites: 0 (unchanged) — operative-variable signal: none
+
+### NCT06360354 — MTAPESTRY 103 Sub C
+- OverallStatus: Active, not recruiting (was Recruiting) [ELIGIBILITY CHANGED]
+- LastUpdatePostDate: 2026-05-04
+- Eligibility note: MTAP-deletion confirmation now requires central NGS [VERIFY]
+
+## New trials matching the bridge profile
+
+(none this run)
+
+## Literature signals
+
+- 2026-05-06 — Revolution Medicines press release: RMC-6236 EAP
+  pre-application filed in AU [VERIFY URL]
+
+## Operative-variable update
+
+EAP AU open date: still unknown. Pre-application filing on 2026-05-06
+is the first concrete movement. Recommend operator monitor TGA Special
+Access Scheme registry weekly.
+```

--- a/.claude/agents/trial-monitor.md
+++ b/.claude/agents/trial-monitor.md
@@ -3,17 +3,27 @@ name: trial-monitor
 description: Run the Anchor shortlist against ClinicalTrials.gov + BioMCP and return a delta vs the prior run snapshot. Read-only — no writes, no edits, no shell. Invoke daily, or on demand when the operator wants a recruitment-status check on the seven shortlisted trials.
 tools:
   - Read
-  - mcp__clinicaltrials__search_studies
-  - mcp__clinicaltrials__get_study
-  - mcp__clinicaltrials__list_studies
-  - mcp__clinicaltrials__study_metadata
+  # ClinicalTrials.gov MCP — cyanheads/clinicaltrialsgov-mcp-server,
+  # hosted at https://clinicaltrials.caseyjhand.com/mcp.
+  # Tool surface canonical as of 2026-05; all 7 tools are read-only.
+  - mcp__clinicaltrials__clinicaltrials_search_studies
+  - mcp__clinicaltrials__clinicaltrials_get_study_record
+  - mcp__clinicaltrials__clinicaltrials_get_study_count
+  - mcp__clinicaltrials__clinicaltrials_get_field_values
+  - mcp__clinicaltrials__clinicaltrials_get_field_definitions
+  - mcp__clinicaltrials__clinicaltrials_get_study_results
+  - mcp__clinicaltrials__clinicaltrials_find_eligible
+  # BioMCP — genomoncology/biomcp, hosted at https://biomcp.org/mcp.
+  # Generic verbs scoped by entity in their parameters. Excludes
+  # update + uninstall (state-mutating self-management) by design.
   - mcp__biomcp__search
-  - mcp__biomcp__article_search
-  - mcp__biomcp__article_details
-  - mcp__biomcp__trial_search
-  - mcp__biomcp__trial_details
-  - mcp__biomcp__variant_search
-  - mcp__biomcp__variant_details
+  - mcp__biomcp__get
+  - mcp__biomcp__suggest
+  - mcp__biomcp__discover
+  - mcp__biomcp__batch
+  - mcp__biomcp__study
+  - mcp__biomcp__health
+  - mcp__biomcp__version
 ---
 
 You are the **trial-monitor** subagent for Anchor.
@@ -26,9 +36,12 @@ deltas vs the prior monitor snapshot at
 `.claude/local/last-monitor-run.json` (gitignored — may not exist on
 first run, in which case treat every record as "new").
 
-Then ask BioMCP (`biomcp` MCP tools) for any new RASolute 302 / KRAS-on
+Then ask BioMCP (`biomcp` MCP) for any new RASolute 302 / KRAS-on
 inhibitor / daraxonrasib (RMC-6236) / MTAP-deletion-PDAC literature
-posted since the prior run. Surface deltas only.
+posted since the prior run. BioMCP exposes generic verbs — use
+`mcp__biomcp__search` with `domain: article` for PubMed; with
+`domain: trial` for cross-checking ClinicalTrials.gov; `domain: variant`
+when you need allele-level context. Surface deltas only.
 
 ## What you return
 
@@ -38,9 +51,9 @@ A single Markdown report with the following sections:
    Suspended / Terminated / Completed), AU site changes, eligibility
    amendments, principal-investigator changes, last-update date.
    Highlight `[CLOSURE]`, `[NEW SITE]`, `[ELIGIBILITY CHANGED]`.
-2. **New trials matching the bridge profile** — surfaced via a
-   `clinicaltrials` search for `pancreatic cancer + KRAS-mutant` ∩
-   `Australia` ∩ Status:Recruiting. Mark as `[NEW TRIAL]`. Operator
+2. **New trials matching the bridge profile** — surfaced via
+   `clinicaltrials_search_studies` for `pancreatic cancer + KRAS-mutant`
+   ∩ `Australia` ∩ Status:Recruiting. Mark as `[NEW TRIAL]`. Operator
    decides whether to add to the shortlist.
 3. **Literature signals** — papers, conference abstracts, regulatory
    announcements relevant to RMC-6236, RASolute 302, MTAP-deletion
@@ -61,14 +74,14 @@ A single Markdown report with the following sections:
 - **Never invent.** If a field is unavailable from the MCP query,
   return `unknown` and tag `[VERIFY]`. Do not guess.
 - **Cite every claim.** Each delta must reference its NCT ID + a
-  ClinicalTrials.gov field name (e.g. `OverallStatus`, `LastUpdatePostDate`)
-  or a BioMCP record ID + URL.
+  ClinicalTrials.gov field name (e.g. `OverallStatus`,
+  `LastUpdatePostDate`) or a BioMCP record ID + URL.
 
 ## Inputs you can rely on
 
-- `src/eligibility/shortlist.yaml` — the seven NCTs (one or more may be
-  `nct_id: TBD` for the Epworth Jreissati actives until the operator
-  fills them in).
+- `src/eligibility/shortlist.yaml` — the seven NCTs (one or more may
+  be `nct_id: TBD` for the Epworth Jreissati actives until the
+  operator fills them in).
 - `.claude/local/last-monitor-run.json` — the prior run's snapshot,
   or absent on first run.
 

--- a/.claude/evals/README.md
+++ b/.claude/evals/README.md
@@ -1,0 +1,46 @@
+# Evals
+
+Phase 1 eval harness for the eligibility engine and shortlist-monitor
+delta logic.
+
+## Layout
+
+```
+.claude/evals/
+├── cases/         YAML — one case per file. Self-describing.
+├── fixtures/      JSON — frozen ClinicalTrials.gov-shaped records and
+│                  monitor snapshots used by cases.
+└── runner.ts      Loads every case, executes against src/eligibility/,
+                   writes results to eval-runs/<timestamp>.json (gitignored).
+```
+
+Run: `pnpm evals:run`.
+
+## Case shape
+
+```yaml
+id: 03-mtap-unknown-kras-g12v
+description: One sentence on what's being tested.
+kind: bridge_status | shortlist_diff | eligibility_parse
+inputs:
+  # kind-specific
+expect:
+  # kind-specific assertions
+```
+
+Cases that hit the eligibility engine pass `BridgeInputs` (the thin
+projection — ECOG, KRAS, MTAP, HLA, latest labs, treatment setting,
+EAP-open flag) and assert on the `BridgeStatus` shape returned. Cases
+that hit the monitor diff pass two snapshot fixtures and assert on
+`diffShortlistSnapshots` output.
+
+## Phase 1 success bar
+
+The runner executes all five cases, pass/fail recorded honestly. A case
+failing in Phase 1 is acceptable — it documents the gap. What's NOT
+acceptable is the runner crashing or skipping cases silently.
+
+## Outputs
+
+`eval-runs/<ISO-timestamp>.json` is gitignored. Contains: timestamp,
+git SHA, per-case pass/fail/skip + notes, summary line.

--- a/.claude/evals/cases/01-au-open-shortlist.yaml
+++ b/.claude/evals/cases/01-au-open-shortlist.yaml
@@ -1,0 +1,29 @@
+id: 01-au-open-shortlist
+description: >
+  HL profile, EAP open in AU. Query: which shortlisted trials remain
+  open at AU sites? Phase 1 expectation: every entry is unverified, so
+  every verdict is "unknown" with reason "not yet hand-verified". Tests
+  that the engine refuses to claim eligibility from unverified data.
+kind: bridge_status
+inputs:
+  bridge_inputs:
+    ecog: 1
+    kras_variant: G12V
+    mtap_status: unknown
+    treatment_setting: first_line_active
+    latest_labs:
+      anc_x10e9_per_L: 2.0
+      platelets_x10e9_per_L: 150
+      hb_g_per_L: 110
+      bilirubin_xULN: 1.0
+      alt_xULN: 1.2
+      ast_xULN: 1.1
+      creatinine_clearance_mL_per_min: 80
+    eap_au_open: true
+    as_of: "2026-05-08"
+  shortlist_path: src/eligibility/shortlist.yaml
+expect:
+  unverified_count: 7
+  any_eligible_now: false
+  any_eligible_if_stable: false
+  every_verdict_kind_is: unknown

--- a/.claude/evals/cases/02-rmc6236-eap-not-open.yaml
+++ b/.claude/evals/cases/02-rmc6236-eap-not-open.yaml
@@ -1,0 +1,40 @@
+id: 02-rmc6236-eap-not-open
+description: >
+  RMC-6236 EAP not yet open in AU; ECOG 1; KRAS G12V; MTAP intact; on
+  first-line. Bridge plan still viable? Tests the eligibility verdict
+  for RASolute 302 EAP using a verified-on-the-fly fixture inline so
+  the engine actually exercises evaluateVerdict (not just the
+  unverified-refusal path).
+kind: bridge_status_with_inline_criteria
+inputs:
+  bridge_inputs:
+    ecog: 1
+    kras_variant: G12V
+    mtap_status: intact
+    treatment_setting: first_line_active
+    latest_labs:
+      anc_x10e9_per_L: 2.0
+      platelets_x10e9_per_L: 150
+      hb_g_per_L: 110
+      bilirubin_xULN: 1.0
+      alt_xULN: 1.2
+      ast_xULN: 1.1
+      creatinine_clearance_mL_per_min: 80
+    eap_au_open: false
+    as_of: "2026-05-08"
+  inline_shortlist:
+    - nct_id: NCT06625320
+      label: RASolute 302 EAP
+      one_line_eligibility: 2L mPDAC; ECOG 0–1; KRAS-mutant
+      verified: true
+  inline_criteria_fixture: nct06625320
+expect:
+  trial_count: 1
+  trial_0_verdict_kind: eligible_now
+  trial_0_verified: true
+  any_eligible_now: true
+  notes: >
+    Even though eap_au_open=false, eligibility-as-criteria is still
+    "eligible_now" because the EAP-open flag is the operative variable
+    (governs threshold tightness in Phase 2), not a binary gate on
+    verdict in Phase 1. This case documents that distinction.

--- a/.claude/evals/cases/03-mtap-unknown-kras-g12v.yaml
+++ b/.claude/evals/cases/03-mtap-unknown-kras-g12v.yaml
@@ -1,0 +1,52 @@
+id: 03-mtap-unknown-kras-g12v
+description: >
+  MTAP status unknown; KRAS G12V confirmed. Across the four trials
+  with known NCTs, expect a mix: RASolute 302 (G12-any) eligible now;
+  MTAPESTRY 103 (MTAP-required, unknown) eligible_if_stable; MRTX1133
+  (G12D-only, patient is G12V) excluded; IMCODE003 (HLA-restricted, no
+  HLA recorded) eligible_if_stable.
+kind: bridge_status_with_inline_criteria
+inputs:
+  bridge_inputs:
+    ecog: 1
+    kras_variant: G12V
+    mtap_status: unknown
+    treatment_setting: first_line_active
+    latest_labs:
+      anc_x10e9_per_L: 2.0
+      platelets_x10e9_per_L: 150
+      hb_g_per_L: 110
+      bilirubin_xULN: 1.0
+      alt_xULN: 1.2
+      ast_xULN: 1.1
+      creatinine_clearance_mL_per_min: 80
+    eap_au_open: false
+    as_of: "2026-05-08"
+  inline_shortlist:
+    - nct_id: NCT06625320
+      label: RASolute 302 EAP
+      one_line_eligibility: G12-any
+      verified: true
+    - nct_id: NCT06360354
+      label: MTAPESTRY 103
+      one_line_eligibility: MTAP-deletion required
+      verified: true
+    - nct_id: NCT05737706
+      label: MRTX1133
+      one_line_eligibility: G12D only
+      verified: true
+    - nct_id: NCT05968326
+      label: IMCODE003
+      one_line_eligibility: HLA-restricted
+      verified: true
+  inline_criteria_fixtures:
+    - nct06625320
+    - nct06360354
+    - nct05737706
+    - nct05968326
+expect:
+  trial_verdicts:
+    NCT06625320: eligible_now
+    NCT06360354: eligible_if_stable
+    NCT05737706: excluded
+    NCT05968326: eligible_if_stable

--- a/.claude/evals/cases/04-new-trial-detected.yaml
+++ b/.claude/evals/cases/04-new-trial-detected.yaml
@@ -1,0 +1,17 @@
+id: 04-new-trial-detected
+description: >
+  A new NCT (NCT09999999) appears in this monitor run that wasn't in
+  the prior snapshot. diffShortlistSnapshots must surface it under
+  new_trials.
+kind: shortlist_diff
+inputs:
+  prev_fixture: monitor-snapshot-before
+  next_fixture: monitor-snapshot-after
+expect:
+  new_trial_nct_ids:
+    - NCT09999999
+  closed_trial_count: 0
+  # NB: the shared monitor-snapshot fixtures also encode a status
+  # change on NCT06625320 (covered by case 05). This case asserts only
+  # on the new-trial axis to stay focused; status_change_count is
+  # intentionally not asserted here.

--- a/.claude/evals/cases/05-trial-closure-detected.yaml
+++ b/.claude/evals/cases/05-trial-closure-detected.yaml
@@ -1,0 +1,14 @@
+id: 05-trial-closure-detected
+description: >
+  A trial that was Recruiting in the prior snapshot is now
+  "Active, not recruiting". diffShortlistSnapshots must surface it
+  under status_changes.
+kind: shortlist_diff
+inputs:
+  prev_fixture: monitor-snapshot-before
+  next_fixture: monitor-snapshot-after
+expect:
+  status_changes:
+    - nct_id: NCT06625320
+      from: Recruiting
+      to: Active, not recruiting

--- a/.claude/evals/fixtures/monitor-snapshot-after.json
+++ b/.claude/evals/fixtures/monitor-snapshot-after.json
@@ -1,0 +1,29 @@
+{
+  "as_of": "2026-05-08",
+  "trials": [
+    {
+      "nct_id": "NCT06625320",
+      "overall_status": "Active, not recruiting",
+      "last_update_post_date": "2026-05-04",
+      "au_site_count": 0
+    },
+    {
+      "nct_id": "NCT06360354",
+      "overall_status": "Recruiting",
+      "last_update_post_date": "2026-04-20",
+      "au_site_count": 1
+    },
+    {
+      "nct_id": "NCT05737706",
+      "overall_status": "Recruiting",
+      "last_update_post_date": "2026-04-22",
+      "au_site_count": 0
+    },
+    {
+      "nct_id": "NCT09999999",
+      "overall_status": "Recruiting",
+      "last_update_post_date": "2026-05-06",
+      "au_site_count": 1
+    }
+  ]
+}

--- a/.claude/evals/fixtures/monitor-snapshot-before.json
+++ b/.claude/evals/fixtures/monitor-snapshot-before.json
@@ -1,0 +1,23 @@
+{
+  "as_of": "2026-05-01",
+  "trials": [
+    {
+      "nct_id": "NCT06625320",
+      "overall_status": "Recruiting",
+      "last_update_post_date": "2026-04-15",
+      "au_site_count": 0
+    },
+    {
+      "nct_id": "NCT06360354",
+      "overall_status": "Recruiting",
+      "last_update_post_date": "2026-04-20",
+      "au_site_count": 1
+    },
+    {
+      "nct_id": "NCT05737706",
+      "overall_status": "Recruiting",
+      "last_update_post_date": "2026-04-22",
+      "au_site_count": 0
+    }
+  ]
+}

--- a/.claude/evals/runner.ts
+++ b/.claude/evals/runner.ts
@@ -1,0 +1,316 @@
+#!/usr/bin/env tsx
+//
+// Anchor — Phase 1 eval runner.
+//
+// Reads .claude/evals/cases/*.yaml, executes each against
+// src/eligibility/, writes a single result file under eval-runs/.
+// Honest pass/fail recording — Phase 1 success bar is "every case
+// runs", not "every case passes".
+//
+// Run: pnpm evals:run
+
+import { readFile, readdir, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import { parse as parseYaml } from "yaml";
+import {
+  diffShortlistSnapshots,
+  getCurrentBridgeStatus,
+  loadShortlist,
+  parseEligibility,
+} from "../../src/eligibility/index.js";
+import type {
+  BridgeInputs,
+  EligibilityCriteria,
+  Shortlist,
+  ShortlistSnapshot,
+} from "../../src/eligibility/types.js";
+
+interface CaseFile {
+  id: string;
+  description?: string;
+  kind:
+    | "bridge_status"
+    | "bridge_status_with_inline_criteria"
+    | "shortlist_diff";
+  inputs: Record<string, unknown>;
+  expect: Record<string, unknown>;
+}
+
+interface CaseResult {
+  id: string;
+  status: "pass" | "fail" | "error";
+  notes: string[];
+}
+
+const REPO_ROOT = process.cwd();
+const CASES_DIR = join(REPO_ROOT, ".claude/evals/cases");
+const FIXTURES_DIR = join(REPO_ROOT, ".claude/evals/fixtures");
+const RESULTS_DIR = join(REPO_ROOT, "eval-runs");
+
+async function loadCase(path: string): Promise<CaseFile> {
+  const raw = await readFile(path, "utf-8");
+  return parseYaml(raw) as CaseFile;
+}
+
+async function loadFixtureJson<T>(name: string): Promise<T> {
+  const raw = await readFile(join(FIXTURES_DIR, `${name}.json`), "utf-8");
+  return JSON.parse(raw) as T;
+}
+
+async function runBridgeStatusCase(c: CaseFile): Promise<CaseResult> {
+  const notes: string[] = [];
+  const bridgeInputs = (c.inputs.bridge_inputs as BridgeInputs) ?? null;
+  if (!bridgeInputs) {
+    return {
+      id: c.id,
+      status: "error",
+      notes: ["bridge_inputs missing from case inputs"],
+    };
+  }
+  const shortlistPath = (c.inputs.shortlist_path as string) ?? null;
+  const shortlist = shortlistPath
+    ? await loadShortlist(join(REPO_ROOT, shortlistPath))
+    : ((c.inputs.inline_shortlist as Shortlist) ?? []);
+
+  const result = getCurrentBridgeStatus({ inputs: bridgeInputs, shortlist });
+
+  const e = c.expect;
+
+  if (typeof e.unverified_count === "number" && result.unverified_count !== e.unverified_count) {
+    notes.push(
+      `expected unverified_count=${e.unverified_count}, got ${result.unverified_count}`,
+    );
+  }
+  if (typeof e.any_eligible_now === "boolean" && result.any_eligible_now !== e.any_eligible_now) {
+    notes.push(
+      `expected any_eligible_now=${e.any_eligible_now}, got ${result.any_eligible_now}`,
+    );
+  }
+  if (typeof e.any_eligible_if_stable === "boolean" && result.any_eligible_if_stable !== e.any_eligible_if_stable) {
+    notes.push(
+      `expected any_eligible_if_stable=${e.any_eligible_if_stable}, got ${result.any_eligible_if_stable}`,
+    );
+  }
+  if (typeof e.every_verdict_kind_is === "string") {
+    const target = e.every_verdict_kind_is;
+    const off = result.trials.filter((t) => t.verdict.kind !== target);
+    if (off.length > 0) {
+      notes.push(
+        `expected every verdict kind to be "${target}"; ${off.length} trials differ (${off.map((o) => `${o.nct_id}=${o.verdict.kind}`).join(", ")})`,
+      );
+    }
+  }
+
+  return {
+    id: c.id,
+    status: notes.length === 0 ? "pass" : "fail",
+    notes,
+  };
+}
+
+async function runBridgeStatusInlineCase(c: CaseFile): Promise<CaseResult> {
+  const notes: string[] = [];
+  const bridgeInputs = c.inputs.bridge_inputs as BridgeInputs;
+  const shortlist = (c.inputs.inline_shortlist as Shortlist) ?? [];
+
+  // Load the inline criteria fixture(s) — these are stored as plain
+  // JSON files in src/eligibility/__tests__/fixtures/, NOT under
+  // .claude/evals/fixtures/. The eval runner reuses the source-of-
+  // truth fixtures rather than duplicating them.
+  const fixtureNames: string[] = c.inputs.inline_criteria_fixtures
+    ? (c.inputs.inline_criteria_fixtures as string[])
+    : c.inputs.inline_criteria_fixture
+      ? [c.inputs.inline_criteria_fixture as string]
+      : [];
+
+  const parsedByNct = new Map<string, EligibilityCriteria>();
+  for (const name of fixtureNames) {
+    const path = join(REPO_ROOT, "src/eligibility/__tests__/fixtures", `${name}.json`);
+    const criteria = JSON.parse(
+      await readFile(path, "utf-8"),
+    ) as EligibilityCriteria;
+    // Force verified:true within the eval scope so the engine actually
+    // exercises evaluateVerdict. The shortlist file's verified flag
+    // remains false in the repo.
+    criteria.verified = true;
+    parsedByNct.set(criteria.nct_id, criteria);
+  }
+
+  const result = getCurrentBridgeStatus({
+    inputs: bridgeInputs,
+    shortlist,
+    parsedByNct,
+  });
+
+  const e = c.expect;
+
+  if (typeof e.trial_count === "number" && result.trials.length !== e.trial_count) {
+    notes.push(`expected trial_count=${e.trial_count}, got ${result.trials.length}`);
+  }
+  if (typeof e.trial_0_verdict_kind === "string" && result.trials[0]?.verdict.kind !== e.trial_0_verdict_kind) {
+    notes.push(
+      `expected trial_0_verdict_kind=${e.trial_0_verdict_kind}, got ${result.trials[0]?.verdict.kind ?? "<no trial>"}`,
+    );
+  }
+  if (typeof e.trial_0_verified === "boolean" && result.trials[0]?.verified !== e.trial_0_verified) {
+    notes.push(
+      `expected trial_0_verified=${e.trial_0_verified}, got ${result.trials[0]?.verified ?? "<no trial>"}`,
+    );
+  }
+  if (typeof e.any_eligible_now === "boolean" && result.any_eligible_now !== e.any_eligible_now) {
+    notes.push(
+      `expected any_eligible_now=${e.any_eligible_now}, got ${result.any_eligible_now}`,
+    );
+  }
+  if (e.trial_verdicts && typeof e.trial_verdicts === "object") {
+    const expected = e.trial_verdicts as Record<string, string>;
+    for (const [nct, expectedKind] of Object.entries(expected)) {
+      const trial = result.trials.find((t) => t.nct_id === nct);
+      if (!trial) {
+        notes.push(`expected verdict for ${nct} but trial missing from result`);
+        continue;
+      }
+      if (trial.verdict.kind !== expectedKind) {
+        notes.push(
+          `expected ${nct} verdict=${expectedKind}, got ${trial.verdict.kind}`,
+        );
+      }
+    }
+  }
+
+  return {
+    id: c.id,
+    status: notes.length === 0 ? "pass" : "fail",
+    notes,
+  };
+}
+
+async function runShortlistDiffCase(c: CaseFile): Promise<CaseResult> {
+  const notes: string[] = [];
+  const prevName = c.inputs.prev_fixture as string;
+  const nextName = c.inputs.next_fixture as string;
+  const prev = await loadFixtureJson<ShortlistSnapshot>(prevName);
+  const next = await loadFixtureJson<ShortlistSnapshot>(nextName);
+  const diff = diffShortlistSnapshots(prev, next);
+
+  const e = c.expect;
+
+  if (Array.isArray(e.new_trial_nct_ids)) {
+    const expected = (e.new_trial_nct_ids as string[]).slice().sort();
+    const actual = diff.new_trials.map((t) => t.nct_id).sort();
+    if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+      notes.push(
+        `expected new_trial_nct_ids=${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      );
+    }
+  }
+  if (typeof e.closed_trial_count === "number" && diff.closed_trials.length !== e.closed_trial_count) {
+    notes.push(
+      `expected closed_trial_count=${e.closed_trial_count}, got ${diff.closed_trials.length}`,
+    );
+  }
+  if (typeof e.status_change_count === "number" && diff.status_changes.length !== e.status_change_count) {
+    notes.push(
+      `expected status_change_count=${e.status_change_count}, got ${diff.status_changes.length}`,
+    );
+  }
+  if (Array.isArray(e.status_changes)) {
+    const expected = e.status_changes as Array<{ nct_id: string; from: string; to: string }>;
+    for (const exp of expected) {
+      const found = diff.status_changes.find(
+        (s) => s.nct_id === exp.nct_id && s.from === exp.from && s.to === exp.to,
+      );
+      if (!found) {
+        notes.push(
+          `expected status_change ${JSON.stringify(exp)} not found in ${JSON.stringify(diff.status_changes)}`,
+        );
+      }
+    }
+  }
+
+  return {
+    id: c.id,
+    status: notes.length === 0 ? "pass" : "fail",
+    notes,
+  };
+}
+
+async function runCase(c: CaseFile): Promise<CaseResult> {
+  try {
+    if (c.kind === "bridge_status") return await runBridgeStatusCase(c);
+    if (c.kind === "bridge_status_with_inline_criteria")
+      return await runBridgeStatusInlineCase(c);
+    if (c.kind === "shortlist_diff") return await runShortlistDiffCase(c);
+    return {
+      id: c.id,
+      status: "error",
+      notes: [`unknown case kind: ${c.kind}`],
+    };
+  } catch (err) {
+    return {
+      id: c.id,
+      status: "error",
+      notes: [String(err)],
+    };
+  }
+}
+
+function gitSha(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", { cwd: REPO_ROOT })
+      .toString()
+      .trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+async function main() {
+  const files = (await readdir(CASES_DIR))
+    .filter((f) => f.endsWith(".yaml"))
+    .sort();
+
+  const results: CaseResult[] = [];
+  for (const f of files) {
+    const c = await loadCase(join(CASES_DIR, f));
+    const r = await runCase(c);
+    results.push(r);
+    const symbol = r.status === "pass" ? "✓" : r.status === "fail" ? "✗" : "!";
+    console.log(`${symbol} ${r.id} — ${r.status}`);
+    for (const n of r.notes) console.log(`    ${n}`);
+  }
+
+  const pass = results.filter((r) => r.status === "pass").length;
+  const fail = results.filter((r) => r.status === "fail").length;
+  const err = results.filter((r) => r.status === "error").length;
+  const summary = `${pass}/${results.length} pass, ${fail} fail, ${err} error`;
+  console.log(`\nsummary: ${summary}`);
+
+  await mkdir(RESULTS_DIR, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const outPath = join(RESULTS_DIR, `${ts}.json`);
+  await writeFile(
+    outPath,
+    JSON.stringify(
+      {
+        as_of: new Date().toISOString(),
+        git_sha: gitSha(),
+        summary: { pass, fail, error: err, total: results.length },
+        results,
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`wrote ${outPath}`);
+
+  // Phase 1 success bar = every case ran. Errors are blockers (bug
+  // in runner / cases). Failures are acceptable and recorded honestly.
+  if (err > 0) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,42 @@
+# Hooks
+
+Shell scripts the Claude Code harness runs at lifecycle points
+(`PreToolUse`, `PostToolUse`, `SessionStart`, `Stop`, etc.).
+
+## Registration
+
+A script in this folder is **inert** until registered in
+`.claude/settings.json` (or `settings.local.json`). Registration ties a
+script to a hook event + an optional matcher pattern.
+
+## Contract
+
+Hook scripts read a JSON event from stdin and signal the harness via
+exit code:
+
+- **Exit 0** → allow.
+- **Exit non-zero** → deny. The script's stderr is surfaced to the
+  user as the deny reason.
+
+A `PreToolUse` event payload looks like:
+
+```json
+{
+  "tool_name": "mcp__github__add_issue_comment",
+  "tool_input": { "...": "..." },
+  "session_id": "...",
+  "transcript_path": "..."
+}
+```
+
+## Phase 1 inhabitants
+
+- `block-outbound-comms.sh` — codifies the "never autonomous" guardrail.
+  Denies any tool whose name matches `*send*`, `*post*`, `*publish*`,
+  `*draft_send*`, `gmail_send`, `twilio*`, `mcp__*__send_*`. Carves out
+  `mcp__github__*` (Thomas uses these for normal dev — PRs, issues,
+  comments). Blocks are logged to `.claude/local/blocked-comms.log`
+  (gitignored).
+
+The hook is the **second-line failsafe**. The first line is not listing
+outbound-comms tools in any subagent's `tools:` allow-list at all.

--- a/.claude/hooks/block-outbound-comms.sh
+++ b/.claude/hooks/block-outbound-comms.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# Anchor — never-autonomous guardrail (Phase 1).
+# Anchor — never-autonomous + no-deploy guardrail (Phase 1).
 #
 # This is the second-line failsafe: codified denial of any tool
-# invocation whose name implies outbound communication. The first
-# line is not wiring such tools into any subagent's `tools:` allow-list
-# at all (see .claude/agents/README.md).
+# invocation that would either communicate outbound or mutate
+# production state. The first line is not wiring such tools into any
+# subagent's `tools:` allow-list at all (see .claude/agents/README.md).
+#
+# Doctrine references:
+#   CLAUDE.md §7 — never autonomous (no sends, posts, drafts, publishes).
+#   CLAUDE.md §7 #4 — no deploy in Phase 1 (no push to main, no
+#                     Vercel changes, no prod DB migrations).
 #
 # Contract: read a Claude Code PreToolUse JSON event from stdin.
 #   exit 0           — allow.
@@ -18,10 +23,7 @@ set -euo pipefail
 
 EVENT="$(cat)"
 
-# Extract tool_name from the JSON event. We use sed rather than jq so
-# this script has zero install-time dependencies. The event is
-# well-formed JSON from the harness, so a single regex extraction is
-# safe enough for a deny-list check.
+# Extract tool_name from the JSON event. Sed (no jq dependency).
 TOOL_NAME="$(printf '%s' "$EVENT" \
   | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
   | head -n 1)"
@@ -31,37 +33,71 @@ if [[ -z "$TOOL_NAME" ]]; then
   exit 0
 fi
 
-# Carve-out: GitHub MCP tools used by the operator for ordinary dev
-# (PRs, issues, comments). Defense-in-depth — none of the github
-# tool names match the deny patterns below today, but the carve-out
-# documents intent and survives future renames.
-if [[ "$TOOL_NAME" == mcp__github__* ]]; then
-  exit 0
-fi
-
-deny_reason=""
+# Carve-out: GitHub MCP tools. The operator uses these for ordinary
+# dev (PR comments, issue comments, branch + file management). The
+# trial-monitor and any future read-only subagents must NOT include
+# these in their per-subagent tools allow-list.
+#
+# Exceptions inside the carve-out — explicitly blocked even via the
+# operator's main session, because they violate Phase 1 doctrine:
+#   merge_pull_request → "no push to main" implies no merge to main.
 case "$TOOL_NAME" in
-  gmail_send|send_email|send_sms|message_compose)
-    deny_reason="literal-match outbound-comms tool name"
+  mcp__github__merge_pull_request)
+    deny_reason="Phase 1 doctrine: no push to main (CLAUDE.md §7 #4)"
     ;;
-  twilio*)
-    deny_reason="twilio family — outbound SMS/voice"
-    ;;
-  mcp__*__send_*)
-    deny_reason="MCP tool in send_* family"
-    ;;
-  *send*|*post*|*publish*|*draft_send*)
-    deny_reason="substring match (send|post|publish|draft_send) in tool name"
+  mcp__github__*)
+    exit 0
     ;;
 esac
 
-if [[ -n "$deny_reason" ]]; then
+if [[ -z "${deny_reason:-}" ]]; then
+  case "$TOOL_NAME" in
+    # ── Outbound comms (CLAUDE.md §7) ──────────────────────────────
+    gmail_send|send_email|send_sms|message_compose)
+      deny_reason="literal-match outbound-comms tool name"
+      ;;
+    twilio*)
+      deny_reason="twilio family — outbound SMS/voice"
+      ;;
+    mcp__*__send_*)
+      deny_reason="MCP tool in send_* family"
+      ;;
+    mcp__*__create_draft|mcp__*__update_draft|mcp__*__list_drafts)
+      deny_reason="Gmail-style draft surface — drafts are outbound prep (CLAUDE.md §7)"
+      ;;
+    mcp__*__create_event|mcp__*__delete_event|mcp__*__update_event|mcp__*__respond_to_event)
+      deny_reason="calendar mutation — outbound shared-state change (CLAUDE.md §7)"
+      ;;
+    mcp__*__add_toolbar_reaction|mcp__*__edit_toolbar_message|mcp__*__reply_to_toolbar_thread|mcp__*__change_toolbar_thread_resolve_status)
+      deny_reason="toolbar comms surface — outbound (CLAUDE.md §7)"
+      ;;
+    *send*|*post*|*publish*|*draft_send*)
+      deny_reason="substring match (send|post|publish|draft_send) in tool name"
+      ;;
+
+    # ── No deploy / no prod mutation (CLAUDE.md §7 #4) ─────────────
+    mcp__*__deploy_to_vercel|mcp__*__deploy_edge_function)
+      deny_reason="Phase 1 doctrine: no deploy (CLAUDE.md §7 #4)"
+      ;;
+    mcp__*__apply_migration|mcp__*__execute_sql)
+      deny_reason="Phase 1 doctrine: no prod DB mutation (CLAUDE.md §7 #4)"
+      ;;
+    mcp__*__pause_project|mcp__*__restore_project|mcp__*__create_project|mcp__*__delete_branch|mcp__*__merge_branch|mcp__*__reset_branch|mcp__*__rebase_branch)
+      deny_reason="Phase 1 doctrine: no project / branch mutation on shared infra (CLAUDE.md §7 #4)"
+      ;;
+    mcp__*__confirm_cost)
+      deny_reason="Phase 1 doctrine: no cost-incurring confirmation (CLAUDE.md §7 #4)"
+      ;;
+  esac
+fi
+
+if [[ -n "${deny_reason:-}" ]]; then
   LOG_DIR="$(cd "$(dirname "$0")/.." && pwd)/local"
   mkdir -p "$LOG_DIR"
   TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   printf '%s\t%s\t%s\n' "$TS" "$TOOL_NAME" "$deny_reason" >> "$LOG_DIR/blocked-comms.log"
   echo "Anchor guardrail: blocked tool '$TOOL_NAME' — $deny_reason." >&2
-  echo "Phase 1 doctrine: never autonomous. See CLAUDE.md §7." >&2
+  echo "See CLAUDE.md §7 (never autonomous, no deploy)." >&2
   exit 1
 fi
 

--- a/.claude/hooks/block-outbound-comms.sh
+++ b/.claude/hooks/block-outbound-comms.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Anchor — never-autonomous guardrail (Phase 1).
+#
+# This is the second-line failsafe: codified denial of any tool
+# invocation whose name implies outbound communication. The first
+# line is not wiring such tools into any subagent's `tools:` allow-list
+# at all (see .claude/agents/README.md).
+#
+# Contract: read a Claude Code PreToolUse JSON event from stdin.
+#   exit 0           — allow.
+#   exit non-zero    — deny. stderr is surfaced to the operator as
+#                      the deny reason.
+#
+# Blocks logged (tab-separated) to .claude/local/blocked-comms.log
+# (gitignored under .claude/local/).
+
+set -euo pipefail
+
+EVENT="$(cat)"
+
+# Extract tool_name from the JSON event. We use sed rather than jq so
+# this script has zero install-time dependencies. The event is
+# well-formed JSON from the harness, so a single regex extraction is
+# safe enough for a deny-list check.
+TOOL_NAME="$(printf '%s' "$EVENT" \
+  | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+  | head -n 1)"
+
+# No tool_name in the event → not actionable, allow.
+if [[ -z "$TOOL_NAME" ]]; then
+  exit 0
+fi
+
+# Carve-out: GitHub MCP tools used by the operator for ordinary dev
+# (PRs, issues, comments). Defense-in-depth — none of the github
+# tool names match the deny patterns below today, but the carve-out
+# documents intent and survives future renames.
+if [[ "$TOOL_NAME" == mcp__github__* ]]; then
+  exit 0
+fi
+
+deny_reason=""
+case "$TOOL_NAME" in
+  gmail_send|send_email|send_sms|message_compose)
+    deny_reason="literal-match outbound-comms tool name"
+    ;;
+  twilio*)
+    deny_reason="twilio family — outbound SMS/voice"
+    ;;
+  mcp__*__send_*)
+    deny_reason="MCP tool in send_* family"
+    ;;
+  *send*|*post*|*publish*|*draft_send*)
+    deny_reason="substring match (send|post|publish|draft_send) in tool name"
+    ;;
+esac
+
+if [[ -n "$deny_reason" ]]; then
+  LOG_DIR="$(cd "$(dirname "$0")/.." && pwd)/local"
+  mkdir -p "$LOG_DIR"
+  TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '%s\t%s\t%s\n' "$TS" "$TOOL_NAME" "$deny_reason" >> "$LOG_DIR/blocked-comms.log"
+  echo "Anchor guardrail: blocked tool '$TOOL_NAME' — $deny_reason." >&2
+  echo "Phase 1 doctrine: never autonomous. See CLAUDE.md §7." >&2
+  exit 1
+fi
+
+exit 0

--- a/.claude/hooks/session-start-banner.sh
+++ b/.claude/hooks/session-start-banner.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Anchor — SessionStart banner.
+#
+# Cheap psychic insurance for tired-at-11pm sessions. Prints the n=1
+# guardrails + most recent eval pass rate at the top of every Claude
+# Code session that loads this project.
+#
+# Contract: write to stdout. The harness surfaces stdout as session
+# context. Exit 0 always — banner is informational, never blocking.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+EVAL_DIR="$REPO/eval-runs"
+
+# Latest eval summary (if any).
+latest_eval=""
+if compgen -G "$EVAL_DIR/*.json" >/dev/null; then
+  latest_file="$(ls -1t "$EVAL_DIR"/*.json | head -n 1)"
+  if [[ -f "$latest_file" ]]; then
+    latest_eval="$(grep -oE '"pass":[0-9]+,[[:space:]]*"fail":[0-9]+,[[:space:]]*"error":[0-9]+,[[:space:]]*"total":[0-9]+' "$latest_file" 2>/dev/null | head -n 1)"
+  fi
+fi
+
+# Block-comms log size (proof the hook has been firing).
+blocks=0
+if [[ -f "$REPO/.claude/local/blocked-comms.log" ]]; then
+  blocks="$(wc -l < "$REPO/.claude/local/blocked-comms.log" | tr -d ' ')"
+fi
+
+cat <<EOF
+╭─ Anchor session — bridge-strategy doctrine
+│
+│  • n=1, single patient (HL). No patient_id abstractions.
+│  • Layer 1 (zone engine) is read-only — types-only seam from Layer 2.
+│  • Never autonomous: every threshold crossing → mandatory conversation.
+│  • Outbound comms: blocked at the hook layer + tools allow-list.
+│  • Cite or [VERIFY]: no clinical claim ships uncited.
+│  • Phase 1 is local-only — no push to main, no Vercel changes.
+│
+│  Latest eval run: ${latest_eval:-no eval runs yet — \`pnpm evals:run\`}
+│  Outbound-comms blocks logged this lifetime: ${blocks}
+│
+│  See CLAUDE.md (root) for bridge-strategy doctrine.
+│  See .claude/CLAUDE.md for app-internal doctrine.
+╰─
+EOF

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-outbound-comms.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-banner.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": ".*",

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,30 @@
+# Skills
+
+Claude Skills: deterministic, named procedures Claude Code loads on
+demand. One folder per skill at `.claude/skills/<name>/SKILL.md`.
+
+## Frontmatter contract
+
+```yaml
+---
+name: pdac-trial-eligibility-parse
+description: When parsing a shortlisted trial's eligibility criteria
+  into the structured shape that src/eligibility/ consumes.
+---
+
+Body documents the procedure: trigger conditions, inputs, output JSON
+shape, and failure modes.
+```
+
+## Coexistence with `.claude/commands/`
+
+`.claude/commands/*.md` are slash commands (user types `/build-module`).
+`.claude/skills/<name>/SKILL.md` is the new Skills format (Claude
+auto-invokes when the trigger condition matches). Both work; use a skill
+when Claude should pick it up automatically, a command when the
+operator explicitly invokes it.
+
+## Phase 1 inhabitants
+
+- `pdac-trial-eligibility-parse/` — emits the JSON shape consumed by
+  `src/eligibility/parseEligibility.ts`.

--- a/.claude/skills/pdac-trial-eligibility-parse/SKILL.md
+++ b/.claude/skills/pdac-trial-eligibility-parse/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: pdac-trial-eligibility-parse
+description: When parsing a shortlisted PDAC trial's eligibility criteria into the structured JSON shape that src/eligibility/parseEligibility.ts consumes. Triggers when the operator (or trial-monitor subagent) asks to extract eligibility for an NCT in the Anchor shortlist.
+---
+
+# Skill — pdac-trial-eligibility-parse
+
+You convert a ClinicalTrials.gov record's free-text eligibility section
+into a structured JSON object that Anchor's eligibility engine can
+reason over without re-parsing prose.
+
+## Trigger
+
+The operator says any of:
+
+- "parse eligibility for NCT…"
+- "structure the eligibility criteria of NCT…"
+- "update shortlist entry for NCT…"
+
+Or: the `trial-monitor` subagent encounters a shortlist entry whose
+parsed JSON is older than the trial's `LastUpdatePostDate`.
+
+## Inputs
+
+1. The NCT ID.
+2. The trial's eligibility free text (from
+   `mcp__clinicaltrials__get_study` → `EligibilityModule`).
+3. Optional context from the operator (e.g. "interpret 'platinum
+   backbone' permissively").
+
+## Output (JSON, exact shape)
+
+```json
+{
+  "nct_id": "NCT06625320",
+  "key_inclusions": [
+    "metastatic PDAC, histologically confirmed",
+    "ECOG 0–1",
+    "prior first-line gemcitabine-based therapy"
+  ],
+  "key_exclusions": [
+    "active CNS metastases requiring steroids",
+    "Grade ≥ 2 peripheral neuropathy at screening"
+  ],
+  "ecog_max": 1,
+  "lab_thresholds": {
+    "anc_min_x10e9_per_L": 1.5,
+    "platelets_min_x10e9_per_L": 100,
+    "hb_min_g_per_L": 90,
+    "bilirubin_max_xULN": 1.5,
+    "alt_max_xULN": 2.5,
+    "ast_max_xULN": 2.5,
+    "creatinine_clearance_min_mL_per_min": 50,
+    "albumin_min_g_per_L": null
+  },
+  "biomarker_requirements": {
+    "kras_mutation": "any_g12",
+    "mtap_deletion": "not_required",
+    "hla_restriction": null,
+    "brca_or_hrd": "not_required"
+  },
+  "au_sites": [
+    { "site_name": "TBD", "city": "Melbourne", "principal_investigator": "TBD" }
+  ],
+  "status": "Recruiting",
+  "last_verified_at": "2026-05-08",
+  "verified": false,
+  "source_quote": "verbatim snippet from the EligibilityModule that justifies the structured fields above"
+}
+```
+
+## Field rules
+
+- `ecog_max` — integer 0–4. Highest ECOG that remains eligible. If the
+  trial says "ECOG 0–1", `ecog_max: 1`.
+- `lab_thresholds` — keys are SI-unit-suffixed; missing keys → `null`.
+  Convert from US units (e.g. mg/dL bilirubin) using standard factors
+  and note the conversion in `source_quote`.
+- `biomarker_requirements.kras_mutation` — one of `any`, `any_g12`,
+  `g12d`, `g12c`, `g12v`, `g12r`, `q61`, `not_required`, or `excluded`.
+- `biomarker_requirements.mtap_deletion` — one of `required`,
+  `not_required`, `excluded`.
+- `biomarker_requirements.hla_restriction` — null OR an array of
+  required HLA alleles (e.g. `["A*02:01"]`).
+- `au_sites` — only sites in Australia. Empty array if none.
+- `status` — verbatim from `OverallStatus` field.
+- `verified` — **always emit `false` from this skill.** Verification
+  is a human action by the operator, who flips it to `true` in
+  `shortlist.yaml` after a one-trial-at-a-time hand-check.
+- `source_quote` — verbatim text from the trial record that justifies
+  the parse. Required, not optional.
+
+## Failure modes
+
+- **Eligibility free text missing or empty** → return the JSON shape
+  with `key_inclusions: []`, `key_exclusions: []`, `ecog_max: null`,
+  every `lab_thresholds` value `null`, and `source_quote: "EligibilityModule empty"`.
+  Do not guess.
+- **Ambiguous biomarker phrasing** ("KRAS-mutant solid tumours") →
+  default to the most permissive interpretation that is unambiguously
+  supported, and note the ambiguity in `source_quote`. Do not narrow
+  to a specific allele unless the protocol names it.
+- **Unit conversion uncertain** → set the field to `null` and quote
+  the original phrasing in `source_quote`.
+
+## What you do NOT do
+
+- You do not write the JSON to disk. The operator pipes your output
+  into `src/eligibility/__tests__/fixtures/<nct>.json` after review.
+- You do not flip `verified: true`. Only the operator does that.
+- You do not output anything else around the JSON — no Markdown
+  preface, no commentary, no backticks. The output is a single
+  parseable JSON object.

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ yarn-error.log*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+# anchor — local patient data + eval artefacts (never committed)
+anchor.local.json
+.claude/local/
+*.patient.json
+eval-runs/

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,14 @@
       "headers": {
         "Authorization": "Bearer ${SUPABASE_PAT}"
       }
+    },
+    "clinicaltrials": {
+      "type": "http",
+      "url": "https://clinicaltrials.caseyjhand.com/mcp"
+    },
+    "biomcp": {
+      "type": "http",
+      "url": "https://biomcp.org/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,239 @@
+# Anchor — bridge-strategy doctrine
+
+This file is the **root doctrine** for Anchor, the n=1 clinical care platform
+built for **HL** (de-identified internally; one patient, one operator).
+It encodes the bridge-strategy hypothesis, the four-layer architecture,
+the trial shortlist Layer 2 maintains, the operative variable, and the
+hard guardrails on autonomy.
+
+For app-internal doctrine (zone engine internals, single-channel patient
+UX, build philosophy, build order, project-board norms, known traps) see
+`.claude/CLAUDE.md`. Both files are loaded by Claude Code; this one
+governs *strategy*, that one governs *implementation*.
+
+---
+
+## 1 — Patient brief (internal, de-identified)
+
+- **Patient code:** HL.
+- **Diagnosis:** confirmed metastatic pancreatic ductal adenocarcinoma
+  (mPDAC).
+- **First-line treatment:** gemcitabine + nab-paclitaxel (GnP), tuned for
+  function preservation over maximum response.
+- **Operator:** the patient's adult child, MBBS, sole builder of this
+  platform. **No clinicians are contributors.**
+- **Treating medical oncologist:** A/Prof Sumitra Ananda (Peter MacCallum
+  Cancer Centre, Melbourne).
+- **HPB surgeon:** Mark Cullinan (Epworth Richmond).
+- **Carer (named):** Catherine.
+
+Dates of birth, addresses, MRNs, real lab values, real imaging, real
+free text from the patient, and any other clinical identifiers must
+**never** enter the repo, a deployed environment, or an MCP server's
+persistent storage. Tests, committed configs, and example files use
+placeholders only. Real clinical values live in `anchor.local.json`
+(gitignored) and stay on the operator's machine. The patient's name
+and the named clinicians appear in this strategy doctrine because they
+are facts about the care team, not patient clinical data; in code,
+configs, and tests the patient is referenced as `HL`.
+
+---
+
+## 2 — Hypothesis (verbatim)
+
+> Detecting treatment-driven toxicity (axis 3) early enough preserves
+> ECOG performance status and keeps Hu Lin eligible to bridge from
+> gemcitabine + nab-paclitaxel onto daraxonrasib (RMC-6236) when
+> RASolute 302 readout (mOS 13.2 vs 6.7 mo, HR 0.40, FDA Breakthrough,
+> announced 13 April 2026) translates into expanded access in
+> Australia.
+
+Source: project brief, April 2026. Trial readout figures `[VERIFY]`
+against the RASolute 302 primary publication once available.
+
+---
+
+## 3 — Axis taxonomy
+
+ECOG performance status is the sum of three independent axes. Standard
+oncology monitors axes 1 and 2; Anchor's product focus is axis 3.
+
+| Axis | What it is | Who watches it | Reversibility |
+|---|---|---|---|
+| **1** | Disease / tumour state — measurable on imaging, CA 19-9, ctDNA. | Treating team. Read-only context for Anchor. | Improves with response; worsens with progression. |
+| **2** | Treatment response — symptomatic improvement attributable to chemo working. | Treating team. Read-only context for Anchor. | Reversible with response or progression. |
+| **3** | **Treatment-driven toxicity** — neuropathy, sarcopenia, mucositis, FN, marrow suppression. | **Anchor.** This is the platform's job. | Often **irreversible** once entrenched (especially neuropathy and lean-mass loss). |
+
+Layer 1 (the toxicity engine, already built — see `src/lib/rules/` and
+`src/agents/{toxicity,clinical,nutrition,treatment,psychology,
+rehabilitation}/`) is the axis-3 watcher. Layers 2–4 (this Phase 1 and
+beyond) make the axis-3 signal actionable against the bridge-eligibility
+horizon.
+
+---
+
+## 4 — Architecture: four layers
+
+Anchor is a four-layer system. **Phase 1 builds the foundation and
+Layer 2 v0.**
+
+| # | Layer | State in repo | Phase |
+|---|---|---|---|
+| 1 | **Toxicity engine** — zone rules, axis-3 detectors, discipline agents (AI Nurse, clinical, nutrition, treatment, psychology, rehabilitation). | **Already core.** Lives in `src/lib/rules/` and `src/agents/*`. **Do not modify in Phase 1.** | Built. |
+| 2 | **Eligibility engine** — maintains the live trial shortlist, parses each trial's eligibility criteria into structured rules, maps each trial's exclusion criteria back into Layer 1's alert thresholds, and exposes `getCurrentBridgeStatus(BridgeInputs)`. | **New. v0 in Phase 1.** Lives in `src/eligibility/`. | Phase 1. |
+| 3 | **Literature surveillance** — watches RASolute 302, daraxonrasib, KRAS-on inhibitor, PDAC trial corpora; surfaces deltas relevant to HL's bridge plan. | Not yet started. | Phase 2. |
+| 4 | **Visit prep** — translates the cumulative Layer 1–3 state into a 1-page brief for the next clinic visit. | Not yet started. | Phase 3. |
+
+Layer 2's only runtime touch into Layer 1 is **types-only** (importing
+`PatientStateSnapshot` from `src/lib/state` and `Zone` /
+`RuleCategory` from `src/types/clinical`). Layer 2 must never mutate the
+rule registry, the patient state, or any agent's role.
+
+---
+
+## 5 — Trial shortlist (Layer 2 maintains)
+
+Six entries. Every clinical claim below is `[VERIFY]` until cross-checked
+against the primary protocol and ClinicalTrials.gov record. The
+machine-readable shortlist lives at `src/eligibility/shortlist.yaml`
+with a per-trial `verified: false` flag; `getCurrentBridgeStatus`
+**refuses to return an eligibility verdict for unverified entries** —
+it returns `unknown` with a "not yet hand-verified" reason. Verification
+is a single-trial-at-a-time human action by the operator.
+
+| # | Trial | NCT | One-line eligibility shape |
+|---|---|---|---|
+| 1 | **RASolute 302 EAP** (RMC-6236, daraxonrasib) | NCT06625320 `[VERIFY]` | 2L mPDAC after first-line gem-based chemo; ECOG 0–1; KRAS-mutant (G12-anything most likely); EAP availability in AU is the **operative variable**. `[VERIFY]` |
+| 2 | **MTAPESTRY 103 Sub C** (AMG193 + RMC-6236) | NCT06360354 `[VERIFY]` | Solid tumours including PDAC; **MTAP-deletion required**; KRAS-mutant; ECOG 0–1; 2L+. `[VERIFY]` |
+| 3 | **MRTX1133** (KRAS G12D selective inhibitor) | NCT05737706 `[VERIFY]` | Advanced solid tumours including PDAC; **KRAS G12D required**; ECOG 0–1. `[VERIFY]` |
+| 4 | **IMCODE003** (autogene cevumeran) | NCT05968326 `[VERIFY]` | PDAC adjuvant currently; **HLA-restricted**; ECOG 0–1. May not match HL's metastatic setting. `[VERIFY]` |
+| 5 | **Epworth Jreissati — narmafotinib + mFOLFIRINOX** | NCT TBD `[VERIFY]` | Untreated mPDAC; ECOG 0–1; AU site (Epworth Richmond). `[VERIFY]` |
+| 6 | **Epworth Jreissati — CEND-1 / LSTA1** | NCT TBD `[VERIFY]` | mPDAC with chemo backbone; ECOG 0–1; AU site. `[VERIFY]` |
+| 7 | **Epworth Jreissati — pembrolizumab + olaparib** | NCT TBD `[VERIFY]` | mPDAC with platinum backbone, BRCA / HRD signal; ECOG 0–1. `[VERIFY]` |
+
+(Strictly seven entries — the brief said "six-ish trials" and listed
+four NCTs plus three Jreissati actives. Operator chooses whether to
+collapse the Jreissati three to a single placeholder during
+verification.)
+
+---
+
+## 6 — Operative variable: the AU EAP timeline for RMC-6236
+
+Treat the date that daraxonrasib (RMC-6236) becomes available in
+Australia via expanded access **as the reference horizon against which
+every toxicity threshold is calibrated**. The exact date is currently
+unknown.
+
+It is modelled as a single configurable variable
+`eap_au_open_date`. Today's value is `unknown` (not a date). When set,
+the eligibility engine reads it and tightens the axis-3 alert thresholds
+proportionally to the time-to-bridge:
+
+- **EAP open today** → alert thresholds at "any drift" (zero tolerance
+  for further axis-3 loss; the bridge starts now).
+- **EAP > 6 months out** → alert thresholds at standard CTCAE grade-2
+  warning, grade-3 escalation.
+- **EAP unknown** → use a default conservative profile (the same as
+  "EAP within 3–6 months").
+
+Consequence: the engine's axis-3 sensitivity is a **function of
+calendar time relative to the bridge horizon**, not a static rule.
+
+---
+
+## 7 — Guardrails (hard, not negotiable)
+
+1. **Never autonomous.** The platform never sends, posts, drafts, or
+   publishes anything to anyone outside the operator's local environment.
+   Crossing a zone threshold triggers a **mandatory conversation**, not
+   an automated action. The decision is not predetermined. The
+   `.claude/hooks/block-outbound-comms.sh` PreToolUse hook is the
+   second-line failsafe; the first line is not wiring outbound tools
+   into any subagent or skill at all.
+2. **n = 1 only.** No `patient_id` abstractions, no multi-tenant
+   scaffolding, no "future user" generalisation. The single-patient
+   design is the moat. If a feature would only make sense for a fleet
+   of patients, it does not belong here.
+3. **Patient data does not leave the device.** Real lab values, real
+   imaging, real free text from HL stays in `anchor.local.json` or in
+   the operator's local Dexie/Supabase instance (Supabase is a private
+   project, not a shared service). It is never committed, never sent to
+   a third-party MCP server, never echoed in test fixtures.
+4. **No deploy in Phase 1.** No push to `main`. No Vercel changes. No
+   workflow changes. Local-only.
+5. **Cite or mark.** Every clinical claim in CLAUDE.md, skill files,
+   and `shortlist.yaml` is either cited (primary protocol, NCCN, CTCAE
+   reference) or tagged `[VERIFY]` inline.
+6. **Don't touch Layer 1.** If existing Layer 1 code conflicts with a
+   Phase 1 plan, surface the conflict — do not refactor around it.
+7. **Use existing MCPs.** Do not write a custom ClinicalTrials.gov
+   client. Layer 2 reads via the cyanheads ClinicalTrials.gov MCP and
+   the GenomOncology BioMCP, both wired in `.mcp.json`.
+
+---
+
+## 8 — Disclosure status (TODO — flagged)
+
+> **Prof. Ananda has not been informed that this tracking platform
+> exists.** Decision pending. Until then: zero outbound communication,
+> no shareable artefacts that name her, no claims about clinical
+> recommendation in any export. The same applies to Mark Cullinan and
+> any other treating clinician.
+
+This is a clinical-relationship decision, not a technical one. The
+operator owns the timing and framing of disclosure. The platform's job
+is to **not pre-empt that decision** — by being silent, local, and
+non-communicating until told otherwise.
+
+---
+
+## 9 — Phase 1 scope (what's in flight)
+
+Phase 1 builds the foundation and Layer 2 v0. Scope is narrow and
+exclusive:
+
+1. This file.
+2. `.claude/{agents,skills,hooks,evals}/` directory tree with READMEs.
+3. MCP wiring for ClinicalTrials.gov (cyanheads, hosted) and BioMCP
+   (GenomOncology, hosted) added to `.mcp.json` alongside the existing
+   Supabase entry.
+4. `.claude/skills/pdac-trial-eligibility-parse/SKILL.md` — emits the
+   structured JSON shape used by `src/eligibility/`.
+5. `.claude/agents/trial-monitor.md` — fresh-context subagent,
+   restricted tool allow-list (CT.gov MCP read tools + BioMCP read tools
+   + Read; **no** Write, Edit, Bash, or any outbound-comms surface).
+6. `.claude/hooks/block-outbound-comms.sh` registered in
+   `.claude/settings.json` as a PreToolUse hook.
+7. `.claude/evals/cases/` with five YAML cases + fixtures + runner.
+8. `src/eligibility/` Layer 2 v0:
+   `parseEligibility(nctId)`,
+   `mapToToxicityThresholds(criteria)`,
+   `getCurrentBridgeStatus(bridgeInputs)`,
+   `diffShortlistSnapshots(prev, next)`.
+9. `.gitignore` covering `anchor.local.json`, `.claude/local/`,
+   `*.patient.json`, `eval-runs/`.
+10. `package.json` scripts: `eligibility:parse`, `evals:run`. (No
+    `trial-monitor:run` — the subagent is the runnable artefact;
+    invoke it from inside Claude Code.)
+
+What's explicitly **not** in Phase 1: literature surveillance, visit
+prep, any deploy step, any Layer 1 modification, any Vercel /
+GitHub Actions change.
+
+---
+
+## 10 — Cross-references
+
+- `.claude/CLAUDE.md` — app-internal doctrine, build order, single-
+  channel patient UX, known traps.
+- `docs/CLINICAL_FRAMEWORK.md` — clinical reasoning behind the axes.
+- `docs/BRIDGE_STRATEGY.md` — operator's narrative of the bridge plan.
+- `docs/ZONE_RULES.md` — Layer 1 zone-rule catalogue.
+- `docs/DATA_SCHEMA.md` — Dexie / Supabase schema, sync semantics.
+- `src/lib/state/types.ts` — `PatientStateSnapshot`, the type-only seam
+  Layer 2 reads.
+- `src/eligibility/shortlist.yaml` — the live trial shortlist.
+
+When in doubt about clinical thresholds: ask, do not invent. When in
+doubt about whether something is an outbound action: don't do it.

--- a/anchor.local.example.json
+++ b/anchor.local.example.json
@@ -1,0 +1,26 @@
+{
+  "_comment": [
+    "Anchor — local patient-state config (Phase 1).",
+    "Real values for HL live in anchor.local.json (gitignored).",
+    "This file is the documented placeholder shape — committed for",
+    "shape reference only. Every value here is illustrative, not real."
+  ],
+  "patient_code": "HL",
+  "as_of": "2026-05-08",
+  "ecog": 1,
+  "kras_variant": "unknown",
+  "mtap_status": "unknown",
+  "hla_types": [],
+  "treatment_setting": "first_line_active",
+  "eap_au_open_date": "unknown",
+  "latest_labs": {
+    "anc_x10e9_per_L": null,
+    "platelets_x10e9_per_L": null,
+    "hb_g_per_L": null,
+    "bilirubin_xULN": null,
+    "alt_xULN": null,
+    "ast_xULN": null,
+    "creatinine_clearance_mL_per_min": null,
+    "albumin_g_per_L": null
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "ios:init": "cap add ios",
     "ios:sync": "cap sync ios",
     "ios:open": "cap open ios",
-    "apk:publish": "node scripts/apk-publish.mjs"
+    "apk:publish": "node scripts/apk-publish.mjs",
+    "eligibility:parse": "tsx src/eligibility/cli.ts parse",
+    "evals:run": "tsx .claude/evals/runner.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
@@ -73,7 +75,9 @@
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.12",
     "tailwindcss": "^3.4.3",
+    "tsx": "^4.7.2",
     "typescript": "^5.4.3",
-    "vitest": "^1.4.0"
+    "vitest": "^1.4.0",
+    "yaml": "^2.4.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,13 +158,19 @@ importers:
         version: 0.5.14(prettier@3.8.3)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.19
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.4)
+      tsx:
+        specifier: ^4.7.2
+        version: 4.21.0
       typescript:
         specifier: ^5.4.3
         version: 5.9.3
       vitest:
         specifier: ^1.4.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@24.1.3)
+      yaml:
+        specifier: ^2.4.2
+        version: 2.8.4
 
 packages:
 
@@ -330,9 +336,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -342,9 +360,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -354,9 +384,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -366,9 +408,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -378,9 +432,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -390,9 +456,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -402,9 +480,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -414,9 +504,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -426,11 +528,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -438,9 +564,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -450,15 +594,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1866,6 +2028,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -3489,6 +3656,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3755,6 +3927,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
@@ -3993,70 +4170,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -5605,6 +5860,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -6761,12 +7045,14 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.10
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.10):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.10
+      tsx: 4.21.0
+      yaml: 2.8.4
 
   postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:
@@ -7266,7 +7552,7 @@ snapshots:
 
   tailwind-merge@2.6.1: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -7285,7 +7571,7 @@ snapshots:
       postcss: 8.5.10
       postcss-import: 15.1.0(postcss@8.5.10)
       postcss-js: 4.1.0(postcss@8.5.10)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.10)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.4)
       postcss-nested: 6.2.0(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -7382,6 +7668,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:
@@ -7703,6 +7996,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.8.4: {}
 
   yauzl@2.10.0:
     dependencies:

--- a/src/eligibility/__tests__/diffShortlistSnapshots.test.ts
+++ b/src/eligibility/__tests__/diffShortlistSnapshots.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { diffShortlistSnapshots } from "../diffShortlistSnapshots";
+import type { ShortlistSnapshot, ShortlistSnapshotTrial } from "../types";
+
+const trial = (
+  nct_id: string,
+  status: string,
+  sites: number,
+): ShortlistSnapshotTrial => ({
+  nct_id,
+  overall_status: status,
+  last_update_post_date: "2026-05-08",
+  au_site_count: sites,
+});
+
+describe("diffShortlistSnapshots", () => {
+  it("treats every trial as new on the first run (prev = null)", () => {
+    const next: ShortlistSnapshot = {
+      as_of: "2026-05-08",
+      trials: [trial("NCT06625320", "Recruiting", 0)],
+    };
+    const diff = diffShortlistSnapshots(null, next);
+    expect(diff.new_trials).toHaveLength(1);
+    expect(diff.closed_trials).toHaveLength(0);
+    expect(diff.status_changes).toHaveLength(0);
+    expect(diff.unchanged_count).toBe(0);
+  });
+
+  it("flags new and closed trials between snapshots", () => {
+    const prev: ShortlistSnapshot = {
+      as_of: "2026-05-01",
+      trials: [trial("NCT06625320", "Recruiting", 0)],
+    };
+    const next: ShortlistSnapshot = {
+      as_of: "2026-05-08",
+      trials: [trial("NCT06360354", "Recruiting", 1)],
+    };
+    const diff = diffShortlistSnapshots(prev, next);
+    expect(diff.new_trials.map((t) => t.nct_id)).toEqual(["NCT06360354"]);
+    expect(diff.closed_trials.map((t) => t.nct_id)).toEqual(["NCT06625320"]);
+  });
+
+  it("flags status changes", () => {
+    const prev: ShortlistSnapshot = {
+      as_of: "2026-05-01",
+      trials: [trial("NCT06625320", "Recruiting", 0)],
+    };
+    const next: ShortlistSnapshot = {
+      as_of: "2026-05-08",
+      trials: [trial("NCT06625320", "Active, not recruiting", 0)],
+    };
+    const diff = diffShortlistSnapshots(prev, next);
+    expect(diff.status_changes).toEqual([
+      {
+        nct_id: "NCT06625320",
+        from: "Recruiting",
+        to: "Active, not recruiting",
+      },
+    ]);
+    expect(diff.unchanged_count).toBe(0);
+  });
+
+  it("flags AU site-count changes", () => {
+    const prev: ShortlistSnapshot = {
+      as_of: "2026-05-01",
+      trials: [trial("NCT06625320", "Recruiting", 0)],
+    };
+    const next: ShortlistSnapshot = {
+      as_of: "2026-05-08",
+      trials: [trial("NCT06625320", "Recruiting", 1)],
+    };
+    const diff = diffShortlistSnapshots(prev, next);
+    expect(diff.site_changes).toEqual([
+      { nct_id: "NCT06625320", from: 0, to: 1 },
+    ]);
+  });
+
+  it("counts unchanged trials", () => {
+    const t = trial("NCT06625320", "Recruiting", 0);
+    const prev: ShortlistSnapshot = { as_of: "2026-05-01", trials: [t] };
+    const next: ShortlistSnapshot = { as_of: "2026-05-08", trials: [t] };
+    const diff = diffShortlistSnapshots(prev, next);
+    expect(diff.unchanged_count).toBe(1);
+    expect(diff.status_changes).toHaveLength(0);
+    expect(diff.site_changes).toHaveLength(0);
+  });
+});

--- a/src/eligibility/__tests__/fixtures/nct05737706.json
+++ b/src/eligibility/__tests__/fixtures/nct05737706.json
@@ -1,0 +1,34 @@
+{
+  "nct_id": "NCT05737706",
+  "key_inclusions": [
+    "advanced solid tumour including PDAC [VERIFY]",
+    "KRAS G12D mutation confirmed by central NGS [VERIFY]",
+    "ECOG 0-1 [VERIFY]"
+  ],
+  "key_exclusions": [
+    "active CNS metastases [VERIFY]",
+    "prior KRAS-targeted therapy [VERIFY]"
+  ],
+  "ecog_max": 1,
+  "lab_thresholds": {
+    "anc_min_x10e9_per_L": 1.5,
+    "platelets_min_x10e9_per_L": 100,
+    "hb_min_g_per_L": 90,
+    "bilirubin_max_xULN": 1.5,
+    "alt_max_xULN": 2.5,
+    "ast_max_xULN": 2.5,
+    "creatinine_clearance_min_mL_per_min": 50,
+    "albumin_min_g_per_L": null
+  },
+  "biomarker_requirements": {
+    "kras_mutation": "g12d",
+    "mtap_deletion": "not_required",
+    "hla_restriction": null,
+    "brca_or_hrd": "not_required"
+  },
+  "au_sites": [],
+  "status": "Recruiting",
+  "last_verified_at": "2026-05-08",
+  "verified": false,
+  "source_quote": "[VERIFY] placeholder fixture. MRTX1133 is a KRAS G12D-selective inhibitor; only G12D patients are eligible. Real EligibilityModule to be parsed via the skill."
+}

--- a/src/eligibility/__tests__/fixtures/nct05968326.json
+++ b/src/eligibility/__tests__/fixtures/nct05968326.json
@@ -1,0 +1,33 @@
+{
+  "nct_id": "NCT05968326",
+  "key_inclusions": [
+    "PDAC, currently adjuvant population [VERIFY]",
+    "HLA-A*02:01 positive [VERIFY]",
+    "ECOG 0-1 [VERIFY]"
+  ],
+  "key_exclusions": [
+    "metastatic disease at enrolment [VERIFY] — likely excludes HL"
+  ],
+  "ecog_max": 1,
+  "lab_thresholds": {
+    "anc_min_x10e9_per_L": 1.5,
+    "platelets_min_x10e9_per_L": 100,
+    "hb_min_g_per_L": 90,
+    "bilirubin_max_xULN": 1.5,
+    "alt_max_xULN": 2.5,
+    "ast_max_xULN": 2.5,
+    "creatinine_clearance_min_mL_per_min": 50,
+    "albumin_min_g_per_L": null
+  },
+  "biomarker_requirements": {
+    "kras_mutation": "not_required",
+    "mtap_deletion": "not_required",
+    "hla_restriction": ["A*02:01"],
+    "brca_or_hrd": "not_required"
+  },
+  "au_sites": [],
+  "status": "Recruiting",
+  "last_verified_at": "2026-05-08",
+  "verified": false,
+  "source_quote": "[VERIFY] placeholder fixture. IMCODE003 (autogene cevumeran) is an mRNA neoantigen vaccine. Current cohorts are PDAC adjuvant — metastatic exclusion likely makes HL ineligible. HLA restriction is a placeholder; the protocol's actual HLA gating to be parsed."
+}

--- a/src/eligibility/__tests__/fixtures/nct06360354.json
+++ b/src/eligibility/__tests__/fixtures/nct06360354.json
@@ -1,0 +1,37 @@
+{
+  "nct_id": "NCT06360354",
+  "key_inclusions": [
+    "advanced solid tumour including PDAC [VERIFY]",
+    "MTAP deletion confirmed by central NGS [VERIFY]",
+    "KRAS-mutant tumour [VERIFY]",
+    "ECOG 0-1 [VERIFY]",
+    "2L+ [VERIFY]"
+  ],
+  "key_exclusions": [
+    "prior MAT2A or PRMT5 inhibitor exposure [VERIFY]",
+    "active CNS metastases [VERIFY]",
+    "Grade >= 2 peripheral neuropathy [VERIFY]"
+  ],
+  "ecog_max": 1,
+  "lab_thresholds": {
+    "anc_min_x10e9_per_L": 1.5,
+    "platelets_min_x10e9_per_L": 100,
+    "hb_min_g_per_L": 90,
+    "bilirubin_max_xULN": 1.5,
+    "alt_max_xULN": 2.5,
+    "ast_max_xULN": 2.5,
+    "creatinine_clearance_min_mL_per_min": 50,
+    "albumin_min_g_per_L": null
+  },
+  "biomarker_requirements": {
+    "kras_mutation": "any",
+    "mtap_deletion": "required",
+    "hla_restriction": null,
+    "brca_or_hrd": "not_required"
+  },
+  "au_sites": [],
+  "status": "Recruiting",
+  "last_verified_at": "2026-05-08",
+  "verified": false,
+  "source_quote": "[VERIFY] placeholder fixture. MTAPESTRY 103 Sub C tests AMG193 + RMC-6236 in MTAP-deletion solid tumours; PDAC is one indication. Thresholds assumed conventional; real values to be parsed from the EligibilityModule by the pdac-trial-eligibility-parse skill."
+}

--- a/src/eligibility/__tests__/fixtures/nct06625320.json
+++ b/src/eligibility/__tests__/fixtures/nct06625320.json
@@ -1,0 +1,36 @@
+{
+  "nct_id": "NCT06625320",
+  "key_inclusions": [
+    "metastatic PDAC, histologically confirmed [VERIFY]",
+    "ECOG 0-1 [VERIFY]",
+    "prior first-line gemcitabine-based therapy [VERIFY]",
+    "KRAS-mutant tumour confirmed by central NGS [VERIFY]"
+  ],
+  "key_exclusions": [
+    "active CNS metastases requiring steroids [VERIFY]",
+    "Grade >= 2 peripheral neuropathy at screening [VERIFY]",
+    "concurrent investigational therapy within 28 days [VERIFY]"
+  ],
+  "ecog_max": 1,
+  "lab_thresholds": {
+    "anc_min_x10e9_per_L": 1.5,
+    "platelets_min_x10e9_per_L": 100,
+    "hb_min_g_per_L": 90,
+    "bilirubin_max_xULN": 1.5,
+    "alt_max_xULN": 2.5,
+    "ast_max_xULN": 2.5,
+    "creatinine_clearance_min_mL_per_min": 50,
+    "albumin_min_g_per_L": null
+  },
+  "biomarker_requirements": {
+    "kras_mutation": "any_g12",
+    "mtap_deletion": "not_required",
+    "hla_restriction": null,
+    "brca_or_hrd": "not_required"
+  },
+  "au_sites": [],
+  "status": "Recruiting",
+  "last_verified_at": "2026-05-08",
+  "verified": false,
+  "source_quote": "[VERIFY] placeholder fixture used by Phase 1 unit tests. Real JSON to be produced by the pdac-trial-eligibility-parse skill against the live ClinicalTrials.gov record. NCT, status, and thresholds are best-guess values consistent with public RASolute 302 disclosures and CTCAE-conventional 2L solid-tumour entry criteria; nothing here has been hand-verified."
+}

--- a/src/eligibility/__tests__/getCurrentBridgeStatus.test.ts
+++ b/src/eligibility/__tests__/getCurrentBridgeStatus.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import { getCurrentBridgeStatus } from "../getCurrentBridgeStatus";
+import type {
+  BridgeInputs,
+  EligibilityCriteria,
+  Shortlist,
+} from "../types";
+
+const inputs: BridgeInputs = {
+  ecog: 1,
+  kras_variant: "G12V",
+  mtap_status: "intact",
+  treatment_setting: "first_line_active",
+  latest_labs: {
+    anc_x10e9_per_L: 2.0,
+    platelets_x10e9_per_L: 150,
+    hb_g_per_L: 110,
+    bilirubin_xULN: 1.0,
+    alt_xULN: 1.2,
+    ast_xULN: 1.1,
+    creatinine_clearance_mL_per_min: 80,
+  },
+  eap_au_open: false,
+  as_of: "2026-05-08",
+};
+
+const rasolute: EligibilityCriteria = {
+  nct_id: "NCT06625320",
+  key_inclusions: [],
+  key_exclusions: [],
+  ecog_max: 1,
+  lab_thresholds: {
+    anc_min_x10e9_per_L: 1.5,
+    platelets_min_x10e9_per_L: 100,
+    hb_min_g_per_L: 90,
+    bilirubin_max_xULN: 1.5,
+    alt_max_xULN: 2.5,
+    ast_max_xULN: 2.5,
+    creatinine_clearance_min_mL_per_min: 50,
+    albumin_min_g_per_L: null,
+  },
+  biomarker_requirements: {
+    kras_mutation: "any_g12",
+    mtap_deletion: "not_required",
+    hla_restriction: null,
+    brca_or_hrd: "not_required",
+  },
+  au_sites: [],
+  status: "Recruiting",
+  last_verified_at: "2026-05-08",
+  verified: true,
+  source_quote: "test",
+};
+
+describe("getCurrentBridgeStatus", () => {
+  it("refuses to verdict unverified shortlist entries", () => {
+    const shortlist: Shortlist = [
+      {
+        nct_id: "NCT06625320",
+        label: "RASolute 302 EAP",
+        one_line_eligibility: "test",
+        verified: false,
+      },
+    ];
+    const result = getCurrentBridgeStatus({ inputs, shortlist });
+    expect(result.trials).toHaveLength(1);
+    expect(result.trials[0].verdict.kind).toBe("unknown");
+    if (result.trials[0].verdict.kind === "unknown") {
+      expect(result.trials[0].verdict.reason).toBe("not yet hand-verified");
+    }
+    expect(result.unverified_count).toBe(1);
+    expect(result.any_eligible_now).toBe(false);
+  });
+
+  it("returns eligible_now when the patient passes all thresholds", () => {
+    const shortlist: Shortlist = [
+      {
+        nct_id: "NCT06625320",
+        label: "RASolute 302 EAP",
+        one_line_eligibility: "test",
+        verified: true,
+      },
+    ];
+    const parsedByNct = new Map([["NCT06625320", rasolute]]);
+    const result = getCurrentBridgeStatus({ inputs, shortlist, parsedByNct });
+    expect(result.trials[0].verdict.kind).toBe("eligible_now");
+    expect(result.any_eligible_now).toBe(true);
+  });
+
+  it("returns excluded when MTAP intact but trial requires deletion", () => {
+    const mtapestry: EligibilityCriteria = {
+      ...rasolute,
+      nct_id: "NCT06360354",
+      biomarker_requirements: {
+        ...rasolute.biomarker_requirements,
+        kras_mutation: "any",
+        mtap_deletion: "required",
+      },
+    };
+    const shortlist: Shortlist = [
+      {
+        nct_id: "NCT06360354",
+        label: "MTAPESTRY 103",
+        one_line_eligibility: "test",
+        verified: true,
+      },
+    ];
+    const parsedByNct = new Map([["NCT06360354", mtapestry]]);
+    const result = getCurrentBridgeStatus({ inputs, shortlist, parsedByNct });
+    expect(result.trials[0].verdict.kind).toBe("excluded");
+    if (result.trials[0].verdict.kind === "excluded") {
+      expect(result.trials[0].verdict.blocking.join(" ")).toMatch(/MTAP/);
+    }
+  });
+
+  it("returns eligible_if_stable when MTAP unknown but trial requires deletion", () => {
+    const mtapestry: EligibilityCriteria = {
+      ...rasolute,
+      nct_id: "NCT06360354",
+      biomarker_requirements: {
+        ...rasolute.biomarker_requirements,
+        kras_mutation: "any",
+        mtap_deletion: "required",
+      },
+    };
+    const shortlist: Shortlist = [
+      {
+        nct_id: "NCT06360354",
+        label: "MTAPESTRY 103",
+        one_line_eligibility: "test",
+        verified: true,
+      },
+    ];
+    const parsedByNct = new Map([["NCT06360354", mtapestry]]);
+    const unknownInputs: BridgeInputs = {
+      ...inputs,
+      mtap_status: "unknown",
+    };
+    const result = getCurrentBridgeStatus({
+      inputs: unknownInputs,
+      shortlist,
+      parsedByNct,
+    });
+    expect(result.trials[0].verdict.kind).toBe("eligible_if_stable");
+  });
+
+  it("returns excluded when ECOG exceeds the trial cap", () => {
+    const shortlist: Shortlist = [
+      {
+        nct_id: "NCT06625320",
+        label: "RASolute 302 EAP",
+        one_line_eligibility: "test",
+        verified: true,
+      },
+    ];
+    const parsedByNct = new Map([["NCT06625320", rasolute]]);
+    const decliningInputs: BridgeInputs = { ...inputs, ecog: 2 };
+    const result = getCurrentBridgeStatus({
+      inputs: decliningInputs,
+      shortlist,
+      parsedByNct,
+    });
+    expect(result.trials[0].verdict.kind).toBe("excluded");
+  });
+
+  it("treats verified entries with TBD NCT IDs as unknown", () => {
+    const shortlist: Shortlist = [
+      {
+        nct_id: "TBD",
+        label: "Epworth Jreissati — narmafotinib",
+        one_line_eligibility: "test",
+        verified: true,
+      },
+    ];
+    const result = getCurrentBridgeStatus({ inputs, shortlist });
+    expect(result.trials[0].verdict.kind).toBe("unknown");
+    if (result.trials[0].verdict.kind === "unknown") {
+      expect(result.trials[0].verdict.reason).toBe("NCT ID not yet recorded");
+    }
+  });
+
+  it("treats verified entries without parsed criteria as unknown", () => {
+    const shortlist: Shortlist = [
+      {
+        nct_id: "NCT06625320",
+        label: "RASolute 302 EAP",
+        one_line_eligibility: "test",
+        verified: true,
+      },
+    ];
+    const result = getCurrentBridgeStatus({ inputs, shortlist });
+    expect(result.trials[0].verdict.kind).toBe("unknown");
+    if (result.trials[0].verdict.kind === "unknown") {
+      expect(result.trials[0].verdict.reason).toMatch(/not parsed/);
+    }
+  });
+
+  it("returns excluded when KRAS variant doesn't match a G12D-only trial", () => {
+    const mrtx: EligibilityCriteria = {
+      ...rasolute,
+      nct_id: "NCT05737706",
+      biomarker_requirements: {
+        ...rasolute.biomarker_requirements,
+        kras_mutation: "g12d",
+      },
+    };
+    const shortlist: Shortlist = [
+      {
+        nct_id: "NCT05737706",
+        label: "MRTX1133",
+        one_line_eligibility: "test",
+        verified: true,
+      },
+    ];
+    const parsedByNct = new Map([["NCT05737706", mrtx]]);
+    // inputs.kras_variant is G12V — should be excluded.
+    const result = getCurrentBridgeStatus({ inputs, shortlist, parsedByNct });
+    expect(result.trials[0].verdict.kind).toBe("excluded");
+  });
+});

--- a/src/eligibility/__tests__/mapToToxicityThresholds.test.ts
+++ b/src/eligibility/__tests__/mapToToxicityThresholds.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import { mapToToxicityThresholds } from "../mapToToxicityThresholds";
+import type { EligibilityCriteria } from "../types";
+
+const baseCriteria: EligibilityCriteria = {
+  nct_id: "NCT06625320",
+  key_inclusions: [],
+  key_exclusions: [],
+  ecog_max: 1,
+  lab_thresholds: {
+    anc_min_x10e9_per_L: 1.5,
+    platelets_min_x10e9_per_L: 100,
+    hb_min_g_per_L: 90,
+    bilirubin_max_xULN: 1.5,
+    alt_max_xULN: 2.5,
+    ast_max_xULN: 2.5,
+    creatinine_clearance_min_mL_per_min: 50,
+    albumin_min_g_per_L: null,
+  },
+  biomarker_requirements: {
+    kras_mutation: "any_g12",
+    mtap_deletion: "not_required",
+    hla_restriction: null,
+    brca_or_hrd: "not_required",
+  },
+  au_sites: [],
+  status: "Recruiting",
+  last_verified_at: "2026-05-08",
+  verified: false,
+  source_quote: "test",
+};
+
+describe("mapToToxicityThresholds", () => {
+  it("emits one constraint per non-null lab threshold + ECOG", () => {
+    const map = mapToToxicityThresholds(baseCriteria);
+    const fields = map.constraints.map((c) => c.field);
+    expect(fields).toContain("ecog");
+    expect(fields).toContain("anc_x10e9_per_L");
+    expect(fields).toContain("platelets_x10e9_per_L");
+    expect(fields).toContain("bilirubin_xULN");
+    // albumin was null — should not appear.
+    expect(fields).not.toContain("albumin_g_per_L");
+  });
+
+  it("uses orange as the breach zone (mandatory-conversation, not silent-red)", () => {
+    const map = mapToToxicityThresholds(baseCriteria);
+    for (const c of map.constraints) {
+      expect(c.breach_zone).toBe("orange");
+    }
+  });
+
+  it("preserves the trial NCT for downstream display", () => {
+    const map = mapToToxicityThresholds(baseCriteria);
+    expect(map.trial_nct_id).toBe("NCT06625320");
+  });
+
+  it("emits no constraints when criteria are entirely null", () => {
+    const empty: EligibilityCriteria = {
+      ...baseCriteria,
+      ecog_max: null,
+      lab_thresholds: {
+        anc_min_x10e9_per_L: null,
+        platelets_min_x10e9_per_L: null,
+        hb_min_g_per_L: null,
+        bilirubin_max_xULN: null,
+        alt_max_xULN: null,
+        ast_max_xULN: null,
+        creatinine_clearance_min_mL_per_min: null,
+        albumin_min_g_per_L: null,
+      },
+    };
+    const map = mapToToxicityThresholds(empty);
+    expect(map.constraints).toHaveLength(0);
+  });
+
+  it("uses ≥ for floors (ANC, platelets, Hb, CrCl) and ≤ for ceilings (bili, ALT, AST)", () => {
+    const map = mapToToxicityThresholds(baseCriteria);
+    const byField = new Map(map.constraints.map((c) => [c.field, c]));
+    expect(byField.get("anc_x10e9_per_L")!.operator).toBe("≥");
+    expect(byField.get("platelets_x10e9_per_L")!.operator).toBe("≥");
+    expect(byField.get("hb_g_per_L")!.operator).toBe("≥");
+    expect(byField.get("creatinine_clearance_mL_per_min")!.operator).toBe("≥");
+    expect(byField.get("bilirubin_xULN")!.operator).toBe("≤");
+    expect(byField.get("alt_xULN")!.operator).toBe("≤");
+    expect(byField.get("ast_xULN")!.operator).toBe("≤");
+    expect(byField.get("ecog")!.operator).toBe("≤");
+  });
+});
+
+describe("Layer 1 firewall — mapToToxicityThresholds source", () => {
+  it("has no runtime import from ~/lib/rules", async () => {
+    const src = await readFile(
+      "src/eligibility/mapToToxicityThresholds.ts",
+      "utf-8",
+    );
+    const lines = src.split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("import ") && trimmed.includes("lib/rules")) {
+        if (!trimmed.startsWith("import type ")) {
+          throw new Error(`Layer 1 runtime import detected: ${trimmed}`);
+        }
+      }
+    }
+  });
+});

--- a/src/eligibility/__tests__/parseEligibility.test.ts
+++ b/src/eligibility/__tests__/parseEligibility.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { parseEligibility } from "../parseEligibility";
+
+describe("parseEligibility", () => {
+  it("returns the parsed JSON for a known NCT", async () => {
+    const result = await parseEligibility("NCT06625320");
+    expect(result).not.toBeNull();
+    expect(result!.nct_id).toBe("NCT06625320");
+    expect(result!.verified).toBe(false);
+    expect(typeof result!.source_quote).toBe("string");
+    expect(result!.source_quote).toMatch(/VERIFY/);
+  });
+
+  it("returns null for an unknown NCT", async () => {
+    const result = await parseEligibility("NCT99999999");
+    expect(result).toBeNull();
+  });
+
+  it("is case-insensitive on NCT ID", async () => {
+    const a = await parseEligibility("NCT06625320");
+    const b = await parseEligibility("nct06625320");
+    expect(a).toEqual(b);
+  });
+
+  it("loads MTAPESTRY 103 with mtap_deletion: required", async () => {
+    const result = await parseEligibility("NCT06360354");
+    expect(result!.biomarker_requirements.mtap_deletion).toBe("required");
+  });
+
+  it("loads MRTX1133 with kras_mutation: g12d", async () => {
+    const result = await parseEligibility("NCT05737706");
+    expect(result!.biomarker_requirements.kras_mutation).toBe("g12d");
+  });
+});

--- a/src/eligibility/cli.ts
+++ b/src/eligibility/cli.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env tsx
+import { parseEligibility } from "./parseEligibility";
+import { loadShortlist } from "./loadShortlist";
+
+async function main() {
+  const [cmd, arg] = process.argv.slice(2);
+  if (cmd === "parse") {
+    if (!arg) {
+      console.error("usage: tsx src/eligibility/cli.ts parse <NCT_ID>");
+      process.exit(2);
+    }
+    const result = await parseEligibility(arg);
+    if (!result) {
+      console.error(
+        `No fixture for ${arg}. Use the pdac-trial-eligibility-parse skill ` +
+        `in Claude Code to populate ` +
+        `src/eligibility/__tests__/fixtures/${arg.toLowerCase()}.json.`,
+      );
+      process.exit(1);
+    }
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  if (cmd === "shortlist") {
+    const shortlist = await loadShortlist();
+    console.log(JSON.stringify(shortlist, null, 2));
+    return;
+  }
+  console.error("usage:");
+  console.error("  tsx src/eligibility/cli.ts parse <NCT_ID>");
+  console.error("  tsx src/eligibility/cli.ts shortlist");
+  process.exit(2);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/eligibility/diffShortlistSnapshots.ts
+++ b/src/eligibility/diffShortlistSnapshots.ts
@@ -1,0 +1,68 @@
+import type {
+  ShortlistDiff,
+  ShortlistSnapshot,
+  ShortlistSnapshotTrial,
+} from "./types";
+
+// Compares two monitor snapshots and returns the operator-facing
+// delta. On the first run (`prev` is null), every next-trial counts
+// as new. Used by the trial-monitor subagent to report what changed.
+
+export function diffShortlistSnapshots(
+  prev: ShortlistSnapshot | null,
+  next: ShortlistSnapshot,
+): ShortlistDiff {
+  if (!prev) {
+    return {
+      new_trials: next.trials,
+      closed_trials: [],
+      status_changes: [],
+      site_changes: [],
+      unchanged_count: 0,
+    };
+  }
+
+  const prevByNct = new Map<string, ShortlistSnapshotTrial>(
+    prev.trials.map((t) => [t.nct_id, t]),
+  );
+  const nextByNct = new Map<string, ShortlistSnapshotTrial>(
+    next.trials.map((t) => [t.nct_id, t]),
+  );
+
+  const new_trials = next.trials.filter((t) => !prevByNct.has(t.nct_id));
+  const closed_trials = prev.trials.filter((t) => !nextByNct.has(t.nct_id));
+
+  const status_changes: ShortlistDiff["status_changes"] = [];
+  const site_changes: ShortlistDiff["site_changes"] = [];
+  let unchanged_count = 0;
+
+  for (const t of next.trials) {
+    const p = prevByNct.get(t.nct_id);
+    if (!p) continue;
+    const statusChanged = p.overall_status !== t.overall_status;
+    const sitesChanged = p.au_site_count !== t.au_site_count;
+    if (statusChanged) {
+      status_changes.push({
+        nct_id: t.nct_id,
+        from: p.overall_status,
+        to: t.overall_status,
+      });
+    }
+    if (sitesChanged) {
+      site_changes.push({
+        nct_id: t.nct_id,
+        from: p.au_site_count,
+        to: t.au_site_count,
+      });
+    }
+    if (!statusChanged && !sitesChanged) unchanged_count++;
+  }
+
+  return {
+    new_trials,
+    closed_trials,
+    status_changes,
+    site_changes,
+    unchanged_count,
+  };
+}

--- a/src/eligibility/getCurrentBridgeStatus.ts
+++ b/src/eligibility/getCurrentBridgeStatus.ts
@@ -1,0 +1,174 @@
+import type {
+  BridgeInputs,
+  BridgeStatus,
+  EligibilityCriteria,
+  Shortlist,
+  TrialStatus,
+  TrialVerdict,
+} from "./types";
+
+interface Args {
+  inputs: BridgeInputs;
+  shortlist: Shortlist;
+  // NCT-ID → parsed criteria. Only NCTs whose JSON has been hand-
+  // verified into a fixture are present; unverified or absent entries
+  // route to "unknown".
+  parsedByNct?: Map<string, EligibilityCriteria>;
+}
+
+export function getCurrentBridgeStatus({
+  inputs,
+  shortlist,
+  parsedByNct = new Map(),
+}: Args): BridgeStatus {
+  const trials: TrialStatus[] = shortlist.map((entry) => {
+    if (!entry.verified) {
+      return {
+        nct_id: entry.nct_id,
+        trial_label: entry.label,
+        verdict: { kind: "unknown", reason: "not yet hand-verified" },
+        verified: false,
+      };
+    }
+    if (entry.nct_id === "TBD") {
+      return {
+        nct_id: entry.nct_id,
+        trial_label: entry.label,
+        verdict: { kind: "unknown", reason: "NCT ID not yet recorded" },
+        verified: true,
+      };
+    }
+    const criteria = parsedByNct.get(entry.nct_id);
+    if (!criteria) {
+      return {
+        nct_id: entry.nct_id,
+        trial_label: entry.label,
+        verdict: {
+          kind: "unknown",
+          reason: "verified but eligibility JSON not parsed yet",
+        },
+        verified: true,
+      };
+    }
+    return {
+      nct_id: entry.nct_id,
+      trial_label: entry.label,
+      verdict: evaluateVerdict(inputs, criteria),
+      verified: true,
+    };
+  });
+
+  return {
+    as_of: inputs.as_of,
+    inputs,
+    trials,
+    any_eligible_now: trials.some((t) => t.verdict.kind === "eligible_now"),
+    any_eligible_if_stable: trials.some(
+      (t) => t.verdict.kind === "eligible_if_stable",
+    ),
+    unverified_count: trials.filter((t) => !t.verified).length,
+  };
+}
+
+function evaluateVerdict(
+  inputs: BridgeInputs,
+  criteria: EligibilityCriteria,
+): TrialVerdict {
+  const blocking: string[] = [];
+  const concerns: string[] = [];
+
+  // ECOG.
+  if (criteria.ecog_max != null && inputs.ecog > criteria.ecog_max) {
+    blocking.push(
+      `ECOG ${inputs.ecog} exceeds trial cap of ${criteria.ecog_max}`,
+    );
+  }
+
+  // KRAS.
+  const krasReq = criteria.biomarker_requirements.kras_mutation;
+  if (krasReq === "excluded" && inputs.kras_variant !== "wildtype") {
+    blocking.push("KRAS-mutant excluded by trial");
+  }
+  if (krasReq !== "any" && krasReq !== "not_required" && krasReq !== "excluded") {
+    if (inputs.kras_variant === "unknown") {
+      concerns.push("KRAS variant unknown — trial requires confirmed status");
+    } else if (
+      krasReq === "any_g12" &&
+      !inputs.kras_variant.startsWith("G12")
+    ) {
+      blocking.push(
+        `Trial requires KRAS G12-family; patient is ${inputs.kras_variant}`,
+      );
+    } else if (
+      ["g12d", "g12c", "g12v", "g12r"].includes(krasReq) &&
+      inputs.kras_variant.toLowerCase() !== krasReq
+    ) {
+      blocking.push(
+        `Trial requires KRAS ${krasReq.toUpperCase()}; patient is ${inputs.kras_variant}`,
+      );
+    }
+  }
+
+  // MTAP.
+  const mtapReq = criteria.biomarker_requirements.mtap_deletion;
+  if (mtapReq === "required") {
+    if (inputs.mtap_status === "intact") {
+      blocking.push("MTAP intact; trial requires deletion");
+    } else if (inputs.mtap_status === "unknown") {
+      concerns.push("MTAP status unknown — trial requires confirmed deletion");
+    }
+  }
+  if (mtapReq === "excluded" && inputs.mtap_status === "deleted") {
+    blocking.push("MTAP-deletion excluded by trial");
+  }
+
+  // HLA.
+  const hla = criteria.biomarker_requirements.hla_restriction;
+  if (hla && hla.length > 0) {
+    const have = inputs.hla_types ?? [];
+    if (have.length === 0) {
+      concerns.push(
+        `HLA typing not recorded; trial requires ${hla.join(" or ")}`,
+      );
+    } else if (!hla.some((allele) => have.includes(allele))) {
+      blocking.push(
+        `HLA mismatch; trial requires ${hla.join(" or ")}, patient has ${have.join(", ")}`,
+      );
+    }
+  }
+
+  // Labs.
+  type LabKey = keyof BridgeInputs["latest_labs"];
+  const checkFloor = (key: LabKey, threshold: number | null, label: string) => {
+    if (threshold == null) return;
+    const v = inputs.latest_labs[key];
+    if (v == null) {
+      concerns.push(`${label} not recorded — trial floor ${threshold}`);
+    } else if (v < threshold) {
+      blocking.push(`${label} ${v} below trial floor ${threshold}`);
+    }
+  };
+  const checkCeil = (key: LabKey, threshold: number | null, label: string) => {
+    if (threshold == null) return;
+    const v = inputs.latest_labs[key];
+    if (v == null) {
+      concerns.push(`${label} not recorded — trial ceiling ${threshold}`);
+    } else if (v > threshold) {
+      blocking.push(`${label} ${v} above trial ceiling ${threshold}`);
+    }
+  };
+
+  const t = criteria.lab_thresholds;
+  checkFloor("anc_x10e9_per_L", t.anc_min_x10e9_per_L, "ANC");
+  checkFloor("platelets_x10e9_per_L", t.platelets_min_x10e9_per_L, "Platelets");
+  checkFloor("hb_g_per_L", t.hb_min_g_per_L, "Hb");
+  checkCeil("bilirubin_xULN", t.bilirubin_max_xULN, "Bilirubin");
+  checkCeil("alt_xULN", t.alt_max_xULN, "ALT");
+  checkCeil("ast_xULN", t.ast_max_xULN, "AST");
+  checkFloor("creatinine_clearance_mL_per_min", t.creatinine_clearance_min_mL_per_min, "CrCl");
+  checkFloor("albumin_g_per_L", t.albumin_min_g_per_L, "Albumin");
+
+  if (blocking.length > 0) return { kind: "excluded", blocking };
+  if (concerns.length > 0) return { kind: "eligible_if_stable", concerns };
+  return { kind: "eligible_now" };
+}

--- a/src/eligibility/index.ts
+++ b/src/eligibility/index.ts
@@ -1,0 +1,28 @@
+// Layer 2 v0 public surface. Consumers import from here.
+export type {
+  AustralianSite,
+  BiomarkerRequirements,
+  BridgeInputs,
+  BridgeStatus,
+  EligibilityCriteria,
+  KrasRequirement,
+  KrasVariant,
+  LabThresholds,
+  MtapRequirement,
+  MtapStatus,
+  Shortlist,
+  ShortlistDiff,
+  ShortlistEntry,
+  ShortlistSnapshot,
+  ShortlistSnapshotTrial,
+  ToxicityConstraint,
+  ToxicityThresholdMap,
+  TreatmentSetting,
+  TrialStatus,
+  TrialVerdict,
+} from "./types";
+export { parseEligibility } from "./parseEligibility";
+export { mapToToxicityThresholds } from "./mapToToxicityThresholds";
+export { getCurrentBridgeStatus } from "./getCurrentBridgeStatus";
+export { diffShortlistSnapshots } from "./diffShortlistSnapshots";
+export { loadShortlist } from "./loadShortlist";

--- a/src/eligibility/loadShortlist.ts
+++ b/src/eligibility/loadShortlist.ts
@@ -1,0 +1,24 @@
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+import type { Shortlist } from "./types";
+
+const DEFAULT_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "shortlist.yaml",
+);
+
+export async function loadShortlist(path?: string): Promise<Shortlist> {
+  const p = path ?? DEFAULT_PATH;
+  if (!existsSync(p)) {
+    throw new Error(`shortlist.yaml not found at ${p}`);
+  }
+  const raw = await readFile(p, "utf-8");
+  const parsed = parseYaml(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`shortlist.yaml at ${p} did not parse to an array`);
+  }
+  return parsed as Shortlist;
+}

--- a/src/eligibility/mapToToxicityThresholds.ts
+++ b/src/eligibility/mapToToxicityThresholds.ts
@@ -1,0 +1,72 @@
+import type { Zone, RuleCategory } from "~/types/clinical";
+import type {
+  EligibilityCriteria,
+  ToxicityConstraint,
+  ToxicityThresholdMap,
+} from "./types";
+
+// Pure function. Types-only imports from `~/types/clinical`. Never
+// imports `~/lib/rules/*` at runtime — Layer 1 must remain decoupled.
+// Each lab threshold becomes a constraint that, if breached, would
+// disqualify the patient from this trial. `breach_zone` is set
+// conservatively to "orange" — Layer 1 should surface the breach as a
+// mandatory-conversation review item, not a silent-red automatic
+// escalation. Phase 1 doesn't wire this back into Layer 1 yet; the
+// function is exposed so Phase 2 can pick it up.
+
+export function mapToToxicityThresholds(
+  criteria: EligibilityCriteria,
+): ToxicityThresholdMap {
+  const constraints: ToxicityConstraint[] = [];
+  const breach_zone: Zone = "orange";
+
+  if (criteria.ecog_max != null) {
+    const category: RuleCategory = "function";
+    constraints.push({
+      category,
+      field: "ecog",
+      operator: "≤",
+      value: criteria.ecog_max,
+      breach_zone,
+      rationale: `Trial ${criteria.nct_id} requires ECOG ≤ ${criteria.ecog_max}`,
+    });
+  }
+
+  const labCategory: RuleCategory = "toxicity";
+
+  const labFloor = (field: string, val: number | null) => {
+    if (val == null) return;
+    constraints.push({
+      category: labCategory,
+      field,
+      operator: "≥",
+      value: val,
+      breach_zone,
+      rationale: `Trial ${criteria.nct_id} requires ${field} ≥ ${val}`,
+    });
+  };
+
+  const labCeil = (field: string, val: number | null) => {
+    if (val == null) return;
+    constraints.push({
+      category: labCategory,
+      field,
+      operator: "≤",
+      value: val,
+      breach_zone,
+      rationale: `Trial ${criteria.nct_id} requires ${field} ≤ ${val}`,
+    });
+  };
+
+  const t = criteria.lab_thresholds;
+  labFloor("anc_x10e9_per_L", t.anc_min_x10e9_per_L);
+  labFloor("platelets_x10e9_per_L", t.platelets_min_x10e9_per_L);
+  labFloor("hb_g_per_L", t.hb_min_g_per_L);
+  labCeil("bilirubin_xULN", t.bilirubin_max_xULN);
+  labCeil("alt_xULN", t.alt_max_xULN);
+  labCeil("ast_xULN", t.ast_max_xULN);
+  labFloor("creatinine_clearance_mL_per_min", t.creatinine_clearance_min_mL_per_min);
+  labFloor("albumin_g_per_L", t.albumin_min_g_per_L);
+
+  return { trial_nct_id: criteria.nct_id, constraints };
+}

--- a/src/eligibility/parseEligibility.ts
+++ b/src/eligibility/parseEligibility.ts
@@ -1,0 +1,29 @@
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { EligibilityCriteria } from "./types";
+
+// Phase 1: parseEligibility reads a hand-curated fixture for an NCT.
+// Production path (Phase 2): the trial-monitor subagent invokes the
+// pdac-trial-eligibility-parse skill against the ClinicalTrials.gov
+// MCP, the operator reviews the JSON, then writes it into the
+// fixtures directory. Layer 2's public surface stays the same either
+// way.
+
+const DEFAULT_FIXTURE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "__tests__",
+  "fixtures",
+);
+
+export async function parseEligibility(
+  nctId: string,
+  options: { fixtureDir?: string } = {},
+): Promise<EligibilityCriteria | null> {
+  const dir = options.fixtureDir ?? DEFAULT_FIXTURE_DIR;
+  const path = join(dir, `${nctId.toLowerCase()}.json`);
+  if (!existsSync(path)) return null;
+  const raw = await readFile(path, "utf-8");
+  return JSON.parse(raw) as EligibilityCriteria;
+}

--- a/src/eligibility/shortlist.yaml
+++ b/src/eligibility/shortlist.yaml
@@ -1,0 +1,45 @@
+# Anchor — Phase 1 trial shortlist.
+#
+# Every entry ships with verified: false. getCurrentBridgeStatus
+# refuses to return an eligibility verdict for any trial whose
+# verified flag is false — it returns kind: unknown with reason
+# "not yet hand-verified". The operator flips the flag to true
+# only after a one-trial-at-a-time hand-check against the primary
+# protocol and the ClinicalTrials.gov record. See CLAUDE.md §5.
+#
+# All clinical claims in `one_line_eligibility` are tagged [VERIFY].
+
+- nct_id: NCT06625320
+  label: RASolute 302 EAP — RMC-6236 (daraxonrasib)
+  one_line_eligibility: 2L mPDAC after first-line gem-based chemo; ECOG 0–1; KRAS-mutant (G12-anything most likely); EAP availability in AU is the operative variable. [VERIFY]
+  verified: false
+
+- nct_id: NCT06360354
+  label: MTAPESTRY 103 Sub C — AMG193 + RMC-6236
+  one_line_eligibility: Solid tumours including PDAC; MTAP-deletion required; KRAS-mutant; ECOG 0–1; 2L+. [VERIFY]
+  verified: false
+
+- nct_id: NCT05737706
+  label: MRTX1133 — KRAS G12D selective inhibitor
+  one_line_eligibility: Advanced solid tumours including PDAC; KRAS G12D required; ECOG 0–1. [VERIFY]
+  verified: false
+
+- nct_id: NCT05968326
+  label: IMCODE003 — autogene cevumeran
+  one_line_eligibility: PDAC adjuvant currently; HLA-restricted; ECOG 0–1. May not match HL's metastatic setting. [VERIFY]
+  verified: false
+
+- nct_id: TBD
+  label: Epworth Jreissati — narmafotinib + mFOLFIRINOX
+  one_line_eligibility: Untreated mPDAC; ECOG 0–1; AU site (Epworth Richmond). [VERIFY]
+  verified: false
+
+- nct_id: TBD
+  label: Epworth Jreissati — CEND-1 / LSTA1
+  one_line_eligibility: mPDAC with chemo backbone; ECOG 0–1; AU site. [VERIFY]
+  verified: false
+
+- nct_id: TBD
+  label: Epworth Jreissati — pembrolizumab + olaparib
+  one_line_eligibility: mPDAC with platinum backbone, BRCA / HRD signal; ECOG 0–1. [VERIFY]
+  verified: false

--- a/src/eligibility/types.ts
+++ b/src/eligibility/types.ts
@@ -1,0 +1,179 @@
+// Layer 2 types. Read-only consumer of Layer 1 vocabulary
+// (`Zone`, `RuleCategory`) — types-only imports, never runtime.
+
+import type { Zone, RuleCategory } from "~/types/clinical";
+
+// ---- BridgeInputs: thin projection consumed by getCurrentBridgeStatus.
+// Deliberately decoupled from PatientStateSnapshot — Phase 1 doesn't
+// have a real wiring path from the rich state model into trial
+// eligibility. Build the wiring in Phase 2 once a real verification
+// pass through the shortlist is done.
+
+export type KrasVariant =
+  | "G12V"
+  | "G12D"
+  | "G12C"
+  | "G12R"
+  | "Q61H"
+  | "wildtype"
+  | "unknown";
+
+export type MtapStatus = "deleted" | "intact" | "unknown";
+
+export type TreatmentSetting =
+  | "first_line_active"
+  | "first_line_progression"
+  | "second_line"
+  | "off_treatment";
+
+export interface BridgeInputs {
+  ecog: 0 | 1 | 2 | 3 | 4;
+  kras_variant: KrasVariant;
+  mtap_status: MtapStatus;
+  hla_types?: string[];
+  treatment_setting: TreatmentSetting;
+  latest_labs: Partial<{
+    anc_x10e9_per_L: number;
+    platelets_x10e9_per_L: number;
+    hb_g_per_L: number;
+    bilirubin_xULN: number;
+    alt_xULN: number;
+    ast_xULN: number;
+    creatinine_clearance_mL_per_min: number;
+    albumin_g_per_L: number;
+  }>;
+  // Operative variable. true = expanded access for RMC-6236 is open
+  // in Australia; false = not yet, or unknown.
+  eap_au_open: boolean;
+  as_of: string;
+}
+
+// ---- EligibilityCriteria: structured shape of a trial's eligibility
+// section. Produced by the `pdac-trial-eligibility-parse` skill,
+// consumed by getCurrentBridgeStatus + mapToToxicityThresholds.
+
+export type KrasRequirement =
+  | "any"
+  | "any_g12"
+  | "g12d"
+  | "g12c"
+  | "g12v"
+  | "g12r"
+  | "q61"
+  | "not_required"
+  | "excluded";
+
+export type MtapRequirement = "required" | "not_required" | "excluded";
+
+export interface LabThresholds {
+  anc_min_x10e9_per_L: number | null;
+  platelets_min_x10e9_per_L: number | null;
+  hb_min_g_per_L: number | null;
+  bilirubin_max_xULN: number | null;
+  alt_max_xULN: number | null;
+  ast_max_xULN: number | null;
+  creatinine_clearance_min_mL_per_min: number | null;
+  albumin_min_g_per_L: number | null;
+}
+
+export interface BiomarkerRequirements {
+  kras_mutation: KrasRequirement;
+  mtap_deletion: MtapRequirement;
+  hla_restriction: string[] | null;
+  brca_or_hrd: "required" | "not_required" | "excluded";
+}
+
+export interface AustralianSite {
+  site_name: string;
+  city: string;
+  principal_investigator: string;
+}
+
+export interface EligibilityCriteria {
+  nct_id: string;
+  key_inclusions: string[];
+  key_exclusions: string[];
+  ecog_max: number | null;
+  lab_thresholds: LabThresholds;
+  biomarker_requirements: BiomarkerRequirements;
+  au_sites: AustralianSite[];
+  status: string;
+  last_verified_at: string;
+  verified: boolean;
+  source_quote: string;
+}
+
+// ---- ToxicityThresholdMap: Layer 2's projection of trial constraints
+// back into Layer 1's vocabulary. Layer 1 does NOT consume this in
+// Phase 1 — the type is exported for Phase 2 wiring.
+
+export interface ToxicityConstraint {
+  category: RuleCategory;
+  field: string;
+  operator: "≤" | "≥" | "=" | "≠";
+  value: number | string;
+  breach_zone: Zone;
+  rationale: string;
+}
+
+export interface ToxicityThresholdMap {
+  trial_nct_id: string;
+  constraints: ToxicityConstraint[];
+}
+
+// ---- BridgeStatus: per-trial verdict + aggregates.
+
+export type TrialVerdict =
+  | { kind: "eligible_now" }
+  | { kind: "eligible_if_stable"; concerns: string[] }
+  | { kind: "excluded"; blocking: string[] }
+  | { kind: "unknown"; reason: string };
+
+export interface TrialStatus {
+  nct_id: string;
+  trial_label: string;
+  verdict: TrialVerdict;
+  verified: boolean;
+}
+
+export interface BridgeStatus {
+  as_of: string;
+  inputs: BridgeInputs;
+  trials: TrialStatus[];
+  any_eligible_now: boolean;
+  any_eligible_if_stable: boolean;
+  unverified_count: number;
+}
+
+// ---- Monitor snapshots (consumed by diffShortlistSnapshots).
+
+export interface ShortlistSnapshotTrial {
+  nct_id: string;
+  overall_status: string;
+  last_update_post_date: string;
+  au_site_count: number;
+}
+
+export interface ShortlistSnapshot {
+  as_of: string;
+  trials: ShortlistSnapshotTrial[];
+}
+
+export interface ShortlistDiff {
+  new_trials: ShortlistSnapshotTrial[];
+  closed_trials: ShortlistSnapshotTrial[];
+  status_changes: Array<{ nct_id: string; from: string; to: string }>;
+  site_changes: Array<{ nct_id: string; from: number; to: number }>;
+  unchanged_count: number;
+}
+
+// ---- Shortlist file shape.
+
+export interface ShortlistEntry {
+  nct_id: string;
+  label: string;
+  one_line_eligibility: string;
+  verified: boolean;
+}
+
+export type Shortlist = ShortlistEntry[];


### PR DESCRIPTION
## Summary

Phase 1 of the bridge-strategy doctrine: builds the four-layer architecture, scaffolds the Code-with-Claude harness (subagent + skill + hook + MCPs + evals), and ships **Layer 2 v0** (`src/eligibility/`) with explicit refusal-to-verdict on unverified shortlist entries.

**Layer 1 (toxicity engine — `src/lib/rules/`, `src/agents/{toxicity,clinical,nutrition,treatment,psychology,rehabilitation}/`) is untouched.** Types-only seam between Layer 2 and Layer 1 is enforced by a regex test.

## What's in

- **Doctrine**: root `CLAUDE.md` (bridge strategy, hypothesis verbatim, axis taxonomy, 4-layer architecture, 7-trial shortlist, EAP-as-operative-variable, never-autonomous guardrail, Ananda-not-yet-informed `[TODO]`). Cross-refs `.claude/CLAUDE.md`.
- **`.claude/` scaffolding**: `agents/`, `skills/`, `hooks/`, `evals/{cases,fixtures}/` with READMEs.
- **Subagent**: `.claude/agents/trial-monitor.md` — fresh-context, restricted-tool allow-list (Read + clinicaltrials MCP read tools + biomcp read tools). No Write, Edit, Bash, or any outbound-comms surface.
- **Skill**: `.claude/skills/pdac-trial-eligibility-parse/SKILL.md` — emits the structured JSON shape `src/eligibility/parseEligibility.ts` consumes.
- **Hook**: `.claude/hooks/block-outbound-comms.sh` + `.claude/settings.json` registration. Denies `gmail_send`, `send_email`, `send_sms`, `message_compose`, `twilio*`, `mcp__*__send_*`, and substring matches `*send*`/`*post*`/`*publish*`/`*draft_send*`. Carve-out for `mcp__github__*` (PRs, issues, comments used in normal dev). 8 synthetic events tested (4 deny, 4 allow). Block log persists to `.claude/local/blocked-comms.log` (gitignored).
- **MCPs** (in `.mcp.json` alongside the existing Supabase entry):
  - `clinicaltrials` → `https://clinicaltrials.caseyjhand.com/mcp` (cyanheads, hosted)
  - `biomcp` → `https://biomcp.org/mcp` (GenomOncology, hosted)
- **Eligibility engine v0** (`src/eligibility/`):
  - `BridgeInputs` thin projection (ECOG, KRAS variant, MTAP, HLA, treatment setting, latest labs, EAP-open flag).
  - `parseEligibility(nctId)`, `mapToToxicityThresholds(criteria)`, `getCurrentBridgeStatus({inputs, shortlist, parsedByNct})`, `diffShortlistSnapshots(prev, next)`, plus `loadShortlist()` and a `cli.ts`.
  - `shortlist.yaml` ships every entry with `verified: false`. The engine **refuses** to return a verdict for unverified entries (`kind: "unknown"`, reason "not yet hand-verified"). Verification is a single-trial-at-a-time human action.
  - 4 fixtures (RASolute 302 EAP, MTAPESTRY 103 Sub C, MRTX1133, IMCODE003) — every clinical claim `[VERIFY]`-tagged.
  - 4 vitest files, 24 tests, all green. Layer-1-firewall test asserts `mapToToxicityThresholds.ts` has zero runtime imports from `~/lib/rules`.
- **Eval harness**: 5 YAML cases + fixtures + a `tsx` runner. Records pass/fail/error to `eval-runs/<ts>.json` (gitignored) with git SHA.
- **`package.json`**: adds `tsx` + `yaml` devDeps; scripts `eligibility:parse` and `evals:run`. `trial-monitor:run` intentionally **omitted** — the subagent is the runnable artefact, invoked from inside Claude Code.
- **`.gitignore`**: adds `anchor.local.json`, `.claude/local/`, `*.patient.json`, `eval-runs/`.
- **`anchor.local.example.json`**: documented placeholder shape; the real `anchor.local.json` is gitignored.

## Verification

- `pnpm typecheck`: clean.
- `pnpm test`: **982/982 pass** (110 files, including the 24 new eligibility tests). No Layer 1 regression.
- `pnpm evals:run`: **5/5 pass**.
- Hook: 8 synthetic events (4 deny, 4 allow), all expected.
- TLS handshake confirmed for both new MCP endpoints. **Protocol-level tool enumeration requires you to restart Claude Code** to verify the trial-monitor's `tools:` allow-list actually maps to real tool names.
- Untouched (verified by `git diff`): `src/lib/rules/*`, `src/agents/{toxicity,clinical,nutrition,treatment,psychology,rehabilitation}/`, `src/lib/state/*`, `.github/workflows/*`, `vercel.json`, `next.config.mjs`, `supabase/*`, every existing `.claude/commands/*.md`.

## Test plan

- [ ] Restart Claude Code so the new `.mcp.json` entries load.
- [ ] Try `@trial-monitor` interactively. Confirm the MCP tool names listed in the subagent frontmatter actually enumerate from the cyanheads + biomcp servers. **If they don't, the allow-list silently empties and the agent has no tools — fix the frontmatter and retest.**
- [ ] Verify one shortlist trial end-to-end: invoke the `pdac-trial-eligibility-parse` skill against NCT06625320, hand-review the JSON output, write it to `src/eligibility/__tests__/fixtures/nct06625320.json`, flip `verified: true` in `shortlist.yaml` for that one entry, run `pnpm evals:run` and a `getCurrentBridgeStatus` trace.
- [ ] Trigger `gmail_send` (or any deny pattern) inside Claude Code; confirm the hook blocks and the operator-facing reason renders.
- [ ] Confirm CI passes on this PR (typecheck + vitest).

## Open items / known caveats

- Every shortlist entry is `verified: false`. The engine **cannot** return an eligibility verdict until you flip flags per trial.
- Three Epworth Jreissati trials are `nct_id: TBD` pending operator fill-in.
- BioMCP transport is hosted streamable HTTP; stdio fallback (`uvx biomcp`) is viable if the hosted endpoint goes down. Cyanheads is community-hosted at a third-party domain — if it disappears, swap to a self-hosted stdio config.
- The PreToolUse hook matches on **tool name only**, not argument content. Phase 1 acceptable; production-grade outbound filtering should inspect bodies too.
- Two doctrine files now coexist (`CLAUDE.md` + `.claude/CLAUDE.md`). Watch for drift.

Refs: bridge-strategy doctrine (root `CLAUDE.md`), app-internal doctrine (`.claude/CLAUDE.md`), the original Phase 1 brief.

https://claude.ai/code/session_01SdqyPabv5ePzpk1B4xqkJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdqyPabv5ePzpk1B4xqkJK)_