### PR TITLE
refactor(types): centralise IconComponent + LocalizedText, DRY severity scoring

### DIFF
--- a/src/app/care-team/page.tsx
+++ b/src/app/care-team/page.tsx
@@ -11,11 +11,12 @@ import type {
   CareTeamContact,
   CareTeamContactKind,
 } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 import { differenceInCalendarDays, format, parseISO } from "date-fns";
 import { cn } from "~/lib/utils/cn";
 import { todayISO } from "~/lib/utils/date";
 
-const KIND_LABELS: Record<CareTeamContactKind, { en: string; zh: string }> = {
+const KIND_LABELS: Record<CareTeamContactKind, LocalizedText> = {
   clinic_visit: { en: "Clinic visit", zh: "门诊" },
   clinician_call: { en: "Phone / telehealth", zh: "电话 / 远程医疗" },
   specialist_visit: { en: "Specialist visit", zh: "专科门诊" },

--- a/src/app/diary/page.tsx
+++ b/src/app/diary/page.tsx
@@ -24,6 +24,7 @@ import { Alert } from "~/components/ui/alert";
 import { EmptyState } from "~/components/ui/empty-state";
 import { VoiceMemoCard } from "~/components/diary/voice-memo-card";
 import type { AgentRunRow } from "~/types/agent";
+import type { LocalizedText } from "~/types/localized";
 
 // /diary — the patient's daily timeline. One section per day, newest
 // first, combining:
@@ -307,7 +308,7 @@ function buildDailySummary(
   locale: "en" | "zh",
 ): string {
   const parts: string[] = [];
-  function push(label: { en: string; zh: string }, value: string) {
+  function push(label: LocalizedText, value: string) {
     parts.push(`${locale === "zh" ? label.zh : label.en} ${value}`);
   }
   if (typeof entry.energy === "number") {

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -30,6 +30,7 @@ import {
   Users,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { IconComponent } from "~/types/ui";
 
 type Filter = "all" | HistoryCategory;
 
@@ -47,10 +48,7 @@ const FILTERS: { key: Filter; en: string; zh: string }[] = [
   { key: "life_event", en: "Life events", zh: "生活事件" },
 ];
 
-const CATEGORY_ICON: Record<
-  HistoryCategory,
-  React.ComponentType<{ className?: string }>
-> = {
+const CATEGORY_ICON: Record<HistoryCategory, IconComponent> = {
   signal: AlertTriangle,
   action: Sparkles,
   medication: Pill,

--- a/src/app/ingest/meal/page.tsx
+++ b/src/app/ingest/meal/page.tsx
@@ -23,6 +23,8 @@ import {
 import { todayISO } from "~/lib/utils/date";
 import { HttpError } from "~/lib/utils/http";
 import { Sparkles, Check, Loader2 } from "lucide-react";
+import type { IconComponent } from "~/types/ui";
+import type { LocalizedText } from "~/types/localized";
 
 export default function MealIngestPage() {
   const locale = useLocale();
@@ -264,7 +266,7 @@ function Status({
   icon: Icon,
   text,
 }: {
-  icon: React.ComponentType<{ className?: string }>;
+  icon: IconComponent;
   text: string;
 }) {
   return (
@@ -288,7 +290,7 @@ function MealResult({
   onDiscard: () => void;
   saving: boolean;
 }) {
-  const confidenceLabel: Record<MealEstimate["confidence"], { en: string; zh: string }> = {
+  const confidenceLabel: Record<MealEstimate["confidence"], LocalizedText> = {
     low: { en: "low confidence", zh: "置信度低" },
     medium: { en: "medium confidence", zh: "置信度中" },
     high: { en: "high confidence", zh: "置信度高" },

--- a/src/app/ingest/notes/page.tsx
+++ b/src/app/ingest/notes/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "~/lib/ingest/notes-vision";
 import { todayISO } from "~/lib/utils/date";
 import { Sparkles, Check, Loader2 } from "lucide-react";
+import type { IconComponent } from "~/types/ui";
 
 type DailyPatch = NonNullable<NotesStructure["daily_patch"]>;
 
@@ -229,7 +230,7 @@ function Status({
   icon: Icon,
   text,
 }: {
-  icon: React.ComponentType<{ className?: string }>;
+  icon: IconComponent;
   text: string;
 }) {
   return (

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -16,6 +16,7 @@ import { parseVoiceMemo } from "~/lib/voice-memo/parse";
 import { useUIStore } from "~/stores/ui-store";
 import { LOG_TAGS, type AgentId, type LogTag } from "~/types/agent";
 import type { AppliedPatch, VoiceMemoParsedFields } from "~/types/voice-memo";
+import type { LocalizedText } from "~/types/localized";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
 import { Textarea } from "~/components/ui/field";
@@ -34,7 +35,7 @@ import {
 } from "lucide-react";
 import { useVoiceTranscription } from "~/hooks/use-voice-transcription";
 
-const TAG_LABELS: Record<LogTag, { en: string; zh: string }> = {
+const TAG_LABELS: Record<LogTag, LocalizedText> = {
   diet: { en: "diet", zh: "饮食" },
   toxicity: { en: "toxicity", zh: "毒性反应" },
   physical: { en: "physical", zh: "活动" },
@@ -54,7 +55,7 @@ const TAG_LABELS: Record<LogTag, { en: string; zh: string }> = {
   legacy_session: { en: "legacy session", zh: "传承" },
 };
 
-const AGENT_LABELS: Record<AgentId, { en: string; zh: string }> = {
+const AGENT_LABELS: Record<AgentId, LocalizedText> = {
   nutrition: { en: "nutrition", zh: "营养" },
   toxicity: { en: "toxicity", zh: "毒性反应" },
   clinical: { en: "clinical", zh: "临床" },
@@ -83,7 +84,7 @@ type RunState =
     }
   | {
       kind: "filed";
-      summary: { en: string; zh: string };
+      summary: LocalizedText;
       target: "lab" | "daily";
       rowId: number;
       filed: DirectFileResult;

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -8,8 +8,9 @@ import { Card, CardContent } from "~/components/ui/card";
 import { DRUG_REGISTRY } from "~/config/drug-registry";
 import { ChevronRight } from "lucide-react";
 import type { MedicationCategory, DrugInfo } from "~/types/medication";
+import type { LocalizedText } from "~/types/localized";
 
-const CATEGORY_LABELS: Record<MedicationCategory, { en: string; zh: string }> = {
+const CATEGORY_LABELS: Record<MedicationCategory, LocalizedText> = {
   chemo: { en: "Chemotherapy", zh: "化疗" },
   targeted: { en: "Targeted / Investigational", zh: "靶向 / 试验性" },
   immunotherapy: { en: "Immunotherapy", zh: "免疫治疗" },

--- a/src/app/nutrition/foods/page.tsx
+++ b/src/app/nutrition/foods/page.tsx
@@ -16,8 +16,9 @@ import { Button } from "~/components/ui/button";
 import { TextInput, Field, Textarea } from "~/components/ui/field";
 import { cn } from "~/lib/utils/cn";
 import type { FoodCategory, FoodItem } from "~/types/nutrition";
+import type { LocalizedText } from "~/types/localized";
 
-const CATEGORY_LABEL: Record<FoodCategory, { en: string; zh: string }> = {
+const CATEGORY_LABEL: Record<FoodCategory, LocalizedText> = {
   protein: { en: "Protein", zh: "蛋白" },
   dairy: { en: "Dairy", zh: "奶制品" },
   fat_oil: { en: "Fats & oils", zh: "脂肪/油" },

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "~/config/oncologists";
 import type { ProtocolId } from "~/types/treatment";
 import type { Locale, Settings } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 import {
   Anchor,
   ChevronLeft,
@@ -611,8 +612,8 @@ function UserTypeStep({
 }) {
   const options: Array<{
     id: "patient" | "caregiver" | "clinician";
-    title: { en: string; zh: string };
-    body: { en: string; zh: string };
+    title: LocalizedText;
+    body: LocalizedText;
   }> = [
     {
       id: "patient",

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -33,6 +33,8 @@ import {
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { format, parseISO } from "date-fns";
+import type { IconComponent } from "~/types/ui";
+import type { LocalizedText } from "~/types/localized";
 
 type Filter = "all" | "open" | "resolved";
 
@@ -146,7 +148,7 @@ function FilterButton({
 
 const STATUS_TONE: Record<
   ChangeSignalRow["status"],
-  { wrap: string; Icon: React.ComponentType<{ className?: string }> }
+  { wrap: string; Icon: IconComponent }
 > = {
   open: { wrap: "bg-paper-2", Icon: Circle },
   acknowledged: { wrap: "bg-paper-2", Icon: CheckCircle2 },
@@ -157,10 +159,7 @@ const STATUS_TONE: Record<
   },
 };
 
-const SEV_ICON: Record<
-  SignalSeverity,
-  React.ComponentType<{ className?: string }>
-> = {
+const SEV_ICON: Record<SignalSeverity, IconComponent> = {
   caution: Bell,
   warning: AlertTriangle,
 };
@@ -291,7 +290,7 @@ function SignalHistoryRow({
 
 function StatusBadge({ status }: { status: ChangeSignalRow["status"] }) {
   const locale = useLocale();
-  const labels: Record<ChangeSignalRow["status"], { en: string; zh: string }> = {
+  const labels: Record<ChangeSignalRow["status"], LocalizedText> = {
     open: { en: "OPEN", zh: "未结" },
     acknowledged: { en: "ACK", zh: "已知" },
     dismissed: { en: "DISMISSED", zh: "关闭" },
@@ -315,10 +314,7 @@ function StatusBadge({ status }: { status: ChangeSignalRow["status"] }) {
   );
 }
 
-const EVENT_KIND_LABEL: Record<
-  SignalEventKind,
-  { en: string; zh: string }
-> = {
+const EVENT_KIND_LABEL: Record<SignalEventKind, LocalizedText> = {
   emitted: { en: "signal emitted", zh: "信号触发" },
   acknowledged: { en: "acknowledged", zh: "已知" },
   dismissed: { en: "dismissed", zh: "关闭" },

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -15,6 +15,7 @@ import {
   useTaskInstances,
 } from "~/hooks/use-task-instances";
 import { Plus, Sparkles, ListTodo } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 export default function TasksPage() {
   const t = useT();
@@ -39,7 +40,7 @@ export default function TasksPage() {
 
   const sectionOrder: [
     string,
-    { en: string; zh: string },
+    LocalizedText,
   ][] = [
     ["overdue", { en: "Overdue", zh: "已超期" }],
     ["due_today", { en: "Due today", zh: "今日到期" }],

--- a/src/app/treatment/new/page.tsx
+++ b/src/app/treatment/new/page.tsx
@@ -20,6 +20,7 @@ import type {
   ProtocolId,
   TreatmentCycle,
 } from "~/types/treatment";
+import type { LocalizedText } from "~/types/localized";
 import type {
   DoseSchedule,
   Medication,
@@ -302,7 +303,7 @@ export default function NewTreatmentCyclePage() {
 }
 
 function Stepper({ step, locale }: { step: Step; locale: "en" | "zh" }) {
-  const labels: Array<{ en: string; zh: string }> = [
+  const labels: Array<LocalizedText> = [
     { en: "Protocol", zh: "方案" },
     { en: "Schedule", zh: "细节" },
     { en: "Review", zh: "检查" },

--- a/src/app/treatment/page.tsx
+++ b/src/app/treatment/page.tsx
@@ -11,9 +11,10 @@ import { PROTOCOL_BY_ID } from "~/config/protocols";
 import { formatDate } from "~/lib/utils/date";
 import { cn } from "~/lib/utils/cn";
 import type { CycleStatus } from "~/types/treatment";
+import type { LocalizedText } from "~/types/localized";
 import { BookOpen, ChevronRight, ClipboardList, Pencil, Syringe } from "lucide-react";
 
-const STATUS_STYLES: Record<CycleStatus, { label: { en: string; zh: string }; cls: string }> = {
+const STATUS_STYLES: Record<CycleStatus, { label: LocalizedText; cls: string }> = {
   planned: {
     label: { en: "Planned", zh: "已计划" },
     cls: "bg-ink-100 text-ink-600",

--- a/src/components/assessment/helper-kickoff.tsx
+++ b/src/components/assessment/helper-kickoff.tsx
@@ -6,6 +6,8 @@ import { useLocale } from "~/hooks/use-translate";
 import { Field, TextInput, Textarea } from "~/components/ui/field";
 import { cn } from "~/lib/utils/cn";
 import type { AssessmentHelperRole } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
+import type { IconComponent } from "~/types/ui";
 
 // Captured at the start of a guided assessment session. The patient
 // rarely runs this alone — for the bridge strategy we want to know who
@@ -20,9 +22,9 @@ import type { AssessmentHelperRole } from "~/types/clinical";
 // that case.
 const ROLE_OPTIONS: Array<{
   id: AssessmentHelperRole;
-  icon: React.ComponentType<{ className?: string }>;
-  label: { en: string; zh: string };
-  hint: { en: string; zh: string };
+  icon: IconComponent;
+  label: LocalizedText;
+  hint: LocalizedText;
 }> = [
   {
     id: "self",
@@ -70,7 +72,7 @@ export interface HelperKickoffValue {
 
 const EQUIPMENT_ITEMS: Array<{
   id: string;
-  label: { en: string; zh: string };
+  label: LocalizedText;
 }> = [
   { id: "scale", label: { en: "Bathroom scale", zh: "体重秤" } },
   { id: "tape", label: { en: "Soft tape measure", zh: "软尺" } },

--- a/src/components/assessment/test-list-builder.tsx
+++ b/src/components/assessment/test-list-builder.tsx
@@ -14,6 +14,8 @@ import {
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
+import type { IconComponent } from "~/types/ui";
 import {
   Activity,
   AlertCircle,
@@ -27,7 +29,7 @@ import {
 
 const CATEGORY_META: Record<
   TestCategory,
-  { icon: React.ComponentType<{ className?: string }>; label: { en: string; zh: string } }
+  { icon: IconComponent; label: LocalizedText }
 > = {
   physical: { icon: HeartPulse, label: { en: "Physical", zh: "身体" } },
   symptoms: { icon: AlertCircle, label: { en: "Symptoms", zh: "症状" } },

--- a/src/components/assessment/wizard.tsx
+++ b/src/components/assessment/wizard.tsx
@@ -16,6 +16,7 @@ import {
 } from "~/lib/assessment/catalog";
 import { todayISO } from "~/lib/utils/date";
 import type { ComprehensiveAssessment } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
@@ -44,7 +45,7 @@ const HELPER_ROLE_ICON = {
 
 const HELPER_ROLE_LABEL: Record<
   "self" | "family" | "coach" | "clinician",
-  { en: string; zh: string }
+  LocalizedText
 > = {
   self: { en: "Patient alone", zh: "患者独自" },
   family: { en: "Family member", zh: "家人" },

--- a/src/components/daily/daily-wizard.tsx
+++ b/src/components/daily/daily-wizard.tsx
@@ -16,6 +16,7 @@ import { Toggle } from "./toggle";
 import { SymptomStep } from "./symptom-step";
 import { isInChemoWindow } from "~/lib/daily/symptom-catalog";
 import type { DailyEntry } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 import {
   Activity,
   Bed,
@@ -36,7 +37,7 @@ import {
 import { cn } from "~/lib/utils/cn";
 
 type Draft = Partial<DailyEntry>;
-type Bilingual = { en: string; zh: string };
+type Bilingual = LocalizedText;
 
 const CATS = [
   {
@@ -956,7 +957,7 @@ function DigestionFields({
   // stool on the daily wizard).
   const BRISTOL: Array<{
     n: 1 | 2 | 3 | 4 | 5 | 6 | 7;
-    label: { en: string; zh: string };
+    label: LocalizedText;
   }> = [
     { n: 1, label: { en: "Hard lumps", zh: "硬块" } },
     { n: 2, label: { en: "Lumpy", zh: "成块" } },
@@ -968,7 +969,7 @@ function DigestionFields({
   ];
   const COLORS: Array<{
     v: NonNullable<DailyEntry["stool_color"]>;
-    label: { en: string; zh: string };
+    label: LocalizedText;
   }> = [
     { v: "normal", label: { en: "Brown", zh: "棕色" } },
     { v: "pale", label: { en: "Pale / clay", zh: "灰白" } },
@@ -980,7 +981,7 @@ function DigestionFields({
   ];
   const PERT: Array<{
     v: NonNullable<DailyEntry["pert_with_meals_today"]>;
-    label: { en: string; zh: string };
+    label: LocalizedText;
   }> = [
     { v: "all", label: { en: "Every fatty meal", zh: "每次高脂餐" } },
     { v: "some", label: { en: "Missed some", zh: "漏了几次" } },

--- a/src/components/dashboard/change-signals-card.tsx
+++ b/src/components/dashboard/change-signals-card.tsx
@@ -39,10 +39,11 @@ import {
   Sparkles,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { IconComponent } from "~/types/ui";
 
 const TONE_BY_SEVERITY: Record<
   SignalSeverity,
-  { wrap: string; chip: string; Icon: React.ComponentType<{ className?: string }> }
+  { wrap: string; chip: string; Icon: IconComponent }
 > = {
   caution: {
     wrap: "bg-[var(--sand)]/40 border-l-[3px] border-l-[oklch(45%_0.06_70)]",

--- a/src/components/dashboard/emergency-card.tsx
+++ b/src/components/dashboard/emergency-card.tsx
@@ -5,6 +5,7 @@ import { useZoneStatus } from "~/hooks/use-zone-status";
 import { useT } from "~/hooks/use-translate";
 import { useSettings } from "~/hooks/use-settings";
 import { Phone, AlertOctagon, MapPin, ChevronDown, ChevronUp } from "lucide-react";
+import type { IconComponent } from "~/types/ui";
 
 // Only rendered when zone is red/orange — on green/yellow days this stays
 // silent so the dashboard doesn't carry a standing alarm. Contacts live on
@@ -124,7 +125,7 @@ function ContactLink({
   href,
   tone,
 }: {
-  icon: React.ComponentType<{ className?: string }>;
+  icon: IconComponent;
   label: string;
   value: string;
   href: string;

--- a/src/components/dashboard/medication-prompts-card.tsx
+++ b/src/components/dashboard/medication-prompts-card.tsx
@@ -24,10 +24,11 @@ import {
   Info,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { IconComponent } from "~/types/ui";
 
 const TONE_BY_SEVERITY: Record<
   PromptSeverity,
-  { wrap: string; chip: string; Icon: React.ComponentType<{ className?: string }> }
+  { wrap: string; chip: string; Icon: IconComponent }
 > = {
   info: {
     wrap: "bg-paper-2",

--- a/src/components/dashboard/schedule-card.tsx
+++ b/src/components/dashboard/schedule-card.tsx
@@ -24,8 +24,9 @@ import {
 import { cn } from "~/lib/utils/cn";
 import { localeTag } from "~/lib/utils/date";
 import { upcomingAppointments } from "~/lib/appointments/upcoming";
+import type { IconComponent } from "~/types/ui";
 
-const KIND_ICON: Record<AppointmentKind, React.ComponentType<{ className?: string }>> = {
+const KIND_ICON: Record<AppointmentKind, IconComponent> = {
   clinic: Stethoscope,
   chemo: Syringe,
   scan: ScanLine,

--- a/src/components/dashboard/today-feed.tsx
+++ b/src/components/dashboard/today-feed.tsx
@@ -37,12 +37,14 @@ import {
 } from "lucide-react";
 import { snoozeCoverageField } from "~/lib/coverage/snooze";
 import { todayISO as todayIsoFn } from "~/lib/utils/date";
+import type { IconComponent } from "~/types/ui";
+import type { LocalizedText } from "~/types/localized";
 
 // Bumped when the narrative prompt or shape changes so that stale
 // payloads in localStorage are ignored without forcing a manual clear.
 const NARRATIVE_CACHE_VERSION = "v2";
 
-const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+const ICONS: Record<string, IconComponent> = {
   thermo: Thermometer,
   shield: ShieldAlert,
   pill: Pill,
@@ -385,7 +387,7 @@ function categoryLabel(
   c: FeedItem["category"],
   locale: "en" | "zh",
 ): string {
-  const labels: Record<FeedItem["category"], { en: string; zh: string }> = {
+  const labels: Record<FeedItem["category"], LocalizedText> = {
     safety: { en: "Safety", zh: "安全" },
     checkin: { en: "Check-in", zh: "记录" },
     treatment: { en: "Treatment", zh: "治疗" },

--- a/src/components/diary/voice-memo-card.tsx
+++ b/src/components/diary/voice-memo-card.tsx
@@ -12,6 +12,7 @@ import {
   CheckCircle2,
 } from "lucide-react";
 import type { VoiceMemo, VoiceMemoParsedFields } from "~/types/voice-memo";
+import type { LocalizedText } from "~/types/localized";
 import { resolveVoiceMemoAudioUrl } from "~/lib/voice-memo/cloud";
 import { Card } from "~/components/ui/card";
 import { cn } from "~/lib/utils/cn";
@@ -271,14 +272,14 @@ function collectChips(
   locale: "en" | "zh",
 ): { label: string; value: string }[] {
   const chips: { label: string; value: string }[] = [];
-  function num(label: { en: string; zh: string }, val: number | undefined, suffix = "/10") {
+  function num(label: LocalizedText, val: number | undefined, suffix = "/10") {
     if (typeof val !== "number") return;
     chips.push({
       label: locale === "zh" ? label.zh : label.en,
       value: `${val}${suffix}`,
     });
   }
-  function bool(label: { en: string; zh: string }, val: boolean | undefined) {
+  function bool(label: LocalizedText, val: boolean | undefined) {
     if (val !== true) return;
     chips.push({
       label: locale === "zh" ? label.zh : label.en,

--- a/src/components/family/call-list.tsx
+++ b/src/components/family/call-list.tsx
@@ -5,6 +5,7 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "~/lib/db/dexie";
 import { useLocale, useL } from "~/hooks/use-translate";
 import type { CareTeamMember, CareTeamRole } from "~/types/care-team";
+import type { LocalizedText } from "~/types/localized";
 import { Phone, Mail, Star } from "lucide-react";
 
 // Tap-to-call directory, grouped by role. Reads the care-team
@@ -22,7 +23,7 @@ const ROLE_ORDER: CareTeamRole[] = [
   "other",
 ];
 
-const ROLE_LABEL: Record<CareTeamRole, { en: string; zh: string }> = {
+const ROLE_LABEL: Record<CareTeamRole, LocalizedText> = {
   oncologist: { en: "Oncology", zh: "肿瘤科" },
   surgeon: { en: "Surgery", zh: "外科" },
   nurse: { en: "Nursing", zh: "护理" },

--- a/src/components/family/next-up.tsx
+++ b/src/components/family/next-up.tsx
@@ -22,16 +22,14 @@ import {
 import { cn } from "~/lib/utils/cn";
 import { localeTag } from "~/lib/utils/date";
 import { upcomingAppointments } from "~/lib/appointments/upcoming";
+import type { IconComponent } from "~/types/ui";
 
 // Calm, two-or-three-item strip of what's coming up in the next seven
 // days. Location is tappable if we have a URL; attendee chips show who
 // is (or is planning to be) there. This is the surface that closes the
 // "when is dad's PET CT?" coordination gap.
 
-const KIND_ICON: Record<
-  AppointmentKind,
-  React.ComponentType<{ className?: string }>
-> = {
+const KIND_ICON: Record<AppointmentKind, IconComponent> = {
   clinic: Stethoscope,
   chemo: Syringe,
   scan: ScanLine,

--- a/src/components/family/timeline-stream.tsx
+++ b/src/components/family/timeline-stream.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { localeTag } from "~/lib/utils/date";
+import type { IconComponent } from "~/types/ui";
 
 // Chronological, date-grouped, reverse-chrono timeline.
 //
@@ -158,10 +159,7 @@ function FilterChip({
   );
 }
 
-const CATEGORY_ICON: Record<
-  LifeEvent["category"],
-  React.ComponentType<{ className?: string }>
-> = {
+const CATEGORY_ICON: Record<LifeEvent["category"], IconComponent> = {
   family: Heart,
   cultural: Flag,
   travel: MapPin,
@@ -222,10 +220,7 @@ function LifeEventCard({
   );
 }
 
-const APPT_ICON: Record<
-  Appointment["kind"],
-  React.ComponentType<{ className?: string }>
-> = {
+const APPT_ICON: Record<Appointment["kind"], IconComponent> = {
   clinic: Stethoscope,
   chemo: Syringe,
   scan: ScanLine,

--- a/src/components/family/zone-banner.tsx
+++ b/src/components/family/zone-banner.tsx
@@ -5,6 +5,7 @@ import { db } from "~/lib/db/dexie";
 import { highestZone } from "~/lib/rules/engine";
 import { useLocale } from "~/hooks/use-translate";
 import type { Zone } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 import { cn } from "~/lib/utils/cn";
 
 // A calm, one-line status banner for the family surface. Reads all open
@@ -12,14 +13,14 @@ import { cn } from "~/lib/utils/cn";
 // stacked alerts, no rule ids, no agent output. Family members just need
 // to know "is dad OK right now".
 
-const LABEL: Record<Zone, { en: string; zh: string }> = {
+const LABEL: Record<Zone, LocalizedText> = {
   green: { en: "Stable", zh: "稳定" },
   yellow: { en: "Review needed", zh: "需要复核" },
   orange: { en: "Urgent review", zh: "紧急复核" },
   red: { en: "Immediate action", zh: "立即处理" },
 };
 
-const DETAIL: Record<Zone, { en: string; zh: string }> = {
+const DETAIL: Record<Zone, LocalizedText> = {
   green: {
     en: "Nothing urgent right now.",
     zh: "目前没有紧急情况。",

--- a/src/components/ingest/bulk-queue.tsx
+++ b/src/components/ingest/bulk-queue.tsx
@@ -5,6 +5,8 @@ import type { UnifiedExtraction } from "~/lib/ingest/save";
 import { useLocale } from "~/hooks/use-translate";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
+import type { IconComponent } from "~/types/ui";
 import {
   Check,
   Loader2,
@@ -18,7 +20,7 @@ import {
 
 const STATUS_META: Record<
   BulkItem["status"],
-  { label: { en: string; zh: string }; tone: string; icon: React.ComponentType<{ className?: string }> }
+  { label: LocalizedText; tone: string; icon: IconComponent }
 > = {
   queued: {
     label: { en: "Queued", zh: "排队" },

--- a/src/components/ingest/ingest-modal.tsx
+++ b/src/components/ingest/ingest-modal.tsx
@@ -10,6 +10,7 @@ import { PreviewDiff } from "~/components/ingest/preview-diff";
 import type { IngestApplyResult, IngestDraft } from "~/types/ingest";
 import { X, Phone, FileUp, Calendar } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { IconComponent } from "~/types/ui";
 
 // A globally-mountable ingest modal. Anything in the app can flip
 // `useIngestModal.getState().open()` to surface the same drop /
@@ -183,7 +184,7 @@ function TabButton({
 }: {
   active: boolean;
   onClick: () => void;
-  icon: React.ComponentType<{ className?: string }>;
+  icon: IconComponent;
   label: string;
 }) {
   return (

--- a/src/components/ingest/preview-diff.tsx
+++ b/src/components/ingest/preview-diff.tsx
@@ -34,8 +34,10 @@ import {
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
 import { toDatetimeLocalInput as toDatetimeLocal } from "~/lib/utils/date";
+import type { LocalizedText } from "~/types/localized";
+import type { IconComponent } from "~/types/ui";
 
-const OP_ICON: Record<IngestOpKind, React.ComponentType<{ className?: string }>> = {
+const OP_ICON: Record<IngestOpKind, IconComponent> = {
   add_appointment: CalendarPlus,
   update_appointment: CalendarClock,
   add_lab_result: TestTube2,
@@ -52,7 +54,7 @@ const OP_ICON: Record<IngestOpKind, React.ComponentType<{ className?: string }>>
   update_settings: SettingsIcon,
 };
 
-const OP_LABEL: Record<IngestOpKind, { en: string; zh: string }> = {
+const OP_LABEL: Record<IngestOpKind, LocalizedText> = {
   add_appointment: { en: "New appointment", zh: "新增预约" },
   update_appointment: { en: "Update appointment", zh: "更新预约" },
   add_lab_result: { en: "New lab result", zh: "新增化验结果" },

--- a/src/components/invite/local-contacts-section.tsx
+++ b/src/components/invite/local-contacts-section.tsx
@@ -17,6 +17,7 @@ import type {
   CareTeamRole,
 } from "~/types/care-team";
 import type { HouseholdMemberWithProfile } from "~/types/household";
+import type { LocalizedText } from "~/types/localized";
 import { useLocale } from "~/hooks/use-translate";
 import { Field, TextInput } from "~/components/ui/field";
 import { Button } from "~/components/ui/button";
@@ -59,7 +60,7 @@ const ROLES: CareTeamRole[] = [
   "other",
 ];
 
-const ROLE_LABELS: Record<CareTeamRole, { en: string; zh: string }> = {
+const ROLE_LABELS: Record<CareTeamRole, LocalizedText> = {
   family: { en: "Family", zh: "家人" },
   oncologist: { en: "Oncologist", zh: "肿瘤科" },
   surgeon: { en: "Surgeon", zh: "外科" },

--- a/src/components/invite/members-list.tsx
+++ b/src/components/invite/members-list.tsx
@@ -25,8 +25,9 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { IconComponent } from "~/types/ui";
 
-const ROLE_ICON: Record<HouseholdRole, React.ComponentType<{ className?: string }>> = {
+const ROLE_ICON: Record<HouseholdRole, IconComponent> = {
   primary_carer: Crown,
   patient: UserIcon,
   family: UsersIcon,

--- a/src/components/schedule/attendance-controls.tsx
+++ b/src/components/schedule/attendance-controls.tsx
@@ -12,6 +12,8 @@ import { useLocale, useL } from "~/hooks/use-translate";
 import type { Appointment } from "~/types/appointment";
 import { Check, Clock, X, CircleDashed } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
+import type { IconComponent } from "~/types/ui";
 
 // Per-member attendance chip row on the appointment detail page.
 // Each household member gets one button that cycles through the
@@ -19,7 +21,7 @@ import { cn } from "~/lib/utils/cn";
 // appointment.attendees) render as passive pending chips — they
 // can't claim themselves from this device.
 
-const STATUS_LABEL: Record<PendingOrStatus, { en: string; zh: string }> = {
+const STATUS_LABEL: Record<PendingOrStatus, LocalizedText> = {
   pending: { en: "Tap to confirm", zh: "点击确认" },
   confirmed: { en: "Going", zh: "参加" },
   tentative: { en: "Maybe", zh: "可能" },
@@ -33,7 +35,7 @@ const STATUS_TONE: Record<PendingOrStatus, string> = {
   declined: "bg-ink-100 text-ink-500 border-ink-300 line-through",
 };
 
-const STATUS_ICON: Record<PendingOrStatus, React.ComponentType<{ className?: string }>> = {
+const STATUS_ICON: Record<PendingOrStatus, IconComponent> = {
   pending: CircleDashed,
   confirmed: Check,
   tentative: Clock,

--- a/src/components/schedule/linked-records.tsx
+++ b/src/components/schedule/linked-records.tsx
@@ -21,6 +21,8 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { cn } from "~/lib/utils/cn";
+import type { LocalizedText } from "~/types/localized";
+import type { IconComponent } from "~/types/ui";
 
 // Shows every cross-module record an appointment is linked to. A
 // chemo appointment → its treatment cycle; a blood-test appointment
@@ -31,10 +33,7 @@ import { cn } from "~/lib/utils/cn";
 // Read-only in this slice — ingest ops propose the links, Dexie
 // writes them. Manual editing comes in a follow-up PR.
 
-const KIND_ICON: Record<
-  AppointmentLinkedRecordKind,
-  React.ComponentType<{ className?: string }>
-> = {
+const KIND_ICON: Record<AppointmentLinkedRecordKind, IconComponent> = {
   treatment_cycle: Syringe,
   lab_result: TestTube2,
   pending_result: Clock,
@@ -45,10 +44,7 @@ const KIND_ICON: Record<
   task: ListTodo,
 };
 
-const KIND_LABEL: Record<
-  AppointmentLinkedRecordKind,
-  { en: string; zh: string }
-> = {
+const KIND_LABEL: Record<AppointmentLinkedRecordKind, LocalizedText> = {
   treatment_cycle: { en: "Cycle", zh: "疗程" },
   lab_result: { en: "Lab", zh: "化验" },
   pending_result: { en: "Pending", zh: "待出" },

--- a/src/components/schedule/prep-editor.tsx
+++ b/src/components/schedule/prep-editor.tsx
@@ -13,6 +13,7 @@ import { Field, TextInput } from "~/components/ui/field";
 import { Button } from "~/components/ui/button";
 import { Plus, Trash2 } from "lucide-react";
 import { toDatetimeLocalInput as toLocalInput } from "~/lib/utils/date";
+import type { LocalizedText } from "~/types/localized";
 
 // Reusable prep-item editor — used in the appointment form (on
 // create / edit) and surfaced on the detail page when the patient
@@ -41,7 +42,7 @@ const SOURCE_OPTIONS: AppointmentPrepSource[] = [
   "other",
 ];
 
-const SOURCE_LABEL: Record<AppointmentPrepSource, { en: string; zh: string }> = {
+const SOURCE_LABEL: Record<AppointmentPrepSource, LocalizedText> = {
   phone: { en: "Phone", zh: "电话" },
   email: { en: "Email", zh: "邮件" },
   letter: { en: "Letter", zh: "信函" },

--- a/src/components/settings/tracked-symptoms-section.tsx
+++ b/src/components/settings/tracked-symptoms-section.tsx
@@ -12,6 +12,7 @@ import { cn } from "~/lib/utils/cn";
 import { localeTag } from "~/lib/utils/date";
 import { Card, CardContent } from "~/components/ui/card";
 import { Stethoscope, RotateCcw } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 const TAG_STYLE: Record<SymptomTag, string> = {
   pdac: "bg-[var(--tide-soft)] text-[var(--tide-2)]",
@@ -21,7 +22,7 @@ const TAG_STYLE: Record<SymptomTag, string> = {
   safety: "bg-[var(--warn-soft)] text-[var(--warn)]",
 };
 
-const TAG_LABEL: Record<SymptomTag, { en: string; zh: string }> = {
+const TAG_LABEL: Record<SymptomTag, LocalizedText> = {
   pdac: { en: "PDAC", zh: "胰腺癌" },
   chemo: { en: "Chemo", zh: "化疗" },
   gnp: { en: "GnP", zh: "GnP" },

--- a/src/components/shared/add-fab.tsx
+++ b/src/components/shared/add-fab.tsx
@@ -18,15 +18,17 @@ import {
 } from "lucide-react";
 import { useIngestModal } from "~/components/ingest/ingest-modal";
 import { useAppPerspective } from "~/lib/caregiver/scope";
+import type { LocalizedText } from "~/types/localized";
+import type { IconComponent } from "~/types/ui";
 
 interface FabItem {
   href?: string;
   // When set, the item is rendered as a button that runs `action`
   // instead of navigating. Used for the smart-ingest opener.
   action?: "ingest";
-  label: { en: string; zh: string };
-  hint: { en: string; zh: string };
-  icon: React.ComponentType<{ className?: string }>;
+  label: LocalizedText;
+  hint: LocalizedText;
+  icon: IconComponent;
   tone?: "tide" | "sand";
 }
 

--- a/src/components/shared/attribution.tsx
+++ b/src/components/shared/attribution.tsx
@@ -4,6 +4,7 @@ import { useHouseholdProfiles } from "~/hooks/use-household-profiles";
 import { useLocale } from "~/hooks/use-translate";
 import { cn } from "~/lib/utils/cn";
 import { localeTag } from "~/lib/utils/date";
+import type { LocalizedText } from "~/types/localized";
 
 // Small inline chip: "Thomas · 2h ago" when a profile exists for the
 // given auth uid; falls back to the legacy `entered_by` label for rows
@@ -14,7 +15,7 @@ import { localeTag } from "~/lib/utils/date";
 // household profile / per-user profile lookup — these are only used
 // when a row was saved by a legacy `entered_by` string and we don't
 // have an auth uid to resolve to a profile row.
-const STRING_LABELS: Record<string, { en: string; zh: string }> = {
+const STRING_LABELS: Record<string, LocalizedText> = {
   patient: { en: "Patient", zh: "患者" },
   carer: { en: "Carer", zh: "照护者" },
   clinician: { en: "Clinician", zh: "医师" },

--- a/src/components/shared/zone-badge.tsx
+++ b/src/components/shared/zone-badge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Zone } from "~/types/clinical";
+import type { IconComponent } from "~/types/ui";
 import { cn } from "~/lib/utils/cn";
 import { useT } from "~/hooks/use-translate";
 import {
@@ -17,7 +18,7 @@ const ZONE_CHIP: Record<Zone, string> = {
   red: "a-chip warn",
 };
 
-const ZONE_ICON: Record<Zone, React.ComponentType<{ className?: string }>> = {
+const ZONE_ICON: Record<Zone, IconComponent> = {
   green: Circle,
   yellow: AlertCircle,
   orange: AlertTriangle,

--- a/src/components/tasks/task-row.tsx
+++ b/src/components/tasks/task-row.tsx
@@ -6,12 +6,14 @@ import { cn } from "~/lib/utils/cn";
 import { useLocale } from "~/hooks/use-translate";
 import type { TaskBucket, TaskInstance } from "~/types/task";
 import { localizedTitle } from "~/types/task";
+import type { LocalizedText } from "~/types/localized";
+import type { IconComponent } from "~/types/ui";
 import { Button } from "~/components/ui/button";
 import { Check, Clock, AlertTriangle, CalendarClock, MoonStar } from "lucide-react";
 
 const BUCKET_META: Record<
   TaskBucket,
-  { tone: string; icon: React.ComponentType<{ className?: string }>; label: { en: string; zh: string } }
+  { tone: string; icon: IconComponent; label: LocalizedText }
 > = {
   overdue: {
     tone: "border-[var(--warn)]/50 bg-[var(--warn-soft)] text-[var(--warn)]",

--- a/src/components/treatment/cycle-calendar.tsx
+++ b/src/components/treatment/cycle-calendar.tsx
@@ -11,11 +11,12 @@ import {
 } from "~/types/treatment";
 import { cycleDayFor, currentPhase } from "~/lib/treatment/engine";
 import { FlaskConical } from "lucide-react";
+import type { LocalizedText } from "~/types/localized";
 
 type Swatch = {
   bg: string;
   color: string;
-  label: { en: string; zh: string };
+  label: LocalizedText;
 };
 
 const SWATCHES: Record<string, Swatch> = {

--- a/src/components/treatment/cycle-day-detail.tsx
+++ b/src/components/treatment/cycle-day-detail.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import type { Appointment } from "~/types/appointment";
 import type { Protocol, TreatmentCycle } from "~/types/treatment";
+import type { IconComponent } from "~/types/ui";
 
 // Bottom-anchored detail panel for a selected cycle day. Shows dose /
 // phase / what-to-expect, any appointments the calendar already knows
@@ -35,13 +36,12 @@ import type { Protocol, TreatmentCycle } from "~/types/treatment";
 // dose-modification record. Writes back into `cycle.day_records` via
 // upsertDayRecord so the cycle page's main calendar shows the same state.
 
-const APPT_ICON: Partial<Record<Appointment["kind"], React.ComponentType<{ className?: string }>>> =
-  {
-    chemo: Syringe,
-    clinic: Stethoscope,
-    scan: ScanLine,
-    blood_test: FlaskConical,
-  };
+const APPT_ICON: Partial<Record<Appointment["kind"], IconComponent>> = {
+  chemo: Syringe,
+  clinic: Stethoscope,
+  scan: ScanLine,
+  blood_test: FlaskConical,
+};
 
 export function CycleDayDetail({
   cycle,

--- a/src/components/treatment/cycle-form.tsx
+++ b/src/components/treatment/cycle-form.tsx
@@ -9,6 +9,7 @@ import { Button } from "~/components/ui/button";
 import { Field, TextInput } from "~/components/ui/field";
 import { cn } from "~/lib/utils/cn";
 import type { CycleStatus, ProtocolId, TreatmentCycle } from "~/types/treatment";
+import type { LocalizedText } from "~/types/localized";
 
 export interface CycleFormValues {
   protocol_id: ProtocolId;
@@ -28,7 +29,7 @@ const STATUSES: CycleStatus[] = [
   "cancelled",
 ];
 
-const STATUS_LABEL: Record<CycleStatus, { en: string; zh: string }> = {
+const STATUS_LABEL: Record<CycleStatus, LocalizedText> = {
   planned: { en: "Planned", zh: "已计划" },
   active: { en: "Active", zh: "进行中" },
   completed: { en: "Completed", zh: "已完成" },
@@ -43,7 +44,7 @@ export function CycleForm({
   onCancel,
 }: {
   initial?: TreatmentCycle;
-  submitLabel: { en: string; zh: string };
+  submitLabel: LocalizedText;
   onSubmit: (values: CycleFormValues) => Promise<void>;
   onCancel?: () => void;
 }) {

--- a/src/components/treatment/cycle-medications-card.tsx
+++ b/src/components/treatment/cycle-medications-card.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { DRUGS_BY_ID } from "~/config/drug-registry";
 import { scheduleSummary } from "~/lib/medication/practices";
 import type { Medication } from "~/types/medication";
+import type { IconComponent } from "~/types/ui";
 import { ChevronRight, Pencil, Pill, Plus, Zap } from "lucide-react";
 
 // Summary of the active prescriptions attached to this cycle. Split into
@@ -104,7 +105,7 @@ function MedSection({
   cycleId,
 }: {
   title: string;
-  icon: React.ComponentType<{ className?: string }>;
+  icon: IconComponent;
   meds: Medication[];
   locale: "en" | "zh";
   emptyLabel: string;

--- a/src/components/treatment/nudge-card.tsx
+++ b/src/components/treatment/nudge-card.tsx
@@ -2,6 +2,8 @@
 
 import { useLocale } from "~/hooks/use-translate";
 import type { NudgeCategory, NudgeTemplate } from "~/types/treatment";
+import type { LocalizedText } from "~/types/localized";
+import type { IconComponent } from "~/types/ui";
 import {
   Apple,
   Bed,
@@ -17,10 +19,7 @@ import {
   X,
 } from "lucide-react";
 
-const CATEGORY_ICON: Record<
-  NudgeCategory,
-  React.ComponentType<{ className?: string }>
-> = {
+const CATEGORY_ICON: Record<NudgeCategory, IconComponent> = {
   diet: Apple,
   hygiene: SprayCan,
   exercise: Dumbbell,
@@ -32,7 +31,7 @@ const CATEGORY_ICON: Record<
   intimacy: Heart,
 };
 
-const CATEGORY_LABEL: Record<NudgeCategory, { en: string; zh: string }> = {
+const CATEGORY_LABEL: Record<NudgeCategory, LocalizedText> = {
   diet: { en: "Diet", zh: "饮食" },
   hygiene: { en: "Hygiene", zh: "卫生" },
   exercise: { en: "Exercise", zh: "运动" },
@@ -48,7 +47,7 @@ type SeverityTone = {
   ringStyle: React.CSSProperties;
   bgStyle: React.CSSProperties;
   pillStyle: React.CSSProperties;
-  icon: React.ComponentType<{ className?: string }>;
+  icon: IconComponent;
 };
 
 const SEVERITY_TONE: Record<"warning" | "caution" | "info", SeverityTone> = {

--- a/src/config/lab-reference-ranges.ts
+++ b/src/config/lab-reference-ranges.ts
@@ -7,6 +7,7 @@
 // remain with Dr Lee.
 
 import type { LabResult } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 
 export type AnalyteKey = Exclude<
   keyof LabResult,
@@ -25,7 +26,7 @@ export type AnalyteGroup =
 
 export interface AnalyteDef {
   key: AnalyteKey;
-  label: { en: string; zh: string };
+  label: LocalizedText;
   short: string; // short label for pills / calendar dots
   unit: string;
   /** Reference range [low, high]. `null` means no standard range (e.g. CA19-9 uses upper-bound only). */
@@ -39,7 +40,7 @@ export interface AnalyteDef {
   /** How many decimal places to display in tables. */
   decimals?: number;
   /** Short 1-line clinical note shown in TestView. */
-  note?: { en: string; zh: string };
+  note?: LocalizedText;
 }
 
 export const ANALYTES: AnalyteDef[] = [
@@ -423,7 +424,7 @@ export const ANALYTE_BY_KEY: Record<AnalyteKey, AnalyteDef> = Object.fromEntries
   ANALYTES.map((a) => [a.key, a]),
 ) as Record<AnalyteKey, AnalyteDef>;
 
-export const GROUP_LABEL: Record<AnalyteGroup, { en: string; zh: string }> = {
+export const GROUP_LABEL: Record<AnalyteGroup, LocalizedText> = {
   tumour_marker: { en: "Tumour markers", zh: "肿瘤标志物" },
   nutrition: { en: "Nutrition & inflammation", zh: "营养与炎症" },
   haematology: { en: "Blood count", zh: "血常规" },

--- a/src/config/oncologists.ts
+++ b/src/config/oncologists.ts
@@ -8,9 +8,11 @@
 // type. Direct office numbers are not seeded because they vary by
 // secretary; the user fills them in if they have them on hand.
 
+import type { LocalizedText } from "~/types/localized";
+
 export interface MelbourneHospital {
   id: string;
-  name: { en: string; zh: string };
+  name: LocalizedText;
   phone: string;
   address: string;
   // 24/7 on-call number when the hospital publishes one distinct from
@@ -20,14 +22,14 @@ export interface MelbourneHospital {
 
 export interface MelbourneOncologist {
   id: string;
-  name: { en: string; zh: string };
+  name: LocalizedText;
   // Primary hospital affiliation used to pre-fill hospital fields. Some
   // clinicians work across multiple sites; this is the dominant one for
   // GI / pancreas care.
   hospital_id: string;
   // Optional secondary affiliation shown in the picker label.
   also_at?: string;
-  specialty: { en: string; zh: string };
+  specialty: LocalizedText;
 }
 
 export const MELBOURNE_HOSPITALS: MelbourneHospital[] = [

--- a/src/lib/appointments/prep.ts
+++ b/src/lib/appointments/prep.ts
@@ -3,6 +3,7 @@ import type {
   AppointmentPrep,
   AppointmentPrepKind,
 } from "~/types/appointment";
+import type { LocalizedText } from "~/types/localized";
 import type { PatientTask } from "~/types/task";
 
 // Slice I helpers. Pure functions around AppointmentPrep so the UI
@@ -149,7 +150,7 @@ export function deriveAwaitingPrepTasks(args: {
 // Small label helpers for the UI.
 export const PREP_KIND_LABEL: Record<
   AppointmentPrepKind,
-  { en: string; zh: string }
+  LocalizedText
 > = {
   fast: { en: "Fast", zh: "禁食" },
   medication_hold: { en: "Hold medication", zh: "停药" },

--- a/src/lib/assessment/catalog.ts
+++ b/src/lib/assessment/catalog.ts
@@ -1,3 +1,5 @@
+import type { LocalizedText } from "~/types/localized";
+
 export type TestCategory =
   | "physical"
   | "symptoms"
@@ -36,10 +38,10 @@ export type TestId =
 export interface TestDef {
   id: TestId;
   category: TestCategory;
-  title: { en: string; zh: string };
-  description: { en: string; zh: string };
+  title: LocalizedText;
+  description: LocalizedText;
   est_minutes: number;
-  equipment?: { en: string; zh: string };
+  equipment?: LocalizedText;
   default_on: boolean;
   // Numbered, read-aloud-ready setup steps for the helper. Empty for
   // questionnaire tests where the on-screen form already drives the
@@ -511,7 +513,7 @@ export type PresetId = "comprehensive" | "quick" | "function" | "custom";
 
 export const PRESETS: Record<
   PresetId,
-  { title: { en: string; zh: string }; description: { en: string; zh: string }; tests: TestId[] }
+  { title: LocalizedText; description: LocalizedText; tests: TestId[] }
 > = {
   comprehensive: {
     title: { en: "Comprehensive baseline", zh: "完整基线" },

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -1,4 +1,5 @@
 import type { HouseholdRole } from "~/types/household";
+import type { LocalizedText } from "~/types/localized";
 import type { SyncedTable } from "~/lib/sync/tables";
 
 // Authoritative permission matrix. This file is the single source of
@@ -92,7 +93,7 @@ export function actionsFor(role: HouseholdRole): PermissionAction[] {
 // post-invite welcome screen and any "permission denied" toast.
 export const ACTION_LABEL: Record<
   PermissionAction,
-  { en: string; zh: string }
+  LocalizedText
 > = {
   invite_members: { en: "Invite new members", zh: "邀请新成员" },
   remove_members: { en: "Remove members", zh: "移除成员" },
@@ -117,7 +118,7 @@ export const ACTION_LABEL: Record<
 };
 
 // Roles expanded with their user-facing label, sorted for display.
-export const ROLE_LABEL: Record<HouseholdRole, { en: string; zh: string }> = {
+export const ROLE_LABEL: Record<HouseholdRole, LocalizedText> = {
   primary_carer: { en: "Primary carer", zh: "主要照护者" },
   patient: { en: "Patient", zh: "患者" },
   family: { en: "Family", zh: "家人" },
@@ -170,7 +171,7 @@ export const TABLE_WRITE_ACTION: Partial<Record<SyncedTable, PermissionAction>> 
 // on the welcome screen after acceptance.
 export const ROLE_DESCRIPTION: Record<
   HouseholdRole,
-  { en: string; zh: string }
+  LocalizedText
 > = {
   primary_carer: {
     en: "Runs the household — can invite, remove, and edit the treatment plan.",

--- a/src/lib/calculations/scoring.ts
+++ b/src/lib/calculations/scoring.ts
@@ -1,28 +1,54 @@
-export function phq9Score(responses: number[]): number {
-  if (responses.length !== 9) {
-    throw new Error(`PHQ-9 requires 9 responses, got ${responses.length}`);
+// Threshold descending: the first row whose score is >= threshold wins.
+// Categorisations sit at the floor (>= 0) so a falsy score still picks
+// up the "minimal" / least-severe bucket.
+function severityFor<T extends string>(
+  score: number,
+  thresholds: ReadonlyArray<readonly [number, T]>,
+): T {
+  for (const [min, severity] of thresholds) {
+    if (score >= min) return severity;
+  }
+  // Unreachable when the last threshold is 0, which all current tables provide.
+  return thresholds[thresholds.length - 1][1];
+}
+
+function sumOrThrow(responses: number[], expected: number, name: string): number {
+  if (responses.length !== expected) {
+    throw new Error(`${name} requires ${expected} responses, got ${responses.length}`);
   }
   return responses.reduce((a, b) => a + b, 0);
+}
+
+export function phq9Score(responses: number[]): number {
+  return sumOrThrow(responses, 9, "PHQ-9");
 }
 
 export function gad7Score(responses: number[]): number {
-  if (responses.length !== 7) {
-    throw new Error(`GAD-7 requires 7 responses, got ${responses.length}`);
-  }
-  return responses.reduce((a, b) => a + b, 0);
+  return sumOrThrow(responses, 7, "GAD-7");
 }
 
-export function phq9Severity(score: number): "minimal" | "mild" | "moderate" | "moderately-severe" | "severe" {
-  if (score >= 20) return "severe";
-  if (score >= 15) return "moderately-severe";
-  if (score >= 10) return "moderate";
-  if (score >= 5) return "mild";
-  return "minimal";
+export type Phq9Severity = "minimal" | "mild" | "moderate" | "moderately-severe" | "severe";
+export type Gad7Severity = "minimal" | "mild" | "moderate" | "severe";
+
+const PHQ9_THRESHOLDS: ReadonlyArray<readonly [number, Phq9Severity]> = [
+  [20, "severe"],
+  [15, "moderately-severe"],
+  [10, "moderate"],
+  [5, "mild"],
+  [0, "minimal"],
+];
+
+const GAD7_THRESHOLDS: ReadonlyArray<readonly [number, Gad7Severity]> = [
+  [15, "severe"],
+  [10, "moderate"],
+  [5, "mild"],
+  [0, "minimal"],
+];
+
+export function phq9Severity(score: number): Phq9Severity {
+  return severityFor(score, PHQ9_THRESHOLDS);
 }
 
-export function gad7Severity(score: number): "minimal" | "mild" | "moderate" | "severe" {
-  if (score >= 15) return "severe";
-  if (score >= 10) return "moderate";
-  if (score >= 5) return "mild";
-  return "minimal";
+export function gad7Severity(score: number): Gad7Severity {
+  return severityFor(score, GAD7_THRESHOLDS);
 }

--- a/src/lib/cron/digest.ts
+++ b/src/lib/cron/digest.ts
@@ -1,4 +1,5 @@
 import type { Zone } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 import { highestZone } from "~/lib/rules/engine";
 import { localeTag } from "~/lib/utils/date";
 
@@ -53,7 +54,7 @@ function startOfDay(d: Date): Date {
 }
 
 function zoneLabel(z: Zone, locale: "en" | "zh"): string {
-  const labels: Record<Zone, { en: string; zh: string }> = {
+  const labels: Record<Zone, LocalizedText> = {
     green: { en: "Stable", zh: "稳定" },
     yellow: { en: "Review needed", zh: "需复核" },
     orange: { en: "Urgent review", zh: "紧急复核" },

--- a/src/lib/daily/symptom-catalog.ts
+++ b/src/lib/daily/symptom-catalog.ts
@@ -1,4 +1,5 @@
 import type { DailyEntry } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 
 // The curated mPDAC/ GnP symptom catalog. Each entry is one checkable
 // item on the daily-wizard "Symptoms" step. The catalog is the single
@@ -37,8 +38,8 @@ export type SymptomTag =
 
 export interface SymptomDefinition {
   id: string;
-  label: { en: string; zh: string };
-  hint?: { en: string; zh: string };
+  label: LocalizedText;
+  hint?: LocalizedText;
   scale: SymptomScale;
   tags: readonly SymptomTag[];
   defaultTracked: boolean;

--- a/src/lib/log/direct-file.ts
+++ b/src/lib/log/direct-file.ts
@@ -19,26 +19,27 @@
 
 import { todayISO } from "~/lib/utils/date";
 import type { DailyEntry, LabResult } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 
 export type DirectFileResult =
   | {
       kind: "lab";
       date: string;
       patch: Partial<LabResult> & { date: string; source: "patient_self_report" };
-      summary: { en: string; zh: string };
+      summary: LocalizedText;
       icon: "lab";
     }
   | {
       kind: "daily";
       date: string;
       patch: Partial<DailyEntry>;
-      summary: { en: string; zh: string };
+      summary: LocalizedText;
       icon: "daily";
     };
 
 const DAY_PART_RE = /\b(this morning|morning|am|afternoon|pm|evening|tonight|today|now)\b/i;
 
-function timeOfDay(text: string): { en: string; zh: string } {
+function timeOfDay(text: string): LocalizedText {
   const m = DAY_PART_RE.exec(text);
   const hit = m?.[1]?.toLowerCase();
   if (!hit) return { en: "today", zh: "今日" };

--- a/src/lib/log/follow-ups.ts
+++ b/src/lib/log/follow-ups.ts
@@ -13,14 +13,15 @@ import type { DirectFileResult } from "./direct-file";
 import type { AppointmentDiscussionItem } from "~/types/appointment";
 import type { Appointment } from "~/types/appointment";
 import type { CareTeamMember } from "~/types/care-team";
+import type { LocalizedText } from "~/types/localized";
 
 export type FollowUpSeverity = "routine" | "watch" | "urgent";
 
 export interface FollowUpItem {
   id: string;
   severity: FollowUpSeverity;
-  title: { en: string; zh: string };
-  body: { en: string; zh: string };
+  title: LocalizedText;
+  body: LocalizedText;
   actions: FollowUpAction[];
 }
 
@@ -29,7 +30,7 @@ export type FollowUpAction =
       kind: "add_to_clinic";
       appointment_id: number;
       text: string;
-      label: { en: string; zh: string };
+      label: LocalizedText;
     }
   | {
       kind: "message_care_team";
@@ -37,13 +38,13 @@ export type FollowUpAction =
       channel: "phone" | "sms" | "email";
       target: string;          // tel:+…, sms:+…, mailto:…
       draft?: string;
-      label: { en: string; zh: string };
+      label: LocalizedText;
     }
   | {
       kind: "engage_agent";
       agent_id: "nutrition" | "toxicity" | "clinical" | "psychology" | "rehabilitation" | "treatment";
       prompt: string;
-      label: { en: string; zh: string };
+      label: LocalizedText;
     };
 
 function slug(s: string): string {

--- a/src/lib/nutrition/pert-engine.ts
+++ b/src/lib/nutrition/pert-engine.ts
@@ -1,4 +1,5 @@
 import type { MealType } from "~/types/nutrition";
+import type { LocalizedText } from "~/types/localized";
 import type { Citation } from "./sources";
 
 // JPCC PERT decision rules (Jreissati Family Pancreatic Centre at
@@ -53,7 +54,7 @@ export interface PertEvaluationInput {
 export interface PertEvaluation {
   required: boolean;
   recommendation: PertDoseRecommendation;
-  reason: { en: string; zh: string };
+  reason: LocalizedText;
   citations: Citation[];
 }
 

--- a/src/lib/nutrition/policy.ts
+++ b/src/lib/nutrition/policy.ts
@@ -1,4 +1,5 @@
 import type { DailyEntry, Settings } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 import type { Citation } from "./sources";
 
 // Carb-policy state machine. The /nutrition/guide page in Anchor
@@ -24,14 +25,14 @@ export type PolicyTriggerKind =
 
 export interface PolicyTrigger {
   kind: PolicyTriggerKind;
-  detail: { en: string; zh: string };
+  detail: LocalizedText;
   citations: Citation[];
 }
 
 export interface NutritionPolicyState {
   mode: NutritionMode;
   triggers: PolicyTrigger[];
-  rationale: { en: string; zh: string };
+  rationale: LocalizedText;
 }
 
 export interface PolicyInputs {

--- a/src/lib/nutrition/symptom-context.ts
+++ b/src/lib/nutrition/symptom-context.ts
@@ -1,6 +1,7 @@
 import { db } from "~/lib/db/dexie";
 import { shiftDateISO, todayISO } from "~/lib/utils/date";
 import type { DailyEntry } from "~/types/clinical";
+import type { LocalizedText } from "~/types/localized";
 
 // Symptom-aware context for the food picker and JPCC playbooks.
 // Reads today's DailyEntry (and yesterday's as a fallback so a
@@ -87,10 +88,7 @@ async function loadDayEntry(date: string): Promise<DailyEntry | undefined> {
 }
 
 
-export const SYMPTOM_LABEL: Record<
-  SymptomFlag,
-  { en: string; zh: string }
-> = {
+export const SYMPTOM_LABEL: Record<SymptomFlag, LocalizedText> = {
   nausea: { en: "nausea", zh: "恶心" },
   mucositis: { en: "mouth sores", zh: "口腔溃疡" },
   diarrhoea: { en: "diarrhoea", zh: "腹泻" },

--- a/src/lib/nutrition/taste-tweaks.ts
+++ b/src/lib/nutrition/taste-tweaks.ts
@@ -1,4 +1,5 @@
 import type { Citation } from "./sources";
+import type { LocalizedText } from "~/types/localized";
 
 // JPCC nutrition guide p. 16: four taste-issue quadrants and a
 // remedy list for each. Common during chemotherapy (especially
@@ -27,13 +28,13 @@ export const TASTE_ISSUES: TasteIssue[] = [
 
 export interface TasteTweak {
   issue: TasteIssue;
-  suggestions: { en: string; zh: string }[];
+  suggestions: LocalizedText[];
   citations: Citation[];
 }
 
 const JPCC_TASTE_CITE: Citation = { source_id: "jpcc_2021", page: 16 };
 
-const TWEAKS: Record<TasteIssue, { en: string; zh: string }[]> = {
+const TWEAKS: Record<TasteIssue, LocalizedText[]> = {
   too_sweet: [
     {
       en: "Eat the food cool — lower temperatures reduce sweetness.",

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,4 +1,5 @@
 import type { Locale } from "./clinical";
+import type { LocalizedText } from "./localized";
 import type { PhaseKey } from "./treatment";
 
 export type TaskCategory =
@@ -88,9 +89,9 @@ export interface TaskInstance {
 
 export interface TaskPreset {
   id: string;
-  title: { en: string; zh: string };
+  title: LocalizedText;
   category: TaskCategory;
-  notes?: { en: string; zh: string };
+  notes?: LocalizedText;
   schedule_kind: TaskScheduleKind;
   recurrence_interval_days?: number;
   cycle_day?: number;
@@ -98,7 +99,7 @@ export interface TaskPreset {
   lead_time_days: number;
   priority: TaskPriority;
   default_due_offset_days?: number; // for one-off, set due N days from now
-  rationale: { en: string; zh: string };
+  rationale: LocalizedText;
 }
 
 export function localizedTitle(task: PatientTask, locale: Locale): string {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,0 +1,8 @@
+import type { ComponentType } from "react";
+
+// Single source of truth for the lucide-react icon component shape used
+// across feed cards, badges, schedule rows, ingest previews, etc.
+// Previously duplicated inline as `React.ComponentType<{ className?: string }>`
+// in ~30 files.
+
+export type IconComponent = ComponentType<{ className?: string }>;


### PR DESCRIPTION
## Summary

Three contained DRY refactors removing accumulated type-shape duplication. No behavioural changes — the full 1009-test unit suite, `pnpm lint`, and `pnpm typecheck` all stay green.

### 1. `IconComponent` shared type
`React.ComponentType<{ className?: string }>` was re-declared inline in **26 files** (zone-badge, FAB items, dashboard cards, schedule chips, ingest preview, family timeline, history page, signals page, two ingest route Status sub-components, etc). New `src/types/ui.ts` exports a single `IconComponent` alias; every duplicate now imports it.

### 2. `LocalizedText` sweep
The canonical `{ en: string; zh: string }` shape already lives in `src/types/localized.ts` (added during the earlier `LocalizedString`/`LocalizedText` consolidation) but was still re-inlined as an anonymous literal in **~35 places** — lookup tables (`ROLE_LABEL`, `KIND_LABEL`, `TAG_LABEL`, `STATUS_LABEL`, `CATEGORY_LABEL`, …), prop types, the follow-up engine, JPCC nutrition policy/PERT/taste tweaks, lab reference ranges, oncologist registry, task presets, daily-wizard option arrays, and several route pages. Replaced with the named import everywhere it appeared.

**Intentionally skipped:** `src/lib/nudges/weather-nudges.ts` and `src/lib/legacy/orchestrator.ts`. CLAUDE.md requires reading `docs/AI_SURFACES.md` / `docs/LEGACY_MODULE.md` before editing those surfaces — left as a focused follow-up rather than smuggled into this PR.

### 3. PHQ-9 / GAD-7 scoring DRY
Both `phq9Severity` / `gad7Severity` were hand-written if-cascades; `phq9Score` / `gad7Score` repeated the same "validate length, sum responses" body. Folded into two thin helpers (`severityFor`, `sumOrThrow`) plus declarative threshold tables. Public API preserved; `Phq9Severity` and `Gad7Severity` are now exported as named types.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no warnings or errors
- [x] `pnpm test` — 1009/1009 passing (incl. the existing PHQ-9 / GAD-7 categorisation cases in `tests/unit/calculations.test.ts`)
- [ ] Spot-check at runtime: dashboard cards, schedule chips, FAB labels, ingest preview, family timeline render unchanged

https://claude.ai/code/session_01MDqeXrYqDrBqJoPF5caQVC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDqeXrYqDrBqJoPF5caQVC)_