### PR TITLE
refactor(sync): collapse household-id resolution into ensureHouseholdId helper

### DIFF
--- a/src/lib/sync/household-context.ts
+++ b/src/lib/sync/household-context.ts
@@ -79,6 +79,18 @@ export async function refreshHouseholdId(): Promise<string | null> {
   }
 }
 
+// Read-through accessor for the sync layer: returns the cached household
+// id if known, otherwise triggers a single refresh and returns the result.
+// Callers (queue/pull/realtime/voice-memo upload) all need to satisfy RLS
+// with a household_id before talking to Supabase, and all want the same
+// "use cache or refresh once" behaviour — collapsing it here avoids drift
+// when the refresh strategy changes (e.g. adding a backoff or retry).
+export async function ensureHouseholdId(): Promise<string | null> {
+  const cachedId = getCachedHouseholdId();
+  if (cachedId) return cachedId;
+  return refreshHouseholdId();
+}
+
 // Test-only reset so each test starts from a clean cache.
 export function __resetHouseholdContextForTests(): void {
   cached = null;

--- a/src/lib/sync/pull.ts
+++ b/src/lib/sync/pull.ts
@@ -2,10 +2,7 @@ import { db } from "~/lib/db/dexie";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
 import { SYNCED_TABLES, type SyncedTable } from "./tables";
 import { withSyncSuppressed } from "./queue";
-import {
-  getCachedHouseholdId,
-  refreshHouseholdId,
-} from "./household-context";
+import { ensureHouseholdId } from "./household-context";
 
 const LAST_PULLED_KEY = "anchor.lastPulledAt";
 
@@ -28,10 +25,7 @@ export async function pullFromCloud(): Promise<{ pulled: number } | null> {
   // Slice B: scope the pull to the current user's household. Without
   // a household we skip — the user is either signed out or mid-
   // onboarding before create_household runs.
-  let householdId = getCachedHouseholdId();
-  if (!householdId) {
-    householdId = await refreshHouseholdId();
-  }
+  const householdId = await ensureHouseholdId();
   if (!householdId) return { pulled: 0 };
 
   // Fetch rows newer than our last pull. Limit to 5000 for safety.

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -1,7 +1,7 @@
 import { db } from "~/lib/db/dexie";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
 import { nowISO } from "~/lib/utils/date";
-import { getCachedHouseholdId, refreshHouseholdId } from "./household-context";
+import { ensureHouseholdId } from "./household-context";
 import type { SyncedTable } from "./tables";
 import type { SyncQueueRow } from "~/types/sync-queue";
 
@@ -120,10 +120,7 @@ async function processQueue(): Promise<void> {
   // yet (fresh sign-in, brand-new signup pre-create_household), try
   // to resolve it now; if still unknown, leave the queue intact and
   // retry on the next tick.
-  let householdId = getCachedHouseholdId();
-  if (!householdId) {
-    householdId = await refreshHouseholdId();
-  }
+  const householdId = await ensureHouseholdId();
   if (!householdId) {
     // No household yet — can't satisfy RLS. Hold the ops; the bootstrap
     // path will create the household, and the retry timer will pick

--- a/src/lib/sync/realtime.ts
+++ b/src/lib/sync/realtime.ts
@@ -2,9 +2,8 @@ import type { RealtimeChannel } from "@supabase/supabase-js";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
 import { pullFromCloud } from "./pull";
 import {
-  getCachedHouseholdId,
+  ensureHouseholdId,
   onHouseholdChange,
-  refreshHouseholdId,
 } from "./household-context";
 
 let channel: RealtimeChannel | null = null;
@@ -29,10 +28,7 @@ async function ensureSubscription(): Promise<void> {
   const supabase = getSupabaseBrowser();
   if (!supabase) return;
 
-  let householdId = getCachedHouseholdId();
-  if (!householdId) {
-    householdId = await refreshHouseholdId();
-  }
+  const householdId = await ensureHouseholdId();
 
   // Subscribe only if the household changed (or we have none yet).
   if (householdId === subscribedHouseholdId && channel) return;

--- a/src/lib/voice-memo/cloud.ts
+++ b/src/lib/voice-memo/cloud.ts
@@ -1,9 +1,6 @@
 import { db, now } from "~/lib/db/dexie";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
-import {
-  getCachedHouseholdId,
-  refreshHouseholdId,
-} from "~/lib/sync/household-context";
+import { ensureHouseholdId } from "~/lib/sync/household-context";
 
 // Cloud mirror for voice-memo audio. The metadata row in `voice_memos`
 // already syncs through the cloud_rows queue; this module handles the
@@ -27,8 +24,7 @@ export async function uploadVoiceMemoAudio(memoId: number): Promise<void> {
   const supabase = getSupabaseBrowser();
   if (!supabase) return;
 
-  let householdId = getCachedHouseholdId();
-  if (!householdId) householdId = await refreshHouseholdId();
+  const householdId = await ensureHouseholdId();
   if (!householdId) return;
 
   const media = await db.timeline_media.get(memo.audio_media_id);


### PR DESCRIPTION
## Summary

Four sync-layer callsites — `queue.processQueue`, `pull.pullFromCloud`, `realtime.ensureSubscription`, and `voice-memo.uploadVoiceMemoAudio` — each inlined the same three-line household-id resolution before any RLS-scoped Supabase call:

```ts
let id = getCachedHouseholdId();
if (!id) id = await refreshHouseholdId();
if (!id) <bail>;
```

Replaced with a single `ensureHouseholdId()` helper in `household-context.ts` that composes the existing cache + refresh accessors. Each caller still owns its own null handling (queue retries, pull returns `{ pulled: 0 }`, realtime tears down its channel, voice-memo returns silently) — only the resolution step is consolidated.

## Why

CLAUDE.md guidance: *"Three similar lines is better than a premature abstraction."* Three would have been borderline; **four** copies (the survey missed `voice-memo/cloud.ts`) of code gating the entire RLS surface is past the line. Any future change to the resolution strategy — backoff, drop-the-cache, log-the-miss — would have had to land in four files, and silent drift here is a real failure mode for RLS scoping.

## Scope discipline

Other debt surfaced by the survey but **deliberately not addressed** in this PR:
- Mega-files (`memos/[id]/page.tsx` 1547 lines, `onboarding/page.tsx` 1482 lines, `daily-wizard.tsx` 1464 lines) — architectural refactors that belong in their own focused PRs with explicit kanban issues.
- Duplicate `CloudRow` type between `pull.ts` and `morning-digest/route.ts` — on closer reading these are different projections (`{ data: T }` vs the full 5-field row), not the same type. Unifying would be a forced abstraction.
- `cloud_rows` query patterns differ in their selects/ordering across morning-digest and pull — extracting a shared query helper would distort each callsite's intent.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1009 tests passed (112 files)
- [x] `pnpm lint` — no warnings or errors
- [ ] Manual: sign-in flow still creates a household and queued writes flush (covered by `sync-queue.test.ts` + `households.test.ts`)

Refs the "sync queue must persist to Dexie" trap in CLAUDE.md — this change does not alter the persistence path, only the household-id lookup wrapping it.

https://claude.ai/code/session_013Ud5LNMTzFrJmPZFRgiUBA

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ud5LNMTzFrJmPZFRgiUBA)_