### PR TITLE
fix(ux): correctness bugs and dashboard de-duplication

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -68,12 +68,26 @@ export default function DailyPage() {
                   />
                 </div>
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-500">
-                  <span>
-                    {locale === "zh" ? "精力" : "energy"} {e.energy}
-                  </span>
-                  <span>
-                    {locale === "zh" ? "睡眠" : "sleep"} {e.sleep_quality}
-                  </span>
+                  {typeof e.energy === "number" && (
+                    <span>
+                      {locale === "zh" ? "精力" : "energy"} {e.energy}
+                    </span>
+                  )}
+                  {typeof e.sleep_quality === "number" && (
+                    <span>
+                      {locale === "zh" ? "睡眠" : "sleep"} {e.sleep_quality}
+                    </span>
+                  )}
+                  {typeof e.pain_current === "number" && (
+                    <span>
+                      {locale === "zh" ? "疼痛" : "pain"} {e.pain_current}
+                    </span>
+                  )}
+                  {typeof e.nausea === "number" && e.nausea > 0 && (
+                    <span>
+                      {locale === "zh" ? "恶心" : "nausea"} {e.nausea}
+                    </span>
+                  )}
                   {typeof e.weight_kg === "number" && <span>{e.weight_kg} kg</span>}
                   {typeof e.protein_grams === "number" && (
                     <span>{e.protein_grams} g protein</span>

--- a/src/components/dashboard/pillar-tiles.tsx
+++ b/src/components/dashboard/pillar-tiles.tsx
@@ -8,7 +8,6 @@ import {
   format,
   parseISO,
 } from "date-fns";
-import { useSettings } from "~/hooks/use-settings";
 import {
   latestDailyEntries,
   latestLabs,
@@ -19,16 +18,13 @@ import { useWeather } from "~/hooks/use-weather";
 import { Sparkline } from "~/components/ui/sparkline";
 import { PROTOCOL_BY_ID } from "~/config/protocols";
 import { cn } from "~/lib/utils/cn";
-import { todayISO as getTodayISO } from "~/lib/utils/date";
 import {
   ArrowDown,
   ChevronRight,
-  Pill,
   FlaskConical,
   Sun,
   CloudRain,
   Snowflake,
-  Utensils,
   Flame,
 } from "lucide-react";
 
@@ -38,13 +34,20 @@ function symptomScore(d: {
   sleep_quality?: number;
   energy?: number;
   mood_clarity?: number;
-}): number {
-  const pain = d.pain_current ?? 0;
-  const nausea = d.nausea ?? 0;
-  const fatigue = typeof d.energy === "number" ? 10 - d.energy : 0;
-  const sleep = typeof d.sleep_quality === "number" ? 10 - d.sleep_quality : 0;
-  const mood = typeof d.mood_clarity === "number" ? 10 - d.mood_clarity : 0;
-  return Math.min(10, (pain + nausea + fatigue + sleep + mood) / 5);
+}): number | null {
+  // Average only the components actually entered. The previous version
+  // divided by a fixed 5 and treated undefined fields as 0, which made a
+  // quick-checkin (just energy/pain/nausea) read as a low-symptom day —
+  // missing fields silently dragged the score down and polluted the
+  // 7-day trend. Returning null lets callers skip the entry entirely.
+  const components: number[] = [];
+  if (typeof d.pain_current === "number") components.push(d.pain_current);
+  if (typeof d.nausea === "number") components.push(d.nausea);
+  if (typeof d.energy === "number") components.push(10 - d.energy);
+  if (typeof d.sleep_quality === "number") components.push(10 - d.sleep_quality);
+  if (typeof d.mood_clarity === "number") components.push(10 - d.mood_clarity);
+  if (components.length === 0) return null;
+  return Math.min(10, components.reduce((a, b) => a + b, 0) / components.length);
 }
 
 // Simple liver-derangement thresholds (2–3× typical ULN).
@@ -60,18 +63,20 @@ export function PillarTiles() {
   const dailies = useLiveQuery(() => latestDailyEntries(7));
   const labs = useLiveQuery(() => latestLabs(7));
   const cycles = useLiveQuery(() => latestTreatmentCycles(1));
-  const settings = useSettings();
 
   const ordered = (dailies ?? []).slice().reverse();
-  const todayISO = getTodayISO();
-  const todayEntry = ordered.find((d) => d.date === todayISO);
   const recentCycle = (cycles ?? [])[0];
   const latestLab = (labs ?? [])[0];
-  const baselineWeight = settings?.baseline_weight_kg;
 
   // -- Symptoms 7d -------------------------------------------------------
+  // `symptomScore` returns null when a day has no relevant numeric
+  // entry — skip those days entirely so the trend reflects real
+  // recorded symptoms, not implicit zeros.
   const symptomSeries = useMemo(
-    () => ordered.map((d) => symptomScore(d)),
+    () =>
+      ordered
+        .map((d) => symptomScore(d))
+        .filter((v): v is number => v !== null),
     [ordered],
   );
   const symptomAvg =
@@ -178,22 +183,6 @@ export function PillarTiles() {
     );
     return { date: latestLab.date, ageDays, flags };
   }, [latestLab, locale]);
-
-  // -- Practice today --------------------------------------------------
-  const practiceVisible = !!todayEntry;
-  const practiceDone = todayEntry
-    ? (todayEntry.practice_morning_completed ? 1 : 0) +
-      (todayEntry.practice_evening_completed ? 1 : 0)
-    : 0;
-
-  // -- Protein gap today -----------------------------------------------
-  const proteinTarget =
-    typeof baselineWeight === "number" ? Math.round(baselineWeight * 1.2) : null;
-  const proteinToday = todayEntry?.protein_grams;
-  const proteinGap =
-    proteinTarget !== null &&
-    typeof proteinToday === "number" &&
-    proteinToday < proteinTarget * 0.75;
 
   // -- Weather tile ----------------------------------------------------
   const weatherTile = useMemo(() => {
@@ -403,87 +392,6 @@ export function PillarTiles() {
                 highlight={ca199Series.length - 1}
               />
             )}
-          </div>
-        </Link>
-      ),
-    });
-  }
-
-  if (practiceVisible) {
-    tiles.push({
-      key: "practice",
-      node: (
-        <Link
-          href="/practices"
-          className="a-card flex min-h-[140px] flex-col gap-2 p-4 text-left transition-colors hover:border-ink-300"
-        >
-          <div className="flex items-center justify-between">
-            <span className="eyebrow">
-              {locale === "zh" ? "今日修习" : "Practice · today"}
-            </span>
-            <Pill className="h-3.5 w-3.5 text-ink-300" />
-          </div>
-          <div className="flex items-baseline gap-1">
-            <div className="serif num text-3xl leading-none text-ink-900">
-              {practiceDone}
-            </div>
-            <div className="mono text-[13px] text-ink-400">/ 2</div>
-          </div>
-          <div className="text-[11.5px] text-ink-500">
-            {locale === "zh" ? "晨 + 晚修习" : "Morning + evening practice"}
-          </div>
-          <div className="mt-auto flex gap-1">
-            {[0, 1].map((i) => (
-              <div
-                key={i}
-                className="h-1.5 flex-1 rounded-full"
-                style={{
-                  background:
-                    i < practiceDone ? "var(--tide-2)" : "var(--ink-100)",
-                }}
-              />
-            ))}
-          </div>
-        </Link>
-      ),
-    });
-  }
-
-  if (proteinGap && proteinTarget !== null) {
-    tiles.push({
-      key: "protein",
-      node: (
-        <Link
-          href="/nutrition/log"
-          className="a-card flex min-h-[140px] flex-col gap-2 p-4 text-left transition-colors hover:border-ink-300"
-        >
-          <div className="flex items-center justify-between">
-            <span className="eyebrow">
-              {locale === "zh" ? "蛋白质" : "Protein"}
-            </span>
-            <Utensils className="h-3.5 w-3.5 text-ink-300" />
-          </div>
-          <div className="flex items-baseline gap-1">
-            <div className="serif num text-3xl leading-none text-ink-900">
-              {proteinToday}
-            </div>
-            <span className="mono text-[11px] text-ink-400">
-              / {proteinTarget} g
-            </span>
-          </div>
-          <div className="text-[11.5px] text-ink-500">
-            {locale === "zh"
-              ? "今日进食低于目标 75%"
-              : "Below 75% of today's target"}
-          </div>
-          <div className="mt-auto h-1.5 overflow-hidden rounded-full bg-ink-100">
-            <div
-              className="h-full"
-              style={{
-                width: `${Math.min(100, ((proteinToday ?? 0) / proteinTarget) * 100)}%`,
-                background: "var(--warn)",
-              }}
-            />
           </div>
         </Link>
       ),

--- a/src/components/shared/add-fab.tsx
+++ b/src/components/shared/add-fab.tsx
@@ -8,7 +8,6 @@ import { cn } from "~/lib/utils/cn";
 import {
   Plus,
   X,
-  CalendarDays,
   CalendarClock,
   ListTodo,
   Pill,
@@ -85,12 +84,13 @@ const CAREGIVER_ITEMS: FabItem[] = [
   },
 ];
 
-// Patient FAB — one capture channel, one check-in, one appointment verb,
-// one medication quick-log. The free-text/voice "Say what's happening"
-// stays primary so anything that can be spoken or typed funnels through
-// it; structured shortcuts (daily check-in, meal log, medication log)
-// stay first-class because the patient reaches for them on a tired day
-// without wanting to compose a sentence.
+// Patient FAB — "Say what's happening" is the canonical single-channel
+// input (CLAUDE.md doctrine). Structured shortcuts (meal, medication,
+// appointment, task) are retained as escape hatches for tired days when
+// composing a sentence feels like too much. The daily symptom check-in
+// is *not* listed here — `QuickCheckinCard` sits on the dashboard
+// itself, so a FAB shortcut would duplicate a tap already in front of
+// the patient.
 const ITEMS: FabItem[] = [
   {
     href: "/log",
@@ -110,13 +110,6 @@ const ITEMS: FabItem[] = [
       zh: "化验单、就诊函、影像报告",
     },
     icon: Sparkles,
-    tone: "tide",
-  },
-  {
-    href: "/daily/new",
-    label: { en: "Today's check-in", zh: "今日记录" },
-    hint: { en: "Symptoms, weight, practice", zh: "症状、体重、修习" },
-    icon: CalendarDays,
     tone: "tide",
   },
   {


### PR DESCRIPTION
## Summary

Audit pass on the patient dashboard and check-in flows looking for bugs, jankiness, dead UI, and redundancy. Four targeted fixes — every one of them respects the "single channel out" doctrine from `CLAUDE.md`: when two surfaces show the same data, the fuller one wins.

### Correctness bugs

- **`symptomScore` (PillarTiles)** divided by a fixed `5` even when only a subset of fields was entered. A 30-second quick-checkin (energy + pain + nausea, no sleep / mood) registered as a low-symptom day because the two missing components silently contributed `0`. Now averages only the components that are actually numeric, and skips days with no recorded symptoms entirely. Fixes the 7-day symptom trend on the dashboard.
- **`/daily` list rows** rendered `"energy "` / `"sleep "` with no value for quick-checkin rows (those only persist energy / pain / nausea, leaving `sleep_quality` undefined). Each label is now guarded on `typeof === "number"`, and pain / nausea are surfaced when present.

### Dead / duplicate UI

- **PillarTiles** no longer renders the `practice` tile (PracticesCard already shows today's practice progress with full timer + log buttons) or the `protein` tile (NutritionCard already shows today's protein vs target with the same warning band). Two cards showing the same number is noise, not signal.
- **Patient FAB** drops the "Today's check-in" shortcut. `QuickCheckinCard` sits at the top of the dashboard with three sliders and a save button — the FAB shortcut routed to the longer `/daily/new` wizard, duplicating the entry point. "Say what's happening" stays as the canonical single-channel input.

### Diff

```
 src/app/daily/page.tsx                    |  26 ++++--
 src/components/dashboard/pillar-tiles.tsx | 134 +++++-------------------------
 src/components/shared/add-fab.tsx         |  21 ++---
 3 files changed, 48 insertions(+), 133 deletions(-)
```

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 1009 / 1009 pass
- [x] `pnpm build` — succeeds
- [ ] Manual: quick-checkin → confirm symptoms tile reflects only entered components, not 0s
- [ ] Manual: open `/daily` after a quick-checkin → confirm no bare `sleep ` / `energy ` labels
- [ ] Manual: tap the patient FAB → confirm 6 items, no "Today's check-in"
- [ ] Manual: confirm PracticesCard / NutritionCard still render as before; no orphan tile holes

https://claude.ai/code/session_01WNVQzvd7UnDwDPpiRrbNEW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNVQzvd7UnDwDPpiRrbNEW)_