### PR TITLE
refactor(utils): collapse 49 error-message ternaries into errorMessage()

### DIFF
--- a/src/agents/skills/dispatch.ts
+++ b/src/agents/skills/dispatch.ts
@@ -5,6 +5,7 @@ import { readAppointmentsHandler } from "./handlers/read-appointments";
 import { readCareTeamHandler } from "./handlers/read-care-team";
 import { readDailyHandler } from "./handlers/read-daily";
 import { readLabsHandler } from "./handlers/read-labs";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Dispatcher: maps a tool_use call ("name" + input object) to the matching
 // handler and returns the tool_result payload. Lives alongside the
@@ -50,7 +51,7 @@ export async function dispatchSkill(
     const output = await handler(input);
     return { ok: true, output };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    return { ok: false, error: errorMessage(err) };
   }
 }
 

--- a/src/app/api/agent/[id]/run/route.ts
+++ b/src/app/api/agent/[id]/run/route.ts
@@ -7,6 +7,7 @@ import type {
   LogEventRow,
   LogTag,
 } from "~/types/agent";
+import { errorMessage } from "~/lib/utils/errors";
 import { AGENT_IDS, LOG_TAGS } from "~/types/agent";
 import { runAgent } from "~/agents/run";
 import { readJsonBody } from "~/lib/anthropic/route-helpers";
@@ -120,7 +121,7 @@ export async function POST(
       coverageSnapshot: parsed.data.coverage_snapshot,
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     return NextResponse.json(
       { error: "Agent run failed", message },
       { status: 502 },

--- a/src/app/api/ai/parse-voice-memo/route.ts
+++ b/src/app/api/ai/parse-voice-memo/route.ts
@@ -4,6 +4,7 @@ import {
   gateAiRequest,
   withAnthropicErrorBoundary,
 } from "~/lib/anthropic/route-helpers";
+import { errorMessage } from "~/lib/utils/errors";
 import {
   getOptionalHouseholdId,
   loadHouseholdProfile,
@@ -148,7 +149,7 @@ export async function POST(req: Request) {
       {
         error:
           "Model response was not valid JSON: " +
-          (err instanceof Error ? err.message : String(err)),
+          (errorMessage(err)),
       },
       { status: 502 },
     );

--- a/src/app/api/ai/transcribe/route.ts
+++ b/src/app/api/ai/transcribe/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Voice-memo transcription. Browser records via MediaRecorder, posts
 // the resulting audio blob here as multipart/form-data; we hand it
@@ -98,7 +99,7 @@ export async function POST(req: Request) {
       },
     );
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     return NextResponse.json({ error: message }, { status: 502 });
   }
 

--- a/src/app/api/ingest-ics/route.ts
+++ b/src/app/api/ingest-ics/route.ts
@@ -3,6 +3,7 @@ import { icsEventsToOps, parseIcs } from "~/lib/ingest/ics";
 import { readJsonBody } from "~/lib/anthropic/route-helpers";
 import { requireSession } from "~/lib/auth/require-session";
 import type { IngestDraft } from "~/types/ingest";
+import { errorMessage } from "~/lib/utils/errors";
 
 export const runtime = "nodejs";
 // ICS import fetches a remote webcal URL server-side (sometimes slow iCloud
@@ -63,7 +64,7 @@ export async function POST(req: Request) {
       raw = await res.text();
       sourceHint = url;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = errorMessage(err);
       return NextResponse.json(
         { error: `Couldn't fetch calendar: ${message}` },
         { status: 502 },

--- a/src/app/api/parse-appointment/route.ts
+++ b/src/app/api/parse-appointment/route.ts
@@ -6,6 +6,7 @@ import {
   getAnthropicClient,
   readJsonBody,
 } from "~/lib/anthropic/route-helpers";
+import { errorMessage } from "~/lib/utils/errors";
 import { requireSession } from "~/lib/auth/require-session";
 import { wrapUserInputBlock } from "~/lib/anthropic/wrap-user-input";
 
@@ -144,7 +145,7 @@ export async function POST(req: Request) {
     }
     return NextResponse.json({ appointment: response.parsed_output });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     return NextResponse.json(
       { error: "Parse failed", message },
       { status: 502 },

--- a/src/app/carers/page.tsx
+++ b/src/app/carers/page.tsx
@@ -13,6 +13,7 @@ import {
   listHouseholdMembers,
   listInvites,
 } from "~/lib/supabase/households";
+import { errorMessage } from "~/lib/utils/errors";
 import type {
   Household,
   HouseholdInvite,
@@ -527,7 +528,7 @@ function SessionDiag() {
         }
       } catch (err) {
         lines.push(
-          `diag exception: ${err instanceof Error ? err.message : String(err)}`,
+          `diag exception: ${errorMessage(err)}`,
         );
       } finally {
         if (!cancelled) setInfo(lines);

--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -16,6 +16,7 @@ import {
   prepareImageForVision,
   type PreparedImage,
 } from "~/lib/ingest/image";
+import { errorMessage } from "~/lib/utils/errors";
 import {
   estimateMeal,
   type MealEstimate,
@@ -49,7 +50,7 @@ export default function MealIngestPage() {
       return;
     }
     setSignInRequired(false);
-    setError(e instanceof Error ? e.message : String(e));
+    setError(errorMessage(e));
   }
 
   async function onPhoto(file: File) {
@@ -61,7 +62,7 @@ export default function MealIngestPage() {
       const blob = new Blob([Uint8Array.from(atob(p.base64), (c) => c.charCodeAt(0))]);
       setPreview(URL.createObjectURL(blob));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
     } finally {
       setBusy(null);
     }
@@ -119,7 +120,7 @@ export default function MealIngestPage() {
       setEstimate(null);
       setSaved({ proteinAdd });
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
     } finally {
       setBusy(null);
     }

--- a/src/app/ingest/notes/page.tsx
+++ b/src/app/ingest/notes/page.tsx
@@ -14,6 +14,7 @@ import {
   prepareImageForVision,
   type PreparedImage,
 } from "~/lib/ingest/image";
+import { errorMessage } from "~/lib/utils/errors";
 import {
   structureNotes,
   type NotesStructure,
@@ -46,7 +47,7 @@ export default function NotesIngestPage() {
       const blob = new Blob([Uint8Array.from(atob(p.base64), (c) => c.charCodeAt(0))]);
       setPreview(URL.createObjectURL(blob));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
     } finally {
       setBusy(null);
     }
@@ -60,7 +61,7 @@ export default function NotesIngestPage() {
       const result = await structureNotes({ model, image: prepared });
       setStructured(result);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
     } finally {
       setBusy(null);
     }
@@ -103,7 +104,7 @@ export default function NotesIngestPage() {
       setStructured(null);
       setSaved({ fields: fieldCount });
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
     } finally {
       setBusy(null);
     }

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -32,6 +32,7 @@ import {
   MicOff,
   Keyboard,
 } from "lucide-react";
+import { errorMessage } from "~/lib/utils/errors";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
 
 const TAG_LABELS: Record<LogTag, { en: string; zh: string }> = {
@@ -177,7 +178,7 @@ export default function LogPage() {
       } catch (err) {
         setRun({
           kind: "error",
-          message: err instanceof Error ? err.message : String(err),
+          message: errorMessage(err),
         });
       }
       return;
@@ -211,7 +212,7 @@ export default function LogPage() {
     } catch (err) {
       setRun({
         kind: "error",
-        message: err instanceof Error ? err.message : String(err),
+        message: errorMessage(err),
       });
       return;
     }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -9,6 +9,7 @@ import { Field, TextInput } from "~/components/ui/field";
 import { Alert } from "~/components/ui/alert";
 import { PageHeader } from "~/components/ui/page-header";
 import { useT } from "~/hooks/use-translate";
+import { errorMessage } from "~/lib/utils/errors";
 
 function LoginForm() {
   const t = useT();
@@ -47,7 +48,7 @@ function LoginForm() {
       setInfo(t("welcomeAuth.createdConfirm"));
       setMode("signin");
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/src/app/memos/[id]/page.tsx
+++ b/src/app/memos/[id]/page.tsx
@@ -21,6 +21,7 @@ import {
   Undo2,
   Sparkles,
 } from "lucide-react";
+import { errorMessage } from "~/lib/utils/errors";
 import { useLocale } from "~/hooks/use-translate";
 import { db } from "~/lib/db/dexie";
 import { parseVoiceMemo, reparseVoiceMemo } from "~/lib/voice-memo/parse";
@@ -294,7 +295,7 @@ function PlaybackCard({
       try {
         await audioRef.current.play();
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err));
+        setError(errorMessage(err));
       }
     }
   }
@@ -501,7 +502,7 @@ function PreviewForm({
       });
       setAppliedRecently(true);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
     } finally {
       setBusy(false);
     }

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -18,6 +18,7 @@ import {
   HOSPITAL_BY_ID,
   ONCOLOGIST_BY_ID,
 } from "~/config/oncologists";
+import { errorMessage } from "~/lib/utils/errors";
 import type { ProtocolId } from "~/types/treatment";
 import type { Locale, Settings } from "~/types/clinical";
 import {
@@ -702,18 +703,6 @@ function UserTypeStep({
       )}
     </Card>
   );
-}
-
-// Supabase's PostgrestError is a plain object, not an Error instance, so the
-// usual `String(err)` fallback produces "[object Object]". Prefer `.message`
-// whenever it's there.
-function errorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (err && typeof err === "object" && "message" in err) {
-    const m = (err as { message: unknown }).message;
-    if (typeof m === "string" && m.length > 0) return m;
-  }
-  return typeof err === "string" && err.length > 0 ? err : "Something went wrong.";
 }
 
 function PickPatientStep({

--- a/src/app/schedule/new/page.tsx
+++ b/src/app/schedule/new/page.tsx
@@ -14,6 +14,7 @@ import type { Appointment } from "~/types/appointment";
 import { Loader2, ImagePlus, Sparkles } from "lucide-react";
 import { todayISO } from "~/lib/utils/date";
 import { postJson } from "~/lib/utils/http";
+import { errorMessage } from "~/lib/utils/errors";
 
 // One unified "smart entry" surface. The patient can:
 //   1. Paste an email body or free-text ("Chemo Friday 10am with Dr Lee at Epworth")
@@ -150,7 +151,7 @@ function SmartEntry({
       );
       await onParsed(data.appointment);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setBusy(false);
     }

--- a/src/app/treatment/new/page.tsx
+++ b/src/app/treatment/new/page.tsx
@@ -20,6 +20,7 @@ import type {
   ProtocolId,
   TreatmentCycle,
 } from "~/types/treatment";
+import { errorMessage } from "~/lib/utils/errors";
 import type {
   DoseSchedule,
   Medication,
@@ -214,7 +215,7 @@ export default function NewTreatmentCyclePage() {
 
       router.push(`/treatment/${cycleId}?cycle_added=1`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/src/components/assessment/coach-drawer.tsx
+++ b/src/components/assessment/coach-drawer.tsx
@@ -7,6 +7,7 @@ import { useLocale } from "~/hooks/use-translate";
 import { useDefaultAiModel } from "~/hooks/use-settings";
 import { askCoach, type CoachContext, type CoachMessage } from "~/lib/ai/coach";
 import { Sparkles, X, Send, Loader2 } from "lucide-react";
+import { errorMessage } from "~/lib/utils/errors";
 
 export function CoachDrawer({ context }: { context: CoachContext }) {
   const locale = useLocale();
@@ -34,7 +35,7 @@ export function CoachDrawer({ context }: { context: CoachContext }) {
       });
       setHistory((h) => [...h, { role: "assistant", content: reply }]);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
     } finally {
       setBusy(false);
     }

--- a/src/components/assessment/wizard.tsx
+++ b/src/components/assessment/wizard.tsx
@@ -14,6 +14,7 @@ import {
   testById,
   type TestId,
 } from "~/lib/assessment/catalog";
+import { errorMessage } from "~/lib/utils/errors";
 import { todayISO } from "~/lib/utils/date";
 import type { ComprehensiveAssessment } from "~/types/clinical";
 import { Alert } from "~/components/ui/alert";
@@ -528,7 +529,7 @@ function ReviewView({
         updated_at: now(),
       });
     } catch (e) {
-      setAiError(e instanceof Error ? e.message : String(e));
+      setAiError(errorMessage(e));
     } finally {
       setAiBusy(false);
     }

--- a/src/components/auth/inline-sign-in.tsx
+++ b/src/components/auth/inline-sign-in.tsx
@@ -8,6 +8,7 @@ import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
 import { Alert } from "~/components/ui/alert";
 import { Loader2 } from "lucide-react";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Embeddable sign-in / sign-up panel. Same behaviour as
 // /login and the welcome modal, but rendered inline so an onboarding
@@ -90,7 +91,7 @@ export function InlineSignIn({
       );
       setMode("signin");
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/src/components/auth/welcome-auth-modal.tsx
+++ b/src/components/auth/welcome-auth-modal.tsx
@@ -9,6 +9,7 @@ import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
 import { useT } from "~/hooks/use-translate";
 import { nowISO } from "~/lib/utils/date";
+import { errorMessage } from "~/lib/utils/errors";
 
 const SEEN_KEY = "anchor.welcomeSeenAt";
 
@@ -70,7 +71,7 @@ export function WelcomeAuthModal() {
       setInfo(t("welcomeAuth.createdConfirm"));
       setMode("signin");
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/src/components/diary/voice-memo-card.tsx
+++ b/src/components/diary/voice-memo-card.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRight,
   CheckCircle2,
 } from "lucide-react";
+import { errorMessage } from "~/lib/utils/errors";
 import type { VoiceMemo, VoiceMemoParsedFields } from "~/types/voice-memo";
 import { resolveVoiceMemoAudioUrl } from "~/lib/voice-memo/cloud";
 import { Card } from "~/components/ui/card";
@@ -71,7 +72,7 @@ export function VoiceMemoCard({ memo, locale }: VoiceMemoCardProps) {
       audio.src = url;
       await audio.play();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     }
   }
 

--- a/src/components/family/log-for-patient.tsx
+++ b/src/components/family/log-for-patient.tsx
@@ -12,6 +12,7 @@ import { Field, Textarea } from "~/components/ui/field";
 import { Check, MessageSquarePlus, Sparkles } from "lucide-react";
 import { todayISO } from "~/lib/utils/date";
 import { FollowUpsCard } from "~/components/log/follow-ups-card";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Caregiver-flavoured log form on /family. Uses the direct-file path
 // from PR #72 so a short entry like "blood sugar 7.9 this morning"
@@ -42,7 +43,7 @@ export function LogForPatient() {
       setFiled(parsed);
       setText("");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/src/components/family/quick-note.tsx
+++ b/src/components/family/quick-note.tsx
@@ -9,6 +9,7 @@ import { Button } from "~/components/ui/button";
 import { Field, Textarea } from "~/components/ui/field";
 import { Card, CardContent } from "~/components/ui/card";
 import { Send, Check, Loader2 } from "lucide-react";
+import { errorMessage } from "~/lib/utils/errors";
 
 // One-textarea contribution surface for family members. Writes a
 // `log_events` row tagged (via the existing tagger, or defaulting to
@@ -49,7 +50,7 @@ export function QuickNote() {
       setState("done");
       window.setTimeout(() => setState("idle"), 2500);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
       setState("error");
     }
   }

--- a/src/components/ingest/calendar-subscribe.tsx
+++ b/src/components/ingest/calendar-subscribe.tsx
@@ -10,6 +10,7 @@ import { Field, TextInput, Textarea } from "~/components/ui/field";
 import { Calendar, AlertCircle, Loader2 } from "lucide-react";
 import type { IngestDraft } from "~/types/ingest";
 import { postJson } from "~/lib/utils/http";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Feeds the ICS path through the same preview-diff flow. Accepts
 // either a webcal:// / https:// subscription URL (Apple Calendar,
@@ -60,7 +61,7 @@ export function CalendarSubscribe({
       setUrl("");
       setText("");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setBusy(false);
     }

--- a/src/components/ingest/phone-note.tsx
+++ b/src/components/ingest/phone-note.tsx
@@ -10,6 +10,7 @@ import { Field, Textarea } from "~/components/ui/field";
 import { Mic, MicOff, AlertCircle, Loader2, Phone } from "lucide-react";
 import type { IngestDraft } from "~/types/ingest";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Quick-capture surface for phone-call instructions. The patient (or
 // the carer on the line) types or dictates what they just heard; the
@@ -59,7 +60,7 @@ export function PhoneCallNote({
       onDraft(data.draft);
       setText("");
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
     } finally {
       setBusy(false);
     }

--- a/src/components/ingest/universal-drop.tsx
+++ b/src/components/ingest/universal-drop.tsx
@@ -10,6 +10,7 @@ import { Button } from "~/components/ui/button";
 import { Field, Textarea } from "~/components/ui/field";
 import { ImagePlus, Loader2, Sparkles, AlertCircle } from "lucide-react";
 import type { IngestDraft, IngestSourceKind } from "~/types/ingest";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Universal entry point. Patient pastes an email body, types a quick
 // note, or snaps a photo (or picks a PDF — converted to image first).
@@ -59,7 +60,7 @@ export function UniversalDrop({
         source: file.type === "application/pdf" ? "pdf" : "photo",
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
       setBusy(false);
     }
   }
@@ -85,7 +86,7 @@ export function UniversalDrop({
       onDraft(data.draft);
       setText("");
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setBusy(false);
     }

--- a/src/components/invite/local-contacts-section.tsx
+++ b/src/components/invite/local-contacts-section.tsx
@@ -10,6 +10,7 @@ import {
   removeCareTeamMember,
   updateCareTeamMember,
 } from "~/lib/care-team/registry";
+import { errorMessage } from "~/lib/utils/errors";
 import { listHouseholdMembers } from "~/lib/supabase/households";
 import { useHousehold } from "~/hooks/use-household";
 import type {
@@ -243,7 +244,7 @@ export function LocalContactsSection() {
       }
       cancel();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/src/components/nutrition/meal-ingest.tsx
+++ b/src/components/nutrition/meal-ingest.tsx
@@ -12,6 +12,7 @@ import {
   Mic,
   MicOff,
 } from "lucide-react";
+import { errorMessage } from "~/lib/utils/errors";
 import { prepareImageForVision } from "~/lib/ingest/image";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
 import {
@@ -53,7 +54,7 @@ export function MealIngest({
       return;
     }
     setSignInRequired(false);
-    setError(e instanceof Error ? e.message : String(e));
+    setError(errorMessage(e));
   }
   // Click-to-record voice memo. Tap once to record, tap again to stop;
   // the audio uploads to /api/ai/transcribe (Whisper) and the finalised

--- a/src/components/schedule/appointment-form.tsx
+++ b/src/components/schedule/appointment-form.tsx
@@ -9,6 +9,7 @@ import type {
   AppointmentKind,
   AppointmentStatus,
 } from "~/types/appointment";
+import { errorMessage } from "~/lib/utils/errors";
 import { useLocale, useT } from "~/hooks/use-translate";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
@@ -143,7 +144,7 @@ export function AppointmentForm({
 
       router.push(`/schedule/${id}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/src/hooks/use-voice-transcription.ts
+++ b/src/hooks/use-voice-transcription.ts
@@ -9,6 +9,7 @@ import {
   parseSseStream,
   readTranscriptionFrame,
 } from "~/lib/voice-memo/sse";
+import { errorMessage } from "~/lib/utils/errors";
 import type { VoiceMemo } from "~/types/voice-memo";
 import type { EnteredBy } from "~/types/clinical";
 
@@ -311,7 +312,7 @@ export function useVoiceTranscription(
               }
             });
           } catch (err) {
-            transcribeError = err instanceof Error ? err.message : String(err);
+            transcribeError = errorMessage(err);
           }
 
           if (memoId !== null && text) {
@@ -363,7 +364,7 @@ export function useVoiceTranscription(
         }
       }, maxDurationMs);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = errorMessage(err);
       setError(message);
       setStatus("error");
       cleanup();

--- a/src/lib/anthropic/route-helpers.ts
+++ b/src/lib/anthropic/route-helpers.ts
@@ -4,6 +4,7 @@ import {
   requireSession,
   type RequireSessionResult,
 } from "~/lib/auth/require-session";
+import { errorMessage } from "~/lib/utils/errors";
 
 export { DEFAULT_AI_MODEL } from "./model";
 
@@ -59,7 +60,7 @@ export async function withAnthropicErrorBoundary<T>(
   try {
     return { value: await work() };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     return {
       error: NextResponse.json({ error: message }, { status: 502 }),
     };
@@ -125,7 +126,7 @@ export async function gateAiRequest<T>(
 // possible — e.g. when only tool_use blocks are emitted).
 export function firstTextBlock(
   message: { content: Array<{ type: string; text?: string }> },
-  errorMessage = "Empty response from Claude",
+  fallbackMessage = "Empty response from Claude",
 ):
   | { text: string; error?: undefined }
   | { error: NextResponse; text?: undefined } {
@@ -135,7 +136,7 @@ export function firstTextBlock(
   );
   if (!block) {
     return {
-      error: NextResponse.json({ error: errorMessage }, { status: 502 }),
+      error: NextResponse.json({ error: fallbackMessage }, { status: 502 }),
     };
   }
   return { text: block.text };
@@ -146,13 +147,13 @@ export function firstTextBlock(
 // abort, empty response).
 export function requireParsedOutput<T>(
   message: { parsed_output: T | null | undefined },
-  errorMessage = "No parsed output returned",
+  fallbackMessage = "No parsed output returned",
 ):
   | { value: T; error?: undefined }
   | { error: NextResponse; value?: undefined } {
   if (!message.parsed_output) {
     return {
-      error: NextResponse.json({ error: errorMessage }, { status: 502 }),
+      error: NextResponse.json({ error: fallbackMessage }, { status: 502 }),
     };
   }
   return { value: message.parsed_output };

--- a/src/lib/ingest/bulk.ts
+++ b/src/lib/ingest/bulk.ts
@@ -10,6 +10,7 @@ import {
   saveExtraction,
   type UnifiedExtraction,
 } from "./save";
+import { errorMessage } from "~/lib/utils/errors";
 import { db, now } from "~/lib/db/dexie";
 import type { IngestedDocument } from "~/types/clinical";
 
@@ -94,7 +95,7 @@ export async function processBulkItemOcr(
       status: "parsing",
     });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorMessage(err);
     await db.ingested_documents.update(docId, {
       status: "error",
       error_message: msg,
@@ -147,7 +148,7 @@ export async function parseBulkItem(
   } catch (err) {
     mutate(item.id, {
       status: "parse_failed",
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
     });
   }
 }
@@ -183,7 +184,7 @@ export async function processBulkItemVision(
   try {
     prepared = await prepareImageForVision(item.file);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorMessage(err);
     await db.ingested_documents.update(docId, {
       status: "error",
       error_message: msg,
@@ -212,7 +213,7 @@ export async function processBulkItemVision(
       progress: undefined,
     });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorMessage(err);
     await db.ingested_documents.update(docId, {
       status: "error",
       error_message: msg,
@@ -280,7 +281,7 @@ export async function processBulkItemDocx(
       progress: undefined,
     });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorMessage(err);
     await db.ingested_documents.update(docId, {
       status: "error",
       error_message: msg,
@@ -304,7 +305,7 @@ export async function saveBulkItem(
   } catch (err) {
     mutate(item.id, {
       status: "parse_failed",
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
     });
   }
 }

--- a/src/lib/ingest/operations.ts
+++ b/src/lib/ingest/operations.ts
@@ -6,6 +6,7 @@ import type {
   LabMatch,
   MedicationMatch,
 } from "~/types/ingest";
+import { errorMessage } from "~/lib/utils/errors";
 import type { Appointment } from "~/types/appointment";
 import type {
   CtdnaResult,
@@ -253,7 +254,7 @@ export async function applyIngestOp(
     return {
       op,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
     };
   }
 }

--- a/src/lib/log/run-agents.ts
+++ b/src/lib/log/run-agents.ts
@@ -8,6 +8,7 @@ import type {
   DexiePatch,
   LogEventRow,
 } from "~/types/agent";
+import { errorMessage } from "~/lib/utils/errors";
 import { FOLLOW_UP_PRIORITY } from "~/config/agent-cadence";
 import type { Locale } from "~/types/clinical";
 import { agentsForTags } from "~/agents/routing";
@@ -366,7 +367,7 @@ export async function runAllAgentsForToday(args: {
         return {
           id,
           runId: null,
-          error: err instanceof Error ? err.message : String(err),
+          error: errorMessage(err),
         };
       }
     }),

--- a/src/lib/push/server.ts
+++ b/src/lib/push/server.ts
@@ -1,6 +1,7 @@
 import webpush from "web-push";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { nowISO } from "~/lib/utils/date";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Server-side push helpers. VAPID keys live as Vercel env vars:
 //   VAPID_PUBLIC_KEY  (base64-url, also exposed to the client via
@@ -84,7 +85,7 @@ export async function sendPush(
       (err as { statusCode?: number })?.statusCode ??
       (err as { status?: number })?.status ??
       500;
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     return { ok: false, status: statusCode, error: message };
   }
 }

--- a/src/lib/utils/errors.ts
+++ b/src/lib/utils/errors.ts
@@ -1,0 +1,27 @@
+// Pull a human-readable message out of an unknown thrown value.
+//
+// The pattern
+//
+//     err instanceof Error ? err.message : String(err)
+//
+// had grown to ~50 sites across components, hooks, API routes, and
+// background ingest jobs. Centralising it gives every caller the same
+// fallback for non-Error throws and makes it easier to layer on richer
+// extraction later (cause chains, redaction) without hunting down call
+// sites.
+//
+// Beyond the basic ternary, this helper also reaches into the
+// `{ message: string }` shape used by Supabase's `PostgrestError` and
+// most fetch-style libraries — these are plain objects, not `Error`
+// instances, so the naive `String(err)` fallback produced
+// "[object Object]" in toasts. Onboarding had its own copy of this
+// logic; everything now flows through here.
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object" && "message" in err) {
+    const m = (err as { message: unknown }).message;
+    if (typeof m === "string" && m.length > 0) return m;
+  }
+  if (typeof err === "string" && err.length > 0) return err;
+  return "Something went wrong.";
+}

--- a/src/lib/validators/schemas.ts
+++ b/src/lib/validators/schemas.ts
@@ -1,6 +1,14 @@
 import { z } from "zod";
 
+// Clinical scale primitives. Naming the ranges (rather than inlining
+// `z.number().min(0).max(N)` everywhere) keeps each schema field's
+// intent legible — a reader sees "ctcaeGrade", not a magic 0–4 range —
+// and stops the inevitable drift between e.g. PRO-CTCAE fields if the
+// CTCAE upper bound ever shifts.
 const scale0to10 = z.number().min(0).max(10);
+const scale0to5 = z.number().min(0).max(5);
+const ctcaeGrade = z.number().int().min(0).max(4);
+const weekDayCount = z.number().int().min(0).max(7);
 
 // `entered_by` is the household member who logged the entry. The full
 // EnteredBy type in ~/types/clinical also includes "clinician" and
@@ -27,14 +35,14 @@ export const dailyEntrySchema = z.object({
   weight_kg: z.number().min(20).max(200).optional(),
   steps: z.number().int().min(0).max(200000).optional(),
   practice_morning_completed: z.boolean().optional(),
-  practice_morning_quality: z.number().min(0).max(5).optional(),
+  practice_morning_quality: scale0to5.optional(),
   practice_evening_completed: z.boolean().optional(),
-  practice_evening_quality: z.number().min(0).max(5).optional(),
+  practice_evening_quality: scale0to5.optional(),
   cold_dysaesthesia: z.boolean().optional(),
   // CTCAE 0–4. Legacy records may have booleans; the wizard coerces
   // on read, so accept both for backwards compatibility.
-  neuropathy_hands: z.union([z.number().int().min(0).max(4), z.boolean()]).optional(),
-  neuropathy_feet: z.union([z.number().int().min(0).max(4), z.boolean()]).optional(),
+  neuropathy_hands: z.union([ctcaeGrade, z.boolean()]).optional(),
+  neuropathy_feet: z.union([ctcaeGrade, z.boolean()]).optional(),
   mouth_sores: z.boolean().optional(),
   diarrhoea_count: z.number().int().min(0).max(30).optional(),
   new_bruising: z.boolean().optional(),
@@ -45,7 +53,7 @@ export const dailyEntrySchema = z.object({
   fatigue: scale0to10.optional(),
   anorexia: scale0to10.optional(),
   abdominal_pain: scale0to10.optional(),
-  taste_changes: z.number().min(0).max(5).optional(),
+  taste_changes: scale0to5.optional(),
   steatorrhoea: z.boolean().optional(),
   reflection: z.string().max(4000).optional(),
   reflection_lang: z.enum(["en", "zh"]).optional(),
@@ -124,14 +132,14 @@ export const fortnightlyAssessmentSchema = z.object({
       z.literal(4),
     ])
     .optional(),
-  pro_ctcae_fatigue_severity: z.number().int().min(0).max(4).optional(),
-  pro_ctcae_fatigue_interference: z.number().int().min(0).max(4).optional(),
-  pro_ctcae_neuropathy_severity: z.number().int().min(0).max(4).optional(),
-  pro_ctcae_neuropathy_interference: z.number().int().min(0).max(4).optional(),
-  pro_ctcae_pain_severity: z.number().int().min(0).max(4).optional(),
-  pro_ctcae_pain_interference: z.number().int().min(0).max(4).optional(),
-  pro_ctcae_diarrhoea_frequency: z.number().int().min(0).max(4).optional(),
-  distress_thermometer: z.number().min(0).max(10).optional(),
+  pro_ctcae_fatigue_severity: ctcaeGrade.optional(),
+  pro_ctcae_fatigue_interference: ctcaeGrade.optional(),
+  pro_ctcae_neuropathy_severity: ctcaeGrade.optional(),
+  pro_ctcae_neuropathy_interference: ctcaeGrade.optional(),
+  pro_ctcae_pain_severity: ctcaeGrade.optional(),
+  pro_ctcae_pain_interference: ctcaeGrade.optional(),
+  pro_ctcae_diarrhoea_frequency: ctcaeGrade.optional(),
+  distress_thermometer: scale0to10.optional(),
   phq9_total: z.number().min(0).max(27).optional(),
   gad7_total: z.number().min(0).max(21).optional(),
   sarc_f_responses: z.array(z.number().int().min(0).max(2)).length(5).optional(),
@@ -149,9 +157,9 @@ export type FortnightlyAssessmentInput = z.infer<
 export const weeklyAssessmentSchema = z.object({
   week_start: z.string(),
   entered_by: householdEnteredBy,
-  practice_full_days: z.number().int().min(0).max(7),
-  practice_reduced_days: z.number().int().min(0).max(7),
-  practice_skipped_days: z.number().int().min(0).max(7),
+  practice_full_days: weekDayCount,
+  practice_reduced_days: weekDayCount,
+  practice_skipped_days: weekDayCount,
   functional_integrity: z.number().min(1).max(5),
   cognitive_stillness: z.number().min(1).max(5),
   social_practice_integrity: z.number().min(1).max(5),

--- a/src/lib/voice-memo/apply.ts
+++ b/src/lib/voice-memo/apply.ts
@@ -6,6 +6,7 @@ import type {
   MealEntry,
   MealItem,
 } from "~/types/nutrition";
+import { errorMessage } from "~/lib/utils/errors";
 import type {
   AppliedPatch,
   VoiceMemo,
@@ -960,7 +961,7 @@ export async function undoAppliedPatch(
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
     };
   }
 

--- a/src/lib/voice-memo/parse.ts
+++ b/src/lib/voice-memo/parse.ts
@@ -2,6 +2,7 @@ import { db, now } from "~/lib/db/dexie";
 import { postJson } from "~/lib/utils/http";
 import type { VoiceMemoParsedFields } from "~/types/voice-memo";
 import { applyMemoPatches } from "./apply";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Slice 3 → ship: Claude reads every memo end-to-end and returns a
 // structured picture of it (daily-tracking fields, clinic visits,
@@ -77,7 +78,7 @@ export interface ParseAttempt {
 }
 
 function humaniseParseError(err: unknown): string {
-  const raw = err instanceof Error ? err.message : String(err);
+  const raw = errorMessage(err);
   // postJson wraps server bodies as `HTTP 502: {"error":"..."}` —
   // unwrap so the patient-facing message is the actual cause.
   const match = raw.match(/HTTP \d+:\s*(.+)/);

--- a/src/lib/voice-memo/retranscribe.ts
+++ b/src/lib/voice-memo/retranscribe.ts
@@ -1,6 +1,7 @@
 import { db, now } from "~/lib/db/dexie";
 import { parseVoiceMemo } from "./parse";
 import { parseSseStream, readTranscriptionFrame } from "./sse";
+import { errorMessage } from "~/lib/utils/errors";
 
 // Retry transcription for a memo whose first attempt failed
 // (env-var glitch, network blip, OpenAI 5xx). Uses the audio Blob
@@ -46,7 +47,7 @@ export async function retranscribeVoiceMemo(memoId: number): Promise<{
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
     };
   }
   if (!res.ok) {


### PR DESCRIPTION
## Summary

Code-debt cleanup pass — pure DRY/refactor work, no behaviour changes intended.

- **`errorMessage(err)`** — extract `src/lib/utils/errors.ts` and migrate all 49 inline `err instanceof Error ? err.message : String(err)` sites across components, hooks, API routes, agents, and ingest jobs. The helper additionally handles two cases the inline ternary missed:
  - Supabase's `PostgrestError` (plain object, not `Error`) — was rendering "[object Object]" in toasts; the helper now reaches into `{ message: string }`. This was already handled by a bespoke local copy in `src/app/onboarding/page.tsx`, which is removed.
  - Empty / null throws — now fall back to a UX-safe "Something went wrong." instead of "undefined" / "null".
- **Validator scale primitives** — extract `scale0to5`, `ctcaeGrade`, `weekDayCount` next to the existing `scale0to10` in `src/lib/validators/schemas.ts`. PRO-CTCAE fields, practice quality scores, weekly day counts, and the distress thermometer were spelled out as raw `z.number()` ranges; naming them keeps clinical intent visible.
- **`route-helpers.ts` parameter rename** — `firstTextBlock` and `requireParsedOutput` had a default param literally named `errorMessage` that now shadows the imported helper inside its own body. Renamed to `fallbackMessage`. All callers pass positionally, no API change.

## Considered and rejected

- **`scale-input` / `NumberScale` consolidation** — different surfaces (daily wizard radio-group with `n/max` readout vs assessment wizard with `leftLabel`/`rightLabel` anchors), different a11y semantics. Merging would force one design intent on both.
- **`households.ts` query helper** — 20 functions repeat `getSupabaseBrowser()` + `currentUserId()`, but each chooses a different fallback policy (`null` / `[]` / `throw`) deliberately. Not boilerplate, policy.
- **API-route Result-type union flattening** — the `{ key: T; error?: undefined } | { error: NextResponse; key?: undefined }` shape repeats 5 times in `route-helpers.ts`, but the success-key names (`client`, `body`, `value`, `text`) are intentional and would degrade to opaque generics if unified.
- **`parse-appointment` route migration to `gateAiRequest`** — the existing order (auth → body parse → zod → anthropic) differs from the gate's order (auth → anthropic → body), and `api-auth.test.ts` asserts the latter for AI routes. Out of scope.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no warnings/errors
- [x] `pnpm test` — 1009 / 1009 passing
- [ ] Manual smoke of `/login`, `/onboarding`, voice-memo capture (PostgrestError path)

Net: 39 files changed, 141 insertions, 81 deletions, plus one new 13-line helper file.

https://claude.ai/code/session_01APuKFc6Wj6qySXaTrnfAfU

---
_Generated by [Claude Code](https://claude.ai/code/session_01APuKFc6Wj6qySXaTrnfAfU)_