### PR TITLE
ux: surface partial-save warning, fix nested links, retry diary load

### DIFF
--- a/src/app/diary/page.tsx
+++ b/src/app/diary/page.tsx
@@ -11,6 +11,7 @@ import {
   ClipboardList,
   Sparkles,
   CalendarDays,
+  RotateCcw,
 } from "lucide-react";
 import { useLocale } from "~/hooks/use-translate";
 import { syncPendingVoiceMemoAudio } from "~/lib/voice-memo/cloud";
@@ -55,6 +56,10 @@ export default function DiaryPage() {
   const [days, setDays] = useState<DiaryDay[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  // Bumped by the retry button so the load effect re-runs without
+  // depending on a full page reload. Keeps Dexie live-query identity
+  // stable.
+  const [retryNonce, setRetryNonce] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -92,8 +97,9 @@ export default function DiaryPage() {
     };
     // Re-run whenever any underlying table changes row count or the
     // window expands. Cheap because the aggregator reads each table
-    // once and bins in memory.
-  }, [memoCount, dailyCount, logCount, labCount, runCount, windowDays]);
+    // once and bins in memory. retryNonce lets the user re-trigger
+    // after an error without reloading.
+  }, [memoCount, dailyCount, logCount, labCount, runCount, windowDays, retryNonce]);
 
   // Best-effort: try to flush any voice-memo audio that's still waiting
   // to upload. Runs on mount and never throws into render.
@@ -143,9 +149,21 @@ export default function DiaryPage() {
 
       {loadError ? (
         <Alert variant="warn" role="alert">
-          {locale === "zh"
-            ? "日记加载失败，请刷新页面重试。"
-            : "Diary failed to load. Try refreshing the page."}
+          <div className="text-[13px]">
+            {loadError === "timeout"
+              ? locale === "zh"
+                ? "整理日记花的时间过长。"
+                : "Loading the diary is taking too long."
+              : locale === "zh"
+                ? "日记加载失败。"
+                : "Diary failed to load."}
+          </div>
+          <div className="mt-2">
+            <Button size="sm" onClick={() => setRetryNonce((n) => n + 1)}>
+              <RotateCcw className="h-3.5 w-3.5" />
+              {locale === "zh" ? "重试" : "Try again"}
+            </Button>
+          </div>
         </Alert>
       ) : loading && days.length === 0 ? (
         <Card className="p-5">

--- a/src/components/dashboard/quick-checkin-card.tsx
+++ b/src/components/dashboard/quick-checkin-card.tsx
@@ -115,7 +115,9 @@ export function QuickCheckinCard() {
         await runEngineAndPersist();
       } catch (engineErr) {
         // Entry is saved; zone engine failed. Log and warn but don't lose
-        // the data by re-throwing.
+        // the data by re-throwing. The warning is rendered inside the
+        // just-saved card so the patient sees the partial outcome instead
+        // of a silent green tick.
         // eslint-disable-next-line no-console
         console.warn("[zone-engine] evaluation failed after quick-checkin", engineErr);
         setSaveError(
@@ -165,6 +167,14 @@ export function QuickCheckinCard() {
             </Link>
           </div>
         </div>
+        {saveError && (
+          <div
+            role="alert"
+            className="mt-3 rounded-md border border-[var(--warn)]/40 bg-[var(--warn)]/10 p-2.5 text-xs text-[var(--warn)]"
+          >
+            {saveError}
+          </div>
+        )}
       </Card>
     );
   }

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -281,104 +281,154 @@ function FeedRow({ item }: { item: FeedItem }) {
   const coverageMeta =
     item.meta?.kind === "coverage" ? item.meta : null;
   const [whyOpen, setWhyOpen] = useState(false);
-  const body = (
-    <div
+
+  // Coverage cards carry their own action buttons (why / dismiss).
+  // When they also have a CTA, we render the main content as the link
+  // and the buttons as siblings — placing buttons inside the link is
+  // invalid HTML and screen readers conflate the two click surfaces.
+  // For non-coverage cards with a CTA the whole row remains tappable.
+  const linkable = item.cta && !isAgentRun;
+  const wrapInLink = linkable && !coverageMeta;
+
+  const iconEl = (
+    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-paper-2 text-ink-700">
+      <Icon className="h-4 w-4" />
+    </div>
+  );
+
+  const titleEl = (
+    <div className="text-[13.5px] font-semibold text-ink-900">
+      {localize(item.title, locale)}
+    </div>
+  );
+
+  const bodyEl = (
+    <p className="mt-1 text-[12.5px] leading-relaxed text-ink-700">
+      {localize(item.body, locale)}
+    </p>
+  );
+
+  const categoryEl = (
+    <span
       className={cn(
-        "flex items-start gap-3 rounded-[var(--r-md)] p-3.5 transition-colors",
-        tone.bg,
-        tone.border,
+        "mono shrink-0 text-[9.5px] uppercase tracking-[0.12em]",
+        item.tone === "warning"
+          ? "text-[var(--warn)]"
+          : item.tone === "positive"
+            ? "text-[var(--ok)]"
+            : "text-ink-400",
       )}
     >
-      <div
-        className={cn(
-          "flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-paper-2 text-ink-700",
-        )}
+      {categoryLabel(item.category, locale)}
+    </span>
+  );
+
+  // 32px hit target — comfortable for thumb taps without dominating the
+  // row visually. Previous 14px icon-only buttons were sub-WCAG tap
+  // size and adjacent to each other.
+  const buttonClass =
+    "flex h-8 w-8 items-center justify-center rounded-md text-ink-400 hover:bg-paper hover:text-ink-700";
+
+  const actionsEl = coverageMeta ? (
+    <div className="flex items-center gap-0.5">
+      <button
+        type="button"
+        onClick={() => setWhyOpen((v) => !v)}
+        className={buttonClass}
+        aria-label={locale === "zh" ? "为什么提示这个" : "Why this prompt"}
+        aria-expanded={whyOpen}
       >
-        <Icon className="h-4 w-4" />
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-start justify-between gap-2">
-          <div className="text-[13.5px] font-semibold text-ink-900">
-            {localize(item.title, locale)}
+        <HelpCircle className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void snoozeCoverageField(coverageMeta.field_key, todayIsoFn());
+        }}
+        className={buttonClass}
+        aria-label={locale === "zh" ? "暂时收起" : "Dismiss"}
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  ) : null;
+
+  const whyEl =
+    coverageMeta && whyOpen ? (
+      <p className="mt-2 rounded-md bg-paper/60 p-2 text-[11.5px] leading-relaxed text-ink-500">
+        {localize(coverageMeta.why, locale)}
+      </p>
+    ) : null;
+
+  const feedbackEl =
+    isAgentRun && item.meta?.kind === "agent_run" ? (
+      <AgentFeedbackControls
+        agentId={item.meta.agent_id as AgentId}
+        runId={item.meta.run_id}
+      />
+    ) : null;
+
+  const containerClass = cn(
+    "flex items-start gap-3 rounded-[var(--r-md)] p-3.5 transition-colors",
+    tone.bg,
+    tone.border,
+  );
+
+  // Coverage card: main content is a Link (if there's a CTA) so the
+  // patient can still tap to log; the action buttons sit beside it as
+  // their own click targets. Non-coverage CTA cards still wrap the
+  // whole row in a Link for a single, generous hit area.
+  if (coverageMeta) {
+    const mainBody = (
+      <>
+        {iconEl}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            {titleEl}
+            {categoryEl}
           </div>
-          <div className="flex items-center gap-1.5">
-            <span
-              className={cn(
-                "mono shrink-0 text-[9.5px] uppercase tracking-[0.12em]",
-                item.tone === "warning"
-                  ? "text-[var(--warn)]"
-                  : item.tone === "positive"
-                    ? "text-[var(--ok)]"
-                    : "text-ink-400",
-              )}
-            >
-              {categoryLabel(item.category, locale)}
-            </span>
-            {coverageMeta && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  setWhyOpen((v) => !v);
-                }}
-                className="rounded-md p-0.5 text-ink-400 hover:bg-paper hover:text-ink-700"
-                aria-label={locale === "zh" ? "为什么提示这个" : "Why this prompt"}
-                aria-expanded={whyOpen}
-              >
-                <HelpCircle className="h-3.5 w-3.5" />
-              </button>
-            )}
-            {coverageMeta && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  void snoozeCoverageField(
-                    coverageMeta.field_key,
-                    todayIsoFn(),
-                  );
-                }}
-                className="rounded-md p-0.5 text-ink-400 hover:bg-paper hover:text-ink-700"
-                aria-label={
-                  locale === "zh" ? "暂时收起" : "Dismiss"
-                }
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            )}
-          </div>
+          {bodyEl}
+          {whyEl}
         </div>
-        <p className="mt-1 text-[12.5px] leading-relaxed text-ink-700">
-          {localize(item.body, locale)}
-        </p>
-        {coverageMeta && whyOpen && (
-          <p className="mt-2 rounded-md bg-paper/60 p-2 text-[11.5px] leading-relaxed text-ink-500">
-            {localize(coverageMeta.why, locale)}
-          </p>
+      </>
+    );
+    const mainClass = "flex flex-1 min-w-0 items-start gap-3";
+    return (
+      <div className={containerClass}>
+        {linkable ? (
+          <Link href={item.cta!.href} className={mainClass}>
+            {mainBody}
+          </Link>
+        ) : (
+          <div className={mainClass}>{mainBody}</div>
         )}
-        {isAgentRun && item.meta?.kind === "agent_run" && (
-          <AgentFeedbackControls
-            agentId={item.meta.agent_id as AgentId}
-            runId={item.meta.run_id}
-          />
-        )}
+        {actionsEl}
+      </div>
+    );
+  }
+
+  const inner = (
+    <div className={containerClass}>
+      {iconEl}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          {titleEl}
+          {categoryEl}
+        </div>
+        {bodyEl}
+        {feedbackEl}
       </div>
     </div>
   );
-  // Agent-run cards never wrap in a Link — the embedded feedback controls
-  // need their own click surface. Coverage cards do wrap in a Link but
-  // the dismiss button stops propagation to keep the X click out of the
-  // navigation event.
-  if (item.cta && !isAgentRun) {
+
+  if (wrapInLink) {
     return (
-      <Link href={item.cta.href} className="block">
-        {body}
+      <Link href={item.cta!.href} className="block">
+        {inner}
       </Link>
     );
   }
-  return body;
+  return inner;
 }
 
 function categoryLabel(


### PR DESCRIPTION
## Summary

Audited the patient surface for dead UI, broken flows, jank, and tap-target friction. Three concrete fixes:

**1. `QuickCheckinCard` — silent partial-save warning**
When the entry write succeeded but `runEngineAndPersist()` threw, `setSaveError(...)` was called and so was `setJustSaved(true)`. The `justSaved` early-return wins, so the engine-failure warning was unreachable code. Now the success card renders the warning band beneath the green tick so a partial outcome is visible instead of cosmetic.

**2. `TodayFeed` — nested `<button>` inside `<Link>` + sub-WCAG tap targets**
Coverage cards wrapped the whole row (including the why and dismiss `<button>` elements) in a `<Link>`. Invalid HTML, confuses screen readers, and the 14px icon-only buttons were below the 24px+ tap target floor with two of them adjacent. The Link is now scoped to the main row body; the buttons sit as siblings with 32px hit areas.

**3. `/diary` — load error required a full page reload**
The Dexie-aggregation timeout / failure path showed "try refreshing the page" with no in-place recovery. Added an inline "Try again" button (re-runs the load effect via a retryNonce) and distinguishes the timeout copy from a generic failure.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test tests/unit/diary-build.test.ts tests/unit/diary-ingest.test.ts` passes
- [ ] Manual: trigger an engine failure on quick-checkin (mock throw) — partial-save warning shows under the green tick
- [ ] Manual: dismiss / "why" buttons on a coverage feed item are 32px and don't trigger row navigation
- [ ] Manual: simulate diary timeout → "Try again" button retries without reload

Refs the audit doctrine in `CLAUDE.md`: no dead UI, single channel out, minimise patient backtracking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxpqZZsir5XyxiVtEMt1e4)_