### PR TITLE
fix(ux): trim more dead/janky surfaces from the patient dashboard

### DIFF
--- a/src/app/carers/page.tsx
+++ b/src/app/carers/page.tsx
@@ -303,13 +303,6 @@ export default function CarersPage() {
                 {L("Sign in to invite", "登录后邀请")}
               </Button>
             </Link>
-            {/* Diagnostic block. The page is gated on session.signedIn,
-                which reads the Supabase session straight from local
-                storage / cookies. If the user is convinced they're
-                signed in but the gate disagrees, the actual values
-                here tell us exactly which signal is wrong. Toggle off
-                once we trust the surface. */}
-            <SessionDiag />
           </CardContent>
         </Card>
       ) : !membership || !householdId ? (
@@ -463,89 +456,3 @@ export default function CarersPage() {
   );
 }
 
-// Inline diagnostic for the "Sign in to invite" branch on /carers.
-// Reads the Supabase session directly (separate from useAuthSession's
-// state to avoid a chicken-and-egg with the gate it controls) and
-// dumps a plain-text summary the user can read or screenshot.
-//
-// The bug we keep chasing: a user is convinced they're signed in but
-// the gate disagrees. The only way to distinguish the real cause
-// (cookies cleared / cross-origin session / expired token / browser
-// extension blocking storage) is to see what getSession actually
-// returns in their browser. Self-contained — no props.
-function SessionDiag() {
-  const [info, setInfo] = useState<string[]>(["resolving…"]);
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      const lines: string[] = [];
-      try {
-        const { isSupabaseConfigured: isCfg, getSupabaseBrowser: getSb } =
-          await import("~/lib/supabase/client");
-        lines.push(`supabase configured: ${isCfg() ? "yes" : "no"}`);
-        // Local storage probe — surfaces "blocked by browser /
-        // private mode" cases that silently break Supabase JS auth.
-        try {
-          const probeKey = "__anchor_diag_probe";
-          window.localStorage.setItem(probeKey, "1");
-          window.localStorage.removeItem(probeKey);
-          lines.push("localStorage: writable");
-        } catch {
-          lines.push("localStorage: BLOCKED (private mode / disabled)");
-        }
-        lines.push(`cookies enabled: ${navigator.cookieEnabled ? "yes" : "no"}`);
-        const sb = getSb();
-        if (!sb) {
-          lines.push("client: not constructed");
-          if (!cancelled) setInfo(lines);
-          return;
-        }
-        const sess = await sb.auth.getSession();
-        if (sess.error) {
-          lines.push(`getSession error: ${sess.error.message}`);
-        }
-        const session = sess.data.session;
-        lines.push(`session present: ${session ? "yes" : "no"}`);
-        if (session) {
-          lines.push(`user id: ${session.user.id.slice(0, 8)}…`);
-          if (session.expires_at) {
-            const exp = new Date(session.expires_at * 1000).toISOString();
-            lines.push(`expires at: ${exp}`);
-            lines.push(
-              `expired: ${session.expires_at * 1000 < Date.now() ? "YES" : "no"}`,
-            );
-          }
-        }
-        const userResp = await sb.auth.getUser();
-        if (userResp.error) {
-          lines.push(`getUser error: ${userResp.error.message}`);
-        } else {
-          lines.push(
-            `getUser id: ${userResp.data.user?.id?.slice(0, 8) ?? "(null)"}…`,
-          );
-        }
-      } catch (err) {
-        lines.push(
-          `diag exception: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      } finally {
-        if (!cancelled) setInfo(lines);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  return (
-    <details className="rounded-md border border-ink-200 bg-paper-2 p-2 text-[11px] text-ink-600">
-      <summary className="cursor-pointer select-none font-medium text-ink-700">
-        Why does this say sign in?
-      </summary>
-      <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-[10.5px] leading-snug">
-        {info.join("\n")}
-      </pre>
-    </details>
-  );
-}

--- a/src/app/diary/page.tsx
+++ b/src/app/diary/page.tsx
@@ -55,6 +55,9 @@ export default function DiaryPage() {
   const [days, setDays] = useState<DiaryDay[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  // Manual reload counter so a Retry click forces the build effect to
+  // re-run even when none of its other deps have changed.
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -93,7 +96,7 @@ export default function DiaryPage() {
     // Re-run whenever any underlying table changes row count or the
     // window expands. Cheap because the aggregator reads each table
     // once and bins in memory.
-  }, [memoCount, dailyCount, logCount, labCount, runCount, windowDays]);
+  }, [memoCount, dailyCount, logCount, labCount, runCount, windowDays, reloadKey]);
 
   // Best-effort: try to flush any voice-memo audio that's still waiting
   // to upload. Runs on mount and never throws into render.
@@ -143,9 +146,20 @@ export default function DiaryPage() {
 
       {loadError ? (
         <Alert variant="warn" role="alert">
-          {locale === "zh"
-            ? "日记加载失败，请刷新页面重试。"
-            : "Diary failed to load. Try refreshing the page."}
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span>
+              {locale === "zh"
+                ? "日记加载失败。"
+                : "Diary failed to load."}
+            </span>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => setReloadKey((k) => k + 1)}
+            >
+              {locale === "zh" ? "重试" : "Retry"}
+            </Button>
+          </div>
         </Alert>
       ) : loading && days.length === 0 ? (
         <Card className="p-5">

--- a/src/app/practices/page.tsx
+++ b/src/app/practices/page.tsx
@@ -63,7 +63,7 @@ export default function PracticesPage() {
         </div>
       </Card>
 
-      {active.length === 0 ? (
+      {rows === undefined ? null : active.length === 0 ? (
         <Card className="p-5 text-sm text-ink-500">
           {locale === "zh"
             ? "暂无修习。点击右上角新建第一项。"

--- a/src/components/dashboard/baseline-nudge-card.tsx
+++ b/src/components/dashboard/baseline-nudge-card.tsx
@@ -35,6 +35,11 @@ export function BaselineNudgeCard() {
   if (!s) return null;
   if (!s.onboarded_at) return null;
   if (s.baseline_weight_kg) return null;
+  // Wait for the comprehensive-assessment live query to resolve before
+  // rendering. Otherwise the card flashes "Capture your baselines" on
+  // every dashboard load — even for patients who already finished an
+  // assessment but never set baseline_weight_kg directly in settings.
+  if (hasComplete === undefined) return null;
   if (hasComplete) return null;
 
   const L = pickL(locale);

--- a/src/components/dashboard/quick-checkin-card.tsx
+++ b/src/components/dashboard/quick-checkin-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db, now } from "~/lib/db/dexie";
@@ -67,21 +67,12 @@ export function QuickCheckinCard() {
   const [feverTemp, setFeverTemp] = useState("");
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [justSaved, setJustSaved] = useState(false);
 
-  // After save, the live query picks up `existing` and switches the
-  // card to its compact "Saved today" summary. We don't auto-hide
-  // anymore — silence on the dashboard after a check-in left users
-  // wondering whether the save took. The compact summary stays until
-  // tomorrow's date rolls over (or the entry is edited from the
-  // full log), and the Full-log link gives a one-tap path to amend.
-  useEffect(() => {
-    if (!justSaved) return;
-    const id = setTimeout(() => setJustSaved(false), 6000);
-    return () => clearTimeout(id);
-  }, [justSaved]);
-
-  if (existing && !justSaved) {
+  // After save, the live query picks up `existing` and the card
+  // transitions to the compact SavedTodaySummary. The transition
+  // itself IS the confirmation — no separate "Saved for today" toast
+  // card. Two near-identical cards swapping at a 6s timer was jarring.
+  if (existing) {
     return <SavedTodaySummary entry={existing} />;
   }
 
@@ -124,7 +115,6 @@ export function QuickCheckinCard() {
             : "Saved, but the alert check didn't run.",
         );
       }
-      setJustSaved(true);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error("[quick-checkin] save failed", err);
@@ -136,37 +126,6 @@ export function QuickCheckinCard() {
     } finally {
       setSaving(false);
     }
-  }
-
-  if (justSaved) {
-    return (
-      <Card className="p-5">
-        <div className="flex items-start gap-3">
-          <div
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
-            style={{ background: "var(--ok-soft)", color: "var(--ok)" }}
-          >
-            <Check className="h-4 w-4" strokeWidth={3} />
-          </div>
-          <div className="flex-1">
-            <div className="text-[13px] font-semibold text-ink-900">
-              {locale === "zh" ? "今日已记录" : "Saved for today"}
-            </div>
-            <p className="mt-0.5 text-[12.5px] text-ink-500">
-              {locale === "zh"
-                ? "想补充或修改？"
-                : "Want to add detail or edit?"}
-            </p>
-            <Link
-              href="/daily/new"
-              className="mt-2 inline-flex items-center gap-1 text-[12.5px] font-medium text-[var(--tide-2)] hover:underline"
-            >
-              {locale === "zh" ? "打开完整日志 →" : "Open full log →"}
-            </Link>
-          </div>
-        </div>
-      </Card>
-    );
   }
 
   return (


### PR DESCRIPTION
## Summary

A second-pass UX/bug review of the patient surface, focused on dead UI, broken-by-load-order flicker, and stuck states.

### Fixes

- **`/carers`** — remove the `SessionDiag` debug widget rendered under the "Sign in to invite" CTA. Its own comment said *"Toggle off once we trust the surface"* — that toggle never happened, leaving Supabase session internals visible to patients.
- **`BaselineNudgeCard`** — gate on `hasComplete !== undefined` so the card no longer flashes "Capture your baselines" on every dashboard load while the `comprehensive_assessments` live query is still resolving (visible to any patient who finished an assessment but never wrote `baseline_weight_kg` directly into settings).
- **`/practices`** — gate the "No practices yet" empty-state on `rows === undefined`. Previously the page flickered between empty card and real list on every navigation.
- **`/diary`** — replace the dead "try refreshing the page" alert on load-timeout with an in-page **Retry** button that re-runs the aggregation. A 10s Dexie hang shouldn't trap the user behind a full-page reload.
- **`QuickCheckinCard`** — drop the 6-second `justSaved` interim card. The live-query-driven `SavedTodaySummary` already lands as soon as the `daily_entries` write commits, so two near-identical "saved" cards swapping at 6s was jarring rather than reassuring. The form → summary transition IS the confirmation.

### Audit notes (not fixed in this PR)

The audit also surfaced larger doctrine issues that warrant separate work:
- `PillarTiles` duplicates several feed-eligible items (next infusion, protein gap, liver flag, practice today).
- Three invite-lifecycle cards (`PendingInvites`, `RecentlyAccepted`, `InviteFamily`) should fold into the feed per CLAUDE.md's "single channel out".
- `NextClinicCard` ↔ `ScheduleCard` overlap.
- `/weekly`, `/fortnightly`, `/tasks`, `/safety` are orphaned from the patient bottom-nav; the doctrinal answer is to surface them as feed items, not add nav slots.

These are kept out of this PR because each one is a meaningful redesign rather than a fix.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1009/1009 unit tests pass
- [ ] Manual: open dashboard cold-start → no "Capture your baselines" flash for a patient with a prior comprehensive assessment.
- [ ] Manual: cold-start `/practices` with a configured practice → no empty-state flash.
- [ ] Manual: complete a quick check-in → no second "Saved for today" card 6s later.
- [ ] Manual: simulate a `/diary` aggregation timeout → Retry button re-runs the build.
- [ ] Manual: signed-out `/carers` view → no "Why does this say sign in?" diagnostic block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8NwjKodjDPWfqXQNHZfLr)_