### PR TITLE
refactor(sync): consolidate sync/bootstrap warn logging into logSyncWarn

### DIFF
--- a/src/lib/sync/bootstrap.ts
+++ b/src/lib/sync/bootstrap.ts
@@ -4,6 +4,7 @@ import { SYNCED_TABLES, type SyncedTable } from "./tables";
 import { scrubForSync } from "./hooks";
 import { enqueueSync, kickQueue } from "./queue";
 import { refreshHouseholdId, getCachedHouseholdId } from "./household-context";
+import { logSyncWarn } from "./log";
 
 // Bootstrap heal — fixes the "patient onboarded offline before Supabase
 // auth existed" trap that left Hu Lin with `settings.onboarded_at` set
@@ -55,8 +56,7 @@ export async function bootstrapHouseholdAndProfile(): Promise<string | null> {
         locale: settings?.locale,
       });
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn("[bootstrap] ensureProfileForCurrentUser failed:", err);
+      logSyncWarn("bootstrap", "ensureProfileForCurrentUser failed", err);
     }
 
     // Step 2 — household. Only auto-create for patients, and only when
@@ -74,11 +74,7 @@ export async function bootstrapHouseholdAndProfile(): Promise<string | null> {
           await ensureHouseholdForCurrentUser({ patientName });
         }
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          "[bootstrap] ensureHouseholdForCurrentUser failed:",
-          err,
-        );
+        logSyncWarn("bootstrap", "ensureHouseholdForCurrentUser failed", err);
       }
     }
 
@@ -87,8 +83,7 @@ export async function bootstrapHouseholdAndProfile(): Promise<string | null> {
     const householdId = await refreshHouseholdId();
     return householdId;
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn("[bootstrap] unexpected failure:", err);
+    logSyncWarn("bootstrap", "unexpected failure", err);
     return null;
   }
 }
@@ -130,8 +125,7 @@ export async function flushLocalRowsOnce(): Promise<{
     try {
       rows = await table.toArray();
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn(`[bootstrap] flush: read failed for ${tableName}:`, err);
+      logSyncWarn("bootstrap", `flush: read failed for ${tableName}`, err);
       continue;
     }
     for (const row of rows) {

--- a/src/lib/sync/hooks.ts
+++ b/src/lib/sync/hooks.ts
@@ -1,5 +1,6 @@
 import { db } from "~/lib/db/dexie";
 import { enqueueSync } from "./queue";
+import { logSyncWarn } from "./log";
 import { SYNCED_TABLES, type SyncedTable } from "./tables";
 
 // Per-table scrubbers run before a row is enqueued for cloud sync.
@@ -43,8 +44,7 @@ export function attachSyncHooks(): void {
   for (const name of SYNCED_TABLES) {
     const table = (db as unknown as Record<string, DexieTableLike>)[name];
     if (!table || typeof table.hook !== "function") {
-      // eslint-disable-next-line no-console
-      console.warn(`[sync] table ${name} missing from Dexie schema`);
+      logSyncWarn("sync", `table ${name} missing from Dexie schema`);
       continue;
     }
 

--- a/src/lib/sync/log.ts
+++ b/src/lib/sync/log.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-console */
+// Centralized warn-level logger for the sync + bootstrap subsystems.
+// Wrapping `console.warn` once means swapping in a structured logger
+// later is a single edit, not nine, and keeps `no-console` disables
+// off the call sites. The whole point of this file is to wrap
+// console, hence the per-file disable.
+
+export type SyncLogTag = "sync" | "bootstrap";
+
+export function logSyncWarn(
+  tag: SyncLogTag,
+  context: string,
+  err?: unknown,
+): void {
+  const prefix = `[${tag}] ${context}`;
+  if (err === undefined) console.warn(prefix);
+  else console.warn(`${prefix}:`, err);
+}

--- a/src/lib/sync/pull.ts
+++ b/src/lib/sync/pull.ts
@@ -6,6 +6,7 @@ import {
   getCachedHouseholdId,
   refreshHouseholdId,
 } from "./household-context";
+import { logSyncWarn } from "./log";
 
 const LAST_PULLED_KEY = "anchor.lastPulledAt";
 
@@ -44,8 +45,7 @@ export async function pullFromCloud(): Promise<{ pulled: number } | null> {
     .limit(5000);
 
   if (error) {
-    // eslint-disable-next-line no-console
-    console.warn("[sync] pull failed:", error);
+    logSyncWarn("sync", "pull failed", error);
     return null;
   }
 
@@ -69,9 +69,9 @@ export async function pullFromCloud(): Promise<{ pulled: number } | null> {
           await table.put({ ...row.data, id: row.local_id });
         }
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[sync] apply failed for ${row.table_name}#${row.local_id}`,
+        logSyncWarn(
+          "sync",
+          `apply failed for ${row.table_name}#${row.local_id}`,
           err,
         );
       }

--- a/src/lib/sync/queue.ts
+++ b/src/lib/sync/queue.ts
@@ -2,6 +2,7 @@ import { db } from "~/lib/db/dexie";
 import { getSupabaseBrowser } from "~/lib/supabase/client";
 import { nowISO } from "~/lib/utils/date";
 import { getCachedHouseholdId, refreshHouseholdId } from "./household-context";
+import { logSyncWarn } from "./log";
 import type { SyncedTable } from "./tables";
 import type { SyncQueueRow } from "~/types/sync-queue";
 
@@ -97,8 +98,7 @@ export function enqueueSync(op: SyncOp): void {
       }
       void processQueue();
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn("[sync] failed to persist queue op:", err);
+      logSyncWarn("sync", "failed to persist queue op", err);
     }
   })();
 }
@@ -167,8 +167,7 @@ async function processQueue(): Promise<void> {
       } catch (err) {
         // Write failed (offline, RLS denied, network). Stop draining and
         // leave the op at the head so the next tick retries it.
-        // eslint-disable-next-line no-console
-        console.warn("[sync] push failed, will retry:", err);
+        logSyncWarn("sync", "push failed, will retry", err);
         break;
       }
     }


### PR DESCRIPTION
## Summary

Nine call sites across the sync module repeated the same shape:

```ts
// eslint-disable-next-line no-console
console.warn("[<tag>] <context>:", err);
```

with `<tag>` always either `sync` or `bootstrap`. Each site carried its own `no-console` eslint disable and the message format varied subtly (some with a colon, one without, one multi-line). Future migration to a structured logger would have had to touch all nine.

Add `src/lib/sync/log.ts` exposing a single `logSyncWarn(tag, context, err?)` helper. The file is the sole place in the sync module that calls `console.warn` (per-file eslint disable, intentional). All nine call sites now route through it.

## Sites consolidated

- `src/lib/sync/bootstrap.ts` (4 sites — profile / household ensure failures, top-level catch, per-table flush read failure)
- `src/lib/sync/pull.ts` (2 sites — pull error, per-row apply failure)
- `src/lib/sync/queue.ts` (2 sites — enqueue persistence failure, push retry warning)
- `src/lib/sync/hooks.ts` (1 site — Dexie schema mismatch warning)

## Behaviour

Identical — same `console.warn` channel, same `[tag] context: err` prefix, same error appended. Tag is typed (`"sync" | "bootstrap"`) so new variants cannot drift. Net diff: −22 / +15 lines on existing files plus the 18-line helper.

## Scope discipline

Survey turned up several other candidate consolidations (date-query Dexie patterns, range-validator zod schemas, voice-memo update-then-get pairs). I deliberately did NOT touch them — each had ≤ 3 sites or shaky pattern alignment, which falls on the wrong side of CLAUDE.md's "three similar lines is better than a premature abstraction" rule. This PR is one well-bounded consolidation, not a sweep.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1009 / 1009 passing
- [ ] Manual smoke: sign-in + offline-queue path still logs `[sync] push failed, will retry: …` on a forced offline push (visual confirmation only)

---
_Generated by [Claude Code](https://claude.ai/code/session_016BDyVCxzAm712arVu4XCXp)_